### PR TITLE
Update Batch to use latest AutoRest, remove PORTABLE flag in build

### DIFF
--- a/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
@@ -22,8 +22,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
-    <!-- Portable is defined for legacy reasons, if updating AutoRest removes it from BatchErrorException we can remove it here -->
-    <DefineConstants>$(DefineConstants);netstandard14;PORTABLE</DefineConstants>
+    <DefineConstants>$(DefineConstants);netstandard14</DefineConstants>
   </PropertyGroup>
     
   <ItemGroup>

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/AccountOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/AccountOperations.cs
@@ -8,15 +8,23 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// AccountOperations operations.
     /// </summary>
-    internal partial class AccountOperations : Microsoft.Rest.IServiceOperations<BatchServiceClient>, IAccountOperations
+    internal partial class AccountOperations : IServiceOperations<BatchServiceClient>, IAccountOperations
     {
         /// <summary>
         /// Initializes a new instance of the AccountOperations class.
@@ -33,7 +41,7 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("client");
             }
-            this.Client = client;
+            Client = client;
         }
 
         /// <summary>
@@ -56,10 +64,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -68,11 +76,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>> ListNodeAgentSkusWithHttpMessagesAsync(AccountListNodeAgentSkusOptions accountListNodeAgentSkusOptions = default(AccountListNodeAgentSkusOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>> ListNodeAgentSkusWithHttpMessagesAsync(AccountListNodeAgentSkusOptions accountListNodeAgentSkusOptions = default(AccountListNodeAgentSkusOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (accountListNodeAgentSkusOptions != null)
@@ -105,12 +113,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = accountListNodeAgentSkusOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("filter", filter);
                 tracingParameters.Add("maxResults", maxResults);
                 tracingParameters.Add("timeout", timeout);
@@ -118,15 +126,15 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListNodeAgentSkus", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListNodeAgentSkus", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "nodeagentskus").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -134,33 +142,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -168,7 +176,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -176,7 +184,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -184,7 +192,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -203,23 +211,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -228,21 +236,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -252,7 +260,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>();
+            var _result = new AzureOperationResponse<IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -265,34 +273,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<NodeAgentSku>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<NodeAgentSku>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<AccountListNodeAgentSkusHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<AccountListNodeAgentSkusHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -315,10 +323,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -327,11 +335,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>> ListNodeAgentSkusNextWithHttpMessagesAsync(string nextPageLink, AccountListNodeAgentSkusNextOptions accountListNodeAgentSkusNextOptions = default(AccountListNodeAgentSkusNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>> ListNodeAgentSkusNextWithHttpMessagesAsync(string nextPageLink, AccountListNodeAgentSkusNextOptions accountListNodeAgentSkusNextOptions = default(AccountListNodeAgentSkusNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (accountListNodeAgentSkusNextOptions != null)
@@ -349,44 +357,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = accountListNodeAgentSkusNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListNodeAgentSkusNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListNodeAgentSkusNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -394,7 +402,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -402,7 +410,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -410,7 +418,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -429,23 +437,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -454,21 +462,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -478,7 +486,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>();
+            var _result = new AzureOperationResponse<IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -491,34 +499,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<NodeAgentSku>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<NodeAgentSku>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<AccountListNodeAgentSkusHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<AccountListNodeAgentSkusHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/AccountOperationsExtensions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/AccountOperationsExtensions.cs
@@ -8,8 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Extension methods for AccountOperations.
@@ -25,9 +28,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='accountListNodeAgentSkusOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<NodeAgentSku> ListNodeAgentSkus(this IAccountOperations operations, AccountListNodeAgentSkusOptions accountListNodeAgentSkusOptions = default(AccountListNodeAgentSkusOptions))
+            public static IPage<NodeAgentSku> ListNodeAgentSkus(this IAccountOperations operations, AccountListNodeAgentSkusOptions accountListNodeAgentSkusOptions = default(AccountListNodeAgentSkusOptions))
             {
-                return ((IAccountOperations)operations).ListNodeAgentSkusAsync(accountListNodeAgentSkusOptions).GetAwaiter().GetResult();
+                return operations.ListNodeAgentSkusAsync(accountListNodeAgentSkusOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -42,7 +45,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<NodeAgentSku>> ListNodeAgentSkusAsync(this IAccountOperations operations, AccountListNodeAgentSkusOptions accountListNodeAgentSkusOptions = default(AccountListNodeAgentSkusOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<NodeAgentSku>> ListNodeAgentSkusAsync(this IAccountOperations operations, AccountListNodeAgentSkusOptions accountListNodeAgentSkusOptions = default(AccountListNodeAgentSkusOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNodeAgentSkusWithHttpMessagesAsync(accountListNodeAgentSkusOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -62,9 +65,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='accountListNodeAgentSkusNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<NodeAgentSku> ListNodeAgentSkusNext(this IAccountOperations operations, string nextPageLink, AccountListNodeAgentSkusNextOptions accountListNodeAgentSkusNextOptions = default(AccountListNodeAgentSkusNextOptions))
+            public static IPage<NodeAgentSku> ListNodeAgentSkusNext(this IAccountOperations operations, string nextPageLink, AccountListNodeAgentSkusNextOptions accountListNodeAgentSkusNextOptions = default(AccountListNodeAgentSkusNextOptions))
             {
-                return ((IAccountOperations)operations).ListNodeAgentSkusNextAsync(nextPageLink, accountListNodeAgentSkusNextOptions).GetAwaiter().GetResult();
+                return operations.ListNodeAgentSkusNextAsync(nextPageLink, accountListNodeAgentSkusNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -82,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<NodeAgentSku>> ListNodeAgentSkusNextAsync(this IAccountOperations operations, string nextPageLink, AccountListNodeAgentSkusNextOptions accountListNodeAgentSkusNextOptions = default(AccountListNodeAgentSkusNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<NodeAgentSku>> ListNodeAgentSkusNextAsync(this IAccountOperations operations, string nextPageLink, AccountListNodeAgentSkusNextOptions accountListNodeAgentSkusNextOptions = default(AccountListNodeAgentSkusNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNodeAgentSkusNextWithHttpMessagesAsync(nextPageLink, accountListNodeAgentSkusNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ApplicationOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ApplicationOperations.cs
@@ -8,15 +8,23 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// ApplicationOperations operations.
     /// </summary>
-    internal partial class ApplicationOperations : Microsoft.Rest.IServiceOperations<BatchServiceClient>, IApplicationOperations
+    internal partial class ApplicationOperations : IServiceOperations<BatchServiceClient>, IApplicationOperations
     {
         /// <summary>
         /// Initializes a new instance of the ApplicationOperations class.
@@ -33,7 +41,7 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("client");
             }
-            this.Client = client;
+            Client = client;
         }
 
         /// <summary>
@@ -63,10 +71,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -75,11 +83,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ApplicationSummary>,ApplicationListHeaders>> ListWithHttpMessagesAsync(ApplicationListOptions applicationListOptions = default(ApplicationListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<ApplicationSummary>,ApplicationListHeaders>> ListWithHttpMessagesAsync(ApplicationListOptions applicationListOptions = default(ApplicationListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? maxResults = default(int?);
             if (applicationListOptions != null)
@@ -107,57 +115,57 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = applicationListOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("maxResults", maxResults);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "applications").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -165,7 +173,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -173,7 +181,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -181,7 +189,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -200,23 +208,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -225,21 +233,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -249,7 +257,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ApplicationSummary>,ApplicationListHeaders>();
+            var _result = new AzureOperationResponse<IPage<ApplicationSummary>,ApplicationListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -262,34 +270,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<ApplicationSummary>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<ApplicationSummary>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ApplicationListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ApplicationListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -297,6 +305,13 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <summary>
         /// Gets information about the specified application.
         /// </summary>
+        /// <remarks>
+        /// This operation returns only applications and versions that are available
+        /// for use on compute nodes; that is, that can be used in an application
+        /// package reference. For administrator information about applications and
+        /// versions that are not yet available to compute nodes, use the Azure portal
+        /// or the Azure Resource Manager API.
+        /// </remarks>
         /// <param name='applicationId'>
         /// The ID of the application.
         /// </param>
@@ -312,10 +327,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -324,15 +339,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<ApplicationSummary,ApplicationGetHeaders>> GetWithHttpMessagesAsync(string applicationId, ApplicationGetOptions applicationGetOptions = default(ApplicationGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<ApplicationSummary,ApplicationGetHeaders>> GetWithHttpMessagesAsync(string applicationId, ApplicationGetOptions applicationGetOptions = default(ApplicationGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (applicationId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "applicationId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "applicationId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (applicationGetOptions != null)
@@ -355,54 +370,54 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = applicationGetOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("applicationId", applicationId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "applications/{applicationId}").ToString();
             _url = _url.Replace("{applicationId}", System.Uri.EscapeDataString(applicationId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -410,7 +425,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -418,7 +433,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -426,7 +441,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -445,23 +460,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -470,21 +485,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -494,7 +509,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<ApplicationSummary,ApplicationGetHeaders>();
+            var _result = new AzureOperationResponse<ApplicationSummary,ApplicationGetHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -507,34 +522,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<ApplicationSummary>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<ApplicationSummary>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ApplicationGetHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ApplicationGetHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -564,10 +579,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -576,11 +591,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ApplicationSummary>,ApplicationListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, ApplicationListNextOptions applicationListNextOptions = default(ApplicationListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<ApplicationSummary>,ApplicationListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, ApplicationListNextOptions applicationListNextOptions = default(ApplicationListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (applicationListNextOptions != null)
@@ -598,44 +613,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = applicationListNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -643,7 +658,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -651,7 +666,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -659,7 +674,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -678,23 +693,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -703,21 +718,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -727,7 +742,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ApplicationSummary>,ApplicationListHeaders>();
+            var _result = new AzureOperationResponse<IPage<ApplicationSummary>,ApplicationListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -740,34 +755,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<ApplicationSummary>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<ApplicationSummary>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ApplicationListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ApplicationListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ApplicationOperationsExtensions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ApplicationOperationsExtensions.cs
@@ -8,8 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Extension methods for ApplicationOperations.
@@ -32,9 +35,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='applicationListOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<ApplicationSummary> List(this IApplicationOperations operations, ApplicationListOptions applicationListOptions = default(ApplicationListOptions))
+            public static IPage<ApplicationSummary> List(this IApplicationOperations operations, ApplicationListOptions applicationListOptions = default(ApplicationListOptions))
             {
-                return ((IApplicationOperations)operations).ListAsync(applicationListOptions).GetAwaiter().GetResult();
+                return operations.ListAsync(applicationListOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -56,7 +59,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<ApplicationSummary>> ListAsync(this IApplicationOperations operations, ApplicationListOptions applicationListOptions = default(ApplicationListOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<ApplicationSummary>> ListAsync(this IApplicationOperations operations, ApplicationListOptions applicationListOptions = default(ApplicationListOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListWithHttpMessagesAsync(applicationListOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -67,6 +70,13 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <summary>
             /// Gets information about the specified application.
             /// </summary>
+            /// <remarks>
+            /// This operation returns only applications and versions that are available
+            /// for use on compute nodes; that is, that can be used in an application
+            /// package reference. For administrator information about applications and
+            /// versions that are not yet available to compute nodes, use the Azure portal
+            /// or the Azure Resource Manager API.
+            /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
@@ -78,12 +88,19 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ApplicationSummary Get(this IApplicationOperations operations, string applicationId, ApplicationGetOptions applicationGetOptions = default(ApplicationGetOptions))
             {
-                return ((IApplicationOperations)operations).GetAsync(applicationId, applicationGetOptions).GetAwaiter().GetResult();
+                return operations.GetAsync(applicationId, applicationGetOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
             /// Gets information about the specified application.
             /// </summary>
+            /// <remarks>
+            /// This operation returns only applications and versions that are available
+            /// for use on compute nodes; that is, that can be used in an application
+            /// package reference. For administrator information about applications and
+            /// versions that are not yet available to compute nodes, use the Azure portal
+            /// or the Azure Resource Manager API.
+            /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
@@ -96,7 +113,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ApplicationSummary> GetAsync(this IApplicationOperations operations, string applicationId, ApplicationGetOptions applicationGetOptions = default(ApplicationGetOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ApplicationSummary> GetAsync(this IApplicationOperations operations, string applicationId, ApplicationGetOptions applicationGetOptions = default(ApplicationGetOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetWithHttpMessagesAsync(applicationId, applicationGetOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -123,9 +140,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='applicationListNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<ApplicationSummary> ListNext(this IApplicationOperations operations, string nextPageLink, ApplicationListNextOptions applicationListNextOptions = default(ApplicationListNextOptions))
+            public static IPage<ApplicationSummary> ListNext(this IApplicationOperations operations, string nextPageLink, ApplicationListNextOptions applicationListNextOptions = default(ApplicationListNextOptions))
             {
-                return ((IApplicationOperations)operations).ListNextAsync(nextPageLink, applicationListNextOptions).GetAwaiter().GetResult();
+                return operations.ListNextAsync(nextPageLink, applicationListNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -150,7 +167,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<ApplicationSummary>> ListNextAsync(this IApplicationOperations operations, string nextPageLink, ApplicationListNextOptions applicationListNextOptions = default(ApplicationListNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<ApplicationSummary>> ListNextAsync(this IApplicationOperations operations, string nextPageLink, ApplicationListNextOptions applicationListNextOptions = default(ApplicationListNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNextWithHttpMessagesAsync(nextPageLink, applicationListNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/BatchServiceClient.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/BatchServiceClient.cs
@@ -8,15 +8,23 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
 
     /// <summary>
     /// A client for issuing REST requests to the Azure Batch service.
     /// </summary>
-    public partial class BatchServiceClient : Microsoft.Rest.ServiceClient<BatchServiceClient>, IBatchServiceClient, IAzureClient
+    public partial class BatchServiceClient : ServiceClient<BatchServiceClient>, IBatchServiceClient, IAzureClient
     {
         /// <summary>
         /// The base URI of the service.
@@ -26,17 +34,17 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <summary>
         /// Gets or sets json serialization settings.
         /// </summary>
-        public Newtonsoft.Json.JsonSerializerSettings SerializationSettings { get; private set; }
+        public JsonSerializerSettings SerializationSettings { get; private set; }
 
         /// <summary>
         /// Gets or sets json deserialization settings.
         /// </summary>
-        public Newtonsoft.Json.JsonSerializerSettings DeserializationSettings { get; private set; }
+        public JsonSerializerSettings DeserializationSettings { get; private set; }
 
         /// <summary>
         /// Credentials needed for the client to connect to Azure.
         /// </summary>
-        public Microsoft.Rest.ServiceClientCredentials Credentials { get; private set; }
+        public ServiceClientCredentials Credentials { get; private set; }
 
         /// <summary>
         /// Client API Version.
@@ -111,9 +119,9 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
-        protected BatchServiceClient(params System.Net.Http.DelegatingHandler[] handlers) : base(handlers)
+        protected BatchServiceClient(params DelegatingHandler[] handlers) : base(handlers)
         {
-            this.Initialize();
+            Initialize();
         }
 
         /// <summary>
@@ -125,9 +133,9 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <param name='handlers'>
         /// Optional. The delegating handlers to add to the http client pipeline.
         /// </param>
-        protected BatchServiceClient(System.Net.Http.HttpClientHandler rootHandler, params System.Net.Http.DelegatingHandler[] handlers) : base(rootHandler, handlers)
+        protected BatchServiceClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
-            this.Initialize();
+            Initialize();
         }
 
         /// <summary>
@@ -142,13 +150,13 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        protected BatchServiceClient(System.Uri baseUri, params System.Net.Http.DelegatingHandler[] handlers) : this(handlers)
+        protected BatchServiceClient(System.Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
             {
                 throw new System.ArgumentNullException("baseUri");
             }
-            this.BaseUri = baseUri;
+            BaseUri = baseUri;
         }
 
         /// <summary>
@@ -166,13 +174,13 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        protected BatchServiceClient(System.Uri baseUri, System.Net.Http.HttpClientHandler rootHandler, params System.Net.Http.DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        protected BatchServiceClient(System.Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
             {
                 throw new System.ArgumentNullException("baseUri");
             }
-            this.BaseUri = baseUri;
+            BaseUri = baseUri;
         }
 
         /// <summary>
@@ -187,16 +195,16 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        public BatchServiceClient(Microsoft.Rest.ServiceClientCredentials credentials, params System.Net.Http.DelegatingHandler[] handlers) : this(handlers)
+        public BatchServiceClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
             {
                 throw new System.ArgumentNullException("credentials");
             }
-            this.Credentials = credentials;
-            if (this.Credentials != null)
+            Credentials = credentials;
+            if (Credentials != null)
             {
-                this.Credentials.InitializeServiceClient(this);
+                Credentials.InitializeServiceClient(this);
             }
         }
 
@@ -215,16 +223,16 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        public BatchServiceClient(Microsoft.Rest.ServiceClientCredentials credentials, System.Net.Http.HttpClientHandler rootHandler, params System.Net.Http.DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public BatchServiceClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
             {
                 throw new System.ArgumentNullException("credentials");
             }
-            this.Credentials = credentials;
-            if (this.Credentials != null)
+            Credentials = credentials;
+            if (Credentials != null)
             {
-                this.Credentials.InitializeServiceClient(this);
+                Credentials.InitializeServiceClient(this);
             }
         }
 
@@ -243,7 +251,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        public BatchServiceClient(System.Uri baseUri, Microsoft.Rest.ServiceClientCredentials credentials, params System.Net.Http.DelegatingHandler[] handlers) : this(handlers)
+        public BatchServiceClient(System.Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
             {
@@ -253,11 +261,11 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("credentials");
             }
-            this.BaseUri = baseUri;
-            this.Credentials = credentials;
-            if (this.Credentials != null)
+            BaseUri = baseUri;
+            Credentials = credentials;
+            if (Credentials != null)
             {
-                this.Credentials.InitializeServiceClient(this);
+                Credentials.InitializeServiceClient(this);
             }
         }
 
@@ -279,7 +287,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        public BatchServiceClient(System.Uri baseUri, Microsoft.Rest.ServiceClientCredentials credentials, System.Net.Http.HttpClientHandler rootHandler, params System.Net.Http.DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public BatchServiceClient(System.Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
             {
@@ -289,11 +297,11 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("credentials");
             }
-            this.BaseUri = baseUri;
-            this.Credentials = credentials;
-            if (this.Credentials != null)
+            BaseUri = baseUri;
+            Credentials = credentials;
+            if (Credentials != null)
             {
-                this.Credentials.InitializeServiceClient(this);
+                Credentials.InitializeServiceClient(this);
             }
         }
 
@@ -306,47 +314,47 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </summary>
         private void Initialize()
         {
-            this.Application = new ApplicationOperations(this);
-            this.Pool = new PoolOperations(this);
-            this.Account = new AccountOperations(this);
-            this.Job = new JobOperations(this);
-            this.Certificate = new CertificateOperations(this);
-            this.File = new FileOperations(this);
-            this.JobSchedule = new JobScheduleOperations(this);
-            this.Task = new TaskOperations(this);
-            this.ComputeNode = new ComputeNodeOperations(this);
-            this.BaseUri = new System.Uri("https://batch.core.windows.net");
-            this.ApiVersion = "2017-06-01.5.1";
-            this.AcceptLanguage = "en-US";
-            this.LongRunningOperationRetryTimeout = 30;
-            this.GenerateClientRequestId = true;
-            SerializationSettings = new Newtonsoft.Json.JsonSerializerSettings
+            Application = new ApplicationOperations(this);
+            Pool = new PoolOperations(this);
+            Account = new AccountOperations(this);
+            Job = new JobOperations(this);
+            Certificate = new CertificateOperations(this);
+            File = new FileOperations(this);
+            JobSchedule = new JobScheduleOperations(this);
+            Task = new TaskOperations(this);
+            ComputeNode = new ComputeNodeOperations(this);
+            BaseUri = new System.Uri("https://batch.core.windows.net");
+            ApiVersion = "2017-06-01.5.1";
+            AcceptLanguage = "en-US";
+            LongRunningOperationRetryTimeout = 30;
+            GenerateClientRequestId = true;
+            SerializationSettings = new JsonSerializerSettings
             {
                 Formatting = Newtonsoft.Json.Formatting.Indented,
                 DateFormatHandling = Newtonsoft.Json.DateFormatHandling.IsoDateFormat,
                 DateTimeZoneHandling = Newtonsoft.Json.DateTimeZoneHandling.Utc,
                 NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
                 ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Serialize,
-                ContractResolver = new Microsoft.Rest.Serialization.ReadOnlyJsonContractResolver(),
-                Converters = new System.Collections.Generic.List<Newtonsoft.Json.JsonConverter>
+                ContractResolver = new ReadOnlyJsonContractResolver(),
+                Converters = new List<JsonConverter>
                     {
-                        new Microsoft.Rest.Serialization.Iso8601TimeSpanConverter()
+                        new Iso8601TimeSpanConverter()
                     }
             };
-            DeserializationSettings = new Newtonsoft.Json.JsonSerializerSettings
+            DeserializationSettings = new JsonSerializerSettings
             {
                 DateFormatHandling = Newtonsoft.Json.DateFormatHandling.IsoDateFormat,
                 DateTimeZoneHandling = Newtonsoft.Json.DateTimeZoneHandling.Utc,
                 NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
                 ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Serialize,
-                ContractResolver = new Microsoft.Rest.Serialization.ReadOnlyJsonContractResolver(),
-                Converters = new System.Collections.Generic.List<Newtonsoft.Json.JsonConverter>
+                ContractResolver = new ReadOnlyJsonContractResolver(),
+                Converters = new List<JsonConverter>
                     {
-                        new Microsoft.Rest.Serialization.Iso8601TimeSpanConverter()
+                        new Iso8601TimeSpanConverter()
                     }
             };
             CustomInitialize();
-            DeserializationSettings.Converters.Add(new Microsoft.Rest.Azure.CloudErrorJsonConverter());
+            DeserializationSettings.Converters.Add(new CloudErrorJsonConverter());
         }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/CertificateOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/CertificateOperations.cs
@@ -8,15 +8,23 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// CertificateOperations operations.
     /// </summary>
-    internal partial class CertificateOperations : Microsoft.Rest.IServiceOperations<BatchServiceClient>, ICertificateOperations
+    internal partial class CertificateOperations : IServiceOperations<BatchServiceClient>, ICertificateOperations
     {
         /// <summary>
         /// Initializes a new instance of the CertificateOperations class.
@@ -33,7 +41,7 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("client");
             }
-            this.Client = client;
+            Client = client;
         }
 
         /// <summary>
@@ -59,7 +67,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -68,19 +76,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateAddHeaders>> AddWithHttpMessagesAsync(CertificateAddParameter certificate, CertificateAddOptions certificateAddOptions = default(CertificateAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<CertificateAddHeaders>> AddWithHttpMessagesAsync(CertificateAddParameter certificate, CertificateAddOptions certificateAddOptions = default(CertificateAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (certificate == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "certificate");
+                throw new ValidationException(ValidationRules.CannotBeNull, "certificate");
             }
             if (certificate != null)
             {
                 certificate.Validate();
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (certificateAddOptions != null)
@@ -103,53 +111,53 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = certificateAddOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("certificate", certificate);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Add", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Add", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "certificates").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -157,7 +165,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -165,7 +173,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -173,7 +181,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -193,28 +201,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(certificate != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(certificate, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(certificate, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 201)
@@ -223,21 +231,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -247,7 +255,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateAddHeaders>();
+            var _result = new AzureOperationHeaderResponse<CertificateAddHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -256,20 +264,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateAddHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateAddHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -290,10 +298,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -302,11 +310,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<Certificate>,CertificateListHeaders>> ListWithHttpMessagesAsync(CertificateListOptions certificateListOptions = default(CertificateListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<Certificate>,CertificateListHeaders>> ListWithHttpMessagesAsync(CertificateListOptions certificateListOptions = default(CertificateListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (certificateListOptions != null)
@@ -344,12 +352,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = certificateListOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("filter", filter);
                 tracingParameters.Add("select", select);
                 tracingParameters.Add("maxResults", maxResults);
@@ -358,15 +366,15 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "certificates").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -378,33 +386,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -412,7 +420,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -420,7 +428,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -428,7 +436,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -447,23 +455,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -472,21 +480,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -496,7 +504,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<Certificate>,CertificateListHeaders>();
+            var _result = new AzureOperationResponse<IPage<Certificate>,CertificateListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -509,34 +517,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<Certificate>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<Certificate>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -571,7 +579,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -580,19 +588,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateCancelDeletionHeaders>> CancelDeletionWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateCancelDeletionOptions certificateCancelDeletionOptions = default(CertificateCancelDeletionOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<CertificateCancelDeletionHeaders>> CancelDeletionWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateCancelDeletionOptions certificateCancelDeletionOptions = default(CertificateCancelDeletionOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (thumbprintAlgorithm == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "thumbprintAlgorithm");
+                throw new ValidationException(ValidationRules.CannotBeNull, "thumbprintAlgorithm");
             }
             if (thumbprint == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "thumbprint");
+                throw new ValidationException(ValidationRules.CannotBeNull, "thumbprint");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (certificateCancelDeletionOptions != null)
@@ -615,12 +623,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = certificateCancelDeletionOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("thumbprintAlgorithm", thumbprintAlgorithm);
                 tracingParameters.Add("thumbprint", thumbprint);
                 tracingParameters.Add("timeout", timeout);
@@ -628,43 +636,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "CancelDeletion", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "CancelDeletion", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})/canceldelete").ToString();
             _url = _url.Replace("{thumbprintAlgorithm}", System.Uri.EscapeDataString(thumbprintAlgorithm));
             _url = _url.Replace("{thumbprint}", System.Uri.EscapeDataString(thumbprint));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -672,7 +680,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -680,7 +688,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -688,7 +696,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -707,23 +715,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 204)
@@ -732,21 +740,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -756,7 +764,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateCancelDeletionHeaders>();
+            var _result = new AzureOperationHeaderResponse<CertificateCancelDeletionHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -765,20 +773,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateCancelDeletionHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateCancelDeletionHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -816,7 +824,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -825,19 +833,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateDeleteHeaders>> DeleteWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateDeleteOptions certificateDeleteOptions = default(CertificateDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<CertificateDeleteHeaders>> DeleteWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateDeleteOptions certificateDeleteOptions = default(CertificateDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (thumbprintAlgorithm == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "thumbprintAlgorithm");
+                throw new ValidationException(ValidationRules.CannotBeNull, "thumbprintAlgorithm");
             }
             if (thumbprint == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "thumbprint");
+                throw new ValidationException(ValidationRules.CannotBeNull, "thumbprint");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (certificateDeleteOptions != null)
@@ -860,12 +868,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = certificateDeleteOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("thumbprintAlgorithm", thumbprintAlgorithm);
                 tracingParameters.Add("thumbprint", thumbprint);
                 tracingParameters.Add("timeout", timeout);
@@ -873,43 +881,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Delete", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Delete", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})").ToString();
             _url = _url.Replace("{thumbprintAlgorithm}", System.Uri.EscapeDataString(thumbprintAlgorithm));
             _url = _url.Replace("{thumbprint}", System.Uri.EscapeDataString(thumbprint));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("DELETE");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("DELETE");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -917,7 +925,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -925,7 +933,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -933,7 +941,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -952,23 +960,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -977,21 +985,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1001,7 +1009,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateDeleteHeaders>();
+            var _result = new AzureOperationHeaderResponse<CertificateDeleteHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1010,20 +1018,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateDeleteHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateDeleteHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1049,10 +1057,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1061,19 +1069,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Certificate,CertificateGetHeaders>> GetWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateGetOptions certificateGetOptions = default(CertificateGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<Certificate,CertificateGetHeaders>> GetWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateGetOptions certificateGetOptions = default(CertificateGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (thumbprintAlgorithm == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "thumbprintAlgorithm");
+                throw new ValidationException(ValidationRules.CannotBeNull, "thumbprintAlgorithm");
             }
             if (thumbprint == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "thumbprint");
+                throw new ValidationException(ValidationRules.CannotBeNull, "thumbprint");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string select = default(string);
             if (certificateGetOptions != null)
@@ -1101,12 +1109,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = certificateGetOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("thumbprintAlgorithm", thumbprintAlgorithm);
                 tracingParameters.Add("thumbprint", thumbprint);
                 tracingParameters.Add("select", select);
@@ -1115,17 +1123,17 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "certificates(thumbprintAlgorithm={thumbprintAlgorithm},thumbprint={thumbprint})").ToString();
             _url = _url.Replace("{thumbprintAlgorithm}", System.Uri.EscapeDataString(thumbprintAlgorithm));
             _url = _url.Replace("{thumbprint}", System.Uri.EscapeDataString(thumbprint));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (select != null)
             {
@@ -1133,29 +1141,29 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1163,7 +1171,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1171,7 +1179,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1179,7 +1187,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1198,23 +1206,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1223,21 +1231,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1247,7 +1255,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Certificate,CertificateGetHeaders>();
+            var _result = new AzureOperationResponse<Certificate,CertificateGetHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1260,34 +1268,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Certificate>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Certificate>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateGetHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateGetHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1311,10 +1319,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1323,11 +1331,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<Certificate>,CertificateListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, CertificateListNextOptions certificateListNextOptions = default(CertificateListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<Certificate>,CertificateListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, CertificateListNextOptions certificateListNextOptions = default(CertificateListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (certificateListNextOptions != null)
@@ -1345,44 +1353,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = certificateListNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1390,7 +1398,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1398,7 +1406,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1406,7 +1414,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1425,23 +1433,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1450,21 +1458,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1474,7 +1482,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<Certificate>,CertificateListHeaders>();
+            var _result = new AzureOperationResponse<IPage<Certificate>,CertificateListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1487,34 +1495,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<Certificate>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<Certificate>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<CertificateListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/CertificateOperationsExtensions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/CertificateOperationsExtensions.cs
@@ -8,8 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Extension methods for CertificateOperations.
@@ -30,7 +33,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static CertificateAddHeaders Add(this ICertificateOperations operations, CertificateAddParameter certificate, CertificateAddOptions certificateAddOptions = default(CertificateAddOptions))
             {
-                return ((ICertificateOperations)operations).AddAsync(certificate, certificateAddOptions).GetAwaiter().GetResult();
+                return operations.AddAsync(certificate, certificateAddOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -48,7 +51,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<CertificateAddHeaders> AddAsync(this ICertificateOperations operations, CertificateAddParameter certificate, CertificateAddOptions certificateAddOptions = default(CertificateAddOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<CertificateAddHeaders> AddAsync(this ICertificateOperations operations, CertificateAddParameter certificate, CertificateAddOptions certificateAddOptions = default(CertificateAddOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.AddWithHttpMessagesAsync(certificate, certificateAddOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -66,9 +69,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='certificateListOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<Certificate> List(this ICertificateOperations operations, CertificateListOptions certificateListOptions = default(CertificateListOptions))
+            public static IPage<Certificate> List(this ICertificateOperations operations, CertificateListOptions certificateListOptions = default(CertificateListOptions))
             {
-                return ((ICertificateOperations)operations).ListAsync(certificateListOptions).GetAwaiter().GetResult();
+                return operations.ListAsync(certificateListOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -84,7 +87,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<Certificate>> ListAsync(this ICertificateOperations operations, CertificateListOptions certificateListOptions = default(CertificateListOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<Certificate>> ListAsync(this ICertificateOperations operations, CertificateListOptions certificateListOptions = default(CertificateListOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListWithHttpMessagesAsync(certificateListOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -118,7 +121,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static CertificateCancelDeletionHeaders CancelDeletion(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateCancelDeletionOptions certificateCancelDeletionOptions = default(CertificateCancelDeletionOptions))
             {
-                return ((ICertificateOperations)operations).CancelDeletionAsync(thumbprintAlgorithm, thumbprint, certificateCancelDeletionOptions).GetAwaiter().GetResult();
+                return operations.CancelDeletionAsync(thumbprintAlgorithm, thumbprint, certificateCancelDeletionOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -148,7 +151,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<CertificateCancelDeletionHeaders> CancelDeletionAsync(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateCancelDeletionOptions certificateCancelDeletionOptions = default(CertificateCancelDeletionOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<CertificateCancelDeletionHeaders> CancelDeletionAsync(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateCancelDeletionOptions certificateCancelDeletionOptions = default(CertificateCancelDeletionOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.CancelDeletionWithHttpMessagesAsync(thumbprintAlgorithm, thumbprint, certificateCancelDeletionOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -185,7 +188,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static CertificateDeleteHeaders Delete(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateDeleteOptions certificateDeleteOptions = default(CertificateDeleteOptions))
             {
-                return ((ICertificateOperations)operations).DeleteAsync(thumbprintAlgorithm, thumbprint, certificateDeleteOptions).GetAwaiter().GetResult();
+                return operations.DeleteAsync(thumbprintAlgorithm, thumbprint, certificateDeleteOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -218,7 +221,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<CertificateDeleteHeaders> DeleteAsync(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateDeleteOptions certificateDeleteOptions = default(CertificateDeleteOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<CertificateDeleteHeaders> DeleteAsync(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateDeleteOptions certificateDeleteOptions = default(CertificateDeleteOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DeleteWithHttpMessagesAsync(thumbprintAlgorithm, thumbprint, certificateDeleteOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -243,7 +246,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static Certificate Get(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateGetOptions certificateGetOptions = default(CertificateGetOptions))
             {
-                return ((ICertificateOperations)operations).GetAsync(thumbprintAlgorithm, thumbprint, certificateGetOptions).GetAwaiter().GetResult();
+                return operations.GetAsync(thumbprintAlgorithm, thumbprint, certificateGetOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -264,7 +267,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Certificate> GetAsync(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateGetOptions certificateGetOptions = default(CertificateGetOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<Certificate> GetAsync(this ICertificateOperations operations, string thumbprintAlgorithm, string thumbprint, CertificateGetOptions certificateGetOptions = default(CertificateGetOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetWithHttpMessagesAsync(thumbprintAlgorithm, thumbprint, certificateGetOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -285,9 +288,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='certificateListNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<Certificate> ListNext(this ICertificateOperations operations, string nextPageLink, CertificateListNextOptions certificateListNextOptions = default(CertificateListNextOptions))
+            public static IPage<Certificate> ListNext(this ICertificateOperations operations, string nextPageLink, CertificateListNextOptions certificateListNextOptions = default(CertificateListNextOptions))
             {
-                return ((ICertificateOperations)operations).ListNextAsync(nextPageLink, certificateListNextOptions).GetAwaiter().GetResult();
+                return operations.ListNextAsync(nextPageLink, certificateListNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -306,7 +309,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<Certificate>> ListNextAsync(this ICertificateOperations operations, string nextPageLink, CertificateListNextOptions certificateListNextOptions = default(CertificateListNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<Certificate>> ListNextAsync(this ICertificateOperations operations, string nextPageLink, CertificateListNextOptions certificateListNextOptions = default(CertificateListNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNextWithHttpMessagesAsync(nextPageLink, certificateListNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ComputeNodeOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ComputeNodeOperations.cs
@@ -8,15 +8,24 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// ComputeNodeOperations operations.
     /// </summary>
-    internal partial class ComputeNodeOperations : Microsoft.Rest.IServiceOperations<BatchServiceClient>, IComputeNodeOperations
+    internal partial class ComputeNodeOperations : IServiceOperations<BatchServiceClient>, IComputeNodeOperations
     {
         /// <summary>
         /// Initializes a new instance of the ComputeNodeOperations class.
@@ -33,7 +42,7 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("client");
             }
-            this.Client = client;
+            Client = client;
         }
 
         /// <summary>
@@ -69,7 +78,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -78,27 +87,27 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeAddUserHeaders>> AddUserWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeUser user, ComputeNodeAddUserOptions computeNodeAddUserOptions = default(ComputeNodeAddUserOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<ComputeNodeAddUserHeaders>> AddUserWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeUser user, ComputeNodeAddUserOptions computeNodeAddUserOptions = default(ComputeNodeAddUserOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
             if (user == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "user");
+                throw new ValidationException(ValidationRules.CannotBeNull, "user");
             }
             if (user != null)
             {
                 user.Validate();
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeAddUserOptions != null)
@@ -121,12 +130,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeAddUserOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("user", user);
@@ -135,43 +144,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "AddUser", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "AddUser", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/users").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -179,7 +188,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -187,7 +196,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -195,7 +204,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -215,28 +224,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(user != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(user, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(user, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 201)
@@ -245,21 +254,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -269,7 +278,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeAddUserHeaders>();
+            var _result = new AzureOperationHeaderResponse<ComputeNodeAddUserHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -278,20 +287,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeAddUserHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeAddUserHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -324,7 +333,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -333,23 +342,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeDeleteUserHeaders>> DeleteUserWithHttpMessagesAsync(string poolId, string nodeId, string userName, ComputeNodeDeleteUserOptions computeNodeDeleteUserOptions = default(ComputeNodeDeleteUserOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<ComputeNodeDeleteUserHeaders>> DeleteUserWithHttpMessagesAsync(string poolId, string nodeId, string userName, ComputeNodeDeleteUserOptions computeNodeDeleteUserOptions = default(ComputeNodeDeleteUserOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
             if (userName == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "userName");
+                throw new ValidationException(ValidationRules.CannotBeNull, "userName");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeDeleteUserOptions != null)
@@ -372,12 +381,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeDeleteUserOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("userName", userName);
@@ -386,44 +395,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "DeleteUser", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "DeleteUser", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/users/{userName}").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
             _url = _url.Replace("{userName}", System.Uri.EscapeDataString(userName));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("DELETE");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("DELETE");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -431,7 +440,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -439,7 +448,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -447,7 +456,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -466,23 +475,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -491,21 +500,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -515,7 +524,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeDeleteUserHeaders>();
+            var _result = new AzureOperationHeaderResponse<ComputeNodeDeleteUserHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -524,26 +533,26 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeDeleteUserHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeDeleteUserHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
 
         /// <summary>
-        /// Updates the password or expiration time of a user account on the specified
+        /// Updates the password and expiration time of a user account on the specified
         /// compute node.
         /// </summary>
         /// <remarks>
@@ -576,7 +585,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -585,27 +594,27 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeUpdateUserHeaders>> UpdateUserWithHttpMessagesAsync(string poolId, string nodeId, string userName, NodeUpdateUserParameter nodeUpdateUserParameter, ComputeNodeUpdateUserOptions computeNodeUpdateUserOptions = default(ComputeNodeUpdateUserOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<ComputeNodeUpdateUserHeaders>> UpdateUserWithHttpMessagesAsync(string poolId, string nodeId, string userName, NodeUpdateUserParameter nodeUpdateUserParameter, ComputeNodeUpdateUserOptions computeNodeUpdateUserOptions = default(ComputeNodeUpdateUserOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
             if (userName == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "userName");
+                throw new ValidationException(ValidationRules.CannotBeNull, "userName");
             }
             if (nodeUpdateUserParameter == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeUpdateUserParameter");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeUpdateUserParameter");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeUpdateUserOptions != null)
@@ -628,12 +637,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeUpdateUserOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("userName", userName);
@@ -643,44 +652,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "UpdateUser", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "UpdateUser", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/users/{userName}").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
             _url = _url.Replace("{userName}", System.Uri.EscapeDataString(userName));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("PUT");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("PUT");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -688,7 +697,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -696,7 +705,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -704,7 +713,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -724,28 +733,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(nodeUpdateUserParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(nodeUpdateUserParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(nodeUpdateUserParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -754,21 +763,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -778,7 +787,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeUpdateUserHeaders>();
+            var _result = new AzureOperationHeaderResponse<ComputeNodeUpdateUserHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -787,20 +796,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeUpdateUserHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeUpdateUserHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -826,10 +835,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -838,19 +847,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<ComputeNode,ComputeNodeGetHeaders>> GetWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetOptions computeNodeGetOptions = default(ComputeNodeGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<ComputeNode,ComputeNodeGetHeaders>> GetWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetOptions computeNodeGetOptions = default(ComputeNodeGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string select = default(string);
             if (computeNodeGetOptions != null)
@@ -878,12 +887,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeGetOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("select", select);
@@ -892,17 +901,17 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (select != null)
             {
@@ -910,29 +919,29 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -940,7 +949,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -948,7 +957,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -956,7 +965,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -975,23 +984,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1000,21 +1009,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1024,7 +1033,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<ComputeNode,ComputeNodeGetHeaders>();
+            var _result = new AzureOperationResponse<ComputeNode,ComputeNodeGetHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1037,34 +1046,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<ComputeNode>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<ComputeNode>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeGetHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeGetHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1083,7 +1092,20 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </param>
         /// <param name='nodeRebootOption'>
         /// When to reboot the compute node and what to do with currently running
-        /// tasks. The default value is requeue. Possible values include: 'requeue',
+        /// tasks. Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks. The tasks
+        /// will run again when a node is available. Restart the node as soon as tasks
+        /// have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again. Restart
+        /// the node as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+        /// tasks while waiting. Restart the node when all tasks have completed.
+        /// retaineddata - Allow currently running tasks to complete, then wait for all
+        /// task data retention periods to expire. Schedule no new tasks while waiting.
+        /// Restart the node when all task retention periods have expired.
+        ///
+        /// The default value is requeue. Possible values include: 'requeue',
         /// 'terminate', 'taskCompletion', 'retainedData'
         /// </param>
         /// <param name='computeNodeRebootOptions'>
@@ -1098,7 +1120,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1107,19 +1129,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeRebootHeaders>> RebootWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeRebootOption? nodeRebootOption = default(ComputeNodeRebootOption?), ComputeNodeRebootOptions computeNodeRebootOptions = default(ComputeNodeRebootOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<ComputeNodeRebootHeaders>> RebootWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeRebootOption? nodeRebootOption = default(ComputeNodeRebootOption?), ComputeNodeRebootOptions computeNodeRebootOptions = default(ComputeNodeRebootOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeRebootOptions != null)
@@ -1148,12 +1170,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 nodeRebootParameter.NodeRebootOption = nodeRebootOption;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("timeout", timeout);
@@ -1162,43 +1184,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("nodeRebootParameter", nodeRebootParameter);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Reboot", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Reboot", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/reboot").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1206,7 +1228,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1214,7 +1236,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1222,7 +1244,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1242,28 +1264,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(nodeRebootParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(nodeRebootParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(nodeRebootParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -1272,21 +1294,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1296,7 +1318,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeRebootHeaders>();
+            var _result = new AzureOperationHeaderResponse<ComputeNodeRebootHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1305,20 +1327,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeRebootHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeRebootHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1339,7 +1361,20 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </param>
         /// <param name='nodeReimageOption'>
         /// When to reimage the compute node and what to do with currently running
-        /// tasks. The default value is requeue. Possible values include: 'requeue',
+        /// tasks. Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks. The tasks
+        /// will run again when a node is available. Reimage the node as soon as tasks
+        /// have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again. Reimage
+        /// the node as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+        /// tasks while waiting. Reimage the node when all tasks have completed.
+        /// retaineddata - Allow currently running tasks to complete, then wait for all
+        /// task data retention periods to expire. Schedule no new tasks while waiting.
+        /// Reimage the node when all task retention periods have expired.
+        ///
+        /// The default value is requeue. Possible values include: 'requeue',
         /// 'terminate', 'taskCompletion', 'retainedData'
         /// </param>
         /// <param name='computeNodeReimageOptions'>
@@ -1354,7 +1389,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1363,19 +1398,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeReimageHeaders>> ReimageWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeReimageOption? nodeReimageOption = default(ComputeNodeReimageOption?), ComputeNodeReimageOptions computeNodeReimageOptions = default(ComputeNodeReimageOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<ComputeNodeReimageHeaders>> ReimageWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeReimageOption? nodeReimageOption = default(ComputeNodeReimageOption?), ComputeNodeReimageOptions computeNodeReimageOptions = default(ComputeNodeReimageOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeReimageOptions != null)
@@ -1404,12 +1439,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 nodeReimageParameter.NodeReimageOption = nodeReimageOption;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("timeout", timeout);
@@ -1418,43 +1453,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("nodeReimageParameter", nodeReimageParameter);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Reimage", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Reimage", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/reimage").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1462,7 +1497,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1470,7 +1505,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1478,7 +1513,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1498,28 +1533,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(nodeReimageParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(nodeReimageParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(nodeReimageParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -1528,21 +1563,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1552,7 +1587,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeReimageHeaders>();
+            var _result = new AzureOperationHeaderResponse<ComputeNodeReimageHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1561,20 +1596,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeReimageHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeReimageHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1582,6 +1617,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <summary>
         /// Disables task scheduling on the specified compute node.
         /// </summary>
+        /// <remarks>
+        /// You can disable task scheduling on a node only if its current scheduling
+        /// state is enabled.
+        /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool that contains the compute node.
         /// </param>
@@ -1590,8 +1629,18 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </param>
         /// <param name='nodeDisableSchedulingOption'>
         /// What to do with currently running tasks when disabling task scheduling on
-        /// the compute node. The default value is requeue. Possible values include:
-        /// 'requeue', 'terminate', 'taskCompletion'
+        /// the compute node. Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks. The tasks
+        /// may run again on other compute nodes, or when task scheduling is re-enabled
+        /// on this node. Enter offline state as soon as tasks have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again. Enter
+        /// offline state as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+        /// tasks while waiting. Enter offline state when all tasks have completed.
+        ///
+        /// The default value is requeue. Possible values include: 'requeue',
+        /// 'terminate', 'taskCompletion'
         /// </param>
         /// <param name='computeNodeDisableSchedulingOptions'>
         /// Additional parameters for the operation
@@ -1605,7 +1654,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1614,19 +1663,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeDisableSchedulingHeaders>> DisableSchedulingWithHttpMessagesAsync(string poolId, string nodeId, DisableComputeNodeSchedulingOption? nodeDisableSchedulingOption = default(DisableComputeNodeSchedulingOption?), ComputeNodeDisableSchedulingOptions computeNodeDisableSchedulingOptions = default(ComputeNodeDisableSchedulingOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<ComputeNodeDisableSchedulingHeaders>> DisableSchedulingWithHttpMessagesAsync(string poolId, string nodeId, DisableComputeNodeSchedulingOption? nodeDisableSchedulingOption = default(DisableComputeNodeSchedulingOption?), ComputeNodeDisableSchedulingOptions computeNodeDisableSchedulingOptions = default(ComputeNodeDisableSchedulingOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeDisableSchedulingOptions != null)
@@ -1655,12 +1704,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 nodeDisableSchedulingParameter.NodeDisableSchedulingOption = nodeDisableSchedulingOption;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("timeout", timeout);
@@ -1669,43 +1718,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("nodeDisableSchedulingParameter", nodeDisableSchedulingParameter);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "DisableScheduling", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "DisableScheduling", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/disablescheduling").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1713,7 +1762,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1721,7 +1770,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1729,7 +1778,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1749,28 +1798,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(nodeDisableSchedulingParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(nodeDisableSchedulingParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(nodeDisableSchedulingParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1779,21 +1828,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1803,7 +1852,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeDisableSchedulingHeaders>();
+            var _result = new AzureOperationHeaderResponse<ComputeNodeDisableSchedulingHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1812,20 +1861,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeDisableSchedulingHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeDisableSchedulingHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1833,6 +1882,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <summary>
         /// Enables task scheduling on the specified compute node.
         /// </summary>
+        /// <remarks>
+        /// You can enable task scheduling on a node only if its current scheduling
+        /// state is disabled
+        /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool that contains the compute node.
         /// </param>
@@ -1851,7 +1904,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1860,19 +1913,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeEnableSchedulingHeaders>> EnableSchedulingWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeEnableSchedulingOptions computeNodeEnableSchedulingOptions = default(ComputeNodeEnableSchedulingOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<ComputeNodeEnableSchedulingHeaders>> EnableSchedulingWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeEnableSchedulingOptions computeNodeEnableSchedulingOptions = default(ComputeNodeEnableSchedulingOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeEnableSchedulingOptions != null)
@@ -1895,12 +1948,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeEnableSchedulingOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("timeout", timeout);
@@ -1908,43 +1961,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "EnableScheduling", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "EnableScheduling", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/enablescheduling").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1952,7 +2005,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1960,7 +2013,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1968,7 +2021,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1987,23 +2040,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2012,21 +2065,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2036,7 +2089,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeEnableSchedulingHeaders>();
+            var _result = new AzureOperationHeaderResponse<ComputeNodeEnableSchedulingHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2045,20 +2098,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeEnableSchedulingHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeEnableSchedulingHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2069,7 +2122,8 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <remarks>
         /// Before you can remotely login to a node using the remote login settings,
         /// you must create a user account on the node. This API can be invoked only on
-        /// pools created with the virtual machine configuration property.
+        /// pools created with the virtual machine configuration property. For pools
+        /// created with a cloud service configuration, see the GetRemoteDesktop API.
         /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool that contains the compute node.
@@ -2089,10 +2143,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2101,19 +2155,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<ComputeNodeGetRemoteLoginSettingsResult,ComputeNodeGetRemoteLoginSettingsHeaders>> GetRemoteLoginSettingsWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetRemoteLoginSettingsOptions computeNodeGetRemoteLoginSettingsOptions = default(ComputeNodeGetRemoteLoginSettingsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<ComputeNodeGetRemoteLoginSettingsResult,ComputeNodeGetRemoteLoginSettingsHeaders>> GetRemoteLoginSettingsWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetRemoteLoginSettingsOptions computeNodeGetRemoteLoginSettingsOptions = default(ComputeNodeGetRemoteLoginSettingsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeGetRemoteLoginSettingsOptions != null)
@@ -2136,12 +2190,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeGetRemoteLoginSettingsOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("timeout", timeout);
@@ -2149,43 +2203,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "GetRemoteLoginSettings", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetRemoteLoginSettings", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/remoteloginsettings").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2193,7 +2247,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2201,7 +2255,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2209,7 +2263,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2228,23 +2282,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2253,21 +2307,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2277,7 +2331,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<ComputeNodeGetRemoteLoginSettingsResult,ComputeNodeGetRemoteLoginSettingsHeaders>();
+            var _result = new AzureOperationResponse<ComputeNodeGetRemoteLoginSettingsResult,ComputeNodeGetRemoteLoginSettingsHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2290,34 +2344,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<ComputeNodeGetRemoteLoginSettingsResult>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<ComputeNodeGetRemoteLoginSettingsResult>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeGetRemoteLoginSettingsHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeGetRemoteLoginSettingsHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2327,8 +2381,9 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </summary>
         /// <remarks>
         /// Before you can access a node by using the RDP file, you must create a user
-        /// account on the node. This API can only be invoked on pools created with the
-        /// cloud service configuration property.
+        /// account on the node. This API can only be invoked on pools created with a
+        /// cloud service configuration. For pools created with a virtual machine
+        /// configuration, see the GetRemoteLoginSettings API.
         /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool that contains the compute node.
@@ -2349,10 +2404,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2361,19 +2416,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,ComputeNodeGetRemoteDesktopHeaders>> GetRemoteDesktopWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetRemoteDesktopOptions computeNodeGetRemoteDesktopOptions = default(ComputeNodeGetRemoteDesktopOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<Stream,ComputeNodeGetRemoteDesktopHeaders>> GetRemoteDesktopWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetRemoteDesktopOptions computeNodeGetRemoteDesktopOptions = default(ComputeNodeGetRemoteDesktopOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (computeNodeGetRemoteDesktopOptions != null)
@@ -2396,12 +2451,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeGetRemoteDesktopOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("timeout", timeout);
@@ -2409,43 +2464,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "GetRemoteDesktop", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetRemoteDesktop", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/rdp").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2453,7 +2508,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2461,7 +2516,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2469,7 +2524,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2488,23 +2543,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2513,21 +2568,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2537,7 +2592,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,ComputeNodeGetRemoteDesktopHeaders>();
+            var _result = new AzureOperationResponse<Stream,ComputeNodeGetRemoteDesktopHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2551,20 +2606,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeGetRemoteDesktopHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeGetRemoteDesktopHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2587,10 +2642,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2599,15 +2654,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ComputeNode>,ComputeNodeListHeaders>> ListWithHttpMessagesAsync(string poolId, ComputeNodeListOptions computeNodeListOptions = default(ComputeNodeListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<ComputeNode>,ComputeNodeListHeaders>> ListWithHttpMessagesAsync(string poolId, ComputeNodeListOptions computeNodeListOptions = default(ComputeNodeListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (computeNodeListOptions != null)
@@ -2645,12 +2700,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeListOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("filter", filter);
                 tracingParameters.Add("select", select);
@@ -2660,16 +2715,16 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -2681,33 +2736,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2715,7 +2770,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2723,7 +2778,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2731,7 +2786,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2750,23 +2805,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2775,21 +2830,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2799,7 +2854,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ComputeNode>,ComputeNodeListHeaders>();
+            var _result = new AzureOperationResponse<IPage<ComputeNode>,ComputeNodeListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2812,34 +2867,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<ComputeNode>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<ComputeNode>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2862,10 +2917,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2874,11 +2929,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ComputeNode>,ComputeNodeListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, ComputeNodeListNextOptions computeNodeListNextOptions = default(ComputeNodeListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<ComputeNode>,ComputeNodeListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, ComputeNodeListNextOptions computeNodeListNextOptions = default(ComputeNodeListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (computeNodeListNextOptions != null)
@@ -2896,44 +2951,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = computeNodeListNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2941,7 +2996,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2949,7 +3004,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2957,7 +3012,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2976,23 +3031,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -3001,21 +3056,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -3025,7 +3080,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ComputeNode>,ComputeNodeListHeaders>();
+            var _result = new AzureOperationResponse<IPage<ComputeNode>,ComputeNodeListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -3038,34 +3093,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<ComputeNode>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<ComputeNode>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<ComputeNodeListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ComputeNodeOperationsExtensions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ComputeNodeOperationsExtensions.cs
@@ -8,8 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Extension methods for ComputeNodeOperations.
@@ -40,7 +44,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ComputeNodeAddUserHeaders AddUser(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeUser user, ComputeNodeAddUserOptions computeNodeAddUserOptions = default(ComputeNodeAddUserOptions))
             {
-                return ((IComputeNodeOperations)operations).AddUserAsync(poolId, nodeId, user, computeNodeAddUserOptions).GetAwaiter().GetResult();
+                return operations.AddUserAsync(poolId, nodeId, user, computeNodeAddUserOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -68,7 +72,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNodeAddUserHeaders> AddUserAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeUser user, ComputeNodeAddUserOptions computeNodeAddUserOptions = default(ComputeNodeAddUserOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNodeAddUserHeaders> AddUserAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeUser user, ComputeNodeAddUserOptions computeNodeAddUserOptions = default(ComputeNodeAddUserOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.AddUserWithHttpMessagesAsync(poolId, nodeId, user, computeNodeAddUserOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -100,7 +104,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ComputeNodeDeleteUserHeaders DeleteUser(this IComputeNodeOperations operations, string poolId, string nodeId, string userName, ComputeNodeDeleteUserOptions computeNodeDeleteUserOptions = default(ComputeNodeDeleteUserOptions))
             {
-                return ((IComputeNodeOperations)operations).DeleteUserAsync(poolId, nodeId, userName, computeNodeDeleteUserOptions).GetAwaiter().GetResult();
+                return operations.DeleteUserAsync(poolId, nodeId, userName, computeNodeDeleteUserOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -128,7 +132,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNodeDeleteUserHeaders> DeleteUserAsync(this IComputeNodeOperations operations, string poolId, string nodeId, string userName, ComputeNodeDeleteUserOptions computeNodeDeleteUserOptions = default(ComputeNodeDeleteUserOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNodeDeleteUserHeaders> DeleteUserAsync(this IComputeNodeOperations operations, string poolId, string nodeId, string userName, ComputeNodeDeleteUserOptions computeNodeDeleteUserOptions = default(ComputeNodeDeleteUserOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DeleteUserWithHttpMessagesAsync(poolId, nodeId, userName, computeNodeDeleteUserOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -137,7 +141,7 @@ namespace Microsoft.Azure.Batch.Protocol
             }
 
             /// <summary>
-            /// Updates the password or expiration time of a user account on the specified
+            /// Updates the password and expiration time of a user account on the specified
             /// compute node.
             /// </summary>
             /// <remarks>
@@ -166,11 +170,11 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ComputeNodeUpdateUserHeaders UpdateUser(this IComputeNodeOperations operations, string poolId, string nodeId, string userName, NodeUpdateUserParameter nodeUpdateUserParameter, ComputeNodeUpdateUserOptions computeNodeUpdateUserOptions = default(ComputeNodeUpdateUserOptions))
             {
-                return ((IComputeNodeOperations)operations).UpdateUserAsync(poolId, nodeId, userName, nodeUpdateUserParameter, computeNodeUpdateUserOptions).GetAwaiter().GetResult();
+                return operations.UpdateUserAsync(poolId, nodeId, userName, nodeUpdateUserParameter, computeNodeUpdateUserOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
-            /// Updates the password or expiration time of a user account on the specified
+            /// Updates the password and expiration time of a user account on the specified
             /// compute node.
             /// </summary>
             /// <remarks>
@@ -200,7 +204,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNodeUpdateUserHeaders> UpdateUserAsync(this IComputeNodeOperations operations, string poolId, string nodeId, string userName, NodeUpdateUserParameter nodeUpdateUserParameter, ComputeNodeUpdateUserOptions computeNodeUpdateUserOptions = default(ComputeNodeUpdateUserOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNodeUpdateUserHeaders> UpdateUserAsync(this IComputeNodeOperations operations, string poolId, string nodeId, string userName, NodeUpdateUserParameter nodeUpdateUserParameter, ComputeNodeUpdateUserOptions computeNodeUpdateUserOptions = default(ComputeNodeUpdateUserOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.UpdateUserWithHttpMessagesAsync(poolId, nodeId, userName, nodeUpdateUserParameter, computeNodeUpdateUserOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -225,7 +229,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ComputeNode Get(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetOptions computeNodeGetOptions = default(ComputeNodeGetOptions))
             {
-                return ((IComputeNodeOperations)operations).GetAsync(poolId, nodeId, computeNodeGetOptions).GetAwaiter().GetResult();
+                return operations.GetAsync(poolId, nodeId, computeNodeGetOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -246,7 +250,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNode> GetAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetOptions computeNodeGetOptions = default(ComputeNodeGetOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNode> GetAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetOptions computeNodeGetOptions = default(ComputeNodeGetOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetWithHttpMessagesAsync(poolId, nodeId, computeNodeGetOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -271,7 +275,20 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             /// <param name='nodeRebootOption'>
             /// When to reboot the compute node and what to do with currently running
-            /// tasks. The default value is requeue. Possible values include: 'requeue',
+            /// tasks. Values are:
+            ///
+            /// requeue - Terminate running task processes and requeue the tasks. The tasks
+            /// will run again when a node is available. Restart the node as soon as tasks
+            /// have been terminated.
+            /// terminate - Terminate running tasks. The tasks will not run again. Restart
+            /// the node as soon as tasks have been terminated.
+            /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+            /// tasks while waiting. Restart the node when all tasks have completed.
+            /// retaineddata - Allow currently running tasks to complete, then wait for all
+            /// task data retention periods to expire. Schedule no new tasks while waiting.
+            /// Restart the node when all task retention periods have expired.
+            ///
+            /// The default value is requeue. Possible values include: 'requeue',
             /// 'terminate', 'taskCompletion', 'retainedData'
             /// </param>
             /// <param name='computeNodeRebootOptions'>
@@ -279,7 +296,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ComputeNodeRebootHeaders Reboot(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeRebootOption? nodeRebootOption = default(ComputeNodeRebootOption?), ComputeNodeRebootOptions computeNodeRebootOptions = default(ComputeNodeRebootOptions))
             {
-                return ((IComputeNodeOperations)operations).RebootAsync(poolId, nodeId, nodeRebootOption, computeNodeRebootOptions).GetAwaiter().GetResult();
+                return operations.RebootAsync(poolId, nodeId, nodeRebootOption, computeNodeRebootOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -299,7 +316,20 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             /// <param name='nodeRebootOption'>
             /// When to reboot the compute node and what to do with currently running
-            /// tasks. The default value is requeue. Possible values include: 'requeue',
+            /// tasks. Values are:
+            ///
+            /// requeue - Terminate running task processes and requeue the tasks. The tasks
+            /// will run again when a node is available. Restart the node as soon as tasks
+            /// have been terminated.
+            /// terminate - Terminate running tasks. The tasks will not run again. Restart
+            /// the node as soon as tasks have been terminated.
+            /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+            /// tasks while waiting. Restart the node when all tasks have completed.
+            /// retaineddata - Allow currently running tasks to complete, then wait for all
+            /// task data retention periods to expire. Schedule no new tasks while waiting.
+            /// Restart the node when all task retention periods have expired.
+            ///
+            /// The default value is requeue. Possible values include: 'requeue',
             /// 'terminate', 'taskCompletion', 'retainedData'
             /// </param>
             /// <param name='computeNodeRebootOptions'>
@@ -308,7 +338,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNodeRebootHeaders> RebootAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeRebootOption? nodeRebootOption = default(ComputeNodeRebootOption?), ComputeNodeRebootOptions computeNodeRebootOptions = default(ComputeNodeRebootOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNodeRebootHeaders> RebootAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeRebootOption? nodeRebootOption = default(ComputeNodeRebootOption?), ComputeNodeRebootOptions computeNodeRebootOptions = default(ComputeNodeRebootOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.RebootWithHttpMessagesAsync(poolId, nodeId, nodeRebootOption, computeNodeRebootOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -335,7 +365,20 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             /// <param name='nodeReimageOption'>
             /// When to reimage the compute node and what to do with currently running
-            /// tasks. The default value is requeue. Possible values include: 'requeue',
+            /// tasks. Values are:
+            ///
+            /// requeue - Terminate running task processes and requeue the tasks. The tasks
+            /// will run again when a node is available. Reimage the node as soon as tasks
+            /// have been terminated.
+            /// terminate - Terminate running tasks. The tasks will not run again. Reimage
+            /// the node as soon as tasks have been terminated.
+            /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+            /// tasks while waiting. Reimage the node when all tasks have completed.
+            /// retaineddata - Allow currently running tasks to complete, then wait for all
+            /// task data retention periods to expire. Schedule no new tasks while waiting.
+            /// Reimage the node when all task retention periods have expired.
+            ///
+            /// The default value is requeue. Possible values include: 'requeue',
             /// 'terminate', 'taskCompletion', 'retainedData'
             /// </param>
             /// <param name='computeNodeReimageOptions'>
@@ -343,7 +386,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ComputeNodeReimageHeaders Reimage(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeReimageOption? nodeReimageOption = default(ComputeNodeReimageOption?), ComputeNodeReimageOptions computeNodeReimageOptions = default(ComputeNodeReimageOptions))
             {
-                return ((IComputeNodeOperations)operations).ReimageAsync(poolId, nodeId, nodeReimageOption, computeNodeReimageOptions).GetAwaiter().GetResult();
+                return operations.ReimageAsync(poolId, nodeId, nodeReimageOption, computeNodeReimageOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -365,7 +408,20 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             /// <param name='nodeReimageOption'>
             /// When to reimage the compute node and what to do with currently running
-            /// tasks. The default value is requeue. Possible values include: 'requeue',
+            /// tasks. Values are:
+            ///
+            /// requeue - Terminate running task processes and requeue the tasks. The tasks
+            /// will run again when a node is available. Reimage the node as soon as tasks
+            /// have been terminated.
+            /// terminate - Terminate running tasks. The tasks will not run again. Reimage
+            /// the node as soon as tasks have been terminated.
+            /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+            /// tasks while waiting. Reimage the node when all tasks have completed.
+            /// retaineddata - Allow currently running tasks to complete, then wait for all
+            /// task data retention periods to expire. Schedule no new tasks while waiting.
+            /// Reimage the node when all task retention periods have expired.
+            ///
+            /// The default value is requeue. Possible values include: 'requeue',
             /// 'terminate', 'taskCompletion', 'retainedData'
             /// </param>
             /// <param name='computeNodeReimageOptions'>
@@ -374,7 +430,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNodeReimageHeaders> ReimageAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeReimageOption? nodeReimageOption = default(ComputeNodeReimageOption?), ComputeNodeReimageOptions computeNodeReimageOptions = default(ComputeNodeReimageOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNodeReimageHeaders> ReimageAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeReimageOption? nodeReimageOption = default(ComputeNodeReimageOption?), ComputeNodeReimageOptions computeNodeReimageOptions = default(ComputeNodeReimageOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ReimageWithHttpMessagesAsync(poolId, nodeId, nodeReimageOption, computeNodeReimageOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -385,6 +441,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <summary>
             /// Disables task scheduling on the specified compute node.
             /// </summary>
+            /// <remarks>
+            /// You can disable task scheduling on a node only if its current scheduling
+            /// state is enabled.
+            /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
@@ -396,20 +456,34 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             /// <param name='nodeDisableSchedulingOption'>
             /// What to do with currently running tasks when disabling task scheduling on
-            /// the compute node. The default value is requeue. Possible values include:
-            /// 'requeue', 'terminate', 'taskCompletion'
+            /// the compute node. Values are:
+            ///
+            /// requeue - Terminate running task processes and requeue the tasks. The tasks
+            /// may run again on other compute nodes, or when task scheduling is re-enabled
+            /// on this node. Enter offline state as soon as tasks have been terminated.
+            /// terminate - Terminate running tasks. The tasks will not run again. Enter
+            /// offline state as soon as tasks have been terminated.
+            /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+            /// tasks while waiting. Enter offline state when all tasks have completed.
+            ///
+            /// The default value is requeue. Possible values include: 'requeue',
+            /// 'terminate', 'taskCompletion'
             /// </param>
             /// <param name='computeNodeDisableSchedulingOptions'>
             /// Additional parameters for the operation
             /// </param>
             public static ComputeNodeDisableSchedulingHeaders DisableScheduling(this IComputeNodeOperations operations, string poolId, string nodeId, DisableComputeNodeSchedulingOption? nodeDisableSchedulingOption = default(DisableComputeNodeSchedulingOption?), ComputeNodeDisableSchedulingOptions computeNodeDisableSchedulingOptions = default(ComputeNodeDisableSchedulingOptions))
             {
-                return ((IComputeNodeOperations)operations).DisableSchedulingAsync(poolId, nodeId, nodeDisableSchedulingOption, computeNodeDisableSchedulingOptions).GetAwaiter().GetResult();
+                return operations.DisableSchedulingAsync(poolId, nodeId, nodeDisableSchedulingOption, computeNodeDisableSchedulingOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
             /// Disables task scheduling on the specified compute node.
             /// </summary>
+            /// <remarks>
+            /// You can disable task scheduling on a node only if its current scheduling
+            /// state is enabled.
+            /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
@@ -421,8 +495,18 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             /// <param name='nodeDisableSchedulingOption'>
             /// What to do with currently running tasks when disabling task scheduling on
-            /// the compute node. The default value is requeue. Possible values include:
-            /// 'requeue', 'terminate', 'taskCompletion'
+            /// the compute node. Values are:
+            ///
+            /// requeue - Terminate running task processes and requeue the tasks. The tasks
+            /// may run again on other compute nodes, or when task scheduling is re-enabled
+            /// on this node. Enter offline state as soon as tasks have been terminated.
+            /// terminate - Terminate running tasks. The tasks will not run again. Enter
+            /// offline state as soon as tasks have been terminated.
+            /// taskcompletion - Allow currently running tasks to complete. Schedule no new
+            /// tasks while waiting. Enter offline state when all tasks have completed.
+            ///
+            /// The default value is requeue. Possible values include: 'requeue',
+            /// 'terminate', 'taskCompletion'
             /// </param>
             /// <param name='computeNodeDisableSchedulingOptions'>
             /// Additional parameters for the operation
@@ -430,7 +514,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNodeDisableSchedulingHeaders> DisableSchedulingAsync(this IComputeNodeOperations operations, string poolId, string nodeId, DisableComputeNodeSchedulingOption? nodeDisableSchedulingOption = default(DisableComputeNodeSchedulingOption?), ComputeNodeDisableSchedulingOptions computeNodeDisableSchedulingOptions = default(ComputeNodeDisableSchedulingOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNodeDisableSchedulingHeaders> DisableSchedulingAsync(this IComputeNodeOperations operations, string poolId, string nodeId, DisableComputeNodeSchedulingOption? nodeDisableSchedulingOption = default(DisableComputeNodeSchedulingOption?), ComputeNodeDisableSchedulingOptions computeNodeDisableSchedulingOptions = default(ComputeNodeDisableSchedulingOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DisableSchedulingWithHttpMessagesAsync(poolId, nodeId, nodeDisableSchedulingOption, computeNodeDisableSchedulingOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -441,6 +525,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <summary>
             /// Enables task scheduling on the specified compute node.
             /// </summary>
+            /// <remarks>
+            /// You can enable task scheduling on a node only if its current scheduling
+            /// state is disabled
+            /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
@@ -455,12 +543,16 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ComputeNodeEnableSchedulingHeaders EnableScheduling(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeEnableSchedulingOptions computeNodeEnableSchedulingOptions = default(ComputeNodeEnableSchedulingOptions))
             {
-                return ((IComputeNodeOperations)operations).EnableSchedulingAsync(poolId, nodeId, computeNodeEnableSchedulingOptions).GetAwaiter().GetResult();
+                return operations.EnableSchedulingAsync(poolId, nodeId, computeNodeEnableSchedulingOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
             /// Enables task scheduling on the specified compute node.
             /// </summary>
+            /// <remarks>
+            /// You can enable task scheduling on a node only if its current scheduling
+            /// state is disabled
+            /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
@@ -476,7 +568,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNodeEnableSchedulingHeaders> EnableSchedulingAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeEnableSchedulingOptions computeNodeEnableSchedulingOptions = default(ComputeNodeEnableSchedulingOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNodeEnableSchedulingHeaders> EnableSchedulingAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeEnableSchedulingOptions computeNodeEnableSchedulingOptions = default(ComputeNodeEnableSchedulingOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.EnableSchedulingWithHttpMessagesAsync(poolId, nodeId, computeNodeEnableSchedulingOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -490,7 +582,8 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// Before you can remotely login to a node using the remote login settings,
             /// you must create a user account on the node. This API can be invoked only on
-            /// pools created with the virtual machine configuration property.
+            /// pools created with the virtual machine configuration property. For pools
+            /// created with a cloud service configuration, see the GetRemoteDesktop API.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -506,7 +599,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static ComputeNodeGetRemoteLoginSettingsResult GetRemoteLoginSettings(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetRemoteLoginSettingsOptions computeNodeGetRemoteLoginSettingsOptions = default(ComputeNodeGetRemoteLoginSettingsOptions))
             {
-                return ((IComputeNodeOperations)operations).GetRemoteLoginSettingsAsync(poolId, nodeId, computeNodeGetRemoteLoginSettingsOptions).GetAwaiter().GetResult();
+                return operations.GetRemoteLoginSettingsAsync(poolId, nodeId, computeNodeGetRemoteLoginSettingsOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -515,7 +608,8 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// Before you can remotely login to a node using the remote login settings,
             /// you must create a user account on the node. This API can be invoked only on
-            /// pools created with the virtual machine configuration property.
+            /// pools created with the virtual machine configuration property. For pools
+            /// created with a cloud service configuration, see the GetRemoteDesktop API.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -532,7 +626,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<ComputeNodeGetRemoteLoginSettingsResult> GetRemoteLoginSettingsAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetRemoteLoginSettingsOptions computeNodeGetRemoteLoginSettingsOptions = default(ComputeNodeGetRemoteLoginSettingsOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<ComputeNodeGetRemoteLoginSettingsResult> GetRemoteLoginSettingsAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetRemoteLoginSettingsOptions computeNodeGetRemoteLoginSettingsOptions = default(ComputeNodeGetRemoteLoginSettingsOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetRemoteLoginSettingsWithHttpMessagesAsync(poolId, nodeId, computeNodeGetRemoteLoginSettingsOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -545,8 +639,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </summary>
             /// <remarks>
             /// Before you can access a node by using the RDP file, you must create a user
-            /// account on the node. This API can only be invoked on pools created with the
-            /// cloud service configuration property.
+            /// account on the node. This API can only be invoked on pools created with a
+            /// cloud service configuration. For pools created with a virtual machine
+            /// configuration, see the GetRemoteLoginSettings API.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -561,9 +656,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='computeNodeGetRemoteDesktopOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static System.IO.Stream GetRemoteDesktop(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetRemoteDesktopOptions computeNodeGetRemoteDesktopOptions = default(ComputeNodeGetRemoteDesktopOptions))
+            public static Stream GetRemoteDesktop(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetRemoteDesktopOptions computeNodeGetRemoteDesktopOptions = default(ComputeNodeGetRemoteDesktopOptions))
             {
-                return ((IComputeNodeOperations)operations).GetRemoteDesktopAsync(poolId, nodeId, computeNodeGetRemoteDesktopOptions).GetAwaiter().GetResult();
+                return operations.GetRemoteDesktopAsync(poolId, nodeId, computeNodeGetRemoteDesktopOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -571,8 +666,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </summary>
             /// <remarks>
             /// Before you can access a node by using the RDP file, you must create a user
-            /// account on the node. This API can only be invoked on pools created with the
-            /// cloud service configuration property.
+            /// account on the node. This API can only be invoked on pools created with a
+            /// cloud service configuration. For pools created with a virtual machine
+            /// configuration, see the GetRemoteLoginSettings API.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -590,7 +686,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<System.IO.Stream> GetRemoteDesktopAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetRemoteDesktopOptions computeNodeGetRemoteDesktopOptions = default(ComputeNodeGetRemoteDesktopOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<Stream> GetRemoteDesktopAsync(this IComputeNodeOperations operations, string poolId, string nodeId, ComputeNodeGetRemoteDesktopOptions computeNodeGetRemoteDesktopOptions = default(ComputeNodeGetRemoteDesktopOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 var _result = await operations.GetRemoteDesktopWithHttpMessagesAsync(poolId, nodeId, computeNodeGetRemoteDesktopOptions, null, cancellationToken).ConfigureAwait(false);
                 _result.Request.Dispose();
@@ -609,9 +705,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='computeNodeListOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<ComputeNode> List(this IComputeNodeOperations operations, string poolId, ComputeNodeListOptions computeNodeListOptions = default(ComputeNodeListOptions))
+            public static IPage<ComputeNode> List(this IComputeNodeOperations operations, string poolId, ComputeNodeListOptions computeNodeListOptions = default(ComputeNodeListOptions))
             {
-                return ((IComputeNodeOperations)operations).ListAsync(poolId, computeNodeListOptions).GetAwaiter().GetResult();
+                return operations.ListAsync(poolId, computeNodeListOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -629,7 +725,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<ComputeNode>> ListAsync(this IComputeNodeOperations operations, string poolId, ComputeNodeListOptions computeNodeListOptions = default(ComputeNodeListOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<ComputeNode>> ListAsync(this IComputeNodeOperations operations, string poolId, ComputeNodeListOptions computeNodeListOptions = default(ComputeNodeListOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListWithHttpMessagesAsync(poolId, computeNodeListOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -649,9 +745,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='computeNodeListNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<ComputeNode> ListNext(this IComputeNodeOperations operations, string nextPageLink, ComputeNodeListNextOptions computeNodeListNextOptions = default(ComputeNodeListNextOptions))
+            public static IPage<ComputeNode> ListNext(this IComputeNodeOperations operations, string nextPageLink, ComputeNodeListNextOptions computeNodeListNextOptions = default(ComputeNodeListNextOptions))
             {
-                return ((IComputeNodeOperations)operations).ListNextAsync(nextPageLink, computeNodeListNextOptions).GetAwaiter().GetResult();
+                return operations.ListNextAsync(nextPageLink, computeNodeListNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -669,7 +765,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<ComputeNode>> ListNextAsync(this IComputeNodeOperations operations, string nextPageLink, ComputeNodeListNextOptions computeNodeListNextOptions = default(ComputeNodeListNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<ComputeNode>> ListNextAsync(this IComputeNodeOperations operations, string nextPageLink, ComputeNodeListNextOptions computeNodeListNextOptions = default(ComputeNodeListNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNextWithHttpMessagesAsync(nextPageLink, computeNodeListNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/FileOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/FileOperations.cs
@@ -8,15 +8,24 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// FileOperations operations.
     /// </summary>
-    internal partial class FileOperations : Microsoft.Rest.IServiceOperations<BatchServiceClient>, IFileOperations
+    internal partial class FileOperations : IServiceOperations<BatchServiceClient>, IFileOperations
     {
         /// <summary>
         /// Initializes a new instance of the FileOperations class.
@@ -33,7 +42,7 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("client");
             }
-            this.Client = client;
+            Client = client;
         }
 
         /// <summary>
@@ -51,7 +60,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// The ID of the task whose file you want to delete.
         /// </param>
         /// <param name='filePath'>
-        /// The path to the task file that you want to delete.
+        /// The path to the task file or directory that you want to delete.
         /// </param>
         /// <param name='recursive'>
         /// Whether to delete children of a directory. If the filePath parameter
@@ -71,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -80,23 +89,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileDeleteFromTaskHeaders>> DeleteFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, bool? recursive = default(bool?), FileDeleteFromTaskOptions fileDeleteFromTaskOptions = default(FileDeleteFromTaskOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<FileDeleteFromTaskHeaders>> DeleteFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, bool? recursive = default(bool?), FileDeleteFromTaskOptions fileDeleteFromTaskOptions = default(FileDeleteFromTaskOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
             if (filePath == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "filePath");
+                throw new ValidationException(ValidationRules.CannotBeNull, "filePath");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (fileDeleteFromTaskOptions != null)
@@ -119,12 +128,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = fileDeleteFromTaskOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("filePath", filePath);
@@ -134,48 +143,48 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "DeleteFromTask", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "DeleteFromTask", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}/files/{filePath}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
             _url = _url.Replace("{filePath}", System.Uri.EscapeDataString(filePath));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (recursive != null)
             {
-                _queryParameters.Add(string.Format("recursive={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(recursive, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("recursive={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(recursive, Client.SerializationSettings).Trim('"'))));
             }
-            if (this.Client.ApiVersion != null)
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("DELETE");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("DELETE");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -183,7 +192,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -191,7 +200,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -199,7 +208,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -218,23 +227,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -243,21 +252,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -267,7 +276,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileDeleteFromTaskHeaders>();
+            var _result = new AzureOperationHeaderResponse<FileDeleteFromTaskHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -276,20 +285,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileDeleteFromTaskHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileDeleteFromTaskHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -318,10 +327,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -330,23 +339,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,FileGetFromTaskHeaders>> GetFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, FileGetFromTaskOptions fileGetFromTaskOptions = default(FileGetFromTaskOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<Stream,FileGetFromTaskHeaders>> GetFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, FileGetFromTaskOptions fileGetFromTaskOptions = default(FileGetFromTaskOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
             if (filePath == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "filePath");
+                throw new ValidationException(ValidationRules.CannotBeNull, "filePath");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (fileGetFromTaskOptions != null)
@@ -384,12 +393,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = fileGetFromTaskOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("filePath", filePath);
@@ -401,44 +410,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "GetFromTask", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetFromTask", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}/files/{filePath}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
             _url = _url.Replace("{filePath}", System.Uri.EscapeDataString(filePath));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -446,7 +455,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -454,7 +463,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -462,7 +471,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ocpRange != null)
             {
@@ -478,7 +487,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -486,7 +495,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -505,23 +514,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -530,21 +539,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -554,7 +563,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,FileGetFromTaskHeaders>();
+            var _result = new AzureOperationResponse<Stream,FileGetFromTaskHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -568,20 +577,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileGetFromTaskHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileGetFromTaskHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -610,7 +619,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -619,23 +628,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileGetPropertiesFromTaskHeaders>> GetPropertiesFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, FileGetPropertiesFromTaskOptions fileGetPropertiesFromTaskOptions = default(FileGetPropertiesFromTaskOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<FileGetPropertiesFromTaskHeaders>> GetPropertiesFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, FileGetPropertiesFromTaskOptions fileGetPropertiesFromTaskOptions = default(FileGetPropertiesFromTaskOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
             if (filePath == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "filePath");
+                throw new ValidationException(ValidationRules.CannotBeNull, "filePath");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (fileGetPropertiesFromTaskOptions != null)
@@ -668,12 +677,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = fileGetPropertiesFromTaskOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("filePath", filePath);
@@ -684,44 +693,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "GetPropertiesFromTask", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetPropertiesFromTask", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}/files/{filePath}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
             _url = _url.Replace("{filePath}", System.Uri.EscapeDataString(filePath));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("HEAD");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("HEAD");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -729,7 +738,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -737,7 +746,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -745,7 +754,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifModifiedSince != null)
             {
@@ -753,7 +762,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -761,7 +770,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -780,23 +789,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -805,21 +814,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -829,7 +838,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileGetPropertiesFromTaskHeaders>();
+            var _result = new AzureOperationHeaderResponse<FileGetPropertiesFromTaskHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -838,20 +847,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileGetPropertiesFromTaskHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileGetPropertiesFromTaskHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -866,7 +875,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// The ID of the compute node from which you want to delete the file.
         /// </param>
         /// <param name='filePath'>
-        /// The path to the file that you want to delete.
+        /// The path to the file or directory that you want to delete.
         /// </param>
         /// <param name='recursive'>
         /// Whether to delete children of a directory. If the filePath parameter
@@ -886,7 +895,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -895,23 +904,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileDeleteFromComputeNodeHeaders>> DeleteFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, bool? recursive = default(bool?), FileDeleteFromComputeNodeOptions fileDeleteFromComputeNodeOptions = default(FileDeleteFromComputeNodeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<FileDeleteFromComputeNodeHeaders>> DeleteFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, bool? recursive = default(bool?), FileDeleteFromComputeNodeOptions fileDeleteFromComputeNodeOptions = default(FileDeleteFromComputeNodeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
             if (filePath == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "filePath");
+                throw new ValidationException(ValidationRules.CannotBeNull, "filePath");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (fileDeleteFromComputeNodeOptions != null)
@@ -934,12 +943,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = fileDeleteFromComputeNodeOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("filePath", filePath);
@@ -949,48 +958,48 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "DeleteFromComputeNode", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "DeleteFromComputeNode", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/files/{filePath}").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
             _url = _url.Replace("{filePath}", System.Uri.EscapeDataString(filePath));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (recursive != null)
             {
-                _queryParameters.Add(string.Format("recursive={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(recursive, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("recursive={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(recursive, Client.SerializationSettings).Trim('"'))));
             }
-            if (this.Client.ApiVersion != null)
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("DELETE");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("DELETE");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -998,7 +1007,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1006,7 +1015,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1014,7 +1023,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1033,23 +1042,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1058,21 +1067,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1082,7 +1091,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileDeleteFromComputeNodeHeaders>();
+            var _result = new AzureOperationHeaderResponse<FileDeleteFromComputeNodeHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1091,20 +1100,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileDeleteFromComputeNodeHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileDeleteFromComputeNodeHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1133,10 +1142,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1145,23 +1154,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,FileGetFromComputeNodeHeaders>> GetFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, FileGetFromComputeNodeOptions fileGetFromComputeNodeOptions = default(FileGetFromComputeNodeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<Stream,FileGetFromComputeNodeHeaders>> GetFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, FileGetFromComputeNodeOptions fileGetFromComputeNodeOptions = default(FileGetFromComputeNodeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
             if (filePath == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "filePath");
+                throw new ValidationException(ValidationRules.CannotBeNull, "filePath");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (fileGetFromComputeNodeOptions != null)
@@ -1199,12 +1208,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = fileGetFromComputeNodeOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("filePath", filePath);
@@ -1216,44 +1225,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "GetFromComputeNode", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetFromComputeNode", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/files/{filePath}").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
             _url = _url.Replace("{filePath}", System.Uri.EscapeDataString(filePath));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1261,7 +1270,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1269,7 +1278,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1277,7 +1286,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ocpRange != null)
             {
@@ -1293,7 +1302,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1301,7 +1310,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1320,23 +1329,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1345,21 +1354,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1369,7 +1378,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,FileGetFromComputeNodeHeaders>();
+            var _result = new AzureOperationResponse<Stream,FileGetFromComputeNodeHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1383,20 +1392,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileGetFromComputeNodeHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileGetFromComputeNodeHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1425,7 +1434,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1434,23 +1443,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileGetPropertiesFromComputeNodeHeaders>> GetPropertiesFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, FileGetPropertiesFromComputeNodeOptions fileGetPropertiesFromComputeNodeOptions = default(FileGetPropertiesFromComputeNodeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<FileGetPropertiesFromComputeNodeHeaders>> GetPropertiesFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, FileGetPropertiesFromComputeNodeOptions fileGetPropertiesFromComputeNodeOptions = default(FileGetPropertiesFromComputeNodeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
             if (filePath == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "filePath");
+                throw new ValidationException(ValidationRules.CannotBeNull, "filePath");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (fileGetPropertiesFromComputeNodeOptions != null)
@@ -1483,12 +1492,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = fileGetPropertiesFromComputeNodeOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("filePath", filePath);
@@ -1499,44 +1508,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "GetPropertiesFromComputeNode", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetPropertiesFromComputeNode", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/files/{filePath}").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
             _url = _url.Replace("{filePath}", System.Uri.EscapeDataString(filePath));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("HEAD");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("HEAD");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1544,7 +1553,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1552,7 +1561,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1560,7 +1569,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifModifiedSince != null)
             {
@@ -1568,7 +1577,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1576,7 +1585,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1595,23 +1604,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1620,21 +1629,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1644,7 +1653,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileGetPropertiesFromComputeNodeHeaders>();
+            var _result = new AzureOperationHeaderResponse<FileGetPropertiesFromComputeNodeHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1653,20 +1662,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileGetPropertiesFromComputeNodeHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileGetPropertiesFromComputeNodeHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1681,8 +1690,8 @@ namespace Microsoft.Azure.Batch.Protocol
         /// The ID of the task whose files you want to list.
         /// </param>
         /// <param name='recursive'>
-        /// Whether to list children of a directory. This parameter can be used in
-        /// combination with the filter parameter to list specific type of files.
+        /// Whether to list children of the task directory. This parameter can be used
+        /// in combination with the filter parameter to list specific type of files.
         /// </param>
         /// <param name='fileListFromTaskOptions'>
         /// Additional parameters for the operation
@@ -1696,10 +1705,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1708,19 +1717,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromTaskHeaders>> ListFromTaskWithHttpMessagesAsync(string jobId, string taskId, bool? recursive = default(bool?), FileListFromTaskOptions fileListFromTaskOptions = default(FileListFromTaskOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<NodeFile>,FileListFromTaskHeaders>> ListFromTaskWithHttpMessagesAsync(string jobId, string taskId, bool? recursive = default(bool?), FileListFromTaskOptions fileListFromTaskOptions = default(FileListFromTaskOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (fileListFromTaskOptions != null)
@@ -1753,12 +1762,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = fileListFromTaskOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("recursive", recursive);
@@ -1769,21 +1778,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListFromTask", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListFromTask", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}/files").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (recursive != null)
             {
-                _queryParameters.Add(string.Format("recursive={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(recursive, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("recursive={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(recursive, Client.SerializationSettings).Trim('"'))));
             }
-            if (this.Client.ApiVersion != null)
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -1791,33 +1800,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1825,7 +1834,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1833,7 +1842,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1841,7 +1850,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1860,23 +1869,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1885,21 +1894,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1909,7 +1918,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromTaskHeaders>();
+            var _result = new AzureOperationResponse<IPage<NodeFile>,FileListFromTaskHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1922,34 +1931,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<NodeFile>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<NodeFile>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileListFromTaskHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileListFromTaskHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1978,10 +1987,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1990,19 +1999,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromComputeNodeHeaders>> ListFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, bool? recursive = default(bool?), FileListFromComputeNodeOptions fileListFromComputeNodeOptions = default(FileListFromComputeNodeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<NodeFile>,FileListFromComputeNodeHeaders>> ListFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, bool? recursive = default(bool?), FileListFromComputeNodeOptions fileListFromComputeNodeOptions = default(FileListFromComputeNodeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (poolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "poolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "poolId");
             }
             if (nodeId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nodeId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nodeId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (fileListFromComputeNodeOptions != null)
@@ -2035,12 +2044,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = fileListFromComputeNodeOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("poolId", poolId);
                 tracingParameters.Add("nodeId", nodeId);
                 tracingParameters.Add("recursive", recursive);
@@ -2051,21 +2060,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListFromComputeNode", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListFromComputeNode", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "pools/{poolId}/nodes/{nodeId}/files").ToString();
             _url = _url.Replace("{poolId}", System.Uri.EscapeDataString(poolId));
             _url = _url.Replace("{nodeId}", System.Uri.EscapeDataString(nodeId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (recursive != null)
             {
-                _queryParameters.Add(string.Format("recursive={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(recursive, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("recursive={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(recursive, Client.SerializationSettings).Trim('"'))));
             }
-            if (this.Client.ApiVersion != null)
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -2073,33 +2082,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2107,7 +2116,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2115,7 +2124,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2123,7 +2132,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2142,23 +2151,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2167,21 +2176,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2191,7 +2200,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromComputeNodeHeaders>();
+            var _result = new AzureOperationResponse<IPage<NodeFile>,FileListFromComputeNodeHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2204,34 +2213,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<NodeFile>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<NodeFile>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileListFromComputeNodeHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileListFromComputeNodeHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2254,10 +2263,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2266,11 +2275,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromTaskHeaders>> ListFromTaskNextWithHttpMessagesAsync(string nextPageLink, FileListFromTaskNextOptions fileListFromTaskNextOptions = default(FileListFromTaskNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<NodeFile>,FileListFromTaskHeaders>> ListFromTaskNextWithHttpMessagesAsync(string nextPageLink, FileListFromTaskNextOptions fileListFromTaskNextOptions = default(FileListFromTaskNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (fileListFromTaskNextOptions != null)
@@ -2288,44 +2297,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = fileListFromTaskNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListFromTaskNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListFromTaskNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2333,7 +2342,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2341,7 +2350,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2349,7 +2358,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2368,23 +2377,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2393,21 +2402,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2417,7 +2426,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromTaskHeaders>();
+            var _result = new AzureOperationResponse<IPage<NodeFile>,FileListFromTaskHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2430,34 +2439,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<NodeFile>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<NodeFile>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileListFromTaskHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileListFromTaskHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2480,10 +2489,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2492,11 +2501,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromComputeNodeHeaders>> ListFromComputeNodeNextWithHttpMessagesAsync(string nextPageLink, FileListFromComputeNodeNextOptions fileListFromComputeNodeNextOptions = default(FileListFromComputeNodeNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<NodeFile>,FileListFromComputeNodeHeaders>> ListFromComputeNodeNextWithHttpMessagesAsync(string nextPageLink, FileListFromComputeNodeNextOptions fileListFromComputeNodeNextOptions = default(FileListFromComputeNodeNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (fileListFromComputeNodeNextOptions != null)
@@ -2514,44 +2523,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = fileListFromComputeNodeNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListFromComputeNodeNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListFromComputeNodeNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2559,7 +2568,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2567,7 +2576,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2575,7 +2584,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2594,23 +2603,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2619,21 +2628,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2643,7 +2652,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromComputeNodeHeaders>();
+            var _result = new AzureOperationResponse<IPage<NodeFile>,FileListFromComputeNodeHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2656,34 +2665,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<NodeFile>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<NodeFile>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileListFromComputeNodeHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<FileListFromComputeNodeHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/FileOperationsExtensions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/FileOperationsExtensions.cs
@@ -8,8 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Extension methods for FileOperations.
@@ -29,7 +33,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// The ID of the task whose file you want to delete.
             /// </param>
             /// <param name='filePath'>
-            /// The path to the task file that you want to delete.
+            /// The path to the task file or directory that you want to delete.
             /// </param>
             /// <param name='recursive'>
             /// Whether to delete children of a directory. If the filePath parameter
@@ -42,7 +46,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static FileDeleteFromTaskHeaders DeleteFromTask(this IFileOperations operations, string jobId, string taskId, string filePath, bool? recursive = default(bool?), FileDeleteFromTaskOptions fileDeleteFromTaskOptions = default(FileDeleteFromTaskOptions))
             {
-                return ((IFileOperations)operations).DeleteFromTaskAsync(jobId, taskId, filePath, recursive, fileDeleteFromTaskOptions).GetAwaiter().GetResult();
+                return operations.DeleteFromTaskAsync(jobId, taskId, filePath, recursive, fileDeleteFromTaskOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -58,7 +62,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// The ID of the task whose file you want to delete.
             /// </param>
             /// <param name='filePath'>
-            /// The path to the task file that you want to delete.
+            /// The path to the task file or directory that you want to delete.
             /// </param>
             /// <param name='recursive'>
             /// Whether to delete children of a directory. If the filePath parameter
@@ -72,7 +76,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<FileDeleteFromTaskHeaders> DeleteFromTaskAsync(this IFileOperations operations, string jobId, string taskId, string filePath, bool? recursive = default(bool?), FileDeleteFromTaskOptions fileDeleteFromTaskOptions = default(FileDeleteFromTaskOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<FileDeleteFromTaskHeaders> DeleteFromTaskAsync(this IFileOperations operations, string jobId, string taskId, string filePath, bool? recursive = default(bool?), FileDeleteFromTaskOptions fileDeleteFromTaskOptions = default(FileDeleteFromTaskOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DeleteFromTaskWithHttpMessagesAsync(jobId, taskId, filePath, recursive, fileDeleteFromTaskOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -98,9 +102,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='fileGetFromTaskOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static System.IO.Stream GetFromTask(this IFileOperations operations, string jobId, string taskId, string filePath, FileGetFromTaskOptions fileGetFromTaskOptions = default(FileGetFromTaskOptions))
+            public static Stream GetFromTask(this IFileOperations operations, string jobId, string taskId, string filePath, FileGetFromTaskOptions fileGetFromTaskOptions = default(FileGetFromTaskOptions))
             {
-                return ((IFileOperations)operations).GetFromTaskAsync(jobId, taskId, filePath, fileGetFromTaskOptions).GetAwaiter().GetResult();
+                return operations.GetFromTaskAsync(jobId, taskId, filePath, fileGetFromTaskOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -124,7 +128,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<System.IO.Stream> GetFromTaskAsync(this IFileOperations operations, string jobId, string taskId, string filePath, FileGetFromTaskOptions fileGetFromTaskOptions = default(FileGetFromTaskOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<Stream> GetFromTaskAsync(this IFileOperations operations, string jobId, string taskId, string filePath, FileGetFromTaskOptions fileGetFromTaskOptions = default(FileGetFromTaskOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 var _result = await operations.GetFromTaskWithHttpMessagesAsync(jobId, taskId, filePath, fileGetFromTaskOptions, null, cancellationToken).ConfigureAwait(false);
                 _result.Request.Dispose();
@@ -151,7 +155,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static FileGetPropertiesFromTaskHeaders GetPropertiesFromTask(this IFileOperations operations, string jobId, string taskId, string filePath, FileGetPropertiesFromTaskOptions fileGetPropertiesFromTaskOptions = default(FileGetPropertiesFromTaskOptions))
             {
-                return ((IFileOperations)operations).GetPropertiesFromTaskAsync(jobId, taskId, filePath, fileGetPropertiesFromTaskOptions).GetAwaiter().GetResult();
+                return operations.GetPropertiesFromTaskAsync(jobId, taskId, filePath, fileGetPropertiesFromTaskOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -175,7 +179,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<FileGetPropertiesFromTaskHeaders> GetPropertiesFromTaskAsync(this IFileOperations operations, string jobId, string taskId, string filePath, FileGetPropertiesFromTaskOptions fileGetPropertiesFromTaskOptions = default(FileGetPropertiesFromTaskOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<FileGetPropertiesFromTaskHeaders> GetPropertiesFromTaskAsync(this IFileOperations operations, string jobId, string taskId, string filePath, FileGetPropertiesFromTaskOptions fileGetPropertiesFromTaskOptions = default(FileGetPropertiesFromTaskOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetPropertiesFromTaskWithHttpMessagesAsync(jobId, taskId, filePath, fileGetPropertiesFromTaskOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -196,7 +200,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// The ID of the compute node from which you want to delete the file.
             /// </param>
             /// <param name='filePath'>
-            /// The path to the file that you want to delete.
+            /// The path to the file or directory that you want to delete.
             /// </param>
             /// <param name='recursive'>
             /// Whether to delete children of a directory. If the filePath parameter
@@ -209,7 +213,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static FileDeleteFromComputeNodeHeaders DeleteFromComputeNode(this IFileOperations operations, string poolId, string nodeId, string filePath, bool? recursive = default(bool?), FileDeleteFromComputeNodeOptions fileDeleteFromComputeNodeOptions = default(FileDeleteFromComputeNodeOptions))
             {
-                return ((IFileOperations)operations).DeleteFromComputeNodeAsync(poolId, nodeId, filePath, recursive, fileDeleteFromComputeNodeOptions).GetAwaiter().GetResult();
+                return operations.DeleteFromComputeNodeAsync(poolId, nodeId, filePath, recursive, fileDeleteFromComputeNodeOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -225,7 +229,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// The ID of the compute node from which you want to delete the file.
             /// </param>
             /// <param name='filePath'>
-            /// The path to the file that you want to delete.
+            /// The path to the file or directory that you want to delete.
             /// </param>
             /// <param name='recursive'>
             /// Whether to delete children of a directory. If the filePath parameter
@@ -239,7 +243,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<FileDeleteFromComputeNodeHeaders> DeleteFromComputeNodeAsync(this IFileOperations operations, string poolId, string nodeId, string filePath, bool? recursive = default(bool?), FileDeleteFromComputeNodeOptions fileDeleteFromComputeNodeOptions = default(FileDeleteFromComputeNodeOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<FileDeleteFromComputeNodeHeaders> DeleteFromComputeNodeAsync(this IFileOperations operations, string poolId, string nodeId, string filePath, bool? recursive = default(bool?), FileDeleteFromComputeNodeOptions fileDeleteFromComputeNodeOptions = default(FileDeleteFromComputeNodeOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DeleteFromComputeNodeWithHttpMessagesAsync(poolId, nodeId, filePath, recursive, fileDeleteFromComputeNodeOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -265,9 +269,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='fileGetFromComputeNodeOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static System.IO.Stream GetFromComputeNode(this IFileOperations operations, string poolId, string nodeId, string filePath, FileGetFromComputeNodeOptions fileGetFromComputeNodeOptions = default(FileGetFromComputeNodeOptions))
+            public static Stream GetFromComputeNode(this IFileOperations operations, string poolId, string nodeId, string filePath, FileGetFromComputeNodeOptions fileGetFromComputeNodeOptions = default(FileGetFromComputeNodeOptions))
             {
-                return ((IFileOperations)operations).GetFromComputeNodeAsync(poolId, nodeId, filePath, fileGetFromComputeNodeOptions).GetAwaiter().GetResult();
+                return operations.GetFromComputeNodeAsync(poolId, nodeId, filePath, fileGetFromComputeNodeOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -291,7 +295,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<System.IO.Stream> GetFromComputeNodeAsync(this IFileOperations operations, string poolId, string nodeId, string filePath, FileGetFromComputeNodeOptions fileGetFromComputeNodeOptions = default(FileGetFromComputeNodeOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<Stream> GetFromComputeNodeAsync(this IFileOperations operations, string poolId, string nodeId, string filePath, FileGetFromComputeNodeOptions fileGetFromComputeNodeOptions = default(FileGetFromComputeNodeOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 var _result = await operations.GetFromComputeNodeWithHttpMessagesAsync(poolId, nodeId, filePath, fileGetFromComputeNodeOptions, null, cancellationToken).ConfigureAwait(false);
                 _result.Request.Dispose();
@@ -318,7 +322,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static FileGetPropertiesFromComputeNodeHeaders GetPropertiesFromComputeNode(this IFileOperations operations, string poolId, string nodeId, string filePath, FileGetPropertiesFromComputeNodeOptions fileGetPropertiesFromComputeNodeOptions = default(FileGetPropertiesFromComputeNodeOptions))
             {
-                return ((IFileOperations)operations).GetPropertiesFromComputeNodeAsync(poolId, nodeId, filePath, fileGetPropertiesFromComputeNodeOptions).GetAwaiter().GetResult();
+                return operations.GetPropertiesFromComputeNodeAsync(poolId, nodeId, filePath, fileGetPropertiesFromComputeNodeOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -342,7 +346,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<FileGetPropertiesFromComputeNodeHeaders> GetPropertiesFromComputeNodeAsync(this IFileOperations operations, string poolId, string nodeId, string filePath, FileGetPropertiesFromComputeNodeOptions fileGetPropertiesFromComputeNodeOptions = default(FileGetPropertiesFromComputeNodeOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<FileGetPropertiesFromComputeNodeHeaders> GetPropertiesFromComputeNodeAsync(this IFileOperations operations, string poolId, string nodeId, string filePath, FileGetPropertiesFromComputeNodeOptions fileGetPropertiesFromComputeNodeOptions = default(FileGetPropertiesFromComputeNodeOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetPropertiesFromComputeNodeWithHttpMessagesAsync(poolId, nodeId, filePath, fileGetPropertiesFromComputeNodeOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -363,15 +367,15 @@ namespace Microsoft.Azure.Batch.Protocol
             /// The ID of the task whose files you want to list.
             /// </param>
             /// <param name='recursive'>
-            /// Whether to list children of a directory. This parameter can be used in
-            /// combination with the filter parameter to list specific type of files.
+            /// Whether to list children of the task directory. This parameter can be used
+            /// in combination with the filter parameter to list specific type of files.
             /// </param>
             /// <param name='fileListFromTaskOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<NodeFile> ListFromTask(this IFileOperations operations, string jobId, string taskId, bool? recursive = default(bool?), FileListFromTaskOptions fileListFromTaskOptions = default(FileListFromTaskOptions))
+            public static IPage<NodeFile> ListFromTask(this IFileOperations operations, string jobId, string taskId, bool? recursive = default(bool?), FileListFromTaskOptions fileListFromTaskOptions = default(FileListFromTaskOptions))
             {
-                return ((IFileOperations)operations).ListFromTaskAsync(jobId, taskId, recursive, fileListFromTaskOptions).GetAwaiter().GetResult();
+                return operations.ListFromTaskAsync(jobId, taskId, recursive, fileListFromTaskOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -387,8 +391,8 @@ namespace Microsoft.Azure.Batch.Protocol
             /// The ID of the task whose files you want to list.
             /// </param>
             /// <param name='recursive'>
-            /// Whether to list children of a directory. This parameter can be used in
-            /// combination with the filter parameter to list specific type of files.
+            /// Whether to list children of the task directory. This parameter can be used
+            /// in combination with the filter parameter to list specific type of files.
             /// </param>
             /// <param name='fileListFromTaskOptions'>
             /// Additional parameters for the operation
@@ -396,7 +400,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<NodeFile>> ListFromTaskAsync(this IFileOperations operations, string jobId, string taskId, bool? recursive = default(bool?), FileListFromTaskOptions fileListFromTaskOptions = default(FileListFromTaskOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<NodeFile>> ListFromTaskAsync(this IFileOperations operations, string jobId, string taskId, bool? recursive = default(bool?), FileListFromTaskOptions fileListFromTaskOptions = default(FileListFromTaskOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListFromTaskWithHttpMessagesAsync(jobId, taskId, recursive, fileListFromTaskOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -422,9 +426,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='fileListFromComputeNodeOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<NodeFile> ListFromComputeNode(this IFileOperations operations, string poolId, string nodeId, bool? recursive = default(bool?), FileListFromComputeNodeOptions fileListFromComputeNodeOptions = default(FileListFromComputeNodeOptions))
+            public static IPage<NodeFile> ListFromComputeNode(this IFileOperations operations, string poolId, string nodeId, bool? recursive = default(bool?), FileListFromComputeNodeOptions fileListFromComputeNodeOptions = default(FileListFromComputeNodeOptions))
             {
-                return ((IFileOperations)operations).ListFromComputeNodeAsync(poolId, nodeId, recursive, fileListFromComputeNodeOptions).GetAwaiter().GetResult();
+                return operations.ListFromComputeNodeAsync(poolId, nodeId, recursive, fileListFromComputeNodeOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -448,7 +452,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<NodeFile>> ListFromComputeNodeAsync(this IFileOperations operations, string poolId, string nodeId, bool? recursive = default(bool?), FileListFromComputeNodeOptions fileListFromComputeNodeOptions = default(FileListFromComputeNodeOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<NodeFile>> ListFromComputeNodeAsync(this IFileOperations operations, string poolId, string nodeId, bool? recursive = default(bool?), FileListFromComputeNodeOptions fileListFromComputeNodeOptions = default(FileListFromComputeNodeOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListFromComputeNodeWithHttpMessagesAsync(poolId, nodeId, recursive, fileListFromComputeNodeOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -468,9 +472,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='fileListFromTaskNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<NodeFile> ListFromTaskNext(this IFileOperations operations, string nextPageLink, FileListFromTaskNextOptions fileListFromTaskNextOptions = default(FileListFromTaskNextOptions))
+            public static IPage<NodeFile> ListFromTaskNext(this IFileOperations operations, string nextPageLink, FileListFromTaskNextOptions fileListFromTaskNextOptions = default(FileListFromTaskNextOptions))
             {
-                return ((IFileOperations)operations).ListFromTaskNextAsync(nextPageLink, fileListFromTaskNextOptions).GetAwaiter().GetResult();
+                return operations.ListFromTaskNextAsync(nextPageLink, fileListFromTaskNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -488,7 +492,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<NodeFile>> ListFromTaskNextAsync(this IFileOperations operations, string nextPageLink, FileListFromTaskNextOptions fileListFromTaskNextOptions = default(FileListFromTaskNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<NodeFile>> ListFromTaskNextAsync(this IFileOperations operations, string nextPageLink, FileListFromTaskNextOptions fileListFromTaskNextOptions = default(FileListFromTaskNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListFromTaskNextWithHttpMessagesAsync(nextPageLink, fileListFromTaskNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -508,9 +512,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='fileListFromComputeNodeNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<NodeFile> ListFromComputeNodeNext(this IFileOperations operations, string nextPageLink, FileListFromComputeNodeNextOptions fileListFromComputeNodeNextOptions = default(FileListFromComputeNodeNextOptions))
+            public static IPage<NodeFile> ListFromComputeNodeNext(this IFileOperations operations, string nextPageLink, FileListFromComputeNodeNextOptions fileListFromComputeNodeNextOptions = default(FileListFromComputeNodeNextOptions))
             {
-                return ((IFileOperations)operations).ListFromComputeNodeNextAsync(nextPageLink, fileListFromComputeNodeNextOptions).GetAwaiter().GetResult();
+                return operations.ListFromComputeNodeNextAsync(nextPageLink, fileListFromComputeNodeNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -528,7 +532,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<NodeFile>> ListFromComputeNodeNextAsync(this IFileOperations operations, string nextPageLink, FileListFromComputeNodeNextOptions fileListFromComputeNodeNextOptions = default(FileListFromComputeNodeNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<NodeFile>> ListFromComputeNodeNextAsync(this IFileOperations operations, string nextPageLink, FileListFromComputeNodeNextOptions fileListFromComputeNodeNextOptions = default(FileListFromComputeNodeNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListFromComputeNodeNextWithHttpMessagesAsync(nextPageLink, fileListFromComputeNodeNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IAccountOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IAccountOperations.cs
@@ -8,8 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// AccountOperations operations.
@@ -37,7 +42,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>> ListNodeAgentSkusWithHttpMessagesAsync(AccountListNodeAgentSkusOptions accountListNodeAgentSkusOptions = default(AccountListNodeAgentSkusOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>> ListNodeAgentSkusWithHttpMessagesAsync(AccountListNodeAgentSkusOptions accountListNodeAgentSkusOptions = default(AccountListNodeAgentSkusOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all node agent SKUs supported by the Azure Batch service.
         /// </summary>
@@ -62,6 +67,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>> ListNodeAgentSkusNextWithHttpMessagesAsync(string nextPageLink, AccountListNodeAgentSkusNextOptions accountListNodeAgentSkusNextOptions = default(AccountListNodeAgentSkusNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<NodeAgentSku>,AccountListNodeAgentSkusHeaders>> ListNodeAgentSkusNextWithHttpMessagesAsync(string nextPageLink, AccountListNodeAgentSkusNextOptions accountListNodeAgentSkusNextOptions = default(AccountListNodeAgentSkusNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IApplicationOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IApplicationOperations.cs
@@ -8,8 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// ApplicationOperations operations.
@@ -44,10 +49,17 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ApplicationSummary>,ApplicationListHeaders>> ListWithHttpMessagesAsync(ApplicationListOptions applicationListOptions = default(ApplicationListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<ApplicationSummary>,ApplicationListHeaders>> ListWithHttpMessagesAsync(ApplicationListOptions applicationListOptions = default(ApplicationListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets information about the specified application.
         /// </summary>
+        /// <remarks>
+        /// This operation returns only applications and versions that are
+        /// available for use on compute nodes; that is, that can be used in an
+        /// application package reference. For administrator information about
+        /// applications and versions that are not yet available to compute
+        /// nodes, use the Azure portal or the Azure Resource Manager API.
+        /// </remarks>
         /// <param name='applicationId'>
         /// The ID of the application.
         /// </param>
@@ -69,7 +81,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<ApplicationSummary,ApplicationGetHeaders>> GetWithHttpMessagesAsync(string applicationId, ApplicationGetOptions applicationGetOptions = default(ApplicationGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<ApplicationSummary,ApplicationGetHeaders>> GetWithHttpMessagesAsync(string applicationId, ApplicationGetOptions applicationGetOptions = default(ApplicationGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the applications available in the specified account.
         /// </summary>
@@ -101,6 +113,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ApplicationSummary>,ApplicationListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, ApplicationListNextOptions applicationListNextOptions = default(ApplicationListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<ApplicationSummary>,ApplicationListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, ApplicationListNextOptions applicationListNextOptions = default(ApplicationListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IBatchServiceClient.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IBatchServiceClient.cs
@@ -8,9 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// A client for issuing REST requests to the Azure Batch service.
@@ -25,17 +28,17 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <summary>
         /// Gets or sets json serialization settings.
         /// </summary>
-        Newtonsoft.Json.JsonSerializerSettings SerializationSettings { get; }
+        JsonSerializerSettings SerializationSettings { get; }
 
         /// <summary>
         /// Gets or sets json deserialization settings.
         /// </summary>
-        Newtonsoft.Json.JsonSerializerSettings DeserializationSettings { get; }
+        JsonSerializerSettings DeserializationSettings { get; }
 
         /// <summary>
         /// Credentials needed for the client to connect to Azure.
         /// </summary>
-        Microsoft.Rest.ServiceClientCredentials Credentials { get; }
+        ServiceClientCredentials Credentials { get; }
 
         /// <summary>
         /// Client API Version.

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ICertificateOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ICertificateOperations.cs
@@ -8,8 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// CertificateOperations operations.
@@ -37,7 +42,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateAddHeaders>> AddWithHttpMessagesAsync(CertificateAddParameter certificate, CertificateAddOptions certificateAddOptions = default(CertificateAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<CertificateAddHeaders>> AddWithHttpMessagesAsync(CertificateAddParameter certificate, CertificateAddOptions certificateAddOptions = default(CertificateAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the certificates that have been added to the specified
         /// account.
@@ -60,7 +65,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<Certificate>,CertificateListHeaders>> ListWithHttpMessagesAsync(CertificateListOptions certificateListOptions = default(CertificateListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<Certificate>,CertificateListHeaders>> ListWithHttpMessagesAsync(CertificateListOptions certificateListOptions = default(CertificateListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Cancels a failed deletion of a certificate from the specified
         /// account.
@@ -98,7 +103,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateCancelDeletionHeaders>> CancelDeletionWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateCancelDeletionOptions certificateCancelDeletionOptions = default(CertificateCancelDeletionOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<CertificateCancelDeletionHeaders>> CancelDeletionWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateCancelDeletionOptions certificateCancelDeletionOptions = default(CertificateCancelDeletionOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes a certificate from the specified account.
         /// </summary>
@@ -137,7 +142,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<CertificateDeleteHeaders>> DeleteWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateDeleteOptions certificateDeleteOptions = default(CertificateDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<CertificateDeleteHeaders>> DeleteWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateDeleteOptions certificateDeleteOptions = default(CertificateDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets information about the specified certificate.
         /// </summary>
@@ -166,7 +171,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Certificate,CertificateGetHeaders>> GetWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateGetOptions certificateGetOptions = default(CertificateGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<Certificate,CertificateGetHeaders>> GetWithHttpMessagesAsync(string thumbprintAlgorithm, string thumbprint, CertificateGetOptions certificateGetOptions = default(CertificateGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the certificates that have been added to the specified
         /// account.
@@ -192,6 +197,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<Certificate>,CertificateListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, CertificateListNextOptions certificateListNextOptions = default(CertificateListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<Certificate>,CertificateListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, CertificateListNextOptions certificateListNextOptions = default(CertificateListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IComputeNodeOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IComputeNodeOperations.cs
@@ -8,8 +8,14 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// ComputeNodeOperations operations.
@@ -47,7 +53,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeAddUserHeaders>> AddUserWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeUser user, ComputeNodeAddUserOptions computeNodeAddUserOptions = default(ComputeNodeAddUserOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<ComputeNodeAddUserHeaders>> AddUserWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeUser user, ComputeNodeAddUserOptions computeNodeAddUserOptions = default(ComputeNodeAddUserOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes a user account from the specified compute node.
         /// </summary>
@@ -79,9 +85,9 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeDeleteUserHeaders>> DeleteUserWithHttpMessagesAsync(string poolId, string nodeId, string userName, ComputeNodeDeleteUserOptions computeNodeDeleteUserOptions = default(ComputeNodeDeleteUserOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<ComputeNodeDeleteUserHeaders>> DeleteUserWithHttpMessagesAsync(string poolId, string nodeId, string userName, ComputeNodeDeleteUserOptions computeNodeDeleteUserOptions = default(ComputeNodeDeleteUserOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
-        /// Updates the password or expiration time of a user account on the
+        /// Updates the password and expiration time of a user account on the
         /// specified compute node.
         /// </summary>
         /// <remarks>
@@ -118,7 +124,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeUpdateUserHeaders>> UpdateUserWithHttpMessagesAsync(string poolId, string nodeId, string userName, NodeUpdateUserParameter nodeUpdateUserParameter, ComputeNodeUpdateUserOptions computeNodeUpdateUserOptions = default(ComputeNodeUpdateUserOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<ComputeNodeUpdateUserHeaders>> UpdateUserWithHttpMessagesAsync(string poolId, string nodeId, string userName, NodeUpdateUserParameter nodeUpdateUserParameter, ComputeNodeUpdateUserOptions computeNodeUpdateUserOptions = default(ComputeNodeUpdateUserOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets information about the specified compute node.
         /// </summary>
@@ -146,7 +152,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<ComputeNode,ComputeNodeGetHeaders>> GetWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetOptions computeNodeGetOptions = default(ComputeNodeGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<ComputeNode,ComputeNodeGetHeaders>> GetWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetOptions computeNodeGetOptions = default(ComputeNodeGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Restarts the specified compute node.
         /// </summary>
@@ -161,8 +167,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </param>
         /// <param name='nodeRebootOption'>
         /// When to reboot the compute node and what to do with currently
-        /// running tasks. The default value is requeue. Possible values
-        /// include: 'requeue', 'terminate', 'taskCompletion', 'retainedData'
+        /// running tasks. Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks.
+        /// The tasks will run again when a node is available. Restart the node
+        /// as soon as tasks have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again.
+        /// Restart the node as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete.
+        /// Schedule no new tasks while waiting. Restart the node when all
+        /// tasks have completed.
+        /// retaineddata - Allow currently running tasks to complete, then wait
+        /// for all task data retention periods to expire. Schedule no new
+        /// tasks while waiting. Restart the node when all task retention
+        /// periods have expired.
+        ///
+        /// The default value is requeue. Possible values include: 'requeue',
+        /// 'terminate', 'taskCompletion', 'retainedData'
         /// </param>
         /// <param name='computeNodeRebootOptions'>
         /// Additional parameters for the operation
@@ -179,7 +200,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeRebootHeaders>> RebootWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeRebootOption? nodeRebootOption = default(ComputeNodeRebootOption?), ComputeNodeRebootOptions computeNodeRebootOptions = default(ComputeNodeRebootOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<ComputeNodeRebootHeaders>> RebootWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeRebootOption? nodeRebootOption = default(ComputeNodeRebootOption?), ComputeNodeRebootOptions computeNodeRebootOptions = default(ComputeNodeRebootOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Reinstalls the operating system on the specified compute node.
         /// </summary>
@@ -196,8 +217,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </param>
         /// <param name='nodeReimageOption'>
         /// When to reimage the compute node and what to do with currently
-        /// running tasks. The default value is requeue. Possible values
-        /// include: 'requeue', 'terminate', 'taskCompletion', 'retainedData'
+        /// running tasks. Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks.
+        /// The tasks will run again when a node is available. Reimage the node
+        /// as soon as tasks have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again.
+        /// Reimage the node as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete.
+        /// Schedule no new tasks while waiting. Reimage the node when all
+        /// tasks have completed.
+        /// retaineddata - Allow currently running tasks to complete, then wait
+        /// for all task data retention periods to expire. Schedule no new
+        /// tasks while waiting. Reimage the node when all task retention
+        /// periods have expired.
+        ///
+        /// The default value is requeue. Possible values include: 'requeue',
+        /// 'terminate', 'taskCompletion', 'retainedData'
         /// </param>
         /// <param name='computeNodeReimageOptions'>
         /// Additional parameters for the operation
@@ -214,10 +250,14 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeReimageHeaders>> ReimageWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeReimageOption? nodeReimageOption = default(ComputeNodeReimageOption?), ComputeNodeReimageOptions computeNodeReimageOptions = default(ComputeNodeReimageOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<ComputeNodeReimageHeaders>> ReimageWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeReimageOption? nodeReimageOption = default(ComputeNodeReimageOption?), ComputeNodeReimageOptions computeNodeReimageOptions = default(ComputeNodeReimageOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Disables task scheduling on the specified compute node.
         /// </summary>
+        /// <remarks>
+        /// You can disable task scheduling on a node only if its current
+        /// scheduling state is enabled.
+        /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool that contains the compute node.
         /// </param>
@@ -227,8 +267,20 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </param>
         /// <param name='nodeDisableSchedulingOption'>
         /// What to do with currently running tasks when disabling task
-        /// scheduling on the compute node. The default value is requeue.
-        /// Possible values include: 'requeue', 'terminate', 'taskCompletion'
+        /// scheduling on the compute node. Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks.
+        /// The tasks may run again on other compute nodes, or when task
+        /// scheduling is re-enabled on this node. Enter offline state as soon
+        /// as tasks have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again.
+        /// Enter offline state as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete.
+        /// Schedule no new tasks while waiting. Enter offline state when all
+        /// tasks have completed.
+        ///
+        /// The default value is requeue. Possible values include: 'requeue',
+        /// 'terminate', 'taskCompletion'
         /// </param>
         /// <param name='computeNodeDisableSchedulingOptions'>
         /// Additional parameters for the operation
@@ -245,10 +297,14 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeDisableSchedulingHeaders>> DisableSchedulingWithHttpMessagesAsync(string poolId, string nodeId, DisableComputeNodeSchedulingOption? nodeDisableSchedulingOption = default(DisableComputeNodeSchedulingOption?), ComputeNodeDisableSchedulingOptions computeNodeDisableSchedulingOptions = default(ComputeNodeDisableSchedulingOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<ComputeNodeDisableSchedulingHeaders>> DisableSchedulingWithHttpMessagesAsync(string poolId, string nodeId, DisableComputeNodeSchedulingOption? nodeDisableSchedulingOption = default(DisableComputeNodeSchedulingOption?), ComputeNodeDisableSchedulingOptions computeNodeDisableSchedulingOptions = default(ComputeNodeDisableSchedulingOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Enables task scheduling on the specified compute node.
         /// </summary>
+        /// <remarks>
+        /// You can enable task scheduling on a node only if its current
+        /// scheduling state is disabled
+        /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool that contains the compute node.
         /// </param>
@@ -271,7 +327,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<ComputeNodeEnableSchedulingHeaders>> EnableSchedulingWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeEnableSchedulingOptions computeNodeEnableSchedulingOptions = default(ComputeNodeEnableSchedulingOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<ComputeNodeEnableSchedulingHeaders>> EnableSchedulingWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeEnableSchedulingOptions computeNodeEnableSchedulingOptions = default(ComputeNodeEnableSchedulingOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets the settings required for remote login to a compute node.
         /// </summary>
@@ -279,7 +335,8 @@ namespace Microsoft.Azure.Batch.Protocol
         /// Before you can remotely login to a node using the remote login
         /// settings, you must create a user account on the node. This API can
         /// be invoked only on pools created with the virtual machine
-        /// configuration property.
+        /// configuration property. For pools created with a cloud service
+        /// configuration, see the GetRemoteDesktop API.
         /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool that contains the compute node.
@@ -306,7 +363,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<ComputeNodeGetRemoteLoginSettingsResult,ComputeNodeGetRemoteLoginSettingsHeaders>> GetRemoteLoginSettingsWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetRemoteLoginSettingsOptions computeNodeGetRemoteLoginSettingsOptions = default(ComputeNodeGetRemoteLoginSettingsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<ComputeNodeGetRemoteLoginSettingsResult,ComputeNodeGetRemoteLoginSettingsHeaders>> GetRemoteLoginSettingsWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetRemoteLoginSettingsOptions computeNodeGetRemoteLoginSettingsOptions = default(ComputeNodeGetRemoteLoginSettingsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets the Remote Desktop Protocol file for the specified compute
         /// node.
@@ -314,7 +371,9 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <remarks>
         /// Before you can access a node by using the RDP file, you must create
         /// a user account on the node. This API can only be invoked on pools
-        /// created with the cloud service configuration property.
+        /// created with a cloud service configuration. For pools created with
+        /// a virtual machine configuration, see the GetRemoteLoginSettings
+        /// API.
         /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool that contains the compute node.
@@ -341,7 +400,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,ComputeNodeGetRemoteDesktopHeaders>> GetRemoteDesktopWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetRemoteDesktopOptions computeNodeGetRemoteDesktopOptions = default(ComputeNodeGetRemoteDesktopOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<Stream,ComputeNodeGetRemoteDesktopHeaders>> GetRemoteDesktopWithHttpMessagesAsync(string poolId, string nodeId, ComputeNodeGetRemoteDesktopOptions computeNodeGetRemoteDesktopOptions = default(ComputeNodeGetRemoteDesktopOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the compute nodes in the specified pool.
         /// </summary>
@@ -366,7 +425,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ComputeNode>,ComputeNodeListHeaders>> ListWithHttpMessagesAsync(string poolId, ComputeNodeListOptions computeNodeListOptions = default(ComputeNodeListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<ComputeNode>,ComputeNodeListHeaders>> ListWithHttpMessagesAsync(string poolId, ComputeNodeListOptions computeNodeListOptions = default(ComputeNodeListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the compute nodes in the specified pool.
         /// </summary>
@@ -391,6 +450,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<ComputeNode>,ComputeNodeListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, ComputeNodeListNextOptions computeNodeListNextOptions = default(ComputeNodeListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<ComputeNode>,ComputeNodeListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, ComputeNodeListNextOptions computeNodeListNextOptions = default(ComputeNodeListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IFileOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IFileOperations.cs
@@ -8,8 +8,14 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// FileOperations operations.
@@ -27,7 +33,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// The ID of the task whose file you want to delete.
         /// </param>
         /// <param name='filePath'>
-        /// The path to the task file that you want to delete.
+        /// The path to the task file or directory that you want to delete.
         /// </param>
         /// <param name='recursive'>
         /// Whether to delete children of a directory. If the filePath
@@ -51,7 +57,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileDeleteFromTaskHeaders>> DeleteFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, bool? recursive = default(bool?), FileDeleteFromTaskOptions fileDeleteFromTaskOptions = default(FileDeleteFromTaskOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<FileDeleteFromTaskHeaders>> DeleteFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, bool? recursive = default(bool?), FileDeleteFromTaskOptions fileDeleteFromTaskOptions = default(FileDeleteFromTaskOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Returns the content of the specified task file.
         /// </summary>
@@ -82,7 +88,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,FileGetFromTaskHeaders>> GetFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, FileGetFromTaskOptions fileGetFromTaskOptions = default(FileGetFromTaskOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<Stream,FileGetFromTaskHeaders>> GetFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, FileGetFromTaskOptions fileGetFromTaskOptions = default(FileGetFromTaskOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets the properties of the specified task file.
         /// </summary>
@@ -110,7 +116,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileGetPropertiesFromTaskHeaders>> GetPropertiesFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, FileGetPropertiesFromTaskOptions fileGetPropertiesFromTaskOptions = default(FileGetPropertiesFromTaskOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<FileGetPropertiesFromTaskHeaders>> GetPropertiesFromTaskWithHttpMessagesAsync(string jobId, string taskId, string filePath, FileGetPropertiesFromTaskOptions fileGetPropertiesFromTaskOptions = default(FileGetPropertiesFromTaskOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes the specified file from the compute node.
         /// </summary>
@@ -121,7 +127,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// The ID of the compute node from which you want to delete the file.
         /// </param>
         /// <param name='filePath'>
-        /// The path to the file that you want to delete.
+        /// The path to the file or directory that you want to delete.
         /// </param>
         /// <param name='recursive'>
         /// Whether to delete children of a directory. If the filePath
@@ -145,7 +151,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileDeleteFromComputeNodeHeaders>> DeleteFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, bool? recursive = default(bool?), FileDeleteFromComputeNodeOptions fileDeleteFromComputeNodeOptions = default(FileDeleteFromComputeNodeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<FileDeleteFromComputeNodeHeaders>> DeleteFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, bool? recursive = default(bool?), FileDeleteFromComputeNodeOptions fileDeleteFromComputeNodeOptions = default(FileDeleteFromComputeNodeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Returns the content of the specified compute node file.
         /// </summary>
@@ -177,7 +183,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<System.IO.Stream,FileGetFromComputeNodeHeaders>> GetFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, FileGetFromComputeNodeOptions fileGetFromComputeNodeOptions = default(FileGetFromComputeNodeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<Stream,FileGetFromComputeNodeHeaders>> GetFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, FileGetFromComputeNodeOptions fileGetFromComputeNodeOptions = default(FileGetFromComputeNodeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets the properties of the specified compute node file.
         /// </summary>
@@ -206,7 +212,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<FileGetPropertiesFromComputeNodeHeaders>> GetPropertiesFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, FileGetPropertiesFromComputeNodeOptions fileGetPropertiesFromComputeNodeOptions = default(FileGetPropertiesFromComputeNodeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<FileGetPropertiesFromComputeNodeHeaders>> GetPropertiesFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, string filePath, FileGetPropertiesFromComputeNodeOptions fileGetPropertiesFromComputeNodeOptions = default(FileGetPropertiesFromComputeNodeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the files in a task's directory on its compute node.
         /// </summary>
@@ -217,9 +223,9 @@ namespace Microsoft.Azure.Batch.Protocol
         /// The ID of the task whose files you want to list.
         /// </param>
         /// <param name='recursive'>
-        /// Whether to list children of a directory. This parameter can be used
-        /// in combination with the filter parameter to list specific type of
-        /// files.
+        /// Whether to list children of the task directory. This parameter can
+        /// be used in combination with the filter parameter to list specific
+        /// type of files.
         /// </param>
         /// <param name='fileListFromTaskOptions'>
         /// Additional parameters for the operation
@@ -239,7 +245,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromTaskHeaders>> ListFromTaskWithHttpMessagesAsync(string jobId, string taskId, bool? recursive = default(bool?), FileListFromTaskOptions fileListFromTaskOptions = default(FileListFromTaskOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<NodeFile>,FileListFromTaskHeaders>> ListFromTaskWithHttpMessagesAsync(string jobId, string taskId, bool? recursive = default(bool?), FileListFromTaskOptions fileListFromTaskOptions = default(FileListFromTaskOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the files in task directories on the specified compute
         /// node.
@@ -271,7 +277,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromComputeNodeHeaders>> ListFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, bool? recursive = default(bool?), FileListFromComputeNodeOptions fileListFromComputeNodeOptions = default(FileListFromComputeNodeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<NodeFile>,FileListFromComputeNodeHeaders>> ListFromComputeNodeWithHttpMessagesAsync(string poolId, string nodeId, bool? recursive = default(bool?), FileListFromComputeNodeOptions fileListFromComputeNodeOptions = default(FileListFromComputeNodeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the files in a task's directory on its compute node.
         /// </summary>
@@ -296,7 +302,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromTaskHeaders>> ListFromTaskNextWithHttpMessagesAsync(string nextPageLink, FileListFromTaskNextOptions fileListFromTaskNextOptions = default(FileListFromTaskNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<NodeFile>,FileListFromTaskHeaders>> ListFromTaskNextWithHttpMessagesAsync(string nextPageLink, FileListFromTaskNextOptions fileListFromTaskNextOptions = default(FileListFromTaskNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the files in task directories on the specified compute
         /// node.
@@ -322,6 +328,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<NodeFile>,FileListFromComputeNodeHeaders>> ListFromComputeNodeNextWithHttpMessagesAsync(string nextPageLink, FileListFromComputeNodeNextOptions fileListFromComputeNodeNextOptions = default(FileListFromComputeNodeNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<NodeFile>,FileListFromComputeNodeHeaders>> ListFromComputeNodeNextWithHttpMessagesAsync(string nextPageLink, FileListFromComputeNodeNextOptions fileListFromComputeNodeNextOptions = default(FileListFromComputeNodeNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IJobOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IJobOperations.cs
@@ -8,8 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// JobOperations operations.
@@ -43,7 +48,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<JobStatistics,JobGetAllLifetimeStatisticsHeaders>> GetAllLifetimeStatisticsWithHttpMessagesAsync(JobGetAllLifetimeStatisticsOptions jobGetAllLifetimeStatisticsOptions = default(JobGetAllLifetimeStatisticsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<JobStatistics,JobGetAllLifetimeStatisticsHeaders>> GetAllLifetimeStatisticsWithHttpMessagesAsync(JobGetAllLifetimeStatisticsOptions jobGetAllLifetimeStatisticsOptions = default(JobGetAllLifetimeStatisticsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes a job.
         /// </summary>
@@ -52,7 +57,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// and all job statistics. This also overrides the retention period
         /// for task data; that is, if the job contains tasks which are still
         /// retained on compute nodes, the Batch services deletes those tasks'
-        /// working directories and all their contents.
+        /// working directories and all their contents.  When a Delete Job
+        /// request is received, the Batch service sets the job to the deleting
+        /// state. All update operations on a job that is in deleting state
+        /// will fail with status code 409 (Conflict), with additional
+        /// information indicating that the job is being deleted.
         /// </remarks>
         /// <param name='jobId'>
         /// The ID of the job to delete.
@@ -72,7 +81,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobId, JobDeleteOptions jobDeleteOptions = default(JobDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobId, JobDeleteOptions jobDeleteOptions = default(JobDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets information about the specified job.
         /// </summary>
@@ -97,7 +106,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudJob,JobGetHeaders>> GetWithHttpMessagesAsync(string jobId, JobGetOptions jobGetOptions = default(JobGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<CloudJob,JobGetHeaders>> GetWithHttpMessagesAsync(string jobId, JobGetOptions jobGetOptions = default(JobGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Updates the properties of the specified job.
         /// </summary>
@@ -128,7 +137,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobPatchHeaders>> PatchWithHttpMessagesAsync(string jobId, JobPatchParameter jobPatchParameter, JobPatchOptions jobPatchOptions = default(JobPatchOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobPatchHeaders>> PatchWithHttpMessagesAsync(string jobId, JobPatchParameter jobPatchParameter, JobPatchOptions jobPatchOptions = default(JobPatchOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Updates the properties of the specified job.
         /// </summary>
@@ -159,7 +168,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobId, JobUpdateParameter jobUpdateParameter, JobUpdateOptions jobUpdateOptions = default(JobUpdateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobId, JobUpdateParameter jobUpdateParameter, JobUpdateOptions jobUpdateOptions = default(JobUpdateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Disables the specified job, preventing new tasks from running.
         /// </summary>
@@ -178,11 +187,13 @@ namespace Microsoft.Azure.Batch.Protocol
         /// The ID of the job to disable.
         /// </param>
         /// <param name='disableTasks'>
-        /// What to do with active tasks associated with the job. requeue -
-        /// Terminate running tasks and requeue them. The tasks will run again
-        /// when the job is enabled. terminate - Terminate running tasks. The
-        /// tasks will not run again. wait - Allow currently running tasks to
-        /// complete. Possible values include: 'requeue', 'terminate', 'wait'
+        /// What to do with active tasks associated with the job. Values are:
+        ///
+        /// requeue - Terminate running tasks and requeue them. The tasks will
+        /// run again when the job is enabled.
+        /// terminate - Terminate running tasks. The tasks will not run again.
+        /// wait - Allow currently running tasks to complete. Possible values
+        /// include: 'requeue', 'terminate', 'wait'
         /// </param>
         /// <param name='jobDisableOptions'>
         /// Additional parameters for the operation
@@ -199,7 +210,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobDisableHeaders>> DisableWithHttpMessagesAsync(string jobId, DisableJobOption disableTasks, JobDisableOptions jobDisableOptions = default(JobDisableOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobDisableHeaders>> DisableWithHttpMessagesAsync(string jobId, DisableJobOption disableTasks, JobDisableOptions jobDisableOptions = default(JobDisableOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Enables the specified job, allowing new tasks to run.
         /// </summary>
@@ -230,7 +241,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobEnableHeaders>> EnableWithHttpMessagesAsync(string jobId, JobEnableOptions jobEnableOptions = default(JobEnableOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobEnableHeaders>> EnableWithHttpMessagesAsync(string jobId, JobEnableOptions jobEnableOptions = default(JobEnableOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Terminates the specified job, marking it as completed.
         /// </summary>
@@ -263,7 +274,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobId, string terminateReason = default(string), JobTerminateOptions jobTerminateOptions = default(JobTerminateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobId, string terminateReason = default(string), JobTerminateOptions jobTerminateOptions = default(JobTerminateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Adds a job to the specified account.
         /// </summary>
@@ -297,7 +308,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobAddHeaders>> AddWithHttpMessagesAsync(JobAddParameter job, JobAddOptions jobAddOptions = default(JobAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobAddHeaders>> AddWithHttpMessagesAsync(JobAddParameter job, JobAddOptions jobAddOptions = default(JobAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the jobs in the specified account.
         /// </summary>
@@ -319,7 +330,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListHeaders>> ListWithHttpMessagesAsync(JobListOptions jobListOptions = default(JobListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudJob>,JobListHeaders>> ListWithHttpMessagesAsync(JobListOptions jobListOptions = default(JobListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the jobs that have been created under the specified job
         /// schedule.
@@ -346,7 +357,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListFromJobScheduleHeaders>> ListFromJobScheduleWithHttpMessagesAsync(string jobScheduleId, JobListFromJobScheduleOptions jobListFromJobScheduleOptions = default(JobListFromJobScheduleOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudJob>,JobListFromJobScheduleHeaders>> ListFromJobScheduleWithHttpMessagesAsync(string jobScheduleId, JobListFromJobScheduleOptions jobListFromJobScheduleOptions = default(JobListFromJobScheduleOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the execution status of the Job Preparation and Job Release
         /// task for the specified job across the compute nodes where the job
@@ -356,7 +367,9 @@ namespace Microsoft.Azure.Batch.Protocol
         /// This API returns the Job Preparation and Job Release task status on
         /// all compute nodes that have run the Job Preparation or Job Release
         /// task. This includes nodes which have since been removed from the
-        /// pool.
+        /// pool. If this API is invoked on a job which has no Job Preparation
+        /// or Job Release task, the Batch service returns HTTP status code 409
+        /// (Conflict) with an error code of JobPreparationTaskNotSpecified.
         /// </remarks>
         /// <param name='jobId'>
         /// The ID of the job.
@@ -379,7 +392,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>> ListPreparationAndReleaseTaskStatusWithHttpMessagesAsync(string jobId, JobListPreparationAndReleaseTaskStatusOptions jobListPreparationAndReleaseTaskStatusOptions = default(JobListPreparationAndReleaseTaskStatusOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>> ListPreparationAndReleaseTaskStatusWithHttpMessagesAsync(string jobId, JobListPreparationAndReleaseTaskStatusOptions jobListPreparationAndReleaseTaskStatusOptions = default(JobListPreparationAndReleaseTaskStatusOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets the task counts for the specified job.
         /// </summary>
@@ -413,7 +426,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<TaskCounts,JobGetTaskCountsHeaders>> GetTaskCountsWithHttpMessagesAsync(string jobId, JobGetTaskCountsOptions jobGetTaskCountsOptions = default(JobGetTaskCountsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<TaskCounts,JobGetTaskCountsHeaders>> GetTaskCountsWithHttpMessagesAsync(string jobId, JobGetTaskCountsOptions jobGetTaskCountsOptions = default(JobGetTaskCountsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the jobs in the specified account.
         /// </summary>
@@ -438,7 +451,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, JobListNextOptions jobListNextOptions = default(JobListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudJob>,JobListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, JobListNextOptions jobListNextOptions = default(JobListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the jobs that have been created under the specified job
         /// schedule.
@@ -464,7 +477,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListFromJobScheduleHeaders>> ListFromJobScheduleNextWithHttpMessagesAsync(string nextPageLink, JobListFromJobScheduleNextOptions jobListFromJobScheduleNextOptions = default(JobListFromJobScheduleNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudJob>,JobListFromJobScheduleHeaders>> ListFromJobScheduleNextWithHttpMessagesAsync(string nextPageLink, JobListFromJobScheduleNextOptions jobListFromJobScheduleNextOptions = default(JobListFromJobScheduleNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the execution status of the Job Preparation and Job Release
         /// task for the specified job across the compute nodes where the job
@@ -474,7 +487,9 @@ namespace Microsoft.Azure.Batch.Protocol
         /// This API returns the Job Preparation and Job Release task status on
         /// all compute nodes that have run the Job Preparation or Job Release
         /// task. This includes nodes which have since been removed from the
-        /// pool.
+        /// pool. If this API is invoked on a job which has no Job Preparation
+        /// or Job Release task, the Batch service returns HTTP status code 409
+        /// (Conflict) with an error code of JobPreparationTaskNotSpecified.
         /// </remarks>
         /// <param name='nextPageLink'>
         /// The NextLink from the previous successful call to List operation.
@@ -497,6 +512,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>> ListPreparationAndReleaseTaskStatusNextWithHttpMessagesAsync(string nextPageLink, JobListPreparationAndReleaseTaskStatusNextOptions jobListPreparationAndReleaseTaskStatusNextOptions = default(JobListPreparationAndReleaseTaskStatusNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>> ListPreparationAndReleaseTaskStatusNextWithHttpMessagesAsync(string nextPageLink, JobListPreparationAndReleaseTaskStatusNextOptions jobListPreparationAndReleaseTaskStatusNextOptions = default(JobListPreparationAndReleaseTaskStatusNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IJobScheduleOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IJobScheduleOperations.cs
@@ -8,8 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// JobScheduleOperations operations.
@@ -37,7 +42,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<bool,JobScheduleExistsHeaders>> ExistsWithHttpMessagesAsync(string jobScheduleId, JobScheduleExistsOptions jobScheduleExistsOptions = default(JobScheduleExistsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<bool,JobScheduleExistsHeaders>> ExistsWithHttpMessagesAsync(string jobScheduleId, JobScheduleExistsOptions jobScheduleExistsOptions = default(JobScheduleExistsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes a job schedule from the specified account.
         /// </summary>
@@ -67,7 +72,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobScheduleId, JobScheduleDeleteOptions jobScheduleDeleteOptions = default(JobScheduleDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobScheduleDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobScheduleId, JobScheduleDeleteOptions jobScheduleDeleteOptions = default(JobScheduleDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets information about the specified job schedule.
         /// </summary>
@@ -92,7 +97,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudJobSchedule,JobScheduleGetHeaders>> GetWithHttpMessagesAsync(string jobScheduleId, JobScheduleGetOptions jobScheduleGetOptions = default(JobScheduleGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<CloudJobSchedule,JobScheduleGetHeaders>> GetWithHttpMessagesAsync(string jobScheduleId, JobScheduleGetOptions jobScheduleGetOptions = default(JobScheduleGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Updates the properties of the specified job schedule.
         /// </summary>
@@ -125,7 +130,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobSchedulePatchHeaders>> PatchWithHttpMessagesAsync(string jobScheduleId, JobSchedulePatchParameter jobSchedulePatchParameter, JobSchedulePatchOptions jobSchedulePatchOptions = default(JobSchedulePatchOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobSchedulePatchHeaders>> PatchWithHttpMessagesAsync(string jobScheduleId, JobSchedulePatchParameter jobSchedulePatchParameter, JobSchedulePatchOptions jobSchedulePatchOptions = default(JobSchedulePatchOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Updates the properties of the specified job schedule.
         /// </summary>
@@ -158,7 +163,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobScheduleId, JobScheduleUpdateParameter jobScheduleUpdateParameter, JobScheduleUpdateOptions jobScheduleUpdateOptions = default(JobScheduleUpdateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobScheduleUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobScheduleId, JobScheduleUpdateParameter jobScheduleUpdateParameter, JobScheduleUpdateOptions jobScheduleUpdateOptions = default(JobScheduleUpdateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Disables a job schedule.
         /// </summary>
@@ -184,7 +189,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleDisableHeaders>> DisableWithHttpMessagesAsync(string jobScheduleId, JobScheduleDisableOptions jobScheduleDisableOptions = default(JobScheduleDisableOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobScheduleDisableHeaders>> DisableWithHttpMessagesAsync(string jobScheduleId, JobScheduleDisableOptions jobScheduleDisableOptions = default(JobScheduleDisableOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Enables a job schedule.
         /// </summary>
@@ -206,7 +211,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleEnableHeaders>> EnableWithHttpMessagesAsync(string jobScheduleId, JobScheduleEnableOptions jobScheduleEnableOptions = default(JobScheduleEnableOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobScheduleEnableHeaders>> EnableWithHttpMessagesAsync(string jobScheduleId, JobScheduleEnableOptions jobScheduleEnableOptions = default(JobScheduleEnableOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Terminates a job schedule.
         /// </summary>
@@ -228,7 +233,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobScheduleId, JobScheduleTerminateOptions jobScheduleTerminateOptions = default(JobScheduleTerminateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobScheduleTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobScheduleId, JobScheduleTerminateOptions jobScheduleTerminateOptions = default(JobScheduleTerminateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Adds a job schedule to the specified account.
         /// </summary>
@@ -250,7 +255,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleAddHeaders>> AddWithHttpMessagesAsync(JobScheduleAddParameter cloudJobSchedule, JobScheduleAddOptions jobScheduleAddOptions = default(JobScheduleAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<JobScheduleAddHeaders>> AddWithHttpMessagesAsync(JobScheduleAddParameter cloudJobSchedule, JobScheduleAddOptions jobScheduleAddOptions = default(JobScheduleAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the job schedules in the specified account.
         /// </summary>
@@ -272,7 +277,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJobSchedule>,JobScheduleListHeaders>> ListWithHttpMessagesAsync(JobScheduleListOptions jobScheduleListOptions = default(JobScheduleListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudJobSchedule>,JobScheduleListHeaders>> ListWithHttpMessagesAsync(JobScheduleListOptions jobScheduleListOptions = default(JobScheduleListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the job schedules in the specified account.
         /// </summary>
@@ -297,6 +302,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJobSchedule>,JobScheduleListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, JobScheduleListNextOptions jobScheduleListNextOptions = default(JobScheduleListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudJobSchedule>,JobScheduleListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, JobScheduleListNextOptions jobScheduleListNextOptions = default(JobScheduleListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IPoolOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/IPoolOperations.cs
@@ -8,8 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// PoolOperations operations.
@@ -23,7 +28,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <remarks>
         /// If you do not specify a $filter clause including a poolId, the
         /// response includes all pools that existed in the account in the time
-        /// range of the returned aggregation intervals.
+        /// range of the returned aggregation intervals. If you do not specify
+        /// a $filter clause including a startTime or endTime these filters
+        /// default to the start and end times of the last aggregation interval
+        /// currently available; that is, only the last aggregation interval is
+        /// returned.
         /// </remarks>
         /// <param name='poolListUsageMetricsOptions'>
         /// Additional parameters for the operation
@@ -43,7 +52,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<PoolUsageMetrics>,PoolListUsageMetricsHeaders>> ListUsageMetricsWithHttpMessagesAsync(PoolListUsageMetricsOptions poolListUsageMetricsOptions = default(PoolListUsageMetricsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<PoolUsageMetrics>,PoolListUsageMetricsHeaders>> ListUsageMetricsWithHttpMessagesAsync(PoolListUsageMetricsOptions poolListUsageMetricsOptions = default(PoolListUsageMetricsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets lifetime summary statistics for all of the pools in the
         /// specified account.
@@ -71,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<PoolStatistics,PoolGetAllLifetimeStatisticsHeaders>> GetAllLifetimeStatisticsWithHttpMessagesAsync(PoolGetAllLifetimeStatisticsOptions poolGetAllLifetimeStatisticsOptions = default(PoolGetAllLifetimeStatisticsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<PoolStatistics,PoolGetAllLifetimeStatisticsHeaders>> GetAllLifetimeStatisticsWithHttpMessagesAsync(PoolGetAllLifetimeStatisticsOptions poolGetAllLifetimeStatisticsOptions = default(PoolGetAllLifetimeStatisticsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Adds a pool to the specified account.
         /// </summary>
@@ -98,7 +107,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolAddHeaders>> AddWithHttpMessagesAsync(PoolAddParameter pool, PoolAddOptions poolAddOptions = default(PoolAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolAddHeaders>> AddWithHttpMessagesAsync(PoolAddParameter pool, PoolAddOptions poolAddOptions = default(PoolAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the pools in the specified account.
         /// </summary>
@@ -120,7 +129,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudPool>,PoolListHeaders>> ListWithHttpMessagesAsync(PoolListOptions poolListOptions = default(PoolListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudPool>,PoolListHeaders>> ListWithHttpMessagesAsync(PoolListOptions poolListOptions = default(PoolListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes a pool from the specified account.
         /// </summary>
@@ -158,7 +167,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolDeleteHeaders>> DeleteWithHttpMessagesAsync(string poolId, PoolDeleteOptions poolDeleteOptions = default(PoolDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolDeleteHeaders>> DeleteWithHttpMessagesAsync(string poolId, PoolDeleteOptions poolDeleteOptions = default(PoolDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets basic properties of a pool.
         /// </summary>
@@ -180,7 +189,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<bool,PoolExistsHeaders>> ExistsWithHttpMessagesAsync(string poolId, PoolExistsOptions poolExistsOptions = default(PoolExistsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<bool,PoolExistsHeaders>> ExistsWithHttpMessagesAsync(string poolId, PoolExistsOptions poolExistsOptions = default(PoolExistsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets information about the specified pool.
         /// </summary>
@@ -205,7 +214,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudPool,PoolGetHeaders>> GetWithHttpMessagesAsync(string poolId, PoolGetOptions poolGetOptions = default(PoolGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<CloudPool,PoolGetHeaders>> GetWithHttpMessagesAsync(string poolId, PoolGetOptions poolGetOptions = default(PoolGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Updates the properties of the specified pool.
         /// </summary>
@@ -236,7 +245,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolPatchHeaders>> PatchWithHttpMessagesAsync(string poolId, PoolPatchParameter poolPatchParameter, PoolPatchOptions poolPatchOptions = default(PoolPatchOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolPatchHeaders>> PatchWithHttpMessagesAsync(string poolId, PoolPatchParameter poolPatchParameter, PoolPatchOptions poolPatchOptions = default(PoolPatchOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Disables automatic scaling for a pool.
         /// </summary>
@@ -258,7 +267,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolDisableAutoScaleHeaders>> DisableAutoScaleWithHttpMessagesAsync(string poolId, PoolDisableAutoScaleOptions poolDisableAutoScaleOptions = default(PoolDisableAutoScaleOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolDisableAutoScaleHeaders>> DisableAutoScaleWithHttpMessagesAsync(string poolId, PoolDisableAutoScaleOptions poolDisableAutoScaleOptions = default(PoolDisableAutoScaleOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Enables automatic scaling for a pool.
         /// </summary>
@@ -292,7 +301,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolEnableAutoScaleHeaders>> EnableAutoScaleWithHttpMessagesAsync(string poolId, PoolEnableAutoScaleParameter poolEnableAutoScaleParameter, PoolEnableAutoScaleOptions poolEnableAutoScaleOptions = default(PoolEnableAutoScaleOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolEnableAutoScaleHeaders>> EnableAutoScaleWithHttpMessagesAsync(string poolId, PoolEnableAutoScaleParameter poolEnableAutoScaleParameter, PoolEnableAutoScaleOptions poolEnableAutoScaleOptions = default(PoolEnableAutoScaleOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets the result of evaluating an automatic scaling formula on the
         /// pool.
@@ -300,6 +309,8 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <remarks>
         /// This API is primarily for validating an autoscale formula, as it
         /// simply returns the result without applying the formula to the pool.
+        /// The pool must have auto scaling enabled in order to evaluate a
+        /// formula.
         /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool on which to evaluate the automatic scaling
@@ -332,7 +343,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<AutoScaleRun,PoolEvaluateAutoScaleHeaders>> EvaluateAutoScaleWithHttpMessagesAsync(string poolId, string autoScaleFormula, PoolEvaluateAutoScaleOptions poolEvaluateAutoScaleOptions = default(PoolEvaluateAutoScaleOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<AutoScaleRun,PoolEvaluateAutoScaleHeaders>> EvaluateAutoScaleWithHttpMessagesAsync(string poolId, string autoScaleFormula, PoolEvaluateAutoScaleOptions poolEvaluateAutoScaleOptions = default(PoolEvaluateAutoScaleOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Changes the number of compute nodes that are assigned to a pool.
         /// </summary>
@@ -367,16 +378,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolResizeHeaders>> ResizeWithHttpMessagesAsync(string poolId, PoolResizeParameter poolResizeParameter, PoolResizeOptions poolResizeOptions = default(PoolResizeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolResizeHeaders>> ResizeWithHttpMessagesAsync(string poolId, PoolResizeParameter poolResizeParameter, PoolResizeOptions poolResizeOptions = default(PoolResizeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Stops an ongoing resize operation on the pool.
         /// </summary>
         /// <remarks>
         /// This does not restore the pool to its previous state before the
         /// resize operation: it only stops any further changes being made, and
-        /// the pool maintains its current state. A resize operation need not
-        /// be an explicit resize pool request; this API can also be used to
-        /// halt the initial sizing of the pool when it is created.
+        /// the pool maintains its current state. After stopping, the pool
+        /// stabilizes at the number of nodes it was at when the stop operation
+        /// was done. During the stop operation, the pool allocation state
+        /// changes first to stopping and then to steady. A resize operation
+        /// need not be an explicit resize pool request; this API can also be
+        /// used to halt the initial sizing of the pool when it is created.
         /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool whose resizing you want to stop.
@@ -396,7 +410,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolStopResizeHeaders>> StopResizeWithHttpMessagesAsync(string poolId, PoolStopResizeOptions poolStopResizeOptions = default(PoolStopResizeOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolStopResizeHeaders>> StopResizeWithHttpMessagesAsync(string poolId, PoolStopResizeOptions poolStopResizeOptions = default(PoolStopResizeOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Updates the properties of the specified pool.
         /// </summary>
@@ -427,7 +441,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolUpdatePropertiesHeaders>> UpdatePropertiesWithHttpMessagesAsync(string poolId, PoolUpdatePropertiesParameter poolUpdatePropertiesParameter, PoolUpdatePropertiesOptions poolUpdatePropertiesOptions = default(PoolUpdatePropertiesOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolUpdatePropertiesHeaders>> UpdatePropertiesWithHttpMessagesAsync(string poolId, PoolUpdatePropertiesParameter poolUpdatePropertiesParameter, PoolUpdatePropertiesOptions poolUpdatePropertiesOptions = default(PoolUpdatePropertiesOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Upgrades the operating system of the specified pool.
         /// </summary>
@@ -444,7 +458,13 @@ namespace Microsoft.Azure.Batch.Protocol
         /// pool may be temporarily unavailable to run tasks. When this
         /// operation runs, the pool state changes to upgrading. When all
         /// compute nodes have finished upgrading, the pool state returns to
-        /// active.
+        /// active. While the upgrade is in progress, the pool's
+        /// currentOSVersion reflects the OS version that nodes are upgrading
+        /// from, and targetOSVersion reflects the OS version that nodes are
+        /// upgrading to. Once the upgrade is complete, currentOSVersion is
+        /// updated to reflect the OS version now running on all nodes. This
+        /// operation can only be invoked on pools created with the
+        /// cloudServiceConfiguration property.
         /// </remarks>
         /// <param name='poolId'>
         /// The ID of the pool to upgrade.
@@ -468,7 +488,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolUpgradeOSHeaders>> UpgradeOSWithHttpMessagesAsync(string poolId, string targetOSVersion, PoolUpgradeOSOptions poolUpgradeOSOptions = default(PoolUpgradeOSOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolUpgradeOSHeaders>> UpgradeOSWithHttpMessagesAsync(string poolId, string targetOSVersion, PoolUpgradeOSOptions poolUpgradeOSOptions = default(PoolUpgradeOSOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Removes compute nodes from the specified pool.
         /// </summary>
@@ -498,7 +518,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<PoolRemoveNodesHeaders>> RemoveNodesWithHttpMessagesAsync(string poolId, NodeRemoveParameter nodeRemoveParameter, PoolRemoveNodesOptions poolRemoveNodesOptions = default(PoolRemoveNodesOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<PoolRemoveNodesHeaders>> RemoveNodesWithHttpMessagesAsync(string poolId, NodeRemoveParameter nodeRemoveParameter, PoolRemoveNodesOptions poolRemoveNodesOptions = default(PoolRemoveNodesOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists the usage metrics, aggregated by pool across individual time
         /// intervals, for the specified account.
@@ -506,7 +526,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <remarks>
         /// If you do not specify a $filter clause including a poolId, the
         /// response includes all pools that existed in the account in the time
-        /// range of the returned aggregation intervals.
+        /// range of the returned aggregation intervals. If you do not specify
+        /// a $filter clause including a startTime or endTime these filters
+        /// default to the start and end times of the last aggregation interval
+        /// currently available; that is, only the last aggregation interval is
+        /// returned.
         /// </remarks>
         /// <param name='nextPageLink'>
         /// The NextLink from the previous successful call to List operation.
@@ -529,7 +553,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<PoolUsageMetrics>,PoolListUsageMetricsHeaders>> ListUsageMetricsNextWithHttpMessagesAsync(string nextPageLink, PoolListUsageMetricsNextOptions poolListUsageMetricsNextOptions = default(PoolListUsageMetricsNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<PoolUsageMetrics>,PoolListUsageMetricsHeaders>> ListUsageMetricsNextWithHttpMessagesAsync(string nextPageLink, PoolListUsageMetricsNextOptions poolListUsageMetricsNextOptions = default(PoolListUsageMetricsNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the pools in the specified account.
         /// </summary>
@@ -554,6 +578,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudPool>,PoolListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, PoolListNextOptions poolListNextOptions = default(PoolListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudPool>,PoolListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, PoolListNextOptions poolListNextOptions = default(PoolListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ITaskOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/ITaskOperations.cs
@@ -8,8 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// TaskOperations operations.
@@ -40,7 +45,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskAddHeaders>> AddWithHttpMessagesAsync(string jobId, TaskAddParameter task, TaskAddOptions taskAddOptions = default(TaskAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<TaskAddHeaders>> AddWithHttpMessagesAsync(string jobId, TaskAddParameter task, TaskAddOptions taskAddOptions = default(TaskAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the tasks that are associated with the specified job.
         /// </summary>
@@ -70,7 +75,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudTask>,TaskListHeaders>> ListWithHttpMessagesAsync(string jobId, TaskListOptions taskListOptions = default(TaskListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudTask>,TaskListHeaders>> ListWithHttpMessagesAsync(string jobId, TaskListOptions taskListOptions = default(TaskListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Adds a collection of tasks to the specified job.
         /// </summary>
@@ -82,15 +87,22 @@ namespace Microsoft.Azure.Batch.Protocol
         /// partially or fully processed, or not at all. In such cases, the
         /// user should re-issue the request. Note that it is up to the user to
         /// correctly handle failures when re-issuing a request. For example,
-        /// you should use the same task ids during a retry so that if the
+        /// you should use the same task IDs during a retry so that if the
         /// prior operation succeeded, the retry will not create extra tasks
-        /// unexpectedly.
+        /// unexpectedly. If the response contains any tasks which failed to
+        /// add, a client can retry the request. In a retry, it is most
+        /// efficient to resubmit only tasks that failed to add, and to omit
+        /// tasks that were successfully added on the first attempt.
         /// </remarks>
         /// <param name='jobId'>
         /// The ID of the job to which the task collection is to be added.
         /// </param>
         /// <param name='value'>
-        /// The collection of tasks to add.
+        /// The collection of tasks to add. The total serialized size of this
+        /// collection must be less than 4MB. If it is greater than 4MB (for
+        /// example if each task has 100's of resource files or environment
+        /// variables), the request will fail with code 'RequestBodyTooLarge'
+        /// and should be retried again with fewer tasks.
         /// </param>
         /// <param name='taskAddCollectionOptions'>
         /// Additional parameters for the operation
@@ -110,7 +122,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<TaskAddCollectionResult,TaskAddCollectionHeaders>> AddCollectionWithHttpMessagesAsync(string jobId, System.Collections.Generic.IList<TaskAddParameter> value, TaskAddCollectionOptions taskAddCollectionOptions = default(TaskAddCollectionOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<TaskAddCollectionResult,TaskAddCollectionHeaders>> AddCollectionWithHttpMessagesAsync(string jobId, IList<TaskAddParameter> value, TaskAddCollectionOptions taskAddCollectionOptions = default(TaskAddCollectionOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Deletes a task from the specified job.
         /// </summary>
@@ -142,7 +154,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobId, string taskId, TaskDeleteOptions taskDeleteOptions = default(TaskDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<TaskDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobId, string taskId, TaskDeleteOptions taskDeleteOptions = default(TaskDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets information about the specified task.
         /// </summary>
@@ -175,7 +187,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudTask,TaskGetHeaders>> GetWithHttpMessagesAsync(string jobId, string taskId, TaskGetOptions taskGetOptions = default(TaskGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<CloudTask,TaskGetHeaders>> GetWithHttpMessagesAsync(string jobId, string taskId, TaskGetOptions taskGetOptions = default(TaskGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Updates the properties of the specified task.
         /// </summary>
@@ -187,7 +199,8 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </param>
         /// <param name='constraints'>
         /// Constraints that apply to this task. If omitted, the task is given
-        /// the default constraints.
+        /// the default constraints. For multi-instance tasks, updating the
+        /// retention time applies only to the primary task and not subtasks.
         /// </param>
         /// <param name='taskUpdateOptions'>
         /// Additional parameters for the operation
@@ -204,7 +217,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobId, string taskId, TaskConstraints constraints = default(TaskConstraints), TaskUpdateOptions taskUpdateOptions = default(TaskUpdateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<TaskUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobId, string taskId, TaskConstraints constraints = default(TaskConstraints), TaskUpdateOptions taskUpdateOptions = default(TaskUpdateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the subtasks that are associated with the specified
         /// multi-instance task.
@@ -237,7 +250,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudTaskListSubtasksResult,TaskListSubtasksHeaders>> ListSubtasksWithHttpMessagesAsync(string jobId, string taskId, TaskListSubtasksOptions taskListSubtasksOptions = default(TaskListSubtasksOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<CloudTaskListSubtasksResult,TaskListSubtasksHeaders>> ListSubtasksWithHttpMessagesAsync(string jobId, string taskId, TaskListSubtasksOptions taskListSubtasksOptions = default(TaskListSubtasksOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Terminates the specified task.
         /// </summary>
@@ -268,18 +281,21 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobId, string taskId, TaskTerminateOptions taskTerminateOptions = default(TaskTerminateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<TaskTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobId, string taskId, TaskTerminateOptions taskTerminateOptions = default(TaskTerminateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
-        /// Reactivates the specified task.
+        /// Reactivates a task, allowing it to run again even if its retry
+        /// count has been exhausted.
         /// </summary>
         /// <remarks>
         /// Reactivation makes a task eligible to be retried again up to its
         /// maximum retry count. The task's state is changed to active. As the
         /// task is no longer in the completed state, any previous exit code or
-        /// scheduling error is no longer available after reactivation. This
-        /// will fail for tasks that are not completed or that previously
-        /// completed successfully (with an exit code of 0). Additionally, this
-        /// will fail if the job has completed (or is terminating or deleting).
+        /// failure information is no longer available after reactivation. Each
+        /// time a task is reactivated, its retry count is reset to 0.
+        /// Reactivation will fail for tasks that are not completed or that
+        /// previously completed successfully (with an exit code of 0).
+        /// Additionally, it will fail if the job has completed (or is
+        /// terminating or deleting).
         /// </remarks>
         /// <param name='jobId'>
         /// The ID of the job containing the task.
@@ -302,7 +318,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskReactivateHeaders>> ReactivateWithHttpMessagesAsync(string jobId, string taskId, TaskReactivateOptions taskReactivateOptions = default(TaskReactivateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationHeaderResponse<TaskReactivateHeaders>> ReactivateWithHttpMessagesAsync(string jobId, string taskId, TaskReactivateOptions taskReactivateOptions = default(TaskReactivateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Lists all of the tasks that are associated with the specified job.
         /// </summary>
@@ -332,6 +348,6 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudTask>,TaskListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, TaskListNextOptions taskListNextOptions = default(TaskListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        Task<AzureOperationResponse<IPage<CloudTask>,TaskListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, TaskListNextOptions taskListNextOptions = default(TaskListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/JobOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/JobOperations.cs
@@ -8,15 +8,23 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// JobOperations operations.
     /// </summary>
-    internal partial class JobOperations : Microsoft.Rest.IServiceOperations<BatchServiceClient>, IJobOperations
+    internal partial class JobOperations : IServiceOperations<BatchServiceClient>, IJobOperations
     {
         /// <summary>
         /// Initializes a new instance of the JobOperations class.
@@ -33,7 +41,7 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("client");
             }
-            this.Client = client;
+            Client = client;
         }
 
         /// <summary>
@@ -61,10 +69,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -73,11 +81,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<JobStatistics,JobGetAllLifetimeStatisticsHeaders>> GetAllLifetimeStatisticsWithHttpMessagesAsync(JobGetAllLifetimeStatisticsOptions jobGetAllLifetimeStatisticsOptions = default(JobGetAllLifetimeStatisticsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<JobStatistics,JobGetAllLifetimeStatisticsHeaders>> GetAllLifetimeStatisticsWithHttpMessagesAsync(JobGetAllLifetimeStatisticsOptions jobGetAllLifetimeStatisticsOptions = default(JobGetAllLifetimeStatisticsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobGetAllLifetimeStatisticsOptions != null)
@@ -100,52 +108,52 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobGetAllLifetimeStatisticsOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "GetAllLifetimeStatistics", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetAllLifetimeStatistics", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "lifetimejobstats").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -153,7 +161,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -161,7 +169,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -169,7 +177,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -188,23 +196,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -213,21 +221,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -237,7 +245,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<JobStatistics,JobGetAllLifetimeStatisticsHeaders>();
+            var _result = new AzureOperationResponse<JobStatistics,JobGetAllLifetimeStatisticsHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -250,34 +258,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<JobStatistics>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<JobStatistics>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobGetAllLifetimeStatisticsHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobGetAllLifetimeStatisticsHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -290,7 +298,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// job statistics. This also overrides the retention period for task data;
         /// that is, if the job contains tasks which are still retained on compute
         /// nodes, the Batch services deletes those tasks' working directories and all
-        /// their contents.
+        /// their contents.  When a Delete Job request is received, the Batch service
+        /// sets the job to the deleting state. All update operations on a job that is
+        /// in deleting state will fail with status code 409 (Conflict), with
+        /// additional information indicating that the job is being deleted.
         /// </remarks>
         /// <param name='jobId'>
         /// The ID of the job to delete.
@@ -307,7 +318,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -316,15 +327,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobId, JobDeleteOptions jobDeleteOptions = default(JobDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobId, JobDeleteOptions jobDeleteOptions = default(JobDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobDeleteOptions != null)
@@ -367,12 +378,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobDeleteOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -383,42 +394,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Delete", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Delete", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("DELETE");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("DELETE");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -426,7 +437,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -434,7 +445,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -442,7 +453,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -466,7 +477,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -474,7 +485,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -493,23 +504,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -518,21 +529,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -542,7 +553,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobDeleteHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobDeleteHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -551,20 +562,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobDeleteHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobDeleteHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -587,10 +598,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -599,15 +610,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudJob,JobGetHeaders>> GetWithHttpMessagesAsync(string jobId, JobGetOptions jobGetOptions = default(JobGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<CloudJob,JobGetHeaders>> GetWithHttpMessagesAsync(string jobId, JobGetOptions jobGetOptions = default(JobGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string select = default(string);
             if (jobGetOptions != null)
@@ -660,12 +671,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobGetOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("select", select);
                 tracingParameters.Add("expand", expand);
@@ -678,16 +689,16 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (select != null)
             {
@@ -699,29 +710,29 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -729,7 +740,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -737,7 +748,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -745,7 +756,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -769,7 +780,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -777,7 +788,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -796,23 +807,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -821,21 +832,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -845,7 +856,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<CloudJob,JobGetHeaders>();
+            var _result = new AzureOperationResponse<CloudJob,JobGetHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -858,34 +869,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<CloudJob>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<CloudJob>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobGetHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobGetHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -916,7 +927,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -925,19 +936,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobPatchHeaders>> PatchWithHttpMessagesAsync(string jobId, JobPatchParameter jobPatchParameter, JobPatchOptions jobPatchOptions = default(JobPatchOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobPatchHeaders>> PatchWithHttpMessagesAsync(string jobId, JobPatchParameter jobPatchParameter, JobPatchOptions jobPatchOptions = default(JobPatchOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (jobPatchParameter == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobPatchParameter");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobPatchParameter");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobPatchOptions != null)
@@ -980,12 +991,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobPatchOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("jobPatchParameter", jobPatchParameter);
                 tracingParameters.Add("timeout", timeout);
@@ -997,42 +1008,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Patch", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Patch", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("PATCH");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("PATCH");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1040,7 +1051,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1048,7 +1059,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1056,7 +1067,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1080,7 +1091,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1088,7 +1099,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1108,28 +1119,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(jobPatchParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(jobPatchParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(jobPatchParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1138,21 +1149,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1162,7 +1173,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobPatchHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobPatchHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1171,20 +1182,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobPatchHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobPatchHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1216,7 +1227,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1225,23 +1236,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobId, JobUpdateParameter jobUpdateParameter, JobUpdateOptions jobUpdateOptions = default(JobUpdateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobId, JobUpdateParameter jobUpdateParameter, JobUpdateOptions jobUpdateOptions = default(JobUpdateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (jobUpdateParameter == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobUpdateParameter");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobUpdateParameter");
             }
             if (jobUpdateParameter != null)
             {
                 jobUpdateParameter.Validate();
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobUpdateOptions != null)
@@ -1284,12 +1295,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobUpdateOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("jobUpdateParameter", jobUpdateParameter);
                 tracingParameters.Add("timeout", timeout);
@@ -1301,42 +1312,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Update", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Update", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("PUT");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("PUT");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1344,7 +1355,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1352,7 +1363,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1360,7 +1371,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1384,7 +1395,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1392,7 +1403,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1412,28 +1423,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(jobUpdateParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(jobUpdateParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(jobUpdateParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1442,21 +1453,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1466,7 +1477,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobUpdateHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobUpdateHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1475,20 +1486,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobUpdateHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobUpdateHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1510,9 +1521,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// The ID of the job to disable.
         /// </param>
         /// <param name='disableTasks'>
-        /// What to do with active tasks associated with the job. requeue - Terminate
-        /// running tasks and requeue them. The tasks will run again when the job is
-        /// enabled. terminate - Terminate running tasks. The tasks will not run again.
+        /// What to do with active tasks associated with the job. Values are:
+        ///
+        /// requeue - Terminate running tasks and requeue them. The tasks will run
+        /// again when the job is enabled.
+        /// terminate - Terminate running tasks. The tasks will not run again.
         /// wait - Allow currently running tasks to complete. Possible values include:
         /// 'requeue', 'terminate', 'wait'
         /// </param>
@@ -1528,7 +1541,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1537,15 +1550,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobDisableHeaders>> DisableWithHttpMessagesAsync(string jobId, DisableJobOption disableTasks, JobDisableOptions jobDisableOptions = default(JobDisableOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobDisableHeaders>> DisableWithHttpMessagesAsync(string jobId, DisableJobOption disableTasks, JobDisableOptions jobDisableOptions = default(JobDisableOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobDisableOptions != null)
@@ -1590,12 +1603,12 @@ namespace Microsoft.Azure.Batch.Protocol
             JobDisableParameter jobDisableParameter = new JobDisableParameter();
             jobDisableParameter.DisableTasks = disableTasks;
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -1607,42 +1620,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("jobDisableParameter", jobDisableParameter);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Disable", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Disable", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/disable").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1650,7 +1663,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1658,7 +1671,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1666,7 +1679,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1690,7 +1703,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1698,7 +1711,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1718,28 +1731,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(jobDisableParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(jobDisableParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(jobDisableParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -1748,21 +1761,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1772,7 +1785,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobDisableHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobDisableHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1781,20 +1794,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobDisableHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobDisableHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1825,7 +1838,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1834,15 +1847,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobEnableHeaders>> EnableWithHttpMessagesAsync(string jobId, JobEnableOptions jobEnableOptions = default(JobEnableOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobEnableHeaders>> EnableWithHttpMessagesAsync(string jobId, JobEnableOptions jobEnableOptions = default(JobEnableOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobEnableOptions != null)
@@ -1885,12 +1898,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobEnableOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -1901,42 +1914,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Enable", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Enable", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/enable").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1944,7 +1957,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1952,7 +1965,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1960,7 +1973,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1984,7 +1997,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1992,7 +2005,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2011,23 +2024,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -2036,21 +2049,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2060,7 +2073,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobEnableHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobEnableHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2069,20 +2082,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobEnableHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobEnableHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2115,7 +2128,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2124,15 +2137,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobId, string terminateReason = default(string), JobTerminateOptions jobTerminateOptions = default(JobTerminateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobId, string terminateReason = default(string), JobTerminateOptions jobTerminateOptions = default(JobTerminateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobTerminateOptions != null)
@@ -2181,12 +2194,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 jobTerminateParameter.TerminateReason = terminateReason;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -2198,42 +2211,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("jobTerminateParameter", jobTerminateParameter);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Terminate", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Terminate", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/terminate").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2241,7 +2254,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2249,7 +2262,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2257,7 +2270,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -2281,7 +2294,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -2289,7 +2302,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2309,28 +2322,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(jobTerminateParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(jobTerminateParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(jobTerminateParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -2339,21 +2352,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2363,7 +2376,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobTerminateHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobTerminateHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2372,20 +2385,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobTerminateHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobTerminateHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2419,7 +2432,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2428,19 +2441,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobAddHeaders>> AddWithHttpMessagesAsync(JobAddParameter job, JobAddOptions jobAddOptions = default(JobAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobAddHeaders>> AddWithHttpMessagesAsync(JobAddParameter job, JobAddOptions jobAddOptions = default(JobAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (job == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "job");
+                throw new ValidationException(ValidationRules.CannotBeNull, "job");
             }
             if (job != null)
             {
                 job.Validate();
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobAddOptions != null)
@@ -2463,53 +2476,53 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobAddOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("job", job);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Add", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Add", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2517,7 +2530,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2525,7 +2538,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2533,7 +2546,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2553,28 +2566,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(job != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(job, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(job, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 201)
@@ -2583,21 +2596,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2607,7 +2620,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobAddHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobAddHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2616,20 +2629,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobAddHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobAddHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2649,10 +2662,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2661,11 +2674,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListHeaders>> ListWithHttpMessagesAsync(JobListOptions jobListOptions = default(JobListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<CloudJob>,JobListHeaders>> ListWithHttpMessagesAsync(JobListOptions jobListOptions = default(JobListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (jobListOptions != null)
@@ -2708,12 +2721,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobListOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("filter", filter);
                 tracingParameters.Add("select", select);
                 tracingParameters.Add("expand", expand);
@@ -2723,15 +2736,15 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -2747,33 +2760,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2781,7 +2794,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2789,7 +2802,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2797,7 +2810,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2816,23 +2829,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2841,21 +2854,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2865,7 +2878,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListHeaders>();
+            var _result = new AzureOperationResponse<IPage<CloudJob>,JobListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2878,34 +2891,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<CloudJob>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<CloudJob>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2928,10 +2941,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2940,15 +2953,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListFromJobScheduleHeaders>> ListFromJobScheduleWithHttpMessagesAsync(string jobScheduleId, JobListFromJobScheduleOptions jobListFromJobScheduleOptions = default(JobListFromJobScheduleOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<CloudJob>,JobListFromJobScheduleHeaders>> ListFromJobScheduleWithHttpMessagesAsync(string jobScheduleId, JobListFromJobScheduleOptions jobListFromJobScheduleOptions = default(JobListFromJobScheduleOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (jobListFromJobScheduleOptions != null)
@@ -2991,12 +3004,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobListFromJobScheduleOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("filter", filter);
                 tracingParameters.Add("select", select);
@@ -3007,16 +3020,16 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListFromJobSchedule", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListFromJobSchedule", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}/jobs").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -3032,33 +3045,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -3066,7 +3079,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -3074,7 +3087,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -3082,7 +3095,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -3101,23 +3114,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -3126,21 +3139,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -3150,7 +3163,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListFromJobScheduleHeaders>();
+            var _result = new AzureOperationResponse<IPage<CloudJob>,JobListFromJobScheduleHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -3163,34 +3176,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<CloudJob>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<CloudJob>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListFromJobScheduleHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListFromJobScheduleHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -3202,7 +3215,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <remarks>
         /// This API returns the Job Preparation and Job Release task status on all
         /// compute nodes that have run the Job Preparation or Job Release task. This
-        /// includes nodes which have since been removed from the pool.
+        /// includes nodes which have since been removed from the pool. If this API is
+        /// invoked on a job which has no Job Preparation or Job Release task, the
+        /// Batch service returns HTTP status code 409 (Conflict) with an error code of
+        /// JobPreparationTaskNotSpecified.
         /// </remarks>
         /// <param name='jobId'>
         /// The ID of the job.
@@ -3219,10 +3235,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -3231,15 +3247,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>> ListPreparationAndReleaseTaskStatusWithHttpMessagesAsync(string jobId, JobListPreparationAndReleaseTaskStatusOptions jobListPreparationAndReleaseTaskStatusOptions = default(JobListPreparationAndReleaseTaskStatusOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>> ListPreparationAndReleaseTaskStatusWithHttpMessagesAsync(string jobId, JobListPreparationAndReleaseTaskStatusOptions jobListPreparationAndReleaseTaskStatusOptions = default(JobListPreparationAndReleaseTaskStatusOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (jobListPreparationAndReleaseTaskStatusOptions != null)
@@ -3277,12 +3293,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobListPreparationAndReleaseTaskStatusOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("filter", filter);
                 tracingParameters.Add("select", select);
@@ -3292,16 +3308,16 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListPreparationAndReleaseTaskStatus", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListPreparationAndReleaseTaskStatus", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/jobpreparationandreleasetaskstatus").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -3313,33 +3329,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -3347,7 +3363,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -3355,7 +3371,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -3363,7 +3379,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -3382,23 +3398,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -3407,21 +3423,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -3431,7 +3447,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>();
+            var _result = new AzureOperationResponse<IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -3444,34 +3460,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<JobPreparationAndReleaseTaskExecutionInformation>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<JobPreparationAndReleaseTaskExecutionInformation>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListPreparationAndReleaseTaskStatusHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListPreparationAndReleaseTaskStatusHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -3503,10 +3519,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -3515,15 +3531,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<TaskCounts,JobGetTaskCountsHeaders>> GetTaskCountsWithHttpMessagesAsync(string jobId, JobGetTaskCountsOptions jobGetTaskCountsOptions = default(JobGetTaskCountsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<TaskCounts,JobGetTaskCountsHeaders>> GetTaskCountsWithHttpMessagesAsync(string jobId, JobGetTaskCountsOptions jobGetTaskCountsOptions = default(JobGetTaskCountsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobGetTaskCountsOptions != null)
@@ -3546,54 +3562,54 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobGetTaskCountsOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "GetTaskCounts", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "GetTaskCounts", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/taskcounts").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -3601,7 +3617,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -3609,7 +3625,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -3617,7 +3633,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -3636,23 +3652,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -3661,21 +3677,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -3685,7 +3701,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<TaskCounts,JobGetTaskCountsHeaders>();
+            var _result = new AzureOperationResponse<TaskCounts,JobGetTaskCountsHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -3698,34 +3714,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<TaskCounts>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<TaskCounts>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobGetTaskCountsHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobGetTaskCountsHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -3748,10 +3764,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -3760,11 +3776,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, JobListNextOptions jobListNextOptions = default(JobListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<CloudJob>,JobListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, JobListNextOptions jobListNextOptions = default(JobListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (jobListNextOptions != null)
@@ -3782,44 +3798,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobListNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -3827,7 +3843,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -3835,7 +3851,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -3843,7 +3859,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -3862,23 +3878,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -3887,21 +3903,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -3911,7 +3927,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListHeaders>();
+            var _result = new AzureOperationResponse<IPage<CloudJob>,JobListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -3924,34 +3940,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<CloudJob>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<CloudJob>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -3974,10 +3990,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -3986,11 +4002,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListFromJobScheduleHeaders>> ListFromJobScheduleNextWithHttpMessagesAsync(string nextPageLink, JobListFromJobScheduleNextOptions jobListFromJobScheduleNextOptions = default(JobListFromJobScheduleNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<CloudJob>,JobListFromJobScheduleHeaders>> ListFromJobScheduleNextWithHttpMessagesAsync(string nextPageLink, JobListFromJobScheduleNextOptions jobListFromJobScheduleNextOptions = default(JobListFromJobScheduleNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (jobListFromJobScheduleNextOptions != null)
@@ -4008,44 +4024,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobListFromJobScheduleNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListFromJobScheduleNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListFromJobScheduleNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -4053,7 +4069,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -4061,7 +4077,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -4069,7 +4085,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -4088,23 +4104,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -4113,21 +4129,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -4137,7 +4153,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJob>,JobListFromJobScheduleHeaders>();
+            var _result = new AzureOperationResponse<IPage<CloudJob>,JobListFromJobScheduleHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -4150,34 +4166,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<CloudJob>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<CloudJob>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListFromJobScheduleHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListFromJobScheduleHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -4189,7 +4205,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <remarks>
         /// This API returns the Job Preparation and Job Release task status on all
         /// compute nodes that have run the Job Preparation or Job Release task. This
-        /// includes nodes which have since been removed from the pool.
+        /// includes nodes which have since been removed from the pool. If this API is
+        /// invoked on a job which has no Job Preparation or Job Release task, the
+        /// Batch service returns HTTP status code 409 (Conflict) with an error code of
+        /// JobPreparationTaskNotSpecified.
         /// </remarks>
         /// <param name='nextPageLink'>
         /// The NextLink from the previous successful call to List operation.
@@ -4206,10 +4225,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -4218,11 +4237,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>> ListPreparationAndReleaseTaskStatusNextWithHttpMessagesAsync(string nextPageLink, JobListPreparationAndReleaseTaskStatusNextOptions jobListPreparationAndReleaseTaskStatusNextOptions = default(JobListPreparationAndReleaseTaskStatusNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>> ListPreparationAndReleaseTaskStatusNextWithHttpMessagesAsync(string nextPageLink, JobListPreparationAndReleaseTaskStatusNextOptions jobListPreparationAndReleaseTaskStatusNextOptions = default(JobListPreparationAndReleaseTaskStatusNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (jobListPreparationAndReleaseTaskStatusNextOptions != null)
@@ -4240,44 +4259,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobListPreparationAndReleaseTaskStatusNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListPreparationAndReleaseTaskStatusNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListPreparationAndReleaseTaskStatusNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -4285,7 +4304,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -4293,7 +4312,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -4301,7 +4320,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -4320,23 +4339,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -4345,21 +4364,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -4369,7 +4388,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>();
+            var _result = new AzureOperationResponse<IPage<JobPreparationAndReleaseTaskExecutionInformation>,JobListPreparationAndReleaseTaskStatusHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -4382,34 +4401,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<JobPreparationAndReleaseTaskExecutionInformation>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<JobPreparationAndReleaseTaskExecutionInformation>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListPreparationAndReleaseTaskStatusHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobListPreparationAndReleaseTaskStatusHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/JobOperationsExtensions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/JobOperationsExtensions.cs
@@ -8,8 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Extension methods for JobOperations.
@@ -32,7 +35,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobStatistics GetAllLifetimeStatistics(this IJobOperations operations, JobGetAllLifetimeStatisticsOptions jobGetAllLifetimeStatisticsOptions = default(JobGetAllLifetimeStatisticsOptions))
             {
-                return ((IJobOperations)operations).GetAllLifetimeStatisticsAsync(jobGetAllLifetimeStatisticsOptions).GetAwaiter().GetResult();
+                return operations.GetAllLifetimeStatisticsAsync(jobGetAllLifetimeStatisticsOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -52,7 +55,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobStatistics> GetAllLifetimeStatisticsAsync(this IJobOperations operations, JobGetAllLifetimeStatisticsOptions jobGetAllLifetimeStatisticsOptions = default(JobGetAllLifetimeStatisticsOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobStatistics> GetAllLifetimeStatisticsAsync(this IJobOperations operations, JobGetAllLifetimeStatisticsOptions jobGetAllLifetimeStatisticsOptions = default(JobGetAllLifetimeStatisticsOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetAllLifetimeStatisticsWithHttpMessagesAsync(jobGetAllLifetimeStatisticsOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -68,7 +71,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// job statistics. This also overrides the retention period for task data;
             /// that is, if the job contains tasks which are still retained on compute
             /// nodes, the Batch services deletes those tasks' working directories and all
-            /// their contents.
+            /// their contents.  When a Delete Job request is received, the Batch service
+            /// sets the job to the deleting state. All update operations on a job that is
+            /// in deleting state will fail with status code 409 (Conflict), with
+            /// additional information indicating that the job is being deleted.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -81,7 +87,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobDeleteHeaders Delete(this IJobOperations operations, string jobId, JobDeleteOptions jobDeleteOptions = default(JobDeleteOptions))
             {
-                return ((IJobOperations)operations).DeleteAsync(jobId, jobDeleteOptions).GetAwaiter().GetResult();
+                return operations.DeleteAsync(jobId, jobDeleteOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -92,7 +98,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// job statistics. This also overrides the retention period for task data;
             /// that is, if the job contains tasks which are still retained on compute
             /// nodes, the Batch services deletes those tasks' working directories and all
-            /// their contents.
+            /// their contents.  When a Delete Job request is received, the Batch service
+            /// sets the job to the deleting state. All update operations on a job that is
+            /// in deleting state will fail with status code 409 (Conflict), with
+            /// additional information indicating that the job is being deleted.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -106,7 +115,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobDeleteHeaders> DeleteAsync(this IJobOperations operations, string jobId, JobDeleteOptions jobDeleteOptions = default(JobDeleteOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobDeleteHeaders> DeleteAsync(this IJobOperations operations, string jobId, JobDeleteOptions jobDeleteOptions = default(JobDeleteOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DeleteWithHttpMessagesAsync(jobId, jobDeleteOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -128,7 +137,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static CloudJob Get(this IJobOperations operations, string jobId, JobGetOptions jobGetOptions = default(JobGetOptions))
             {
-                return ((IJobOperations)operations).GetAsync(jobId, jobGetOptions).GetAwaiter().GetResult();
+                return operations.GetAsync(jobId, jobGetOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -146,7 +155,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<CloudJob> GetAsync(this IJobOperations operations, string jobId, JobGetOptions jobGetOptions = default(JobGetOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<CloudJob> GetAsync(this IJobOperations operations, string jobId, JobGetOptions jobGetOptions = default(JobGetOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetWithHttpMessagesAsync(jobId, jobGetOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -176,7 +185,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobPatchHeaders Patch(this IJobOperations operations, string jobId, JobPatchParameter jobPatchParameter, JobPatchOptions jobPatchOptions = default(JobPatchOptions))
             {
-                return ((IJobOperations)operations).PatchAsync(jobId, jobPatchParameter, jobPatchOptions).GetAwaiter().GetResult();
+                return operations.PatchAsync(jobId, jobPatchParameter, jobPatchOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -202,7 +211,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobPatchHeaders> PatchAsync(this IJobOperations operations, string jobId, JobPatchParameter jobPatchParameter, JobPatchOptions jobPatchOptions = default(JobPatchOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobPatchHeaders> PatchAsync(this IJobOperations operations, string jobId, JobPatchParameter jobPatchParameter, JobPatchOptions jobPatchOptions = default(JobPatchOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.PatchWithHttpMessagesAsync(jobId, jobPatchParameter, jobPatchOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -233,7 +242,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobUpdateHeaders Update(this IJobOperations operations, string jobId, JobUpdateParameter jobUpdateParameter, JobUpdateOptions jobUpdateOptions = default(JobUpdateOptions))
             {
-                return ((IJobOperations)operations).UpdateAsync(jobId, jobUpdateParameter, jobUpdateOptions).GetAwaiter().GetResult();
+                return operations.UpdateAsync(jobId, jobUpdateParameter, jobUpdateOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -260,7 +269,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobUpdateHeaders> UpdateAsync(this IJobOperations operations, string jobId, JobUpdateParameter jobUpdateParameter, JobUpdateOptions jobUpdateOptions = default(JobUpdateOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobUpdateHeaders> UpdateAsync(this IJobOperations operations, string jobId, JobUpdateParameter jobUpdateParameter, JobUpdateOptions jobUpdateOptions = default(JobUpdateOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.UpdateWithHttpMessagesAsync(jobId, jobUpdateParameter, jobUpdateOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -288,9 +297,11 @@ namespace Microsoft.Azure.Batch.Protocol
             /// The ID of the job to disable.
             /// </param>
             /// <param name='disableTasks'>
-            /// What to do with active tasks associated with the job. requeue - Terminate
-            /// running tasks and requeue them. The tasks will run again when the job is
-            /// enabled. terminate - Terminate running tasks. The tasks will not run again.
+            /// What to do with active tasks associated with the job. Values are:
+            ///
+            /// requeue - Terminate running tasks and requeue them. The tasks will run
+            /// again when the job is enabled.
+            /// terminate - Terminate running tasks. The tasks will not run again.
             /// wait - Allow currently running tasks to complete. Possible values include:
             /// 'requeue', 'terminate', 'wait'
             /// </param>
@@ -299,7 +310,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobDisableHeaders Disable(this IJobOperations operations, string jobId, DisableJobOption disableTasks, JobDisableOptions jobDisableOptions = default(JobDisableOptions))
             {
-                return ((IJobOperations)operations).DisableAsync(jobId, disableTasks, jobDisableOptions).GetAwaiter().GetResult();
+                return operations.DisableAsync(jobId, disableTasks, jobDisableOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -322,9 +333,11 @@ namespace Microsoft.Azure.Batch.Protocol
             /// The ID of the job to disable.
             /// </param>
             /// <param name='disableTasks'>
-            /// What to do with active tasks associated with the job. requeue - Terminate
-            /// running tasks and requeue them. The tasks will run again when the job is
-            /// enabled. terminate - Terminate running tasks. The tasks will not run again.
+            /// What to do with active tasks associated with the job. Values are:
+            ///
+            /// requeue - Terminate running tasks and requeue them. The tasks will run
+            /// again when the job is enabled.
+            /// terminate - Terminate running tasks. The tasks will not run again.
             /// wait - Allow currently running tasks to complete. Possible values include:
             /// 'requeue', 'terminate', 'wait'
             /// </param>
@@ -334,7 +347,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobDisableHeaders> DisableAsync(this IJobOperations operations, string jobId, DisableJobOption disableTasks, JobDisableOptions jobDisableOptions = default(JobDisableOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobDisableHeaders> DisableAsync(this IJobOperations operations, string jobId, DisableJobOption disableTasks, JobDisableOptions jobDisableOptions = default(JobDisableOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DisableWithHttpMessagesAsync(jobId, disableTasks, jobDisableOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -364,7 +377,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobEnableHeaders Enable(this IJobOperations operations, string jobId, JobEnableOptions jobEnableOptions = default(JobEnableOptions))
             {
-                return ((IJobOperations)operations).EnableAsync(jobId, jobEnableOptions).GetAwaiter().GetResult();
+                return operations.EnableAsync(jobId, jobEnableOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -390,7 +403,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobEnableHeaders> EnableAsync(this IJobOperations operations, string jobId, JobEnableOptions jobEnableOptions = default(JobEnableOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobEnableHeaders> EnableAsync(this IJobOperations operations, string jobId, JobEnableOptions jobEnableOptions = default(JobEnableOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.EnableWithHttpMessagesAsync(jobId, jobEnableOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -422,7 +435,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobTerminateHeaders Terminate(this IJobOperations operations, string jobId, string terminateReason = default(string), JobTerminateOptions jobTerminateOptions = default(JobTerminateOptions))
             {
-                return ((IJobOperations)operations).TerminateAsync(jobId, terminateReason, jobTerminateOptions).GetAwaiter().GetResult();
+                return operations.TerminateAsync(jobId, terminateReason, jobTerminateOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -450,7 +463,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobTerminateHeaders> TerminateAsync(this IJobOperations operations, string jobId, string terminateReason = default(string), JobTerminateOptions jobTerminateOptions = default(JobTerminateOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobTerminateHeaders> TerminateAsync(this IJobOperations operations, string jobId, string terminateReason = default(string), JobTerminateOptions jobTerminateOptions = default(JobTerminateOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.TerminateWithHttpMessagesAsync(jobId, terminateReason, jobTerminateOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -483,7 +496,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobAddHeaders Add(this IJobOperations operations, JobAddParameter job, JobAddOptions jobAddOptions = default(JobAddOptions))
             {
-                return ((IJobOperations)operations).AddAsync(job, jobAddOptions).GetAwaiter().GetResult();
+                return operations.AddAsync(job, jobAddOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -512,7 +525,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobAddHeaders> AddAsync(this IJobOperations operations, JobAddParameter job, JobAddOptions jobAddOptions = default(JobAddOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobAddHeaders> AddAsync(this IJobOperations operations, JobAddParameter job, JobAddOptions jobAddOptions = default(JobAddOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.AddWithHttpMessagesAsync(job, jobAddOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -529,9 +542,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='jobListOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<CloudJob> List(this IJobOperations operations, JobListOptions jobListOptions = default(JobListOptions))
+            public static IPage<CloudJob> List(this IJobOperations operations, JobListOptions jobListOptions = default(JobListOptions))
             {
-                return ((IJobOperations)operations).ListAsync(jobListOptions).GetAwaiter().GetResult();
+                return operations.ListAsync(jobListOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -546,7 +559,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<CloudJob>> ListAsync(this IJobOperations operations, JobListOptions jobListOptions = default(JobListOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<CloudJob>> ListAsync(this IJobOperations operations, JobListOptions jobListOptions = default(JobListOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListWithHttpMessagesAsync(jobListOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -566,9 +579,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='jobListFromJobScheduleOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<CloudJob> ListFromJobSchedule(this IJobOperations operations, string jobScheduleId, JobListFromJobScheduleOptions jobListFromJobScheduleOptions = default(JobListFromJobScheduleOptions))
+            public static IPage<CloudJob> ListFromJobSchedule(this IJobOperations operations, string jobScheduleId, JobListFromJobScheduleOptions jobListFromJobScheduleOptions = default(JobListFromJobScheduleOptions))
             {
-                return ((IJobOperations)operations).ListFromJobScheduleAsync(jobScheduleId, jobListFromJobScheduleOptions).GetAwaiter().GetResult();
+                return operations.ListFromJobScheduleAsync(jobScheduleId, jobListFromJobScheduleOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -586,7 +599,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<CloudJob>> ListFromJobScheduleAsync(this IJobOperations operations, string jobScheduleId, JobListFromJobScheduleOptions jobListFromJobScheduleOptions = default(JobListFromJobScheduleOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<CloudJob>> ListFromJobScheduleAsync(this IJobOperations operations, string jobScheduleId, JobListFromJobScheduleOptions jobListFromJobScheduleOptions = default(JobListFromJobScheduleOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListFromJobScheduleWithHttpMessagesAsync(jobScheduleId, jobListFromJobScheduleOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -601,7 +614,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// This API returns the Job Preparation and Job Release task status on all
             /// compute nodes that have run the Job Preparation or Job Release task. This
-            /// includes nodes which have since been removed from the pool.
+            /// includes nodes which have since been removed from the pool. If this API is
+            /// invoked on a job which has no Job Preparation or Job Release task, the
+            /// Batch service returns HTTP status code 409 (Conflict) with an error code of
+            /// JobPreparationTaskNotSpecified.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -612,9 +628,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='jobListPreparationAndReleaseTaskStatusOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation> ListPreparationAndReleaseTaskStatus(this IJobOperations operations, string jobId, JobListPreparationAndReleaseTaskStatusOptions jobListPreparationAndReleaseTaskStatusOptions = default(JobListPreparationAndReleaseTaskStatusOptions))
+            public static IPage<JobPreparationAndReleaseTaskExecutionInformation> ListPreparationAndReleaseTaskStatus(this IJobOperations operations, string jobId, JobListPreparationAndReleaseTaskStatusOptions jobListPreparationAndReleaseTaskStatusOptions = default(JobListPreparationAndReleaseTaskStatusOptions))
             {
-                return ((IJobOperations)operations).ListPreparationAndReleaseTaskStatusAsync(jobId, jobListPreparationAndReleaseTaskStatusOptions).GetAwaiter().GetResult();
+                return operations.ListPreparationAndReleaseTaskStatusAsync(jobId, jobListPreparationAndReleaseTaskStatusOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -624,7 +640,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// This API returns the Job Preparation and Job Release task status on all
             /// compute nodes that have run the Job Preparation or Job Release task. This
-            /// includes nodes which have since been removed from the pool.
+            /// includes nodes which have since been removed from the pool. If this API is
+            /// invoked on a job which has no Job Preparation or Job Release task, the
+            /// Batch service returns HTTP status code 409 (Conflict) with an error code of
+            /// JobPreparationTaskNotSpecified.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -638,7 +657,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation>> ListPreparationAndReleaseTaskStatusAsync(this IJobOperations operations, string jobId, JobListPreparationAndReleaseTaskStatusOptions jobListPreparationAndReleaseTaskStatusOptions = default(JobListPreparationAndReleaseTaskStatusOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<JobPreparationAndReleaseTaskExecutionInformation>> ListPreparationAndReleaseTaskStatusAsync(this IJobOperations operations, string jobId, JobListPreparationAndReleaseTaskStatusOptions jobListPreparationAndReleaseTaskStatusOptions = default(JobListPreparationAndReleaseTaskStatusOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListPreparationAndReleaseTaskStatusWithHttpMessagesAsync(jobId, jobListPreparationAndReleaseTaskStatusOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -669,7 +688,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static TaskCounts GetTaskCounts(this IJobOperations operations, string jobId, JobGetTaskCountsOptions jobGetTaskCountsOptions = default(JobGetTaskCountsOptions))
             {
-                return ((IJobOperations)operations).GetTaskCountsAsync(jobId, jobGetTaskCountsOptions).GetAwaiter().GetResult();
+                return operations.GetTaskCountsAsync(jobId, jobGetTaskCountsOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -696,7 +715,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<TaskCounts> GetTaskCountsAsync(this IJobOperations operations, string jobId, JobGetTaskCountsOptions jobGetTaskCountsOptions = default(JobGetTaskCountsOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<TaskCounts> GetTaskCountsAsync(this IJobOperations operations, string jobId, JobGetTaskCountsOptions jobGetTaskCountsOptions = default(JobGetTaskCountsOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetTaskCountsWithHttpMessagesAsync(jobId, jobGetTaskCountsOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -716,9 +735,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='jobListNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<CloudJob> ListNext(this IJobOperations operations, string nextPageLink, JobListNextOptions jobListNextOptions = default(JobListNextOptions))
+            public static IPage<CloudJob> ListNext(this IJobOperations operations, string nextPageLink, JobListNextOptions jobListNextOptions = default(JobListNextOptions))
             {
-                return ((IJobOperations)operations).ListNextAsync(nextPageLink, jobListNextOptions).GetAwaiter().GetResult();
+                return operations.ListNextAsync(nextPageLink, jobListNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -736,7 +755,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<CloudJob>> ListNextAsync(this IJobOperations operations, string nextPageLink, JobListNextOptions jobListNextOptions = default(JobListNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<CloudJob>> ListNextAsync(this IJobOperations operations, string nextPageLink, JobListNextOptions jobListNextOptions = default(JobListNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNextWithHttpMessagesAsync(nextPageLink, jobListNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -756,9 +775,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='jobListFromJobScheduleNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<CloudJob> ListFromJobScheduleNext(this IJobOperations operations, string nextPageLink, JobListFromJobScheduleNextOptions jobListFromJobScheduleNextOptions = default(JobListFromJobScheduleNextOptions))
+            public static IPage<CloudJob> ListFromJobScheduleNext(this IJobOperations operations, string nextPageLink, JobListFromJobScheduleNextOptions jobListFromJobScheduleNextOptions = default(JobListFromJobScheduleNextOptions))
             {
-                return ((IJobOperations)operations).ListFromJobScheduleNextAsync(nextPageLink, jobListFromJobScheduleNextOptions).GetAwaiter().GetResult();
+                return operations.ListFromJobScheduleNextAsync(nextPageLink, jobListFromJobScheduleNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -776,7 +795,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<CloudJob>> ListFromJobScheduleNextAsync(this IJobOperations operations, string nextPageLink, JobListFromJobScheduleNextOptions jobListFromJobScheduleNextOptions = default(JobListFromJobScheduleNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<CloudJob>> ListFromJobScheduleNextAsync(this IJobOperations operations, string nextPageLink, JobListFromJobScheduleNextOptions jobListFromJobScheduleNextOptions = default(JobListFromJobScheduleNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListFromJobScheduleNextWithHttpMessagesAsync(nextPageLink, jobListFromJobScheduleNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -791,7 +810,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// This API returns the Job Preparation and Job Release task status on all
             /// compute nodes that have run the Job Preparation or Job Release task. This
-            /// includes nodes which have since been removed from the pool.
+            /// includes nodes which have since been removed from the pool. If this API is
+            /// invoked on a job which has no Job Preparation or Job Release task, the
+            /// Batch service returns HTTP status code 409 (Conflict) with an error code of
+            /// JobPreparationTaskNotSpecified.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -802,9 +824,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='jobListPreparationAndReleaseTaskStatusNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation> ListPreparationAndReleaseTaskStatusNext(this IJobOperations operations, string nextPageLink, JobListPreparationAndReleaseTaskStatusNextOptions jobListPreparationAndReleaseTaskStatusNextOptions = default(JobListPreparationAndReleaseTaskStatusNextOptions))
+            public static IPage<JobPreparationAndReleaseTaskExecutionInformation> ListPreparationAndReleaseTaskStatusNext(this IJobOperations operations, string nextPageLink, JobListPreparationAndReleaseTaskStatusNextOptions jobListPreparationAndReleaseTaskStatusNextOptions = default(JobListPreparationAndReleaseTaskStatusNextOptions))
             {
-                return ((IJobOperations)operations).ListPreparationAndReleaseTaskStatusNextAsync(nextPageLink, jobListPreparationAndReleaseTaskStatusNextOptions).GetAwaiter().GetResult();
+                return operations.ListPreparationAndReleaseTaskStatusNextAsync(nextPageLink, jobListPreparationAndReleaseTaskStatusNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -814,7 +836,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// This API returns the Job Preparation and Job Release task status on all
             /// compute nodes that have run the Job Preparation or Job Release task. This
-            /// includes nodes which have since been removed from the pool.
+            /// includes nodes which have since been removed from the pool. If this API is
+            /// invoked on a job which has no Job Preparation or Job Release task, the
+            /// Batch service returns HTTP status code 409 (Conflict) with an error code of
+            /// JobPreparationTaskNotSpecified.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -828,7 +853,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<JobPreparationAndReleaseTaskExecutionInformation>> ListPreparationAndReleaseTaskStatusNextAsync(this IJobOperations operations, string nextPageLink, JobListPreparationAndReleaseTaskStatusNextOptions jobListPreparationAndReleaseTaskStatusNextOptions = default(JobListPreparationAndReleaseTaskStatusNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<JobPreparationAndReleaseTaskExecutionInformation>> ListPreparationAndReleaseTaskStatusNextAsync(this IJobOperations operations, string nextPageLink, JobListPreparationAndReleaseTaskStatusNextOptions jobListPreparationAndReleaseTaskStatusNextOptions = default(JobListPreparationAndReleaseTaskStatusNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListPreparationAndReleaseTaskStatusNextWithHttpMessagesAsync(nextPageLink, jobListPreparationAndReleaseTaskStatusNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/JobScheduleOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/JobScheduleOperations.cs
@@ -8,15 +8,23 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// JobScheduleOperations operations.
     /// </summary>
-    internal partial class JobScheduleOperations : Microsoft.Rest.IServiceOperations<BatchServiceClient>, IJobScheduleOperations
+    internal partial class JobScheduleOperations : IServiceOperations<BatchServiceClient>, IJobScheduleOperations
     {
         /// <summary>
         /// Initializes a new instance of the JobScheduleOperations class.
@@ -33,7 +41,7 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("client");
             }
-            this.Client = client;
+            Client = client;
         }
 
         /// <summary>
@@ -59,7 +67,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -68,15 +76,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<bool,JobScheduleExistsHeaders>> ExistsWithHttpMessagesAsync(string jobScheduleId, JobScheduleExistsOptions jobScheduleExistsOptions = default(JobScheduleExistsOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<bool,JobScheduleExistsHeaders>> ExistsWithHttpMessagesAsync(string jobScheduleId, JobScheduleExistsOptions jobScheduleExistsOptions = default(JobScheduleExistsOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobScheduleExistsOptions != null)
@@ -119,12 +127,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobScheduleExistsOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -135,42 +143,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Exists", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Exists", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("HEAD");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("HEAD");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -178,7 +186,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -186,7 +194,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -194,7 +202,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -218,7 +226,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -226,7 +234,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -245,23 +253,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200 && (int)_statusCode != 404)
@@ -270,21 +278,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -294,30 +302,30 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<bool,JobScheduleExistsHeaders>();
+            var _result = new AzureOperationResponse<bool,JobScheduleExistsHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
-            _result.Body = (_statusCode == System.Net.HttpStatusCode.OK);
+            _result.Body = _statusCode == System.Net.HttpStatusCode.OK;
             if (_httpResponse.Headers.Contains("request-id"))
             {
                 _result.RequestId = _httpResponse.Headers.GetValues("request-id").FirstOrDefault();
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleExistsHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleExistsHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -348,7 +356,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -357,15 +365,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobScheduleId, JobScheduleDeleteOptions jobScheduleDeleteOptions = default(JobScheduleDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobScheduleDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobScheduleId, JobScheduleDeleteOptions jobScheduleDeleteOptions = default(JobScheduleDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobScheduleDeleteOptions != null)
@@ -408,12 +416,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobScheduleDeleteOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -424,42 +432,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Delete", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Delete", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("DELETE");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("DELETE");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -467,7 +475,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -475,7 +483,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -483,7 +491,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -507,7 +515,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -515,7 +523,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -534,23 +542,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -559,21 +567,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -583,7 +591,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleDeleteHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobScheduleDeleteHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -592,20 +600,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleDeleteHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleDeleteHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -628,10 +636,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -640,15 +648,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudJobSchedule,JobScheduleGetHeaders>> GetWithHttpMessagesAsync(string jobScheduleId, JobScheduleGetOptions jobScheduleGetOptions = default(JobScheduleGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<CloudJobSchedule,JobScheduleGetHeaders>> GetWithHttpMessagesAsync(string jobScheduleId, JobScheduleGetOptions jobScheduleGetOptions = default(JobScheduleGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string select = default(string);
             if (jobScheduleGetOptions != null)
@@ -701,12 +709,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobScheduleGetOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("select", select);
                 tracingParameters.Add("expand", expand);
@@ -719,16 +727,16 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (select != null)
             {
@@ -740,29 +748,29 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -770,7 +778,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -778,7 +786,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -786,7 +794,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -810,7 +818,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -818,7 +826,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -837,23 +845,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -862,21 +870,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -886,7 +894,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<CloudJobSchedule,JobScheduleGetHeaders>();
+            var _result = new AzureOperationResponse<CloudJobSchedule,JobScheduleGetHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -899,34 +907,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<CloudJobSchedule>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<CloudJobSchedule>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleGetHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleGetHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -959,7 +967,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -968,19 +976,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobSchedulePatchHeaders>> PatchWithHttpMessagesAsync(string jobScheduleId, JobSchedulePatchParameter jobSchedulePatchParameter, JobSchedulePatchOptions jobSchedulePatchOptions = default(JobSchedulePatchOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobSchedulePatchHeaders>> PatchWithHttpMessagesAsync(string jobScheduleId, JobSchedulePatchParameter jobSchedulePatchParameter, JobSchedulePatchOptions jobSchedulePatchOptions = default(JobSchedulePatchOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
             if (jobSchedulePatchParameter == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobSchedulePatchParameter");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobSchedulePatchParameter");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobSchedulePatchOptions != null)
@@ -1023,12 +1031,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobSchedulePatchOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("jobSchedulePatchParameter", jobSchedulePatchParameter);
                 tracingParameters.Add("timeout", timeout);
@@ -1040,42 +1048,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Patch", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Patch", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("PATCH");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("PATCH");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1083,7 +1091,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1091,7 +1099,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1099,7 +1107,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1123,7 +1131,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1131,7 +1139,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1151,28 +1159,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(jobSchedulePatchParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(jobSchedulePatchParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(jobSchedulePatchParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1181,21 +1189,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1205,7 +1213,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobSchedulePatchHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobSchedulePatchHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1214,20 +1222,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobSchedulePatchHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobSchedulePatchHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1260,7 +1268,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1269,23 +1277,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobScheduleId, JobScheduleUpdateParameter jobScheduleUpdateParameter, JobScheduleUpdateOptions jobScheduleUpdateOptions = default(JobScheduleUpdateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobScheduleUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobScheduleId, JobScheduleUpdateParameter jobScheduleUpdateParameter, JobScheduleUpdateOptions jobScheduleUpdateOptions = default(JobScheduleUpdateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
             if (jobScheduleUpdateParameter == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleUpdateParameter");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleUpdateParameter");
             }
             if (jobScheduleUpdateParameter != null)
             {
                 jobScheduleUpdateParameter.Validate();
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobScheduleUpdateOptions != null)
@@ -1328,12 +1336,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobScheduleUpdateOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("jobScheduleUpdateParameter", jobScheduleUpdateParameter);
                 tracingParameters.Add("timeout", timeout);
@@ -1345,42 +1353,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Update", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Update", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("PUT");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("PUT");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1388,7 +1396,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1396,7 +1404,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1404,7 +1412,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1428,7 +1436,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1436,7 +1444,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1456,28 +1464,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(jobScheduleUpdateParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(jobScheduleUpdateParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(jobScheduleUpdateParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1486,21 +1494,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1510,7 +1518,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleUpdateHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobScheduleUpdateHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1519,20 +1527,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleUpdateHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleUpdateHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1558,7 +1566,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1567,15 +1575,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleDisableHeaders>> DisableWithHttpMessagesAsync(string jobScheduleId, JobScheduleDisableOptions jobScheduleDisableOptions = default(JobScheduleDisableOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobScheduleDisableHeaders>> DisableWithHttpMessagesAsync(string jobScheduleId, JobScheduleDisableOptions jobScheduleDisableOptions = default(JobScheduleDisableOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobScheduleDisableOptions != null)
@@ -1618,12 +1626,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobScheduleDisableOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -1634,42 +1642,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Disable", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Disable", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}/disable").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1677,7 +1685,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1685,7 +1693,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1693,7 +1701,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1717,7 +1725,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1725,7 +1733,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1744,23 +1752,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 204)
@@ -1769,21 +1777,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1793,7 +1801,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleDisableHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobScheduleDisableHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1802,20 +1810,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleDisableHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleDisableHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1838,7 +1846,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1847,15 +1855,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleEnableHeaders>> EnableWithHttpMessagesAsync(string jobScheduleId, JobScheduleEnableOptions jobScheduleEnableOptions = default(JobScheduleEnableOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobScheduleEnableHeaders>> EnableWithHttpMessagesAsync(string jobScheduleId, JobScheduleEnableOptions jobScheduleEnableOptions = default(JobScheduleEnableOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobScheduleEnableOptions != null)
@@ -1898,12 +1906,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobScheduleEnableOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -1914,42 +1922,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Enable", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Enable", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}/enable").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1957,7 +1965,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1965,7 +1973,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1973,7 +1981,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1997,7 +2005,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -2005,7 +2013,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2024,23 +2032,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 204)
@@ -2049,21 +2057,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2073,7 +2081,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleEnableHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobScheduleEnableHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2082,20 +2090,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleEnableHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleEnableHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2118,7 +2126,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2127,15 +2135,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobScheduleId, JobScheduleTerminateOptions jobScheduleTerminateOptions = default(JobScheduleTerminateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobScheduleTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobScheduleId, JobScheduleTerminateOptions jobScheduleTerminateOptions = default(JobScheduleTerminateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobScheduleId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobScheduleId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobScheduleId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobScheduleTerminateOptions != null)
@@ -2178,12 +2186,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = jobScheduleTerminateOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobScheduleId", jobScheduleId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -2194,42 +2202,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Terminate", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Terminate", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules/{jobScheduleId}/terminate").ToString();
             _url = _url.Replace("{jobScheduleId}", System.Uri.EscapeDataString(jobScheduleId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2237,7 +2245,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2245,7 +2253,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2253,7 +2261,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -2277,7 +2285,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -2285,7 +2293,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2304,23 +2312,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 202)
@@ -2329,21 +2337,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2353,7 +2361,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleTerminateHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobScheduleTerminateHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2362,20 +2370,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleTerminateHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleTerminateHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2398,7 +2406,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2407,19 +2415,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleAddHeaders>> AddWithHttpMessagesAsync(JobScheduleAddParameter cloudJobSchedule, JobScheduleAddOptions jobScheduleAddOptions = default(JobScheduleAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<JobScheduleAddHeaders>> AddWithHttpMessagesAsync(JobScheduleAddParameter cloudJobSchedule, JobScheduleAddOptions jobScheduleAddOptions = default(JobScheduleAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (cloudJobSchedule == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "cloudJobSchedule");
+                throw new ValidationException(ValidationRules.CannotBeNull, "cloudJobSchedule");
             }
             if (cloudJobSchedule != null)
             {
                 cloudJobSchedule.Validate();
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (jobScheduleAddOptions != null)
@@ -2442,53 +2450,53 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobScheduleAddOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("cloudJobSchedule", cloudJobSchedule);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Add", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Add", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2496,7 +2504,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2504,7 +2512,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2512,7 +2520,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2532,28 +2540,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(cloudJobSchedule != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(cloudJobSchedule, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(cloudJobSchedule, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 201)
@@ -2562,21 +2570,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2586,7 +2594,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<JobScheduleAddHeaders>();
+            var _result = new AzureOperationHeaderResponse<JobScheduleAddHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2595,20 +2603,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleAddHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleAddHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2628,10 +2636,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2640,11 +2648,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJobSchedule>,JobScheduleListHeaders>> ListWithHttpMessagesAsync(JobScheduleListOptions jobScheduleListOptions = default(JobScheduleListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<CloudJobSchedule>,JobScheduleListHeaders>> ListWithHttpMessagesAsync(JobScheduleListOptions jobScheduleListOptions = default(JobScheduleListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (jobScheduleListOptions != null)
@@ -2687,12 +2695,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobScheduleListOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("filter", filter);
                 tracingParameters.Add("select", select);
                 tracingParameters.Add("expand", expand);
@@ -2702,15 +2710,15 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobschedules").ToString();
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -2726,33 +2734,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2760,7 +2768,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2768,7 +2776,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2776,7 +2784,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2795,23 +2803,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2820,21 +2828,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2844,7 +2852,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJobSchedule>,JobScheduleListHeaders>();
+            var _result = new AzureOperationResponse<IPage<CloudJobSchedule>,JobScheduleListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2857,34 +2865,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<CloudJobSchedule>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<CloudJobSchedule>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2907,10 +2915,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2919,11 +2927,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJobSchedule>,JobScheduleListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, JobScheduleListNextOptions jobScheduleListNextOptions = default(JobScheduleListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<CloudJobSchedule>,JobScheduleListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, JobScheduleListNextOptions jobScheduleListNextOptions = default(JobScheduleListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (jobScheduleListNextOptions != null)
@@ -2941,44 +2949,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = jobScheduleListNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2986,7 +2994,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2994,7 +3002,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -3002,7 +3010,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -3021,23 +3029,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -3046,21 +3054,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -3070,7 +3078,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudJobSchedule>,JobScheduleListHeaders>();
+            var _result = new AzureOperationResponse<IPage<CloudJobSchedule>,JobScheduleListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -3083,34 +3091,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<CloudJobSchedule>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<CloudJobSchedule>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<JobScheduleListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/JobScheduleOperationsExtensions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/JobScheduleOperationsExtensions.cs
@@ -8,8 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Extension methods for JobScheduleOperations.
@@ -30,7 +33,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static bool Exists(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleExistsOptions jobScheduleExistsOptions = default(JobScheduleExistsOptions))
             {
-                return ((IJobScheduleOperations)operations).ExistsAsync(jobScheduleId, jobScheduleExistsOptions).GetAwaiter().GetResult();
+                return operations.ExistsAsync(jobScheduleId, jobScheduleExistsOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -48,7 +51,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<bool> ExistsAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleExistsOptions jobScheduleExistsOptions = default(JobScheduleExistsOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<bool> ExistsAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleExistsOptions jobScheduleExistsOptions = default(JobScheduleExistsOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ExistsWithHttpMessagesAsync(jobScheduleId, jobScheduleExistsOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -78,7 +81,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobScheduleDeleteHeaders Delete(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleDeleteOptions jobScheduleDeleteOptions = default(JobScheduleDeleteOptions))
             {
-                return ((IJobScheduleOperations)operations).DeleteAsync(jobScheduleId, jobScheduleDeleteOptions).GetAwaiter().GetResult();
+                return operations.DeleteAsync(jobScheduleId, jobScheduleDeleteOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -104,7 +107,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobScheduleDeleteHeaders> DeleteAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleDeleteOptions jobScheduleDeleteOptions = default(JobScheduleDeleteOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobScheduleDeleteHeaders> DeleteAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleDeleteOptions jobScheduleDeleteOptions = default(JobScheduleDeleteOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DeleteWithHttpMessagesAsync(jobScheduleId, jobScheduleDeleteOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -126,7 +129,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static CloudJobSchedule Get(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleGetOptions jobScheduleGetOptions = default(JobScheduleGetOptions))
             {
-                return ((IJobScheduleOperations)operations).GetAsync(jobScheduleId, jobScheduleGetOptions).GetAwaiter().GetResult();
+                return operations.GetAsync(jobScheduleId, jobScheduleGetOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -144,7 +147,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<CloudJobSchedule> GetAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleGetOptions jobScheduleGetOptions = default(JobScheduleGetOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<CloudJobSchedule> GetAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleGetOptions jobScheduleGetOptions = default(JobScheduleGetOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetWithHttpMessagesAsync(jobScheduleId, jobScheduleGetOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -176,7 +179,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobSchedulePatchHeaders Patch(this IJobScheduleOperations operations, string jobScheduleId, JobSchedulePatchParameter jobSchedulePatchParameter, JobSchedulePatchOptions jobSchedulePatchOptions = default(JobSchedulePatchOptions))
             {
-                return ((IJobScheduleOperations)operations).PatchAsync(jobScheduleId, jobSchedulePatchParameter, jobSchedulePatchOptions).GetAwaiter().GetResult();
+                return operations.PatchAsync(jobScheduleId, jobSchedulePatchParameter, jobSchedulePatchOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -204,7 +207,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobSchedulePatchHeaders> PatchAsync(this IJobScheduleOperations operations, string jobScheduleId, JobSchedulePatchParameter jobSchedulePatchParameter, JobSchedulePatchOptions jobSchedulePatchOptions = default(JobSchedulePatchOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobSchedulePatchHeaders> PatchAsync(this IJobScheduleOperations operations, string jobScheduleId, JobSchedulePatchParameter jobSchedulePatchParameter, JobSchedulePatchOptions jobSchedulePatchOptions = default(JobSchedulePatchOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.PatchWithHttpMessagesAsync(jobScheduleId, jobSchedulePatchParameter, jobSchedulePatchOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -236,7 +239,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobScheduleUpdateHeaders Update(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleUpdateParameter jobScheduleUpdateParameter, JobScheduleUpdateOptions jobScheduleUpdateOptions = default(JobScheduleUpdateOptions))
             {
-                return ((IJobScheduleOperations)operations).UpdateAsync(jobScheduleId, jobScheduleUpdateParameter, jobScheduleUpdateOptions).GetAwaiter().GetResult();
+                return operations.UpdateAsync(jobScheduleId, jobScheduleUpdateParameter, jobScheduleUpdateOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -264,7 +267,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobScheduleUpdateHeaders> UpdateAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleUpdateParameter jobScheduleUpdateParameter, JobScheduleUpdateOptions jobScheduleUpdateOptions = default(JobScheduleUpdateOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobScheduleUpdateHeaders> UpdateAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleUpdateParameter jobScheduleUpdateParameter, JobScheduleUpdateOptions jobScheduleUpdateOptions = default(JobScheduleUpdateOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.UpdateWithHttpMessagesAsync(jobScheduleId, jobScheduleUpdateParameter, jobScheduleUpdateOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -289,7 +292,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobScheduleDisableHeaders Disable(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleDisableOptions jobScheduleDisableOptions = default(JobScheduleDisableOptions))
             {
-                return ((IJobScheduleOperations)operations).DisableAsync(jobScheduleId, jobScheduleDisableOptions).GetAwaiter().GetResult();
+                return operations.DisableAsync(jobScheduleId, jobScheduleDisableOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -310,7 +313,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobScheduleDisableHeaders> DisableAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleDisableOptions jobScheduleDisableOptions = default(JobScheduleDisableOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobScheduleDisableHeaders> DisableAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleDisableOptions jobScheduleDisableOptions = default(JobScheduleDisableOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DisableWithHttpMessagesAsync(jobScheduleId, jobScheduleDisableOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -332,7 +335,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobScheduleEnableHeaders Enable(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleEnableOptions jobScheduleEnableOptions = default(JobScheduleEnableOptions))
             {
-                return ((IJobScheduleOperations)operations).EnableAsync(jobScheduleId, jobScheduleEnableOptions).GetAwaiter().GetResult();
+                return operations.EnableAsync(jobScheduleId, jobScheduleEnableOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -350,7 +353,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobScheduleEnableHeaders> EnableAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleEnableOptions jobScheduleEnableOptions = default(JobScheduleEnableOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobScheduleEnableHeaders> EnableAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleEnableOptions jobScheduleEnableOptions = default(JobScheduleEnableOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.EnableWithHttpMessagesAsync(jobScheduleId, jobScheduleEnableOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -372,7 +375,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobScheduleTerminateHeaders Terminate(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleTerminateOptions jobScheduleTerminateOptions = default(JobScheduleTerminateOptions))
             {
-                return ((IJobScheduleOperations)operations).TerminateAsync(jobScheduleId, jobScheduleTerminateOptions).GetAwaiter().GetResult();
+                return operations.TerminateAsync(jobScheduleId, jobScheduleTerminateOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -390,7 +393,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobScheduleTerminateHeaders> TerminateAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleTerminateOptions jobScheduleTerminateOptions = default(JobScheduleTerminateOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobScheduleTerminateHeaders> TerminateAsync(this IJobScheduleOperations operations, string jobScheduleId, JobScheduleTerminateOptions jobScheduleTerminateOptions = default(JobScheduleTerminateOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.TerminateWithHttpMessagesAsync(jobScheduleId, jobScheduleTerminateOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -412,7 +415,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static JobScheduleAddHeaders Add(this IJobScheduleOperations operations, JobScheduleAddParameter cloudJobSchedule, JobScheduleAddOptions jobScheduleAddOptions = default(JobScheduleAddOptions))
             {
-                return ((IJobScheduleOperations)operations).AddAsync(cloudJobSchedule, jobScheduleAddOptions).GetAwaiter().GetResult();
+                return operations.AddAsync(cloudJobSchedule, jobScheduleAddOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -430,7 +433,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<JobScheduleAddHeaders> AddAsync(this IJobScheduleOperations operations, JobScheduleAddParameter cloudJobSchedule, JobScheduleAddOptions jobScheduleAddOptions = default(JobScheduleAddOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<JobScheduleAddHeaders> AddAsync(this IJobScheduleOperations operations, JobScheduleAddParameter cloudJobSchedule, JobScheduleAddOptions jobScheduleAddOptions = default(JobScheduleAddOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.AddWithHttpMessagesAsync(cloudJobSchedule, jobScheduleAddOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -447,9 +450,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='jobScheduleListOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<CloudJobSchedule> List(this IJobScheduleOperations operations, JobScheduleListOptions jobScheduleListOptions = default(JobScheduleListOptions))
+            public static IPage<CloudJobSchedule> List(this IJobScheduleOperations operations, JobScheduleListOptions jobScheduleListOptions = default(JobScheduleListOptions))
             {
-                return ((IJobScheduleOperations)operations).ListAsync(jobScheduleListOptions).GetAwaiter().GetResult();
+                return operations.ListAsync(jobScheduleListOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -464,7 +467,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<CloudJobSchedule>> ListAsync(this IJobScheduleOperations operations, JobScheduleListOptions jobScheduleListOptions = default(JobScheduleListOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<CloudJobSchedule>> ListAsync(this IJobScheduleOperations operations, JobScheduleListOptions jobScheduleListOptions = default(JobScheduleListOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListWithHttpMessagesAsync(jobScheduleListOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -484,9 +487,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='jobScheduleListNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<CloudJobSchedule> ListNext(this IJobScheduleOperations operations, string nextPageLink, JobScheduleListNextOptions jobScheduleListNextOptions = default(JobScheduleListNextOptions))
+            public static IPage<CloudJobSchedule> ListNext(this IJobScheduleOperations operations, string nextPageLink, JobScheduleListNextOptions jobScheduleListNextOptions = default(JobScheduleListNextOptions))
             {
-                return ((IJobScheduleOperations)operations).ListNextAsync(nextPageLink, jobScheduleListNextOptions).GetAwaiter().GetResult();
+                return operations.ListNextAsync(nextPageLink, jobScheduleListNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -504,7 +507,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<CloudJobSchedule>> ListNextAsync(this IJobScheduleOperations operations, string nextPageLink, JobScheduleListNextOptions jobScheduleListNextOptions = default(JobScheduleListNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<CloudJobSchedule>> ListNextAsync(this IJobScheduleOperations operations, string nextPageLink, JobScheduleListNextOptions jobScheduleListNextOptions = default(JobScheduleListNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNextWithHttpMessagesAsync(nextPageLink, jobScheduleListNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AccessScope.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AccessScope.cs
@@ -8,14 +8,46 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for AccessScope.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum AccessScope
     {
-        [System.Runtime.Serialization.EnumMember(Value = "job")]
+        [EnumMember(Value = "job")]
         Job
+    }
+    internal static class AccessScopeEnumExtension
+    {
+        internal static string ToSerializedValue(this AccessScope? value)  =>
+            value == null ? null : ((AccessScope)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this AccessScope value)
+        {
+            switch( value )
+            {
+                case AccessScope.Job:
+                    return "job";
+            }
+            return null;
+        }
+
+        internal static AccessScope? ParseAccessScope(this string value)
+        {
+            switch( value )
+            {
+                case "job":
+                    return AccessScope.Job;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AccountListNodeAgentSkusHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AccountListNodeAgentSkusHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the AccountListNodeAgentSkusHeaders
         /// class.
         /// </summary>
-        public AccountListNodeAgentSkusHeaders() { }
+        public AccountListNodeAgentSkusHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the AccountListNodeAgentSkusHeaders
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public AccountListNodeAgentSkusHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AccountListNodeAgentSkusNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AccountListNodeAgentSkusNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// AccountListNodeAgentSkusNextOptions class.
         /// </summary>
-        public AccountListNodeAgentSkusNextOptions() { }
+        public AccountListNodeAgentSkusNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -35,24 +44,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public AccountListNodeAgentSkusNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -60,8 +75,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AccountListNodeAgentSkusOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AccountListNodeAgentSkusOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the AccountListNodeAgentSkusOptions
         /// class.
         /// </summary>
-        public AccountListNodeAgentSkusOptions() { }
+        public AccountListNodeAgentSkusOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the AccountListNodeAgentSkusOptions
@@ -41,32 +50,38 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public AccountListNodeAgentSkusOptions(string filter = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 results will be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AffinityInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AffinityInformation.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the AffinityInformation class.
         /// </summary>
-        public AffinityInformation() { }
+        public AffinityInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the AffinityInformation class.
@@ -28,31 +36,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// of a compute node or a task that has run previously.</param>
         public AffinityInformation(string affinityId)
         {
-            this.AffinityId = affinityId;
+            AffinityId = affinityId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an opaque string representing the location of a
         /// compute node or a task that has run previously.
         /// </summary>
         /// <remarks>
-        /// You can pass the affinityId of a compute node or task to indicate
-        /// that this task needs to be placed close to the node or task.
+        /// You can pass the affinityId of a compute node to indicate that this
+        /// task needs to run on that compute node. Note that this is just a
+        /// soft affinity. If the target node is busy or unavailable at the
+        /// time the task is scheduled, then the task will be scheduled
+        /// elsewhere.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "affinityId")]
+        [JsonProperty(PropertyName = "affinityId")]
         public string AffinityId { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.AffinityId == null)
+            if (AffinityId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "AffinityId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "AffinityId");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AllocationState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AllocationState.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for AllocationState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum AllocationState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "steady")]
+        [EnumMember(Value = "steady")]
         Steady,
-        [System.Runtime.Serialization.EnumMember(Value = "resizing")]
+        [EnumMember(Value = "resizing")]
         Resizing,
-        [System.Runtime.Serialization.EnumMember(Value = "stopping")]
+        [EnumMember(Value = "stopping")]
         Stopping
+    }
+    internal static class AllocationStateEnumExtension
+    {
+        internal static string ToSerializedValue(this AllocationState? value)  =>
+            value == null ? null : ((AllocationState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this AllocationState value)
+        {
+            switch( value )
+            {
+                case AllocationState.Steady:
+                    return "steady";
+                case AllocationState.Resizing:
+                    return "resizing";
+                case AllocationState.Stopping:
+                    return "stopping";
+            }
+            return null;
+        }
+
+        internal static AllocationState? ParseAllocationState(this string value)
+        {
+            switch( value )
+            {
+                case "steady":
+                    return AllocationState.Steady;
+                case "resizing":
+                    return AllocationState.Resizing;
+                case "stopping":
+                    return AllocationState.Stopping;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationGetHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationGetHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ApplicationGetHeaders class.
         /// </summary>
-        public ApplicationGetHeaders() { }
+        public ApplicationGetHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ApplicationGetHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public ApplicationGetHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationGetOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationGetOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ApplicationGetOptions class.
         /// </summary>
-        public ApplicationGetOptions() { }
+        public ApplicationGetOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ApplicationGetOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ApplicationGetOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationListHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationListHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ApplicationListHeaders class.
         /// </summary>
-        public ApplicationListHeaders() { }
+        public ApplicationListHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ApplicationListHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public ApplicationListHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationListNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationListNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ApplicationListNextOptions class.
         /// </summary>
-        public ApplicationListNextOptions() { }
+        public ApplicationListNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ApplicationListNextOptions class.
@@ -33,24 +42,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ApplicationListNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -58,8 +73,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationListOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationListOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ApplicationListOptions class.
         /// </summary>
-        public ApplicationListOptions() { }
+        public ApplicationListOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ApplicationListOptions class.
@@ -39,25 +48,31 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ApplicationListOptions(int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 applications can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -65,14 +80,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -80,8 +95,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationPackageReference.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationPackageReference.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the ApplicationPackageReference
         /// class.
         /// </summary>
-        public ApplicationPackageReference() { }
+        public ApplicationPackageReference()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ApplicationPackageReference
@@ -31,14 +39,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// omitted, the default version is deployed.</param>
         public ApplicationPackageReference(string applicationId, string version = default(string))
         {
-            this.ApplicationId = applicationId;
-            this.Version = version;
+            ApplicationId = applicationId;
+            Version = version;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ID of the application to deploy.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationId")]
+        [JsonProperty(PropertyName = "applicationId")]
         public string ApplicationId { get; set; }
 
         /// <summary>
@@ -46,25 +60,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the default version is deployed.
         /// </summary>
         /// <remarks>
-        /// If this is omitted, and no default version is specified for this
-        /// application, the request fails with the error code
-        /// InvalidApplicationPackageReferences. If you are calling the REST
-        /// API directly, the HTTP status code is 409.
+        /// If this is omitted on a pool, and no default version is specified
+        /// for this application, the request fails with the error code
+        /// InvalidApplicationPackageReferences and HTTP status code 409. If
+        /// this is omitted on a task, and no default version is specified for
+        /// this application, the task fails with a pre-processing error.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "version")]
+        [JsonProperty(PropertyName = "version")]
         public string Version { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.ApplicationId == null)
+            if (ApplicationId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "ApplicationId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "ApplicationId");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationSummary.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ApplicationSummary.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ApplicationSummary class.
         /// </summary>
-        public ApplicationSummary() { }
+        public ApplicationSummary()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ApplicationSummary class.
@@ -27,53 +37,59 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// within the account.</param>
         /// <param name="displayName">The display name for the
         /// application.</param>
-        /// <param name="versions">The versions of the application which are
-        /// available.</param>
-        public ApplicationSummary(string id, string displayName, System.Collections.Generic.IList<string> versions)
+        /// <param name="versions">The list of available versions of the
+        /// application.</param>
+        public ApplicationSummary(string id, string displayName, IList<string> versions)
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.Versions = versions;
+            Id = id;
+            DisplayName = displayName;
+            Versions = versions;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the application
         /// within the account.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the display name for the application.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Gets or sets the versions of the application which are available.
+        /// Gets or sets the list of available versions of the application.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "versions")]
-        public System.Collections.Generic.IList<string> Versions { get; set; }
+        [JsonProperty(PropertyName = "versions")]
+        public IList<string> Versions { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Id == null)
+            if (Id == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Id");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Id");
             }
-            if (this.DisplayName == null)
+            if (DisplayName == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "DisplayName");
+                throw new ValidationException(ValidationRules.CannotBeNull, "DisplayName");
             }
-            if (this.Versions == null)
+            if (Versions == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Versions");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Versions");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AuthenticationTokenSettings.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AuthenticationTokenSettings.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the AuthenticationTokenSettings
         /// class.
         /// </summary>
-        public AuthenticationTokenSettings() { }
+        public AuthenticationTokenSettings()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the AuthenticationTokenSettings
@@ -28,10 +37,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// </summary>
         /// <param name="access">The Batch resources to which the token grants
         /// access.</param>
-        public AuthenticationTokenSettings(System.Collections.Generic.IList<AccessScope> access = default(System.Collections.Generic.IList<AccessScope>))
+        public AuthenticationTokenSettings(IList<AccessScope> access = default(IList<AccessScope>))
         {
-            this.Access = access;
+            Access = access;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the Batch resources to which the token grants access.
@@ -42,8 +57,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// access property is 'job', which grants access to all operations
         /// related to the job which contains the task.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "access")]
-        public System.Collections.Generic.IList<AccessScope> Access { get; set; }
+        [JsonProperty(PropertyName = "access")]
+        public IList<AccessScope> Access { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoPoolSpecification.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoPoolSpecification.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the AutoPoolSpecification class.
         /// </summary>
-        public AutoPoolSpecification() { }
+        public AutoPoolSpecification()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the AutoPoolSpecification class.
@@ -35,11 +42,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// pool.</param>
         public AutoPoolSpecification(PoolLifetimeOption poolLifetimeOption, string autoPoolIdPrefix = default(string), bool? keepAlive = default(bool?), PoolSpecification pool = default(PoolSpecification))
         {
-            this.AutoPoolIdPrefix = autoPoolIdPrefix;
-            this.PoolLifetimeOption = poolLifetimeOption;
-            this.KeepAlive = keepAlive;
-            this.Pool = pool;
+            AutoPoolIdPrefix = autoPoolIdPrefix;
+            PoolLifetimeOption = poolLifetimeOption;
+            KeepAlive = keepAlive;
+            Pool = pool;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a prefix to be added to the unique identifier when a
@@ -48,10 +61,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// The Batch service assigns each auto pool a unique identifier on
         /// creation. To distinguish between pools created for different
-        /// purposes, you can specify this element to add a prefix to the id
+        /// purposes, you can specify this element to add a prefix to the ID
         /// that is assigned. The prefix can be up to 20 characters long.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoPoolIdPrefix")]
+        [JsonProperty(PropertyName = "autoPoolIdPrefix")]
         public string AutoPoolIdPrefix { get; set; }
 
         /// <summary>
@@ -59,14 +72,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// multiple jobs on a schedule are assigned to pools.
         /// </summary>
         /// <remarks>
-        /// When the pool lifetime scope is jobSchedule level, the Batch
-        /// service keeps track of the last autopool created for the job
-        /// schedule, and deletes that pool when the job schedule completes.
-        /// Batch will also delete this pool if the user updates the auto pool
-        /// specification in a way that changes this lifetime. Possible values
-        /// include: 'jobSchedule', 'job'
+        /// When the pool lifetime is jobSchedule the pool exists for the
+        /// lifetime of the job schedule. The Batch Service creates the pool
+        /// when it creates the first job on the schedule. You may apply this
+        /// option only to job schedules, not to jobs. When the pool lifetime
+        /// is job the pool exists for the lifetime of the job to which it is
+        /// dedicated. The Batch service creates the pool when it creates the
+        /// job. If the 'job' option is applied to a job schedule, the Batch
+        /// service creates a new auto pool for every job created on the
+        /// schedule. Possible values include: 'jobSchedule', 'job'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolLifetimeOption")]
+        [JsonProperty(PropertyName = "poolLifetimeOption")]
         public PoolLifetimeOption PoolLifetimeOption { get; set; }
 
         /// <summary>
@@ -80,26 +96,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// does not delete the pool automatically. It is up to the user to
         /// delete auto pools created with this option.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "keepAlive")]
+        [JsonProperty(PropertyName = "keepAlive")]
         public bool? KeepAlive { get; set; }
 
         /// <summary>
         /// Gets or sets the pool specification for the auto pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "pool")]
+        [JsonProperty(PropertyName = "pool")]
         public PoolSpecification Pool { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Pool != null)
+            if (Pool != null)
             {
-                this.Pool.Validate();
+                Pool.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoScaleRun.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoScaleRun.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the AutoScaleRun class.
         /// </summary>
-        public AutoScaleRun() { }
+        public AutoScaleRun()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the AutoScaleRun class.
@@ -32,16 +39,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// unsuccessful.</param>
         public AutoScaleRun(System.DateTime timestamp, string results = default(string), AutoScaleRunError error = default(AutoScaleRunError))
         {
-            this.Timestamp = timestamp;
-            this.Results = results;
-            this.Error = error;
+            Timestamp = timestamp;
+            Results = results;
+            Error = error;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the time at which the autoscale formula was last
         /// evaluated.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "timestamp")]
+        [JsonProperty(PropertyName = "timestamp")]
         public System.DateTime Timestamp { get; set; }
 
         /// <summary>
@@ -52,20 +65,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Each variable value is returned in the form $variable=value, and
         /// variables are separated by semicolons.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "results")]
+        [JsonProperty(PropertyName = "results")]
         public string Results { get; set; }
 
         /// <summary>
         /// Gets or sets details of the error encountered evaluating the
         /// autoscale formula on the pool, if the evaluation was unsuccessful.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "error")]
+        [JsonProperty(PropertyName = "error")]
         public AutoScaleRunError Error { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoScaleRunError.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoScaleRunError.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the AutoScaleRunError class.
         /// </summary>
-        public AutoScaleRunError() { }
+        public AutoScaleRunError()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the AutoScaleRunError class.
@@ -30,33 +39,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// intended to be suitable for display in a user interface.</param>
         /// <param name="values">A list of additional error details related to
         /// the autoscale error.</param>
-        public AutoScaleRunError(string code = default(string), string message = default(string), System.Collections.Generic.IList<NameValuePair> values = default(System.Collections.Generic.IList<NameValuePair>))
+        public AutoScaleRunError(string code = default(string), string message = default(string), IList<NameValuePair> values = default(IList<NameValuePair>))
         {
-            this.Code = code;
-            this.Message = message;
-            this.Values = values;
+            Code = code;
+            Message = message;
+            Values = values;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an identifier for the autoscale error. Codes are
         /// invariant and are intended to be consumed programmatically.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [JsonProperty(PropertyName = "code")]
         public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets a message describing the autoscale error, intended to
         /// be suitable for display in a user interface.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }
 
         /// <summary>
         /// Gets or sets a list of additional error details related to the
         /// autoscale error.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "values")]
-        public System.Collections.Generic.IList<NameValuePair> Values { get; set; }
+        [JsonProperty(PropertyName = "values")]
+        public IList<NameValuePair> Values { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoUserScope.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoUserScope.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for AutoUserScope.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum AutoUserScope
     {
-        [System.Runtime.Serialization.EnumMember(Value = "task")]
+        [EnumMember(Value = "task")]
         Task,
-        [System.Runtime.Serialization.EnumMember(Value = "pool")]
+        [EnumMember(Value = "pool")]
         Pool
+    }
+    internal static class AutoUserScopeEnumExtension
+    {
+        internal static string ToSerializedValue(this AutoUserScope? value)  =>
+            value == null ? null : ((AutoUserScope)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this AutoUserScope value)
+        {
+            switch( value )
+            {
+                case AutoUserScope.Task:
+                    return "task";
+                case AutoUserScope.Pool:
+                    return "pool";
+            }
+            return null;
+        }
+
+        internal static AutoUserScope? ParseAutoUserScope(this string value)
+        {
+            switch( value )
+            {
+                case "task":
+                    return AutoUserScope.Task;
+                case "pool":
+                    return AutoUserScope.Pool;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoUserSpecification.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/AutoUserSpecification.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the AutoUserSpecification class.
         /// </summary>
-        public AutoUserSpecification() { }
+        public AutoUserSpecification()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the AutoUserSpecification class.
@@ -29,20 +36,29 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// user.</param>
         public AutoUserSpecification(AutoUserScope? scope = default(AutoUserScope?), ElevationLevel? elevationLevel = default(ElevationLevel?))
         {
-            this.Scope = scope;
-            this.ElevationLevel = elevationLevel;
+            Scope = scope;
+            ElevationLevel = elevationLevel;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the scope for the auto user
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
         /// pool - specifies that the task runs as the common auto user account
-        /// which is created on every node in a pool. task - specifies that the
-        /// service should create a new user for the task. The default value is
-        /// task. Possible values include: 'task', 'pool'
+        /// which is created on every node in a pool.
+        /// task - specifies that the service should create a new user for the
+        /// task.
+        /// The default value is task. Possible values include: 'task', 'pool'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "scope")]
+        [JsonProperty(PropertyName = "scope")]
         public AutoUserScope? Scope { get; set; }
 
         /// <summary>
@@ -54,7 +70,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// operates with full Administrator permissions. The default value is
         /// nonAdmin. Possible values include: 'nonAdmin', 'admin'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "elevationLevel")]
+        [JsonProperty(PropertyName = "elevationLevel")]
         public ElevationLevel? ElevationLevel { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/BatchError.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/BatchError.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the BatchError class.
         /// </summary>
-        public BatchError() { }
+        public BatchError()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the BatchError class.
@@ -29,33 +38,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// be suitable for display in a user interface.</param>
         /// <param name="values">A collection of key-value pairs containing
         /// additional details about the error.</param>
-        public BatchError(string code = default(string), ErrorMessage message = default(ErrorMessage), System.Collections.Generic.IList<BatchErrorDetail> values = default(System.Collections.Generic.IList<BatchErrorDetail>))
+        public BatchError(string code = default(string), ErrorMessage message = default(ErrorMessage), IList<BatchErrorDetail> values = default(IList<BatchErrorDetail>))
         {
-            this.Code = code;
-            this.Message = message;
-            this.Values = values;
+            Code = code;
+            Message = message;
+            Values = values;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an identifier for the error. Codes are invariant and
         /// are intended to be consumed programmatically.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [JsonProperty(PropertyName = "code")]
         public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets a message describing the error, intended to be
         /// suitable for display in a user interface.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        [JsonProperty(PropertyName = "message")]
         public ErrorMessage Message { get; set; }
 
         /// <summary>
         /// Gets or sets a collection of key-value pairs containing additional
         /// details about the error.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "values")]
-        public System.Collections.Generic.IList<BatchErrorDetail> Values { get; set; }
+        [JsonProperty(PropertyName = "values")]
+        public IList<BatchErrorDetail> Values { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/BatchErrorDetail.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/BatchErrorDetail.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the BatchErrorDetail class.
         /// </summary>
-        public BatchErrorDetail() { }
+        public BatchErrorDetail()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the BatchErrorDetail class.
@@ -30,22 +37,28 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// error response.</param>
         public BatchErrorDetail(string key = default(string), string value = default(string))
         {
-            this.Key = key;
-            this.Value = value;
+            Key = key;
+            Value = value;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an identifier specifying the meaning of the Value
         /// property.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "key")]
+        [JsonProperty(PropertyName = "key")]
         public string Key { get; set; }
 
         /// <summary>
         /// Gets or sets the additional information included with the error
         /// response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/BatchErrorException.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/BatchErrorException.cs
@@ -8,24 +8,25 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
 
     /// <summary>
     /// Exception thrown for an invalid response with BatchError information.
     /// </summary>
-#if !PORTABLE
-    [System.Serializable]
-#endif
-    public class BatchErrorException : Microsoft.Rest.RestException
+    public class BatchErrorException : RestException
     {
         /// <summary>
         /// Gets information about the associated HTTP request.
         /// </summary>
-        public Microsoft.Rest.HttpRequestMessageWrapper Request { get; set; }
+        public HttpRequestMessageWrapper Request { get; set; }
 
         /// <summary>
         /// Gets information about the associated HTTP response.
         /// </summary>
-        public Microsoft.Rest.HttpResponseMessageWrapper Response { get; set; }
+        public HttpResponseMessageWrapper Response { get; set; }
 
         /// <summary>
         /// Gets or sets the body object.
@@ -57,39 +58,5 @@ namespace Microsoft.Azure.Batch.Protocol.Models
             : base(message, innerException)
         {
         }
-
-#if !PORTABLE
-        /// <summary>
-        /// Initializes a new instance of the BatchErrorException class.
-        /// </summary>
-        /// <param name="info">Serialization info.</param>
-        /// <param name="context">Streaming context.</param>
-        protected BatchErrorException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-            : base(info, context)
-        {
-        }
-
-        /// <summary>
-        /// Serializes content of the exception.
-        /// </summary>
-        /// <param name="info">Serialization info.</param>
-        /// <param name="context">Streaming context.</param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        [System.Security.Permissions.SecurityPermission(System.Security.Permissions.SecurityAction.Demand, SerializationFormatter = true)]
-        public override void GetObjectData(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context)
-        {
-            base.GetObjectData(info, context);
-            if (info == null)
-            {
-                throw new System.ArgumentNullException("info");
-            }
-
-            info.AddValue("Request", Request);
-            info.AddValue("Response", Response);
-            info.AddValue("Body", Body);
-        }
-#endif
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CachingType.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CachingType.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for CachingType.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum CachingType
     {
-        [System.Runtime.Serialization.EnumMember(Value = "none")]
+        [EnumMember(Value = "none")]
         None,
-        [System.Runtime.Serialization.EnumMember(Value = "readOnly")]
+        [EnumMember(Value = "readOnly")]
         ReadOnly,
-        [System.Runtime.Serialization.EnumMember(Value = "readWrite")]
+        [EnumMember(Value = "readWrite")]
         ReadWrite
+    }
+    internal static class CachingTypeEnumExtension
+    {
+        internal static string ToSerializedValue(this CachingType? value)  =>
+            value == null ? null : ((CachingType)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this CachingType value)
+        {
+            switch( value )
+            {
+                case CachingType.None:
+                    return "none";
+                case CachingType.ReadOnly:
+                    return "readOnly";
+                case CachingType.ReadWrite:
+                    return "readWrite";
+            }
+            return null;
+        }
+
+        internal static CachingType? ParseCachingType(this string value)
+        {
+            switch( value )
+            {
+                case "none":
+                    return CachingType.None;
+                case "readOnly":
+                    return CachingType.ReadOnly;
+                case "readWrite":
+                    return CachingType.ReadWrite;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/Certificate.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/Certificate.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the Certificate class.
         /// </summary>
-        public Certificate() { }
+        public Certificate()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the Certificate class.
@@ -42,34 +49,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// last attempt to delete this certificate.</param>
         public Certificate(string thumbprint = default(string), string thumbprintAlgorithm = default(string), string url = default(string), CertificateState? state = default(CertificateState?), System.DateTime? stateTransitionTime = default(System.DateTime?), CertificateState? previousState = default(CertificateState?), System.DateTime? previousStateTransitionTime = default(System.DateTime?), string publicData = default(string), DeleteCertificateError deleteCertificateError = default(DeleteCertificateError))
         {
-            this.Thumbprint = thumbprint;
-            this.ThumbprintAlgorithm = thumbprintAlgorithm;
-            this.Url = url;
-            this.State = state;
-            this.StateTransitionTime = stateTransitionTime;
-            this.PreviousState = previousState;
-            this.PreviousStateTransitionTime = previousStateTransitionTime;
-            this.PublicData = publicData;
-            this.DeleteCertificateError = deleteCertificateError;
+            Thumbprint = thumbprint;
+            ThumbprintAlgorithm = thumbprintAlgorithm;
+            Url = url;
+            State = state;
+            StateTransitionTime = stateTransitionTime;
+            PreviousState = previousState;
+            PreviousStateTransitionTime = previousStateTransitionTime;
+            PublicData = publicData;
+            DeleteCertificateError = deleteCertificateError;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the X.509 thumbprint of the certificate. This is a
         /// sequence of up to 40 hex digits.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "thumbprint")]
+        [JsonProperty(PropertyName = "thumbprint")]
         public string Thumbprint { get; set; }
 
         /// <summary>
         /// Gets or sets the algorithm used to derive the thumbprint.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "thumbprintAlgorithm")]
+        [JsonProperty(PropertyName = "thumbprintAlgorithm")]
         public string ThumbprintAlgorithm { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the certificate.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
@@ -78,14 +91,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'active', 'deleting', 'deleteFailed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public CertificateState? State { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the certificate entered its current
         /// state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stateTransitionTime")]
+        [JsonProperty(PropertyName = "stateTransitionTime")]
         public System.DateTime? StateTransitionTime { get; set; }
 
         /// <summary>
@@ -96,7 +109,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// active state. Possible values include: 'active', 'deleting',
         /// 'deleteFailed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousState")]
+        [JsonProperty(PropertyName = "previousState")]
         public CertificateState? PreviousState { get; set; }
 
         /// <summary>
@@ -107,14 +120,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is not set if the certificate is in its initial
         /// Active state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousStateTransitionTime")]
+        [JsonProperty(PropertyName = "previousStateTransitionTime")]
         public System.DateTime? PreviousStateTransitionTime { get; set; }
 
         /// <summary>
         /// Gets or sets the public part of the certificate as a base-64
         /// encoded .cer file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "publicData")]
+        [JsonProperty(PropertyName = "publicData")]
         public string PublicData { get; set; }
 
         /// <summary>
@@ -125,7 +138,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the certificate is in the DeleteFailed
         /// state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "deleteCertificateError")]
+        [JsonProperty(PropertyName = "deleteCertificateError")]
         public DeleteCertificateError DeleteCertificateError { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateAddHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateAddHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateAddHeaders class.
         /// </summary>
-        public CertificateAddHeaders() { }
+        public CertificateAddHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateAddHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public CertificateAddHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateAddOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateAddOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateAddOptions class.
         /// </summary>
-        public CertificateAddOptions() { }
+        public CertificateAddOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateAddOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public CertificateAddOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateAddParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateAddParameter.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateAddParameter class.
         /// </summary>
-        public CertificateAddParameter() { }
+        public CertificateAddParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateAddParameter class.
@@ -37,33 +45,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// private key.</param>
         public CertificateAddParameter(string thumbprint, string thumbprintAlgorithm, string data, CertificateFormat? certificateFormat = default(CertificateFormat?), string password = default(string))
         {
-            this.Thumbprint = thumbprint;
-            this.ThumbprintAlgorithm = thumbprintAlgorithm;
-            this.Data = data;
-            this.CertificateFormat = certificateFormat;
-            this.Password = password;
+            Thumbprint = thumbprint;
+            ThumbprintAlgorithm = thumbprintAlgorithm;
+            Data = data;
+            CertificateFormat = certificateFormat;
+            Password = password;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the X.509 thumbprint of the certificate. This is a
         /// sequence of up to 40 hex digits (it may include spaces but these
         /// are removed).
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "thumbprint")]
+        [JsonProperty(PropertyName = "thumbprint")]
         public string Thumbprint { get; set; }
 
         /// <summary>
         /// Gets or sets the algorithm used to derive the thumbprint. This must
         /// be sha1.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "thumbprintAlgorithm")]
+        [JsonProperty(PropertyName = "thumbprintAlgorithm")]
         public string ThumbprintAlgorithm { get; set; }
 
         /// <summary>
         /// Gets or sets the base64-encoded contents of the certificate. The
         /// maximum size is 10KB.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "data")]
+        [JsonProperty(PropertyName = "data")]
         public string Data { get; set; }
 
         /// <summary>
@@ -72,7 +86,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'pfx', 'cer'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "certificateFormat")]
+        [JsonProperty(PropertyName = "certificateFormat")]
         public CertificateFormat? CertificateFormat { get; set; }
 
         /// <summary>
@@ -82,28 +96,28 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This is required if the certificate format is pfx. It should be
         /// omitted if the certificate format is cer.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "password")]
+        [JsonProperty(PropertyName = "password")]
         public string Password { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Thumbprint == null)
+            if (Thumbprint == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Thumbprint");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Thumbprint");
             }
-            if (this.ThumbprintAlgorithm == null)
+            if (ThumbprintAlgorithm == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "ThumbprintAlgorithm");
+                throw new ValidationException(ValidationRules.CannotBeNull, "ThumbprintAlgorithm");
             }
-            if (this.Data == null)
+            if (Data == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Data");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Data");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateCancelDeletionHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateCancelDeletionHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the CertificateCancelDeletionHeaders
         /// class.
         /// </summary>
-        public CertificateCancelDeletionHeaders() { }
+        public CertificateCancelDeletionHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateCancelDeletionHeaders
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public CertificateCancelDeletionHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -70,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -80,21 +95,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateCancelDeletionOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateCancelDeletionOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the CertificateCancelDeletionOptions
         /// class.
         /// </summary>
-        public CertificateCancelDeletionOptions() { }
+        public CertificateCancelDeletionOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateCancelDeletionOptions
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public CertificateCancelDeletionOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateDeleteHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateDeleteHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateDeleteHeaders class.
         /// </summary>
-        public CertificateDeleteHeaders() { }
+        public CertificateDeleteHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateDeleteHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public CertificateDeleteHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateDeleteOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateDeleteOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateDeleteOptions class.
         /// </summary>
-        public CertificateDeleteOptions() { }
+        public CertificateDeleteOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateDeleteOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public CertificateDeleteOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateFormat.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateFormat.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for CertificateFormat.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum CertificateFormat
     {
-        [System.Runtime.Serialization.EnumMember(Value = "pfx")]
+        [EnumMember(Value = "pfx")]
         Pfx,
-        [System.Runtime.Serialization.EnumMember(Value = "cer")]
+        [EnumMember(Value = "cer")]
         Cer
+    }
+    internal static class CertificateFormatEnumExtension
+    {
+        internal static string ToSerializedValue(this CertificateFormat? value)  =>
+            value == null ? null : ((CertificateFormat)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this CertificateFormat value)
+        {
+            switch( value )
+            {
+                case CertificateFormat.Pfx:
+                    return "pfx";
+                case CertificateFormat.Cer:
+                    return "cer";
+            }
+            return null;
+        }
+
+        internal static CertificateFormat? ParseCertificateFormat(this string value)
+        {
+            switch( value )
+            {
+                case "pfx":
+                    return CertificateFormat.Pfx;
+                case "cer":
+                    return CertificateFormat.Cer;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateGetHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateGetHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateGetHeaders class.
         /// </summary>
-        public CertificateGetHeaders() { }
+        public CertificateGetHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateGetHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public CertificateGetHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateGetOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateGetOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateGetOptions class.
         /// </summary>
-        public CertificateGetOptions() { }
+        public CertificateGetOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateGetOptions class.
@@ -37,24 +46,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public CertificateGetOptions(string select = default(string), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Select = select;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Select = select;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -62,14 +77,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -77,8 +92,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateListHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateListHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateListHeaders class.
         /// </summary>
-        public CertificateListHeaders() { }
+        public CertificateListHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateListHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public CertificateListHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateListNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateListNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateListNextOptions class.
         /// </summary>
-        public CertificateListNextOptions() { }
+        public CertificateListNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateListNextOptions class.
@@ -33,24 +42,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public CertificateListNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -58,8 +73,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateListOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateListOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateListOptions class.
         /// </summary>
-        public CertificateListOptions() { }
+        public CertificateListOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateListOptions class.
@@ -41,39 +50,45 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public CertificateListOptions(string filter = default(string), string select = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.Select = select;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            Select = select;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 certificates can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -81,14 +96,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -96,8 +111,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateReference.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateReference.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CertificateReference class.
         /// </summary>
-        public CertificateReference() { }
+        public CertificateReference()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CertificateReference class.
@@ -33,26 +43,32 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node into which to install the certificate.</param>
         /// <param name="visibility">Which user accounts on the compute node
         /// should have access to the private data of the certificate.</param>
-        public CertificateReference(string thumbprint, string thumbprintAlgorithm, CertificateStoreLocation? storeLocation = default(CertificateStoreLocation?), string storeName = default(string), System.Collections.Generic.IList<CertificateVisibility> visibility = default(System.Collections.Generic.IList<CertificateVisibility>))
+        public CertificateReference(string thumbprint, string thumbprintAlgorithm, CertificateStoreLocation? storeLocation = default(CertificateStoreLocation?), string storeName = default(string), IList<CertificateVisibility> visibility = default(IList<CertificateVisibility>))
         {
-            this.Thumbprint = thumbprint;
-            this.ThumbprintAlgorithm = thumbprintAlgorithm;
-            this.StoreLocation = storeLocation;
-            this.StoreName = storeName;
-            this.Visibility = visibility;
+            Thumbprint = thumbprint;
+            ThumbprintAlgorithm = thumbprintAlgorithm;
+            StoreLocation = storeLocation;
+            StoreName = storeName;
+            Visibility = visibility;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the thumbprint of the certificate.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "thumbprint")]
+        [JsonProperty(PropertyName = "thumbprint")]
         public string Thumbprint { get; set; }
 
         /// <summary>
         /// Gets or sets the algorithm with which the thumbprint is associated.
         /// This must be sha1.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "thumbprintAlgorithm")]
+        [JsonProperty(PropertyName = "thumbprintAlgorithm")]
         public string ThumbprintAlgorithm { get; set; }
 
         /// <summary>
@@ -72,7 +88,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// certificates are placed in that directory. Possible values include:
         /// 'currentUser', 'localMachine'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "storeLocation")]
+        [JsonProperty(PropertyName = "storeLocation")]
         public CertificateStoreLocation? StoreLocation { get; set; }
 
         /// <summary>
@@ -80,12 +96,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// into which to install the certificate.
         /// </summary>
         /// <remarks>
-        /// The default value is My. This property is applicable only for pools
-        /// configured with Windows nodes (that is, created with
-        /// cloudServiceConfiguration, or with virtualMachineConfiguration
-        /// using a Windows image reference).
+        /// This property is applicable only for pools configured with Windows
+        /// nodes (that is, created with cloudServiceConfiguration, or with
+        /// virtualMachineConfiguration using a Windows image reference).
+        /// Common store names include: My, Root, CA, Trust, Disallowed,
+        /// TrustedPeople, TrustedPublisher, AuthRoot, AddressBook, but any
+        /// custom store name can also be used. The default value is My.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "storeName")]
+        [JsonProperty(PropertyName = "storeName")]
         public string StoreName { get; set; }
 
         /// <summary>
@@ -93,26 +111,34 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// access to the private data of the certificate.
         /// </summary>
         /// <remarks>
-        /// The default is all accounts.
+        /// Values are:
+        ///
+        /// starttask - The user account under which the start task is run.
+        /// task - The accounts under which job tasks are run.
+        /// remoteuser - The accounts under which users remotely access the
+        /// node.
+        ///
+        /// You can specify more than one visibility in this collection. The
+        /// default is all accounts.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "visibility")]
-        public System.Collections.Generic.IList<CertificateVisibility> Visibility { get; set; }
+        [JsonProperty(PropertyName = "visibility")]
+        public IList<CertificateVisibility> Visibility { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Thumbprint == null)
+            if (Thumbprint == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Thumbprint");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Thumbprint");
             }
-            if (this.ThumbprintAlgorithm == null)
+            if (ThumbprintAlgorithm == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "ThumbprintAlgorithm");
+                throw new ValidationException(ValidationRules.CannotBeNull, "ThumbprintAlgorithm");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateState.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for CertificateState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum CertificateState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "active")]
+        [EnumMember(Value = "active")]
         Active,
-        [System.Runtime.Serialization.EnumMember(Value = "deleting")]
+        [EnumMember(Value = "deleting")]
         Deleting,
-        [System.Runtime.Serialization.EnumMember(Value = "deleteFailed")]
+        [EnumMember(Value = "deleteFailed")]
         DeleteFailed
+    }
+    internal static class CertificateStateEnumExtension
+    {
+        internal static string ToSerializedValue(this CertificateState? value)  =>
+            value == null ? null : ((CertificateState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this CertificateState value)
+        {
+            switch( value )
+            {
+                case CertificateState.Active:
+                    return "active";
+                case CertificateState.Deleting:
+                    return "deleting";
+                case CertificateState.DeleteFailed:
+                    return "deleteFailed";
+            }
+            return null;
+        }
+
+        internal static CertificateState? ParseCertificateState(this string value)
+        {
+            switch( value )
+            {
+                case "active":
+                    return CertificateState.Active;
+                case "deleting":
+                    return CertificateState.Deleting;
+                case "deleteFailed":
+                    return CertificateState.DeleteFailed;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateStoreLocation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateStoreLocation.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for CertificateStoreLocation.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum CertificateStoreLocation
     {
-        [System.Runtime.Serialization.EnumMember(Value = "currentUser")]
+        [EnumMember(Value = "currentUser")]
         CurrentUser,
-        [System.Runtime.Serialization.EnumMember(Value = "localMachine")]
+        [EnumMember(Value = "localMachine")]
         LocalMachine
+    }
+    internal static class CertificateStoreLocationEnumExtension
+    {
+        internal static string ToSerializedValue(this CertificateStoreLocation? value)  =>
+            value == null ? null : ((CertificateStoreLocation)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this CertificateStoreLocation value)
+        {
+            switch( value )
+            {
+                case CertificateStoreLocation.CurrentUser:
+                    return "currentUser";
+                case CertificateStoreLocation.LocalMachine:
+                    return "localMachine";
+            }
+            return null;
+        }
+
+        internal static CertificateStoreLocation? ParseCertificateStoreLocation(this string value)
+        {
+            switch( value )
+            {
+                case "currentUser":
+                    return CertificateStoreLocation.CurrentUser;
+                case "localMachine":
+                    return CertificateStoreLocation.LocalMachine;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateVisibility.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CertificateVisibility.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for CertificateVisibility.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum CertificateVisibility
     {
-        [System.Runtime.Serialization.EnumMember(Value = "startTask")]
+        [EnumMember(Value = "startTask")]
         StartTask,
-        [System.Runtime.Serialization.EnumMember(Value = "task")]
+        [EnumMember(Value = "task")]
         Task,
-        [System.Runtime.Serialization.EnumMember(Value = "remoteUser")]
+        [EnumMember(Value = "remoteUser")]
         RemoteUser
+    }
+    internal static class CertificateVisibilityEnumExtension
+    {
+        internal static string ToSerializedValue(this CertificateVisibility? value)  =>
+            value == null ? null : ((CertificateVisibility)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this CertificateVisibility value)
+        {
+            switch( value )
+            {
+                case CertificateVisibility.StartTask:
+                    return "startTask";
+                case CertificateVisibility.Task:
+                    return "task";
+                case CertificateVisibility.RemoteUser:
+                    return "remoteUser";
+            }
+            return null;
+        }
+
+        internal static CertificateVisibility? ParseCertificateVisibility(this string value)
+        {
+            switch( value )
+            {
+                case "startTask":
+                    return CertificateVisibility.StartTask;
+                case "task":
+                    return CertificateVisibility.Task;
+                case "remoteUser":
+                    return CertificateVisibility.RemoteUser;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudJob.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudJob.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CloudJob class.
         /// </summary>
-        public CloudJob() { }
+        public CloudJob()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CloudJob class.
@@ -26,8 +35,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="id">A string that uniquely identifies the job within
         /// the account.</param>
         /// <param name="displayName">The display name for the job.</param>
-        /// <param name="usesTaskDependencies">The flag that determines if this
-        /// job will use tasks with dependencies.</param>
+        /// <param name="usesTaskDependencies">Whether tasks in the job can
+        /// define dependencies on each other. The default is false.</param>
         /// <param name="url">The URL of the job.</param>
         /// <param name="eTag">The ETag of the job.</param>
         /// <param name="lastModified">The last modified time of the
@@ -56,71 +65,74 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// should take when all tasks in the job are in the completed
         /// state.</param>
         /// <param name="onTaskFailure">The action the Batch service should
-        /// take when any task in the job fails. A task is considered to have
-        /// failed if it completes with a non-zero exit code and has exhausted
-        /// its retry count, or if it had a scheduling error.</param>
+        /// take when any task in the job fails.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the job as metadata.</param>
         /// <param name="executionInfo">The execution information for the
         /// job.</param>
         /// <param name="stats">Resource usage statistics for the entire
         /// lifetime of the job.</param>
-        public CloudJob(string id = default(string), string displayName = default(string), bool? usesTaskDependencies = default(bool?), string url = default(string), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? creationTime = default(System.DateTime?), JobState? state = default(JobState?), System.DateTime? stateTransitionTime = default(System.DateTime?), JobState? previousState = default(JobState?), System.DateTime? previousStateTransitionTime = default(System.DateTime?), int? priority = default(int?), JobConstraints constraints = default(JobConstraints), JobManagerTask jobManagerTask = default(JobManagerTask), JobPreparationTask jobPreparationTask = default(JobPreparationTask), JobReleaseTask jobReleaseTask = default(JobReleaseTask), System.Collections.Generic.IList<EnvironmentSetting> commonEnvironmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), PoolInformation poolInfo = default(PoolInformation), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?), OnTaskFailure? onTaskFailure = default(OnTaskFailure?), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>), JobExecutionInformation executionInfo = default(JobExecutionInformation), JobStatistics stats = default(JobStatistics))
+        public CloudJob(string id = default(string), string displayName = default(string), bool? usesTaskDependencies = default(bool?), string url = default(string), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? creationTime = default(System.DateTime?), JobState? state = default(JobState?), System.DateTime? stateTransitionTime = default(System.DateTime?), JobState? previousState = default(JobState?), System.DateTime? previousStateTransitionTime = default(System.DateTime?), int? priority = default(int?), JobConstraints constraints = default(JobConstraints), JobManagerTask jobManagerTask = default(JobManagerTask), JobPreparationTask jobPreparationTask = default(JobPreparationTask), JobReleaseTask jobReleaseTask = default(JobReleaseTask), IList<EnvironmentSetting> commonEnvironmentSettings = default(IList<EnvironmentSetting>), PoolInformation poolInfo = default(PoolInformation), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?), OnTaskFailure? onTaskFailure = default(OnTaskFailure?), IList<MetadataItem> metadata = default(IList<MetadataItem>), JobExecutionInformation executionInfo = default(JobExecutionInformation), JobStatistics stats = default(JobStatistics))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.UsesTaskDependencies = usesTaskDependencies;
-            this.Url = url;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.CreationTime = creationTime;
-            this.State = state;
-            this.StateTransitionTime = stateTransitionTime;
-            this.PreviousState = previousState;
-            this.PreviousStateTransitionTime = previousStateTransitionTime;
-            this.Priority = priority;
-            this.Constraints = constraints;
-            this.JobManagerTask = jobManagerTask;
-            this.JobPreparationTask = jobPreparationTask;
-            this.JobReleaseTask = jobReleaseTask;
-            this.CommonEnvironmentSettings = commonEnvironmentSettings;
-            this.PoolInfo = poolInfo;
-            this.OnAllTasksComplete = onAllTasksComplete;
-            this.OnTaskFailure = onTaskFailure;
-            this.Metadata = metadata;
-            this.ExecutionInfo = executionInfo;
-            this.Stats = stats;
+            Id = id;
+            DisplayName = displayName;
+            UsesTaskDependencies = usesTaskDependencies;
+            Url = url;
+            ETag = eTag;
+            LastModified = lastModified;
+            CreationTime = creationTime;
+            State = state;
+            StateTransitionTime = stateTransitionTime;
+            PreviousState = previousState;
+            PreviousStateTransitionTime = previousStateTransitionTime;
+            Priority = priority;
+            Constraints = constraints;
+            JobManagerTask = jobManagerTask;
+            JobPreparationTask = jobPreparationTask;
+            JobReleaseTask = jobReleaseTask;
+            CommonEnvironmentSettings = commonEnvironmentSettings;
+            PoolInfo = poolInfo;
+            OnAllTasksComplete = onAllTasksComplete;
+            OnTaskFailure = onTaskFailure;
+            Metadata = metadata;
+            ExecutionInfo = executionInfo;
+            Stats = stats;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the job within the
         /// account.
         /// </summary>
         /// <remarks>
-        /// The ID can contain any combination of alphanumeric characters
-        /// including hyphens and underscores, and cannot contain more than 64
-        /// characters. It is common to use a GUID for the id.
+        /// The ID is case-preserving and case-insensitive (that is, you may
+        /// not have two IDs within an account that differ only by case).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the display name for the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag that determines if this job will use tasks
-        /// with dependencies.
+        /// Gets or sets whether tasks in the job can define dependencies on
+        /// each other. The default is false.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "usesTaskDependencies")]
+        [JsonProperty(PropertyName = "usesTaskDependencies")]
         public bool? UsesTaskDependencies { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
@@ -132,7 +144,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// ETag when updating a job to specify that your changes should take
         /// effect only if nobody else has modified the job in the meantime.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "eTag")]
+        [JsonProperty(PropertyName = "eTag")]
         public string ETag { get; set; }
 
         /// <summary>
@@ -143,13 +155,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// state or priority, changed. It does not factor in task-level
         /// changes such as adding new tasks or tasks changing state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastModified")]
+        [JsonProperty(PropertyName = "lastModified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the creation time of the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "creationTime")]
+        [JsonProperty(PropertyName = "creationTime")]
         public System.DateTime? CreationTime { get; set; }
 
         /// <summary>
@@ -159,13 +171,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Possible values include: 'active', 'disabling', 'disabled',
         /// 'enabling', 'terminating', 'completed', 'deleting'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public JobState? State { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the job entered its current state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stateTransitionTime")]
+        [JsonProperty(PropertyName = "stateTransitionTime")]
         public System.DateTime? StateTransitionTime { get; set; }
 
         /// <summary>
@@ -176,7 +188,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Possible values include: 'active', 'disabling', 'disabled',
         /// 'enabling', 'terminating', 'completed', 'deleting'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousState")]
+        [JsonProperty(PropertyName = "previousState")]
         public JobState? PreviousState { get; set; }
 
         /// <summary>
@@ -185,7 +197,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property is not set if the job is in its initial Active state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousStateTransitionTime")]
+        [JsonProperty(PropertyName = "previousStateTransitionTime")]
         public System.DateTime? PreviousStateTransitionTime { get; set; }
 
         /// <summary>
@@ -196,20 +208,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// lowest priority and 1000 being the highest priority. The default
         /// value is 0.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "priority")]
+        [JsonProperty(PropertyName = "priority")]
         public int? Priority { get; set; }
 
         /// <summary>
         /// Gets or sets the execution constraints for the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public JobConstraints Constraints { get; set; }
 
         /// <summary>
         /// Gets or sets details of a Job Manager task to be launched when the
         /// job is started.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobManagerTask")]
+        [JsonProperty(PropertyName = "jobManagerTask")]
         public JobManagerTask JobManagerTask { get; set; }
 
         /// <summary>
@@ -219,7 +231,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Job Preparation task is a special task run on each node before
         /// any other task of the job.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobPreparationTask")]
+        [JsonProperty(PropertyName = "jobPreparationTask")]
         public JobPreparationTask JobPreparationTask { get; set; }
 
         /// <summary>
@@ -229,7 +241,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Job Release task is a special task run at the end of the job on
         /// each node that has run any other task of the job.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobReleaseTask")]
+        [JsonProperty(PropertyName = "jobReleaseTask")]
         public JobReleaseTask JobReleaseTask { get; set; }
 
         /// <summary>
@@ -237,13 +249,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// These environment variables are set for all tasks in the job
         /// (including the Job Manager, Job Preparation and Job Release tasks).
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commonEnvironmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> CommonEnvironmentSettings { get; set; }
+        /// <remarks>
+        /// Individual tasks can override an environment setting specified here
+        /// by specifying the same setting name with a different value.
+        /// </remarks>
+        [JsonProperty(PropertyName = "commonEnvironmentSettings")]
+        public IList<EnvironmentSetting> CommonEnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets the pool settings associated with the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolInfo")]
+        [JsonProperty(PropertyName = "poolInfo")]
         public PoolInformation PoolInfo { get; set; }
 
         /// <summary>
@@ -256,16 +272,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// job's terminateReason is set to 'AllTasksComplete'. The default is
         /// noAction. Possible values include: 'noAction', 'terminateJob'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "onAllTasksComplete")]
+        [JsonProperty(PropertyName = "onAllTasksComplete")]
         public OnAllTasksComplete? OnAllTasksComplete { get; set; }
 
         /// <summary>
         /// Gets or sets the action the Batch service should take when any task
-        /// in the job fails. A task is considered to have failed if it
-        /// completes with a non-zero exit code and has exhausted its retry
-        /// count, or if it had a scheduling error.
+        /// in the job fails.
         /// </summary>
         /// <remarks>
+        /// A task is considered to have failed if has a failureInfo. A
+        /// failureInfo is set if the task completes with a non-zero exit code
+        /// after exhausting its retry count, or if there was an error starting
+        /// the task, for example due to a resource file download error.
         /// noAction - do nothing. performExitOptionsJobAction - take the
         /// action associated with the task exit condition in the task's
         /// exitConditions collection. (This may still result in no action
@@ -273,7 +291,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// noAction. Possible values include: 'noAction',
         /// 'performExitOptionsJobAction'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "onTaskFailure")]
+        [JsonProperty(PropertyName = "onTaskFailure")]
         public OnTaskFailure? OnTaskFailure { get; set; }
 
         /// <summary>
@@ -284,45 +302,45 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Batch service does not assign any meaning to metadata; it is
         /// solely for the use of user code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Gets or sets the execution information for the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "executionInfo")]
+        [JsonProperty(PropertyName = "executionInfo")]
         public JobExecutionInformation ExecutionInfo { get; set; }
 
         /// <summary>
         /// Gets or sets resource usage statistics for the entire lifetime of
         /// the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stats")]
+        [JsonProperty(PropertyName = "stats")]
         public JobStatistics Stats { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.JobManagerTask != null)
+            if (JobManagerTask != null)
             {
-                this.JobManagerTask.Validate();
+                JobManagerTask.Validate();
             }
-            if (this.JobPreparationTask != null)
+            if (JobPreparationTask != null)
             {
-                this.JobPreparationTask.Validate();
+                JobPreparationTask.Validate();
             }
-            if (this.JobReleaseTask != null)
+            if (JobReleaseTask != null)
             {
-                this.JobReleaseTask.Validate();
+                JobReleaseTask.Validate();
             }
-            if (this.CommonEnvironmentSettings != null)
+            if (CommonEnvironmentSettings != null)
             {
-                foreach (var element in this.CommonEnvironmentSettings)
+                foreach (var element in CommonEnvironmentSettings)
                 {
                     if (element != null)
                     {
@@ -330,13 +348,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.PoolInfo != null)
+            if (PoolInfo != null)
             {
-                this.PoolInfo.Validate();
+                PoolInfo.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element1 in this.Metadata)
+                foreach (var element1 in Metadata)
                 {
                     if (element1 != null)
                     {
@@ -344,13 +362,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.ExecutionInfo != null)
+            if (ExecutionInfo != null)
             {
-                this.ExecutionInfo.Validate();
+                ExecutionInfo.Validate();
             }
-            if (this.Stats != null)
+            if (Stats != null)
             {
-                this.Stats.Validate();
+                Stats.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudJobSchedule.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudJobSchedule.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CloudJobSchedule class.
         /// </summary>
-        public CloudJobSchedule() { }
+        public CloudJobSchedule()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CloudJobSchedule class.
@@ -51,45 +60,48 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the schedule as metadata.</param>
         /// <param name="stats">The lifetime resource usage statistics for the
         /// job schedule.</param>
-        public CloudJobSchedule(string id = default(string), string displayName = default(string), string url = default(string), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? creationTime = default(System.DateTime?), JobScheduleState? state = default(JobScheduleState?), System.DateTime? stateTransitionTime = default(System.DateTime?), JobScheduleState? previousState = default(JobScheduleState?), System.DateTime? previousStateTransitionTime = default(System.DateTime?), Schedule schedule = default(Schedule), JobSpecification jobSpecification = default(JobSpecification), JobScheduleExecutionInformation executionInfo = default(JobScheduleExecutionInformation), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>), JobScheduleStatistics stats = default(JobScheduleStatistics))
+        public CloudJobSchedule(string id = default(string), string displayName = default(string), string url = default(string), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? creationTime = default(System.DateTime?), JobScheduleState? state = default(JobScheduleState?), System.DateTime? stateTransitionTime = default(System.DateTime?), JobScheduleState? previousState = default(JobScheduleState?), System.DateTime? previousStateTransitionTime = default(System.DateTime?), Schedule schedule = default(Schedule), JobSpecification jobSpecification = default(JobSpecification), JobScheduleExecutionInformation executionInfo = default(JobScheduleExecutionInformation), IList<MetadataItem> metadata = default(IList<MetadataItem>), JobScheduleStatistics stats = default(JobScheduleStatistics))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.Url = url;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.CreationTime = creationTime;
-            this.State = state;
-            this.StateTransitionTime = stateTransitionTime;
-            this.PreviousState = previousState;
-            this.PreviousStateTransitionTime = previousStateTransitionTime;
-            this.Schedule = schedule;
-            this.JobSpecification = jobSpecification;
-            this.ExecutionInfo = executionInfo;
-            this.Metadata = metadata;
-            this.Stats = stats;
+            Id = id;
+            DisplayName = displayName;
+            Url = url;
+            ETag = eTag;
+            LastModified = lastModified;
+            CreationTime = creationTime;
+            State = state;
+            StateTransitionTime = stateTransitionTime;
+            PreviousState = previousState;
+            PreviousStateTransitionTime = previousStateTransitionTime;
+            Schedule = schedule;
+            JobSpecification = jobSpecification;
+            ExecutionInfo = executionInfo;
+            Metadata = metadata;
+            Stats = stats;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the schedule within
         /// the account.
         /// </summary>
-        /// <remarks>
-        /// It is common to use a GUID for the id.
-        /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the display name for the schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the job schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
@@ -102,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// your changes should take effect only if nobody else has modified
         /// the schedule in the meantime.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "eTag")]
+        [JsonProperty(PropertyName = "eTag")]
         public string ETag { get; set; }
 
         /// <summary>
@@ -114,13 +126,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// factor in job-level changes such as new jobs being created or jobs
         /// changing state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastModified")]
+        [JsonProperty(PropertyName = "lastModified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the creation time of the job schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "creationTime")]
+        [JsonProperty(PropertyName = "creationTime")]
         public System.DateTime? CreationTime { get; set; }
 
         /// <summary>
@@ -130,14 +142,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Possible values include: 'active', 'completed', 'disabled',
         /// 'terminating', 'deleting'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public JobScheduleState? State { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the job schedule entered the current
         /// state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stateTransitionTime")]
+        [JsonProperty(PropertyName = "stateTransitionTime")]
         public System.DateTime? StateTransitionTime { get; set; }
 
         /// <summary>
@@ -148,7 +160,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// active state. Possible values include: 'active', 'completed',
         /// 'disabled', 'terminating', 'deleting'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousState")]
+        [JsonProperty(PropertyName = "previousState")]
         public JobScheduleState? PreviousState { get; set; }
 
         /// <summary>
@@ -159,27 +171,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is not present if the job schedule is in its initial
         /// active state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousStateTransitionTime")]
+        [JsonProperty(PropertyName = "previousStateTransitionTime")]
         public System.DateTime? PreviousStateTransitionTime { get; set; }
 
         /// <summary>
         /// Gets or sets the schedule according to which jobs will be created.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "schedule")]
+        [JsonProperty(PropertyName = "schedule")]
         public Schedule Schedule { get; set; }
 
         /// <summary>
         /// Gets or sets the details of the jobs to be created on this
         /// schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobSpecification")]
+        [JsonProperty(PropertyName = "jobSpecification")]
         public JobSpecification JobSpecification { get; set; }
 
         /// <summary>
         /// Gets or sets information about jobs that have been and will be run
         /// under this schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "executionInfo")]
+        [JsonProperty(PropertyName = "executionInfo")]
         public JobScheduleExecutionInformation ExecutionInfo { get; set; }
 
         /// <summary>
@@ -190,31 +202,31 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Batch service does not assign any meaning to metadata; it is
         /// solely for the use of user code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Gets or sets the lifetime resource usage statistics for the job
         /// schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stats")]
+        [JsonProperty(PropertyName = "stats")]
         public JobScheduleStatistics Stats { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.JobSpecification != null)
+            if (JobSpecification != null)
             {
-                this.JobSpecification.Validate();
+                JobSpecification.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element in this.Metadata)
+                foreach (var element in Metadata)
                 {
                     if (element != null)
                     {
@@ -222,9 +234,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.Stats != null)
+            if (Stats != null)
             {
-                this.Stats.Validate();
+                Stats.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudPool.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudPool.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CloudPool class.
         /// </summary>
-        public CloudPool() { }
+        public CloudPool()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CloudPool class.
@@ -79,51 +88,57 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// pool.</param>
         /// <param name="maxTasksPerNode">The maximum number of tasks that can
         /// run concurrently on a single compute node in the pool.</param>
-        /// <param name="taskSchedulingPolicy">How the Batch service
-        /// distributes tasks between compute nodes in the pool.</param>
+        /// <param name="taskSchedulingPolicy">How tasks are distributed across
+        /// compute nodes in a pool.</param>
         /// <param name="userAccounts">The list of user accounts to be created
         /// on each node in the pool.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the pool as metadata.</param>
         /// <param name="stats">Utilization and resource usage statistics for
         /// the entire lifetime of the pool.</param>
-        public CloudPool(string id = default(string), string displayName = default(string), string url = default(string), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? creationTime = default(System.DateTime?), PoolState? state = default(PoolState?), System.DateTime? stateTransitionTime = default(System.DateTime?), AllocationState? allocationState = default(AllocationState?), System.DateTime? allocationStateTransitionTime = default(System.DateTime?), string vmSize = default(string), CloudServiceConfiguration cloudServiceConfiguration = default(CloudServiceConfiguration), VirtualMachineConfiguration virtualMachineConfiguration = default(VirtualMachineConfiguration), System.TimeSpan? resizeTimeout = default(System.TimeSpan?), System.Collections.Generic.IList<ResizeError> resizeErrors = default(System.Collections.Generic.IList<ResizeError>), int? currentDedicatedNodes = default(int?), int? currentLowPriorityNodes = default(int?), int? targetDedicatedNodes = default(int?), int? targetLowPriorityNodes = default(int?), bool? enableAutoScale = default(bool?), string autoScaleFormula = default(string), System.TimeSpan? autoScaleEvaluationInterval = default(System.TimeSpan?), AutoScaleRun autoScaleRun = default(AutoScaleRun), bool? enableInterNodeCommunication = default(bool?), NetworkConfiguration networkConfiguration = default(NetworkConfiguration), StartTask startTask = default(StartTask), System.Collections.Generic.IList<CertificateReference> certificateReferences = default(System.Collections.Generic.IList<CertificateReference>), System.Collections.Generic.IList<ApplicationPackageReference> applicationPackageReferences = default(System.Collections.Generic.IList<ApplicationPackageReference>), System.Collections.Generic.IList<string> applicationLicenses = default(System.Collections.Generic.IList<string>), int? maxTasksPerNode = default(int?), TaskSchedulingPolicy taskSchedulingPolicy = default(TaskSchedulingPolicy), System.Collections.Generic.IList<UserAccount> userAccounts = default(System.Collections.Generic.IList<UserAccount>), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>), PoolStatistics stats = default(PoolStatistics))
+        public CloudPool(string id = default(string), string displayName = default(string), string url = default(string), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? creationTime = default(System.DateTime?), PoolState? state = default(PoolState?), System.DateTime? stateTransitionTime = default(System.DateTime?), AllocationState? allocationState = default(AllocationState?), System.DateTime? allocationStateTransitionTime = default(System.DateTime?), string vmSize = default(string), CloudServiceConfiguration cloudServiceConfiguration = default(CloudServiceConfiguration), VirtualMachineConfiguration virtualMachineConfiguration = default(VirtualMachineConfiguration), System.TimeSpan? resizeTimeout = default(System.TimeSpan?), IList<ResizeError> resizeErrors = default(IList<ResizeError>), int? currentDedicatedNodes = default(int?), int? currentLowPriorityNodes = default(int?), int? targetDedicatedNodes = default(int?), int? targetLowPriorityNodes = default(int?), bool? enableAutoScale = default(bool?), string autoScaleFormula = default(string), System.TimeSpan? autoScaleEvaluationInterval = default(System.TimeSpan?), AutoScaleRun autoScaleRun = default(AutoScaleRun), bool? enableInterNodeCommunication = default(bool?), NetworkConfiguration networkConfiguration = default(NetworkConfiguration), StartTask startTask = default(StartTask), IList<CertificateReference> certificateReferences = default(IList<CertificateReference>), IList<ApplicationPackageReference> applicationPackageReferences = default(IList<ApplicationPackageReference>), IList<string> applicationLicenses = default(IList<string>), int? maxTasksPerNode = default(int?), TaskSchedulingPolicy taskSchedulingPolicy = default(TaskSchedulingPolicy), IList<UserAccount> userAccounts = default(IList<UserAccount>), IList<MetadataItem> metadata = default(IList<MetadataItem>), PoolStatistics stats = default(PoolStatistics))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.Url = url;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.CreationTime = creationTime;
-            this.State = state;
-            this.StateTransitionTime = stateTransitionTime;
-            this.AllocationState = allocationState;
-            this.AllocationStateTransitionTime = allocationStateTransitionTime;
-            this.VmSize = vmSize;
-            this.CloudServiceConfiguration = cloudServiceConfiguration;
-            this.VirtualMachineConfiguration = virtualMachineConfiguration;
-            this.ResizeTimeout = resizeTimeout;
-            this.ResizeErrors = resizeErrors;
-            this.CurrentDedicatedNodes = currentDedicatedNodes;
-            this.CurrentLowPriorityNodes = currentLowPriorityNodes;
-            this.TargetDedicatedNodes = targetDedicatedNodes;
-            this.TargetLowPriorityNodes = targetLowPriorityNodes;
-            this.EnableAutoScale = enableAutoScale;
-            this.AutoScaleFormula = autoScaleFormula;
-            this.AutoScaleEvaluationInterval = autoScaleEvaluationInterval;
-            this.AutoScaleRun = autoScaleRun;
-            this.EnableInterNodeCommunication = enableInterNodeCommunication;
-            this.NetworkConfiguration = networkConfiguration;
-            this.StartTask = startTask;
-            this.CertificateReferences = certificateReferences;
-            this.ApplicationPackageReferences = applicationPackageReferences;
-            this.ApplicationLicenses = applicationLicenses;
-            this.MaxTasksPerNode = maxTasksPerNode;
-            this.TaskSchedulingPolicy = taskSchedulingPolicy;
-            this.UserAccounts = userAccounts;
-            this.Metadata = metadata;
-            this.Stats = stats;
+            Id = id;
+            DisplayName = displayName;
+            Url = url;
+            ETag = eTag;
+            LastModified = lastModified;
+            CreationTime = creationTime;
+            State = state;
+            StateTransitionTime = stateTransitionTime;
+            AllocationState = allocationState;
+            AllocationStateTransitionTime = allocationStateTransitionTime;
+            VmSize = vmSize;
+            CloudServiceConfiguration = cloudServiceConfiguration;
+            VirtualMachineConfiguration = virtualMachineConfiguration;
+            ResizeTimeout = resizeTimeout;
+            ResizeErrors = resizeErrors;
+            CurrentDedicatedNodes = currentDedicatedNodes;
+            CurrentLowPriorityNodes = currentLowPriorityNodes;
+            TargetDedicatedNodes = targetDedicatedNodes;
+            TargetLowPriorityNodes = targetLowPriorityNodes;
+            EnableAutoScale = enableAutoScale;
+            AutoScaleFormula = autoScaleFormula;
+            AutoScaleEvaluationInterval = autoScaleEvaluationInterval;
+            AutoScaleRun = autoScaleRun;
+            EnableInterNodeCommunication = enableInterNodeCommunication;
+            NetworkConfiguration = networkConfiguration;
+            StartTask = startTask;
+            CertificateReferences = certificateReferences;
+            ApplicationPackageReferences = applicationPackageReferences;
+            ApplicationLicenses = applicationLicenses;
+            MaxTasksPerNode = maxTasksPerNode;
+            TaskSchedulingPolicy = taskSchedulingPolicy;
+            UserAccounts = userAccounts;
+            Metadata = metadata;
+            Stats = stats;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the pool within the
@@ -132,9 +147,11 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// The ID can contain any combination of alphanumeric characters
         /// including hyphens and underscores, and cannot contain more than 64
-        /// characters. It is common to use a GUID for the id.
+        /// characters. The ID is case-preserving and case-insensitive (that
+        /// is, you may not have two IDs within an account that differ only by
+        /// case).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -144,13 +161,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The display name need not be unique and can contain any Unicode
         /// characters up to a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
@@ -162,7 +179,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// ETag when updating a pool to specify that your changes should take
         /// effect only if nobody else has modified the pool in the meantime.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "eTag")]
+        [JsonProperty(PropertyName = "eTag")]
         public string ETag { get; set; }
 
         /// <summary>
@@ -174,60 +191,66 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// not factor in node-level changes such as a compute node changing
         /// state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastModified")]
+        [JsonProperty(PropertyName = "lastModified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the creation time of the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "creationTime")]
+        [JsonProperty(PropertyName = "creationTime")]
         public System.DateTime? CreationTime { get; set; }
 
         /// <summary>
         /// Gets or sets the current state of the pool.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
         /// active - The pool is available to run tasks subject to the
-        /// availability of compute nodes. deleting - The user has requested
-        /// that the pool be deleted, but the delete operation has not yet
-        /// completed. upgrading - The user has requested that the operating
-        /// system of the pool's nodes be upgraded, but the upgrade operation
-        /// has not yet completed (that is, some nodes in the pool have not yet
-        /// been upgraded). While upgrading, the pool may be able to run tasks
-        /// (with reduced capacity) but this is not guaranteed. Possible values
+        /// availability of compute nodes.
+        /// deleting - The user has requested that the pool be deleted, but the
+        /// delete operation has not yet completed.
+        /// upgrading - The user has requested that the operating system of the
+        /// pool's nodes be upgraded, but the upgrade operation has not yet
+        /// completed (that is, some nodes in the pool have not yet been
+        /// upgraded). While upgrading, the pool may be able to run tasks (with
+        /// reduced capacity) but this is not guaranteed. Possible values
         /// include: 'active', 'deleting', 'upgrading'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public PoolState? State { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the pool entered its current state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stateTransitionTime")]
+        [JsonProperty(PropertyName = "stateTransitionTime")]
         public System.DateTime? StateTransitionTime { get; set; }
 
         /// <summary>
         /// Gets or sets whether the pool is resizing.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
         /// steady - The pool is not resizing. There are no changes to the
         /// number of nodes in the pool in progress. A pool enters this state
         /// when it is created and when no operations are being performed on
-        /// the pool to change the number of dedicated nodes. resizing - The
-        /// pool is resizing; that is, compute nodes are being added to or
-        /// removed from the pool. stopping - The pool was resizing, but the
-        /// user has requested that the resize be stopped, but the stop request
-        /// has not yet been completed. Possible values include: 'steady',
-        /// 'resizing', 'stopping'
+        /// the pool to change the number of dedicated nodes.
+        /// resizing - The pool is resizing; that is, compute nodes are being
+        /// added to or removed from the pool.
+        /// stopping - The pool was resizing, but the user has requested that
+        /// the resize be stopped, but the stop request has not yet been
+        /// completed. Possible values include: 'steady', 'resizing',
+        /// 'stopping'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "allocationState")]
+        [JsonProperty(PropertyName = "allocationState")]
         public AllocationState? AllocationState { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the pool entered its current
         /// allocation state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "allocationStateTransitionTime")]
+        [JsonProperty(PropertyName = "allocationStateTransitionTime")]
         public System.DateTime? AllocationStateTransitionTime { get; set; }
 
         /// <summary>
@@ -250,7 +273,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// premium storage (STANDARD_GS, STANDARD_DS, and STANDARD_DSV2
         /// series).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "vmSize")]
+        [JsonProperty(PropertyName = "vmSize")]
         public string VmSize { get; set; }
 
         /// <summary>
@@ -262,7 +285,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// property cannot be specified if the Batch account was created with
         /// its poolAllocationMode property set to 'UserSubscription'.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "cloudServiceConfiguration")]
+        [JsonProperty(PropertyName = "cloudServiceConfiguration")]
         public CloudServiceConfiguration CloudServiceConfiguration { get; set; }
 
         /// <summary>
@@ -272,7 +295,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property and cloudServiceConfiguration are mutually exclusive
         /// and one of the properties must be specified.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "virtualMachineConfiguration")]
+        [JsonProperty(PropertyName = "virtualMachineConfiguration")]
         public VirtualMachineConfiguration VirtualMachineConfiguration { get; set; }
 
         /// <summary>
@@ -284,7 +307,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// initial sizing when the pool is created counts as a resize.) The
         /// default value is 15 minutes.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resizeTimeout")]
+        [JsonProperty(PropertyName = "resizeTimeout")]
         public System.TimeSpan? ResizeTimeout { get; set; }
 
         /// <summary>
@@ -295,14 +318,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if one or more errors occurred during the
         /// last pool resize, and only when the pool allocationState is Steady.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resizeErrors")]
-        public System.Collections.Generic.IList<ResizeError> ResizeErrors { get; set; }
+        [JsonProperty(PropertyName = "resizeErrors")]
+        public IList<ResizeError> ResizeErrors { get; set; }
 
         /// <summary>
         /// Gets or sets the number of dedicated compute nodes currently in the
         /// pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "currentDedicatedNodes")]
+        [JsonProperty(PropertyName = "currentDedicatedNodes")]
         public int? CurrentDedicatedNodes { get; set; }
 
         /// <summary>
@@ -313,21 +336,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Low-priority compute nodes which have been preempted are included
         /// in this count.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "currentLowPriorityNodes")]
+        [JsonProperty(PropertyName = "currentLowPriorityNodes")]
         public int? CurrentLowPriorityNodes { get; set; }
 
         /// <summary>
         /// Gets or sets the desired number of dedicated compute nodes in the
         /// pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetDedicatedNodes")]
+        [JsonProperty(PropertyName = "targetDedicatedNodes")]
         public int? TargetDedicatedNodes { get; set; }
 
         /// <summary>
         /// Gets or sets the desired number of low-priority compute nodes in
         /// the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetLowPriorityNodes")]
+        [JsonProperty(PropertyName = "targetLowPriorityNodes")]
         public int? TargetLowPriorityNodes { get; set; }
 
         /// <summary>
@@ -340,7 +363,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// autoScaleFormula property is required and the pool automatically
         /// resizes according to the formula. The default value is false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "enableAutoScale")]
+        [JsonProperty(PropertyName = "enableAutoScale")]
         public bool? EnableAutoScale { get; set; }
 
         /// <summary>
@@ -351,7 +374,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the pool automatically scales, i.e.
         /// enableAutoScale is true.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleFormula")]
+        [JsonProperty(PropertyName = "autoScaleFormula")]
         public string AutoScaleFormula { get; set; }
 
         /// <summary>
@@ -362,7 +385,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the pool automatically scales, i.e.
         /// enableAutoScale is true.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleEvaluationInterval")]
+        [JsonProperty(PropertyName = "autoScaleEvaluationInterval")]
         public System.TimeSpan? AutoScaleEvaluationInterval { get; set; }
 
         /// <summary>
@@ -373,7 +396,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the pool automatically scales, i.e.
         /// enableAutoScale is true.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleRun")]
+        [JsonProperty(PropertyName = "autoScaleRun")]
         public AutoScaleRun AutoScaleRun { get; set; }
 
         /// <summary>
@@ -385,20 +408,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// pool. Specifying this value can reduce the chance of the requested
         /// number of nodes to be allocated in the pool.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "enableInterNodeCommunication")]
+        [JsonProperty(PropertyName = "enableInterNodeCommunication")]
         public bool? EnableInterNodeCommunication { get; set; }
 
         /// <summary>
         /// Gets or sets the network configuration for the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "networkConfiguration")]
+        [JsonProperty(PropertyName = "networkConfiguration")]
         public NetworkConfiguration NetworkConfiguration { get; set; }
 
         /// <summary>
         /// Gets or sets a task specified to run on each compute node as it
         /// joins the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTask")]
+        [JsonProperty(PropertyName = "startTask")]
         public StartTask StartTask { get; set; }
 
         /// <summary>
@@ -416,15 +439,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// /home/{user-name}/certs) and certificates are placed in that
         /// directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "certificateReferences")]
-        public System.Collections.Generic.IList<CertificateReference> CertificateReferences { get; set; }
+        [JsonProperty(PropertyName = "certificateReferences")]
+        public IList<CertificateReference> CertificateReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the list of application packages to be installed on
         /// each compute node in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationPackageReferences")]
-        public System.Collections.Generic.IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
+        [JsonProperty(PropertyName = "applicationPackageReferences")]
+        public IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the list of application licenses the Batch service
@@ -435,75 +458,75 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch service application licenses. If a license is requested which
         /// is not supported, pool creation will fail.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationLicenses")]
-        public System.Collections.Generic.IList<string> ApplicationLicenses { get; set; }
+        [JsonProperty(PropertyName = "applicationLicenses")]
+        public IList<string> ApplicationLicenses { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of tasks that can run concurrently
         /// on a single compute node in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxTasksPerNode")]
+        [JsonProperty(PropertyName = "maxTasksPerNode")]
         public int? MaxTasksPerNode { get; set; }
 
         /// <summary>
-        /// Gets or sets how the Batch service distributes tasks between
-        /// compute nodes in the pool.
+        /// Gets or sets how tasks are distributed across compute nodes in a
+        /// pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskSchedulingPolicy")]
+        [JsonProperty(PropertyName = "taskSchedulingPolicy")]
         public TaskSchedulingPolicy TaskSchedulingPolicy { get; set; }
 
         /// <summary>
         /// Gets or sets the list of user accounts to be created on each node
         /// in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userAccounts")]
-        public System.Collections.Generic.IList<UserAccount> UserAccounts { get; set; }
+        [JsonProperty(PropertyName = "userAccounts")]
+        public IList<UserAccount> UserAccounts { get; set; }
 
         /// <summary>
         /// Gets or sets a list of name-value pairs associated with the pool as
         /// metadata.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Gets or sets utilization and resource usage statistics for the
         /// entire lifetime of the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stats")]
+        [JsonProperty(PropertyName = "stats")]
         public PoolStatistics Stats { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.CloudServiceConfiguration != null)
+            if (CloudServiceConfiguration != null)
             {
-                this.CloudServiceConfiguration.Validate();
+                CloudServiceConfiguration.Validate();
             }
-            if (this.VirtualMachineConfiguration != null)
+            if (VirtualMachineConfiguration != null)
             {
-                this.VirtualMachineConfiguration.Validate();
+                VirtualMachineConfiguration.Validate();
             }
-            if (this.AutoScaleRun != null)
+            if (AutoScaleRun != null)
             {
-                this.AutoScaleRun.Validate();
+                AutoScaleRun.Validate();
             }
-            if (this.NetworkConfiguration != null)
+            if (NetworkConfiguration != null)
             {
-                this.NetworkConfiguration.Validate();
+                NetworkConfiguration.Validate();
             }
-            if (this.StartTask != null)
+            if (StartTask != null)
             {
-                this.StartTask.Validate();
+                StartTask.Validate();
             }
-            if (this.CertificateReferences != null)
+            if (CertificateReferences != null)
             {
-                foreach (var element in this.CertificateReferences)
+                foreach (var element in CertificateReferences)
                 {
                     if (element != null)
                     {
@@ -511,9 +534,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.ApplicationPackageReferences != null)
+            if (ApplicationPackageReferences != null)
             {
-                foreach (var element1 in this.ApplicationPackageReferences)
+                foreach (var element1 in ApplicationPackageReferences)
                 {
                     if (element1 != null)
                     {
@@ -521,13 +544,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.TaskSchedulingPolicy != null)
+            if (TaskSchedulingPolicy != null)
             {
-                this.TaskSchedulingPolicy.Validate();
+                TaskSchedulingPolicy.Validate();
             }
-            if (this.UserAccounts != null)
+            if (UserAccounts != null)
             {
-                foreach (var element2 in this.UserAccounts)
+                foreach (var element2 in UserAccounts)
                 {
                     if (element2 != null)
                     {
@@ -535,9 +558,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element3 in this.Metadata)
+                foreach (var element3 in Metadata)
                 {
                     if (element3 != null)
                     {
@@ -545,9 +568,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.Stats != null)
+            if (Stats != null)
             {
-                this.Stats.Validate();
+                Stats.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudServiceConfiguration.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudServiceConfiguration.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CloudServiceConfiguration class.
         /// </summary>
-        public CloudServiceConfiguration() { }
+        public CloudServiceConfiguration()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CloudServiceConfiguration class.
@@ -32,10 +40,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// installed on the virtual machines in the pool.</param>
         public CloudServiceConfiguration(string osFamily, string targetOSVersion = default(string), string currentOSVersion = default(string))
         {
-            this.OsFamily = osFamily;
-            this.TargetOSVersion = targetOSVersion;
-            this.CurrentOSVersion = currentOSVersion;
+            OsFamily = osFamily;
+            TargetOSVersion = targetOSVersion;
+            CurrentOSVersion = currentOSVersion;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the Azure Guest OS family to be installed on the
@@ -49,7 +63,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Azure Guest OS Releases
         /// (https://azure.microsoft.com/documentation/articles/cloud-services-guestos-update-matrix/#releases).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "osFamily")]
+        [JsonProperty(PropertyName = "osFamily")]
         public string OsFamily { get; set; }
 
         /// <summary>
@@ -60,7 +74,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The default value is * which specifies the latest operating system
         /// version for the specified OS family.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetOSVersion")]
+        [JsonProperty(PropertyName = "targetOSVersion")]
         public string TargetOSVersion { get; set; }
 
         /// <summary>
@@ -74,20 +88,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// upgrade process. Once all virtual machines have upgraded,
         /// currentOSVersion is updated to be the same as targetOSVersion.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "currentOSVersion")]
+        [JsonProperty(PropertyName = "currentOSVersion")]
         public string CurrentOSVersion { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.OsFamily == null)
+            if (OsFamily == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "OsFamily");
+                throw new ValidationException(ValidationRules.CannotBeNull, "OsFamily");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudTask.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudTask.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the CloudTask class.
         /// </summary>
-        public CloudTask() { }
+        public CloudTask()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CloudTask class.
@@ -71,34 +80,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="authenticationTokenSettings">The settings for an
         /// authentication token that the task can use to perform Batch service
         /// operations.</param>
-        public CloudTask(string id = default(string), string displayName = default(string), string url = default(string), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? creationTime = default(System.DateTime?), ExitConditions exitConditions = default(ExitConditions), TaskState? state = default(TaskState?), System.DateTime? stateTransitionTime = default(System.DateTime?), TaskState? previousState = default(TaskState?), System.DateTime? previousStateTransitionTime = default(System.DateTime?), string commandLine = default(string), System.Collections.Generic.IList<ResourceFile> resourceFiles = default(System.Collections.Generic.IList<ResourceFile>), System.Collections.Generic.IList<OutputFile> outputFiles = default(System.Collections.Generic.IList<OutputFile>), System.Collections.Generic.IList<EnvironmentSetting> environmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), AffinityInformation affinityInfo = default(AffinityInformation), TaskConstraints constraints = default(TaskConstraints), UserIdentity userIdentity = default(UserIdentity), TaskExecutionInformation executionInfo = default(TaskExecutionInformation), ComputeNodeInformation nodeInfo = default(ComputeNodeInformation), MultiInstanceSettings multiInstanceSettings = default(MultiInstanceSettings), TaskStatistics stats = default(TaskStatistics), TaskDependencies dependsOn = default(TaskDependencies), System.Collections.Generic.IList<ApplicationPackageReference> applicationPackageReferences = default(System.Collections.Generic.IList<ApplicationPackageReference>), AuthenticationTokenSettings authenticationTokenSettings = default(AuthenticationTokenSettings))
+        public CloudTask(string id = default(string), string displayName = default(string), string url = default(string), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? creationTime = default(System.DateTime?), ExitConditions exitConditions = default(ExitConditions), TaskState? state = default(TaskState?), System.DateTime? stateTransitionTime = default(System.DateTime?), TaskState? previousState = default(TaskState?), System.DateTime? previousStateTransitionTime = default(System.DateTime?), string commandLine = default(string), IList<ResourceFile> resourceFiles = default(IList<ResourceFile>), IList<OutputFile> outputFiles = default(IList<OutputFile>), IList<EnvironmentSetting> environmentSettings = default(IList<EnvironmentSetting>), AffinityInformation affinityInfo = default(AffinityInformation), TaskConstraints constraints = default(TaskConstraints), UserIdentity userIdentity = default(UserIdentity), TaskExecutionInformation executionInfo = default(TaskExecutionInformation), ComputeNodeInformation nodeInfo = default(ComputeNodeInformation), MultiInstanceSettings multiInstanceSettings = default(MultiInstanceSettings), TaskStatistics stats = default(TaskStatistics), TaskDependencies dependsOn = default(TaskDependencies), IList<ApplicationPackageReference> applicationPackageReferences = default(IList<ApplicationPackageReference>), AuthenticationTokenSettings authenticationTokenSettings = default(AuthenticationTokenSettings))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.Url = url;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.CreationTime = creationTime;
-            this.ExitConditions = exitConditions;
-            this.State = state;
-            this.StateTransitionTime = stateTransitionTime;
-            this.PreviousState = previousState;
-            this.PreviousStateTransitionTime = previousStateTransitionTime;
-            this.CommandLine = commandLine;
-            this.ResourceFiles = resourceFiles;
-            this.OutputFiles = outputFiles;
-            this.EnvironmentSettings = environmentSettings;
-            this.AffinityInfo = affinityInfo;
-            this.Constraints = constraints;
-            this.UserIdentity = userIdentity;
-            this.ExecutionInfo = executionInfo;
-            this.NodeInfo = nodeInfo;
-            this.MultiInstanceSettings = multiInstanceSettings;
-            this.Stats = stats;
-            this.DependsOn = dependsOn;
-            this.ApplicationPackageReferences = applicationPackageReferences;
-            this.AuthenticationTokenSettings = authenticationTokenSettings;
+            Id = id;
+            DisplayName = displayName;
+            Url = url;
+            ETag = eTag;
+            LastModified = lastModified;
+            CreationTime = creationTime;
+            ExitConditions = exitConditions;
+            State = state;
+            StateTransitionTime = stateTransitionTime;
+            PreviousState = previousState;
+            PreviousStateTransitionTime = previousStateTransitionTime;
+            CommandLine = commandLine;
+            ResourceFiles = resourceFiles;
+            OutputFiles = outputFiles;
+            EnvironmentSettings = environmentSettings;
+            AffinityInfo = affinityInfo;
+            Constraints = constraints;
+            UserIdentity = userIdentity;
+            ExecutionInfo = executionInfo;
+            NodeInfo = nodeInfo;
+            MultiInstanceSettings = multiInstanceSettings;
+            Stats = stats;
+            DependsOn = dependsOn;
+            ApplicationPackageReferences = applicationPackageReferences;
+            AuthenticationTokenSettings = authenticationTokenSettings;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the task within the
@@ -109,7 +124,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// including hyphens and underscores, and cannot contain more than 64
         /// characters.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -119,13 +134,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The display name need not be unique and can contain any Unicode
         /// characters up to a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
@@ -137,26 +152,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// ETag when updating a task to specify that your changes should take
         /// effect only if nobody else has modified the task in the meantime.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "eTag")]
+        [JsonProperty(PropertyName = "eTag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the last modified time of the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastModified")]
+        [JsonProperty(PropertyName = "lastModified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the creation time of the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "creationTime")]
+        [JsonProperty(PropertyName = "creationTime")]
         public System.DateTime? CreationTime { get; set; }
 
         /// <summary>
         /// Gets or sets how the Batch service should respond when the task
         /// completes.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitConditions")]
+        [JsonProperty(PropertyName = "exitConditions")]
         public ExitConditions ExitConditions { get; set; }
 
         /// <summary>
@@ -166,13 +181,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Possible values include: 'active', 'preparing', 'running',
         /// 'completed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public TaskState? State { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the task entered its current state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stateTransitionTime")]
+        [JsonProperty(PropertyName = "stateTransitionTime")]
         public System.DateTime? StateTransitionTime { get; set; }
 
         /// <summary>
@@ -183,7 +198,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// state. Possible values include: 'active', 'preparing', 'running',
         /// 'completed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousState")]
+        [JsonProperty(PropertyName = "previousState")]
         public TaskState? PreviousState { get; set; }
 
         /// <summary>
@@ -193,7 +208,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is not set if the task is in its initial Active
         /// state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousStateTransitionTime")]
+        [JsonProperty(PropertyName = "previousStateTransitionTime")]
         public System.DateTime? PreviousStateTransitionTime { get; set; }
 
         /// <summary>
@@ -209,7 +224,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// command line, for example using "cmd /c MyCommand" in Windows or
         /// "/bin/sh -c MyCommand" in Linux.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commandLine")]
+        [JsonProperty(PropertyName = "commandLine")]
         public string CommandLine { get; set; }
 
         /// <summary>
@@ -221,8 +236,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// downloaded to the compute node on which the primary task is
         /// executed.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resourceFiles")]
-        public System.Collections.Generic.IList<ResourceFile> ResourceFiles { get; set; }
+        [JsonProperty(PropertyName = "resourceFiles")]
+        public IList<ResourceFile> ResourceFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of files that the Batch service will upload
@@ -232,26 +247,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// For multi-instance tasks, the files will only be uploaded from the
         /// compute node on which the primary task is executed.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "outputFiles")]
-        public System.Collections.Generic.IList<OutputFile> OutputFiles { get; set; }
+        [JsonProperty(PropertyName = "outputFiles")]
+        public IList<OutputFile> OutputFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of environment variable settings for the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "environmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> EnvironmentSettings { get; set; }
+        [JsonProperty(PropertyName = "environmentSettings")]
+        public IList<EnvironmentSetting> EnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets a locality hint that can be used by the Batch service
         /// to select a compute node on which to start the new task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "affinityInfo")]
+        [JsonProperty(PropertyName = "affinityInfo")]
         public AffinityInformation AffinityInfo { get; set; }
 
         /// <summary>
         /// Gets or sets the execution constraints that apply to this task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public TaskConstraints Constraints { get; set; }
 
         /// <summary>
@@ -261,20 +276,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, the task runs as a non-administrative user unique to
         /// the task.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userIdentity")]
+        [JsonProperty(PropertyName = "userIdentity")]
         public UserIdentity UserIdentity { get; set; }
 
         /// <summary>
         /// Gets or sets information about the execution of the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "executionInfo")]
+        [JsonProperty(PropertyName = "executionInfo")]
         public TaskExecutionInformation ExecutionInfo { get; set; }
 
         /// <summary>
         /// Gets or sets information about the compute node on which the task
         /// ran.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeInfo")]
+        [JsonProperty(PropertyName = "nodeInfo")]
         public ComputeNodeInformation NodeInfo { get; set; }
 
         /// <summary>
@@ -282,13 +297,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// multi-instance task, and contains information about how to run the
         /// multi-instance task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "multiInstanceSettings")]
+        [JsonProperty(PropertyName = "multiInstanceSettings")]
         public MultiInstanceSettings MultiInstanceSettings { get; set; }
 
         /// <summary>
         /// Gets or sets resource usage statistics for the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stats")]
+        [JsonProperty(PropertyName = "stats")]
         public TaskStatistics Stats { get; set; }
 
         /// <summary>
@@ -299,15 +314,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// have completed successfully. If any of those tasks fail and exhaust
         /// their retry counts, this task will never be scheduled.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "dependsOn")]
+        [JsonProperty(PropertyName = "dependsOn")]
         public TaskDependencies DependsOn { get; set; }
 
         /// <summary>
         /// Gets or sets a list of application packages that the Batch service
         /// will deploy to the compute node before running the command line.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationPackageReferences")]
-        public System.Collections.Generic.IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
+        /// <remarks>
+        /// Application packages are downloaded and deployed to a shared
+        /// directory, not the task working directory. Therefore, if a
+        /// referenced package is already on the compute node, and is up to
+        /// date, then it is not re-downloaded; the existing copy on the
+        /// compute node is used. If a referenced application package cannot be
+        /// installed, for example because the package has been deleted or
+        /// because download failed, the task fails.
+        /// </remarks>
+        [JsonProperty(PropertyName = "applicationPackageReferences")]
+        public IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the settings for an authentication token that the task
@@ -323,20 +347,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// permissions in order to add other tasks to the job, or check the
         /// status of the job or of other tasks under the job.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "authenticationTokenSettings")]
+        [JsonProperty(PropertyName = "authenticationTokenSettings")]
         public AuthenticationTokenSettings AuthenticationTokenSettings { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.ResourceFiles != null)
+            if (ResourceFiles != null)
             {
-                foreach (var element in this.ResourceFiles)
+                foreach (var element in ResourceFiles)
                 {
                     if (element != null)
                     {
@@ -344,9 +368,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.OutputFiles != null)
+            if (OutputFiles != null)
             {
-                foreach (var element1 in this.OutputFiles)
+                foreach (var element1 in OutputFiles)
                 {
                     if (element1 != null)
                     {
@@ -354,9 +378,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.EnvironmentSettings != null)
+            if (EnvironmentSettings != null)
             {
-                foreach (var element2 in this.EnvironmentSettings)
+                foreach (var element2 in EnvironmentSettings)
                 {
                     if (element2 != null)
                     {
@@ -364,25 +388,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.AffinityInfo != null)
+            if (AffinityInfo != null)
             {
-                this.AffinityInfo.Validate();
+                AffinityInfo.Validate();
             }
-            if (this.ExecutionInfo != null)
+            if (ExecutionInfo != null)
             {
-                this.ExecutionInfo.Validate();
+                ExecutionInfo.Validate();
             }
-            if (this.MultiInstanceSettings != null)
+            if (MultiInstanceSettings != null)
             {
-                this.MultiInstanceSettings.Validate();
+                MultiInstanceSettings.Validate();
             }
-            if (this.Stats != null)
+            if (Stats != null)
             {
-                this.Stats.Validate();
+                Stats.Validate();
             }
-            if (this.ApplicationPackageReferences != null)
+            if (ApplicationPackageReferences != null)
             {
-                foreach (var element3 in this.ApplicationPackageReferences)
+                foreach (var element3 in ApplicationPackageReferences)
                 {
                     if (element3 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudTaskListSubtasksResult.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/CloudTaskListSubtasksResult.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,23 +25,32 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the CloudTaskListSubtasksResult
         /// class.
         /// </summary>
-        public CloudTaskListSubtasksResult() { }
+        public CloudTaskListSubtasksResult()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the CloudTaskListSubtasksResult
         /// class.
         /// </summary>
         /// <param name="value">The list of subtasks.</param>
-        public CloudTaskListSubtasksResult(System.Collections.Generic.IList<SubtaskInformation> value = default(System.Collections.Generic.IList<SubtaskInformation>))
+        public CloudTaskListSubtasksResult(IList<SubtaskInformation> value = default(IList<SubtaskInformation>))
         {
-            this.Value = value;
+            Value = value;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the list of subtasks.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
-        public System.Collections.Generic.IList<SubtaskInformation> Value { get; set; }
+        [JsonProperty(PropertyName = "value")]
+        public IList<SubtaskInformation> Value { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNode.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNode.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNode class.
         /// </summary>
-        public ComputeNode() { }
+        public ComputeNode()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNode class.
@@ -37,8 +46,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="ipAddress">The IP address that other compute nodes can
         /// use to communicate with this compute node.</param>
         /// <param name="affinityId">An identifier which can be passed when
-        /// adding a task to request that the task be scheduled close to this
-        /// compute node.</param>
+        /// adding a task to request that the task be scheduled on this
+        /// node.</param>
         /// <param name="vmSize">The size of the virtual machine hosting the
         /// compute node.</param>
         /// <param name="totalTasksRun">The total number of job tasks completed
@@ -52,8 +61,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// which completed successfully (with exitCode 0) on the compute node.
         /// This includes Job Preparation, Job Release, and Job Manager tasks,
         /// but not the pool start task.</param>
-        /// <param name="recentTasks">The list of tasks that are currently
-        /// running on the compute node.</param>
+        /// <param name="recentTasks">A list of tasks whose state has recently
+        /// changed.</param>
         /// <param name="startTask">The task specified to run on the compute
         /// node as it joins the pool.</param>
         /// <param name="startTaskInfo">Runtime information about the execution
@@ -66,29 +75,35 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// node. If false, the node is a low-priority node.</param>
         /// <param name="endpointConfiguration">The endpoint configuration for
         /// the compute node.</param>
-        public ComputeNode(string id = default(string), string url = default(string), ComputeNodeState? state = default(ComputeNodeState?), SchedulingState? schedulingState = default(SchedulingState?), System.DateTime? stateTransitionTime = default(System.DateTime?), System.DateTime? lastBootTime = default(System.DateTime?), System.DateTime? allocationTime = default(System.DateTime?), string ipAddress = default(string), string affinityId = default(string), string vmSize = default(string), int? totalTasksRun = default(int?), int? runningTasksCount = default(int?), int? totalTasksSucceeded = default(int?), System.Collections.Generic.IList<TaskInformation> recentTasks = default(System.Collections.Generic.IList<TaskInformation>), StartTask startTask = default(StartTask), StartTaskInformation startTaskInfo = default(StartTaskInformation), System.Collections.Generic.IList<CertificateReference> certificateReferences = default(System.Collections.Generic.IList<CertificateReference>), System.Collections.Generic.IList<ComputeNodeError> errors = default(System.Collections.Generic.IList<ComputeNodeError>), bool? isDedicated = default(bool?), ComputeNodeEndpointConfiguration endpointConfiguration = default(ComputeNodeEndpointConfiguration))
+        public ComputeNode(string id = default(string), string url = default(string), ComputeNodeState? state = default(ComputeNodeState?), SchedulingState? schedulingState = default(SchedulingState?), System.DateTime? stateTransitionTime = default(System.DateTime?), System.DateTime? lastBootTime = default(System.DateTime?), System.DateTime? allocationTime = default(System.DateTime?), string ipAddress = default(string), string affinityId = default(string), string vmSize = default(string), int? totalTasksRun = default(int?), int? runningTasksCount = default(int?), int? totalTasksSucceeded = default(int?), IList<TaskInformation> recentTasks = default(IList<TaskInformation>), StartTask startTask = default(StartTask), StartTaskInformation startTaskInfo = default(StartTaskInformation), IList<CertificateReference> certificateReferences = default(IList<CertificateReference>), IList<ComputeNodeError> errors = default(IList<ComputeNodeError>), bool? isDedicated = default(bool?), ComputeNodeEndpointConfiguration endpointConfiguration = default(ComputeNodeEndpointConfiguration))
         {
-            this.Id = id;
-            this.Url = url;
-            this.State = state;
-            this.SchedulingState = schedulingState;
-            this.StateTransitionTime = stateTransitionTime;
-            this.LastBootTime = lastBootTime;
-            this.AllocationTime = allocationTime;
-            this.IpAddress = ipAddress;
-            this.AffinityId = affinityId;
-            this.VmSize = vmSize;
-            this.TotalTasksRun = totalTasksRun;
-            this.RunningTasksCount = runningTasksCount;
-            this.TotalTasksSucceeded = totalTasksSucceeded;
-            this.RecentTasks = recentTasks;
-            this.StartTask = startTask;
-            this.StartTaskInfo = startTaskInfo;
-            this.CertificateReferences = certificateReferences;
-            this.Errors = errors;
-            this.IsDedicated = isDedicated;
-            this.EndpointConfiguration = endpointConfiguration;
+            Id = id;
+            Url = url;
+            State = state;
+            SchedulingState = schedulingState;
+            StateTransitionTime = stateTransitionTime;
+            LastBootTime = lastBootTime;
+            AllocationTime = allocationTime;
+            IpAddress = ipAddress;
+            AffinityId = affinityId;
+            VmSize = vmSize;
+            TotalTasksRun = totalTasksRun;
+            RunningTasksCount = runningTasksCount;
+            TotalTasksSucceeded = totalTasksSucceeded;
+            RecentTasks = recentTasks;
+            StartTask = startTask;
+            StartTaskInfo = startTaskInfo;
+            CertificateReferences = certificateReferences;
+            Errors = errors;
+            IsDedicated = isDedicated;
+            EndpointConfiguration = endpointConfiguration;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ID of the compute node.
@@ -98,25 +113,54 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Whenever a node is removed from a pool, all of its local files are
         /// deleted, and the ID is reclaimed and could be reused for new nodes.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the current state of the compute node.
         /// </summary>
         /// <remarks>
-        /// Possible values include: 'idle', 'rebooting', 'reimaging',
-        /// 'running', 'unusable', 'creating', 'starting',
-        /// 'waitingForStartTask', 'startTaskFailed', 'unknown', 'leavingPool',
-        /// 'offline', 'preempted'
+        /// Values are:
+        ///
+        /// idle - The node is not currently running a task.
+        /// rebooting - The node is rebooting.
+        /// reimaging - The node is reimaging.
+        /// running - The node is running one or more tasks (other than a start
+        /// task).
+        /// unusable - The node cannot be used for task execution due to
+        /// errors.
+        /// creating - The Batch service has obtained the underlying virtual
+        /// machine from Azure Compute, but it has not yet started to join the
+        /// pool.
+        /// starting - the Batch service is starting on the underlying virtual
+        /// machine.
+        /// waitingforstarttask - The start task has started running on the
+        /// compute node, but waitForSuccess is set and the start task has not
+        /// yet completed.
+        /// starttaskfailed - The start task has failed on the compute node
+        /// (and exhausted all retries), and waitForSuccess is set. The node is
+        /// not usable for running tasks.
+        /// unknown - The Batch service has lost contact with the node, and
+        /// does not know its true state.
+        /// leavingpool - The node is leaving the pool, either because the user
+        /// explicitly removed it or because the pool is resizing or
+        /// autoscaling down.
+        /// offline - The node is not currently running a task, and scheduling
+        /// of new tasks to the node is disabled.
+        /// preempted - The low-priority node has been preempted. Tasks which
+        /// were running on the node when it was pre-empted will be rescheduled
+        /// when another node becomes available. Possible values include:
+        /// 'idle', 'rebooting', 'reimaging', 'running', 'unusable',
+        /// 'creating', 'starting', 'waitingForStartTask', 'startTaskFailed',
+        /// 'unknown', 'leavingPool', 'offline', 'preempted'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public ComputeNodeState? State { get; set; }
 
         /// <summary>
@@ -124,19 +168,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// scheduling.
         /// </summary>
         /// <remarks>
-        /// enabled - Tasks can be scheduled on the node. disabled - No new
-        /// tasks will be scheduled on the node. Tasks already running on the
-        /// node may still run to completion. All nodes start with scheduling
-        /// enabled. Possible values include: 'enabled', 'disabled'
+        /// Values are:
+        ///
+        /// enabled - Tasks can be scheduled on the node.
+        /// disabled - No new tasks will be scheduled on the node. Tasks
+        /// already running on the node may still run to completion. All nodes
+        /// start with scheduling enabled. Possible values include: 'enabled',
+        /// 'disabled'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "schedulingState")]
+        [JsonProperty(PropertyName = "schedulingState")]
         public SchedulingState? SchedulingState { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the compute node entered its current
         /// state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stateTransitionTime")]
+        [JsonProperty(PropertyName = "stateTransitionTime")]
         public System.DateTime? StateTransitionTime { get; set; }
 
         /// <summary>
@@ -145,14 +192,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property may not be present if the node state is unusable.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastBootTime")]
+        [JsonProperty(PropertyName = "lastBootTime")]
         public System.DateTime? LastBootTime { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which this compute node was allocated to
         /// the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "allocationTime")]
+        [JsonProperty(PropertyName = "allocationTime")]
         public System.DateTime? AllocationTime { get; set; }
 
         /// <summary>
@@ -165,14 +212,19 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// deleted, and the IP address is reclaimed and could be reused for
         /// new nodes.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ipAddress")]
+        [JsonProperty(PropertyName = "ipAddress")]
         public string IpAddress { get; set; }
 
         /// <summary>
         /// Gets or sets an identifier which can be passed when adding a task
-        /// to request that the task be scheduled close to this compute node.
+        /// to request that the task be scheduled on this node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "affinityId")]
+        /// <remarks>
+        /// Note that this is just a soft affinity. If the target node is busy
+        /// or unavailable at the time the task is scheduled, then the task
+        /// will be scheduled elsewhere.
+        /// </remarks>
+        [JsonProperty(PropertyName = "affinityId")]
         public string AffinityId { get; set; }
 
         /// <summary>
@@ -195,7 +247,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// premium storage (STANDARD_GS, STANDARD_DS, and STANDARD_DSV2
         /// series).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "vmSize")]
+        [JsonProperty(PropertyName = "vmSize")]
         public string VmSize { get; set; }
 
         /// <summary>
@@ -203,7 +255,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// node. This includes Job Preparation, Job Release and Job Manager
         /// tasks, but not the pool start task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "totalTasksRun")]
+        [JsonProperty(PropertyName = "totalTasksRun")]
         public int? TotalTasksRun { get; set; }
 
         /// <summary>
@@ -211,7 +263,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node. This includes Job Preparation, Job Release, and Job
         /// Manager tasks, but not the pool start task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "runningTasksCount")]
+        [JsonProperty(PropertyName = "runningTasksCount")]
         public int? RunningTasksCount { get; set; }
 
         /// <summary>
@@ -220,28 +272,31 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Job Preparation, Job Release, and Job Manager tasks, but not the
         /// pool start task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "totalTasksSucceeded")]
+        [JsonProperty(PropertyName = "totalTasksSucceeded")]
         public int? TotalTasksSucceeded { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of tasks that are currently running on the
-        /// compute node.
+        /// Gets or sets a list of tasks whose state has recently changed.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "recentTasks")]
-        public System.Collections.Generic.IList<TaskInformation> RecentTasks { get; set; }
+        /// <remarks>
+        /// This property is present only if at least one task has run on this
+        /// node since it was assigned to the pool.
+        /// </remarks>
+        [JsonProperty(PropertyName = "recentTasks")]
+        public IList<TaskInformation> RecentTasks { get; set; }
 
         /// <summary>
         /// Gets or sets the task specified to run on the compute node as it
         /// joins the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTask")]
+        [JsonProperty(PropertyName = "startTask")]
         public StartTask StartTask { get; set; }
 
         /// <summary>
         /// Gets or sets runtime information about the execution of the start
         /// task on the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTaskInfo")]
+        [JsonProperty(PropertyName = "startTaskInfo")]
         public StartTaskInformation StartTaskInfo { get; set; }
 
         /// <summary>
@@ -259,40 +314,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// /home/{user-name}/certs) and certificates are placed in that
         /// directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "certificateReferences")]
-        public System.Collections.Generic.IList<CertificateReference> CertificateReferences { get; set; }
+        [JsonProperty(PropertyName = "certificateReferences")]
+        public IList<CertificateReference> CertificateReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the list of errors that are currently being
         /// encountered by the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "errors")]
-        public System.Collections.Generic.IList<ComputeNodeError> Errors { get; set; }
+        [JsonProperty(PropertyName = "errors")]
+        public IList<ComputeNodeError> Errors { get; set; }
 
         /// <summary>
         /// Gets or sets whether this compute node is a dedicated node. If
         /// false, the node is a low-priority node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "isDedicated")]
+        [JsonProperty(PropertyName = "isDedicated")]
         public bool? IsDedicated { get; set; }
 
         /// <summary>
         /// Gets or sets the endpoint configuration for the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endpointConfiguration")]
+        [JsonProperty(PropertyName = "endpointConfiguration")]
         public ComputeNodeEndpointConfiguration EndpointConfiguration { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.RecentTasks != null)
+            if (RecentTasks != null)
             {
-                foreach (var element in this.RecentTasks)
+                foreach (var element in RecentTasks)
                 {
                     if (element != null)
                     {
@@ -300,17 +355,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.StartTask != null)
+            if (StartTask != null)
             {
-                this.StartTask.Validate();
+                StartTask.Validate();
             }
-            if (this.StartTaskInfo != null)
+            if (StartTaskInfo != null)
             {
-                this.StartTaskInfo.Validate();
+                StartTaskInfo.Validate();
             }
-            if (this.CertificateReferences != null)
+            if (CertificateReferences != null)
             {
-                foreach (var element1 in this.CertificateReferences)
+                foreach (var element1 in CertificateReferences)
                 {
                     if (element1 != null)
                     {
@@ -318,9 +373,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.EndpointConfiguration != null)
+            if (EndpointConfiguration != null)
             {
-                this.EndpointConfiguration.Validate();
+                EndpointConfiguration.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeAddUserHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeAddUserHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeAddUserHeaders class.
         /// </summary>
-        public ComputeNodeAddUserHeaders() { }
+        public ComputeNodeAddUserHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeAddUserHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public ComputeNodeAddUserHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeAddUserOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeAddUserOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeAddUserOptions class.
         /// </summary>
-        public ComputeNodeAddUserOptions() { }
+        public ComputeNodeAddUserOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeAddUserOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeAddUserOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDeallocationOption.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDeallocationOption.cs
@@ -8,20 +8,64 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for ComputeNodeDeallocationOption.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ComputeNodeDeallocationOption
     {
-        [System.Runtime.Serialization.EnumMember(Value = "requeue")]
+        [EnumMember(Value = "requeue")]
         Requeue,
-        [System.Runtime.Serialization.EnumMember(Value = "terminate")]
+        [EnumMember(Value = "terminate")]
         Terminate,
-        [System.Runtime.Serialization.EnumMember(Value = "taskCompletion")]
+        [EnumMember(Value = "taskCompletion")]
         TaskCompletion,
-        [System.Runtime.Serialization.EnumMember(Value = "retainedData")]
+        [EnumMember(Value = "retainedData")]
         RetainedData
+    }
+    internal static class ComputeNodeDeallocationOptionEnumExtension
+    {
+        internal static string ToSerializedValue(this ComputeNodeDeallocationOption? value)  =>
+            value == null ? null : ((ComputeNodeDeallocationOption)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this ComputeNodeDeallocationOption value)
+        {
+            switch( value )
+            {
+                case ComputeNodeDeallocationOption.Requeue:
+                    return "requeue";
+                case ComputeNodeDeallocationOption.Terminate:
+                    return "terminate";
+                case ComputeNodeDeallocationOption.TaskCompletion:
+                    return "taskCompletion";
+                case ComputeNodeDeallocationOption.RetainedData:
+                    return "retainedData";
+            }
+            return null;
+        }
+
+        internal static ComputeNodeDeallocationOption? ParseComputeNodeDeallocationOption(this string value)
+        {
+            switch( value )
+            {
+                case "requeue":
+                    return ComputeNodeDeallocationOption.Requeue;
+                case "terminate":
+                    return ComputeNodeDeallocationOption.Terminate;
+                case "taskCompletion":
+                    return ComputeNodeDeallocationOption.TaskCompletion;
+                case "retainedData":
+                    return ComputeNodeDeallocationOption.RetainedData;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDeleteUserHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDeleteUserHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the ComputeNodeDeleteUserHeaders
         /// class.
         /// </summary>
-        public ComputeNodeDeleteUserHeaders() { }
+        public ComputeNodeDeleteUserHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeDeleteUserHeaders
@@ -37,16 +44,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public ComputeNodeDeleteUserHeaders(string clientRequestId = default(string), string requestId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public string ClientRequestId { get; set; }
 
         /// <summary>
@@ -58,7 +71,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public string RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDeleteUserOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDeleteUserOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the ComputeNodeDeleteUserOptions
         /// class.
         /// </summary>
-        public ComputeNodeDeleteUserOptions() { }
+        public ComputeNodeDeleteUserOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeDeleteUserOptions
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeDeleteUserOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDisableSchedulingHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDisableSchedulingHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeDisableSchedulingHeaders class.
         /// </summary>
-        public ComputeNodeDisableSchedulingHeaders() { }
+        public ComputeNodeDisableSchedulingHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public ComputeNodeDisableSchedulingHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -70,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -80,21 +95,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDisableSchedulingOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeDisableSchedulingOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeDisableSchedulingOptions class.
         /// </summary>
-        public ComputeNodeDisableSchedulingOptions() { }
+        public ComputeNodeDisableSchedulingOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeDisableSchedulingOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeEnableSchedulingHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeEnableSchedulingHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeEnableSchedulingHeaders class.
         /// </summary>
-        public ComputeNodeEnableSchedulingHeaders() { }
+        public ComputeNodeEnableSchedulingHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public ComputeNodeEnableSchedulingHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -70,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -80,21 +95,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeEnableSchedulingOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeEnableSchedulingOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeEnableSchedulingOptions class.
         /// </summary>
-        public ComputeNodeEnableSchedulingOptions() { }
+        public ComputeNodeEnableSchedulingOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeEnableSchedulingOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeEndpointConfiguration.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeEndpointConfiguration.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the ComputeNodeEndpointConfiguration
         /// class.
         /// </summary>
-        public ComputeNodeEndpointConfiguration() { }
+        public ComputeNodeEndpointConfiguration()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeEndpointConfiguration
@@ -27,33 +37,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// </summary>
         /// <param name="inboundEndpoints">The list of inbound endpoints that
         /// are accessible on the compute node.</param>
-        public ComputeNodeEndpointConfiguration(System.Collections.Generic.IList<InboundEndpoint> inboundEndpoints)
+        public ComputeNodeEndpointConfiguration(IList<InboundEndpoint> inboundEndpoints)
         {
-            this.InboundEndpoints = inboundEndpoints;
+            InboundEndpoints = inboundEndpoints;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the list of inbound endpoints that are accessible on
         /// the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "inboundEndpoints")]
-        public System.Collections.Generic.IList<InboundEndpoint> InboundEndpoints { get; set; }
+        [JsonProperty(PropertyName = "inboundEndpoints")]
+        public IList<InboundEndpoint> InboundEndpoints { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.InboundEndpoints == null)
+            if (InboundEndpoints == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "InboundEndpoints");
+                throw new ValidationException(ValidationRules.CannotBeNull, "InboundEndpoints");
             }
-            if (this.InboundEndpoints != null)
+            if (InboundEndpoints != null)
             {
-                foreach (var element in this.InboundEndpoints)
+                foreach (var element in InboundEndpoints)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeError.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeError.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeError class.
         /// </summary>
-        public ComputeNodeError() { }
+        public ComputeNodeError()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeError class.
@@ -30,33 +39,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// intended to be suitable for display in a user interface.</param>
         /// <param name="errorDetails">The list of additional error details
         /// related to the compute node error.</param>
-        public ComputeNodeError(string code = default(string), string message = default(string), System.Collections.Generic.IList<NameValuePair> errorDetails = default(System.Collections.Generic.IList<NameValuePair>))
+        public ComputeNodeError(string code = default(string), string message = default(string), IList<NameValuePair> errorDetails = default(IList<NameValuePair>))
         {
-            this.Code = code;
-            this.Message = message;
-            this.ErrorDetails = errorDetails;
+            Code = code;
+            Message = message;
+            ErrorDetails = errorDetails;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an identifier for the compute node error. Codes are
         /// invariant and are intended to be consumed programmatically.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [JsonProperty(PropertyName = "code")]
         public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets a message describing the compute node error, intended
         /// to be suitable for display in a user interface.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }
 
         /// <summary>
         /// Gets or sets the list of additional error details related to the
         /// compute node error.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "errorDetails")]
-        public System.Collections.Generic.IList<NameValuePair> ErrorDetails { get; set; }
+        [JsonProperty(PropertyName = "errorDetails")]
+        public IList<NameValuePair> ErrorDetails { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeFillType.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeFillType.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for ComputeNodeFillType.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ComputeNodeFillType
     {
-        [System.Runtime.Serialization.EnumMember(Value = "spread")]
+        [EnumMember(Value = "spread")]
         Spread,
-        [System.Runtime.Serialization.EnumMember(Value = "pack")]
+        [EnumMember(Value = "pack")]
         Pack
+    }
+    internal static class ComputeNodeFillTypeEnumExtension
+    {
+        internal static string ToSerializedValue(this ComputeNodeFillType? value)  =>
+            value == null ? null : ((ComputeNodeFillType)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this ComputeNodeFillType value)
+        {
+            switch( value )
+            {
+                case ComputeNodeFillType.Spread:
+                    return "spread";
+                case ComputeNodeFillType.Pack:
+                    return "pack";
+            }
+            return null;
+        }
+
+        internal static ComputeNodeFillType? ParseComputeNodeFillType(this string value)
+        {
+            switch( value )
+            {
+                case "spread":
+                    return ComputeNodeFillType.Spread;
+                case "pack":
+                    return ComputeNodeFillType.Pack;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeGetHeaders class.
         /// </summary>
-        public ComputeNodeGetHeaders() { }
+        public ComputeNodeGetHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeGetHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public ComputeNodeGetHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeGetOptions class.
         /// </summary>
-        public ComputeNodeGetOptions() { }
+        public ComputeNodeGetOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeGetOptions class.
@@ -37,24 +46,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeGetOptions(string select = default(string), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Select = select;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Select = select;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -62,14 +77,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -77,8 +92,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteDesktopHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteDesktopHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeGetRemoteDesktopHeaders class.
         /// </summary>
-        public ComputeNodeGetRemoteDesktopHeaders() { }
+        public ComputeNodeGetRemoteDesktopHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public ComputeNodeGetRemoteDesktopHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteDesktopOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteDesktopOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeGetRemoteDesktopOptions class.
         /// </summary>
-        public ComputeNodeGetRemoteDesktopOptions() { }
+        public ComputeNodeGetRemoteDesktopOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeGetRemoteDesktopOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteLoginSettingsHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteLoginSettingsHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeGetRemoteLoginSettingsHeaders class.
         /// </summary>
-        public ComputeNodeGetRemoteLoginSettingsHeaders() { }
+        public ComputeNodeGetRemoteLoginSettingsHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public ComputeNodeGetRemoteLoginSettingsHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteLoginSettingsOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteLoginSettingsOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeGetRemoteLoginSettingsOptions class.
         /// </summary>
-        public ComputeNodeGetRemoteLoginSettingsOptions() { }
+        public ComputeNodeGetRemoteLoginSettingsOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -39,17 +48,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeGetRemoteLoginSettingsOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -57,14 +72,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -72,8 +87,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteLoginSettingsResult.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeGetRemoteLoginSettingsResult.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// ComputeNodeGetRemoteLoginSettingsResult class.
         /// </summary>
-        public ComputeNodeGetRemoteLoginSettingsResult() { }
+        public ComputeNodeGetRemoteLoginSettingsResult()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -31,34 +39,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node.</param>
         public ComputeNodeGetRemoteLoginSettingsResult(string remoteLoginIPAddress, int remoteLoginPort)
         {
-            this.RemoteLoginIPAddress = remoteLoginIPAddress;
-            this.RemoteLoginPort = remoteLoginPort;
+            RemoteLoginIPAddress = remoteLoginIPAddress;
+            RemoteLoginPort = remoteLoginPort;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the IP address used for remote login to the compute
         /// node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "remoteLoginIPAddress")]
+        [JsonProperty(PropertyName = "remoteLoginIPAddress")]
         public string RemoteLoginIPAddress { get; set; }
 
         /// <summary>
         /// Gets or sets the port used for remote login to the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "remoteLoginPort")]
+        [JsonProperty(PropertyName = "remoteLoginPort")]
         public int RemoteLoginPort { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.RemoteLoginIPAddress == null)
+            if (RemoteLoginIPAddress == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "RemoteLoginIPAddress");
+                throw new ValidationException(ValidationRules.CannotBeNull, "RemoteLoginIPAddress");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,15 +22,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeInformation class.
         /// </summary>
-        public ComputeNodeInformation() { }
+        public ComputeNodeInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeInformation class.
         /// </summary>
         /// <param name="affinityId">An identifier for the compute node on
         /// which the task ran, which can be passed when adding a task to
-        /// request that the task be scheduled close to this compute
-        /// node.</param>
+        /// request that the task be scheduled on this compute node.</param>
         /// <param name="nodeUrl">The URL of the node on which the task ran.
         /// </param>
         /// <param name="poolId">The ID of the pool on which the task
@@ -39,51 +45,57 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the task on the compute node.</param>
         public ComputeNodeInformation(string affinityId = default(string), string nodeUrl = default(string), string poolId = default(string), string nodeId = default(string), string taskRootDirectory = default(string), string taskRootDirectoryUrl = default(string))
         {
-            this.AffinityId = affinityId;
-            this.NodeUrl = nodeUrl;
-            this.PoolId = poolId;
-            this.NodeId = nodeId;
-            this.TaskRootDirectory = taskRootDirectory;
-            this.TaskRootDirectoryUrl = taskRootDirectoryUrl;
+            AffinityId = affinityId;
+            NodeUrl = nodeUrl;
+            PoolId = poolId;
+            NodeId = nodeId;
+            TaskRootDirectory = taskRootDirectory;
+            TaskRootDirectoryUrl = taskRootDirectoryUrl;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an identifier for the compute node on which the task
         /// ran, which can be passed when adding a task to request that the
-        /// task be scheduled close to this compute node.
+        /// task be scheduled on this compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "affinityId")]
+        [JsonProperty(PropertyName = "affinityId")]
         public string AffinityId { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the node on which the task ran.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeUrl")]
+        [JsonProperty(PropertyName = "nodeUrl")]
         public string NodeUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the pool on which the task ran.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolId")]
+        [JsonProperty(PropertyName = "poolId")]
         public string PoolId { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the node on which the task ran.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeId")]
+        [JsonProperty(PropertyName = "nodeId")]
         public string NodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the root directory of the task on the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskRootDirectory")]
+        [JsonProperty(PropertyName = "taskRootDirectory")]
         public string TaskRootDirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the URL to the root directory of the task on the
         /// compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskRootDirectoryUrl")]
+        [JsonProperty(PropertyName = "taskRootDirectoryUrl")]
         public string TaskRootDirectoryUrl { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeListHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeListHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeListHeaders class.
         /// </summary>
-        public ComputeNodeListHeaders() { }
+        public ComputeNodeListHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeListHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public ComputeNodeListHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeListNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeListNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeListNextOptions class.
         /// </summary>
-        public ComputeNodeListNextOptions() { }
+        public ComputeNodeListNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeListNextOptions class.
@@ -33,24 +42,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeListNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -58,8 +73,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeListOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeListOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeListOptions class.
         /// </summary>
-        public ComputeNodeListOptions() { }
+        public ComputeNodeListOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeListOptions class.
@@ -40,39 +49,45 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeListOptions(string filter = default(string), string select = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.Select = select;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            Select = select;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause..
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 nodes can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -80,14 +95,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -95,8 +110,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeRebootHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeRebootHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeRebootHeaders class.
         /// </summary>
-        public ComputeNodeRebootHeaders() { }
+        public ComputeNodeRebootHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeRebootHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public ComputeNodeRebootHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeRebootOption.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeRebootOption.cs
@@ -8,20 +8,64 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for ComputeNodeRebootOption.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ComputeNodeRebootOption
     {
-        [System.Runtime.Serialization.EnumMember(Value = "requeue")]
+        [EnumMember(Value = "requeue")]
         Requeue,
-        [System.Runtime.Serialization.EnumMember(Value = "terminate")]
+        [EnumMember(Value = "terminate")]
         Terminate,
-        [System.Runtime.Serialization.EnumMember(Value = "taskCompletion")]
+        [EnumMember(Value = "taskCompletion")]
         TaskCompletion,
-        [System.Runtime.Serialization.EnumMember(Value = "retainedData")]
+        [EnumMember(Value = "retainedData")]
         RetainedData
+    }
+    internal static class ComputeNodeRebootOptionEnumExtension
+    {
+        internal static string ToSerializedValue(this ComputeNodeRebootOption? value)  =>
+            value == null ? null : ((ComputeNodeRebootOption)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this ComputeNodeRebootOption value)
+        {
+            switch( value )
+            {
+                case ComputeNodeRebootOption.Requeue:
+                    return "requeue";
+                case ComputeNodeRebootOption.Terminate:
+                    return "terminate";
+                case ComputeNodeRebootOption.TaskCompletion:
+                    return "taskCompletion";
+                case ComputeNodeRebootOption.RetainedData:
+                    return "retainedData";
+            }
+            return null;
+        }
+
+        internal static ComputeNodeRebootOption? ParseComputeNodeRebootOption(this string value)
+        {
+            switch( value )
+            {
+                case "requeue":
+                    return ComputeNodeRebootOption.Requeue;
+                case "terminate":
+                    return ComputeNodeRebootOption.Terminate;
+                case "taskCompletion":
+                    return ComputeNodeRebootOption.TaskCompletion;
+                case "retainedData":
+                    return ComputeNodeRebootOption.RetainedData;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeRebootOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeRebootOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeRebootOptions class.
         /// </summary>
-        public ComputeNodeRebootOptions() { }
+        public ComputeNodeRebootOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeRebootOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeRebootOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeReimageHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeReimageHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeReimageHeaders class.
         /// </summary>
-        public ComputeNodeReimageHeaders() { }
+        public ComputeNodeReimageHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeReimageHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public ComputeNodeReimageHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeReimageOption.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeReimageOption.cs
@@ -8,20 +8,64 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for ComputeNodeReimageOption.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ComputeNodeReimageOption
     {
-        [System.Runtime.Serialization.EnumMember(Value = "requeue")]
+        [EnumMember(Value = "requeue")]
         Requeue,
-        [System.Runtime.Serialization.EnumMember(Value = "terminate")]
+        [EnumMember(Value = "terminate")]
         Terminate,
-        [System.Runtime.Serialization.EnumMember(Value = "taskCompletion")]
+        [EnumMember(Value = "taskCompletion")]
         TaskCompletion,
-        [System.Runtime.Serialization.EnumMember(Value = "retainedData")]
+        [EnumMember(Value = "retainedData")]
         RetainedData
+    }
+    internal static class ComputeNodeReimageOptionEnumExtension
+    {
+        internal static string ToSerializedValue(this ComputeNodeReimageOption? value)  =>
+            value == null ? null : ((ComputeNodeReimageOption)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this ComputeNodeReimageOption value)
+        {
+            switch( value )
+            {
+                case ComputeNodeReimageOption.Requeue:
+                    return "requeue";
+                case ComputeNodeReimageOption.Terminate:
+                    return "terminate";
+                case ComputeNodeReimageOption.TaskCompletion:
+                    return "taskCompletion";
+                case ComputeNodeReimageOption.RetainedData:
+                    return "retainedData";
+            }
+            return null;
+        }
+
+        internal static ComputeNodeReimageOption? ParseComputeNodeReimageOption(this string value)
+        {
+            switch( value )
+            {
+                case "requeue":
+                    return ComputeNodeReimageOption.Requeue;
+                case "terminate":
+                    return ComputeNodeReimageOption.Terminate;
+                case "taskCompletion":
+                    return ComputeNodeReimageOption.TaskCompletion;
+                case "retainedData":
+                    return ComputeNodeReimageOption.RetainedData;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeReimageOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeReimageOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeReimageOptions class.
         /// </summary>
-        public ComputeNodeReimageOptions() { }
+        public ComputeNodeReimageOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeReimageOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeReimageOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeState.cs
@@ -8,38 +8,118 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for ComputeNodeState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ComputeNodeState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "idle")]
+        [EnumMember(Value = "idle")]
         Idle,
-        [System.Runtime.Serialization.EnumMember(Value = "rebooting")]
+        [EnumMember(Value = "rebooting")]
         Rebooting,
-        [System.Runtime.Serialization.EnumMember(Value = "reimaging")]
+        [EnumMember(Value = "reimaging")]
         Reimaging,
-        [System.Runtime.Serialization.EnumMember(Value = "running")]
+        [EnumMember(Value = "running")]
         Running,
-        [System.Runtime.Serialization.EnumMember(Value = "unusable")]
+        [EnumMember(Value = "unusable")]
         Unusable,
-        [System.Runtime.Serialization.EnumMember(Value = "creating")]
+        [EnumMember(Value = "creating")]
         Creating,
-        [System.Runtime.Serialization.EnumMember(Value = "starting")]
+        [EnumMember(Value = "starting")]
         Starting,
-        [System.Runtime.Serialization.EnumMember(Value = "waitingForStartTask")]
+        [EnumMember(Value = "waitingForStartTask")]
         WaitingForStartTask,
-        [System.Runtime.Serialization.EnumMember(Value = "startTaskFailed")]
+        [EnumMember(Value = "startTaskFailed")]
         StartTaskFailed,
-        [System.Runtime.Serialization.EnumMember(Value = "unknown")]
+        [EnumMember(Value = "unknown")]
         Unknown,
-        [System.Runtime.Serialization.EnumMember(Value = "leavingPool")]
+        [EnumMember(Value = "leavingPool")]
         LeavingPool,
-        [System.Runtime.Serialization.EnumMember(Value = "offline")]
+        [EnumMember(Value = "offline")]
         Offline,
-        [System.Runtime.Serialization.EnumMember(Value = "preempted")]
+        [EnumMember(Value = "preempted")]
         Preempted
+    }
+    internal static class ComputeNodeStateEnumExtension
+    {
+        internal static string ToSerializedValue(this ComputeNodeState? value)  =>
+            value == null ? null : ((ComputeNodeState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this ComputeNodeState value)
+        {
+            switch( value )
+            {
+                case ComputeNodeState.Idle:
+                    return "idle";
+                case ComputeNodeState.Rebooting:
+                    return "rebooting";
+                case ComputeNodeState.Reimaging:
+                    return "reimaging";
+                case ComputeNodeState.Running:
+                    return "running";
+                case ComputeNodeState.Unusable:
+                    return "unusable";
+                case ComputeNodeState.Creating:
+                    return "creating";
+                case ComputeNodeState.Starting:
+                    return "starting";
+                case ComputeNodeState.WaitingForStartTask:
+                    return "waitingForStartTask";
+                case ComputeNodeState.StartTaskFailed:
+                    return "startTaskFailed";
+                case ComputeNodeState.Unknown:
+                    return "unknown";
+                case ComputeNodeState.LeavingPool:
+                    return "leavingPool";
+                case ComputeNodeState.Offline:
+                    return "offline";
+                case ComputeNodeState.Preempted:
+                    return "preempted";
+            }
+            return null;
+        }
+
+        internal static ComputeNodeState? ParseComputeNodeState(this string value)
+        {
+            switch( value )
+            {
+                case "idle":
+                    return ComputeNodeState.Idle;
+                case "rebooting":
+                    return ComputeNodeState.Rebooting;
+                case "reimaging":
+                    return ComputeNodeState.Reimaging;
+                case "running":
+                    return ComputeNodeState.Running;
+                case "unusable":
+                    return ComputeNodeState.Unusable;
+                case "creating":
+                    return ComputeNodeState.Creating;
+                case "starting":
+                    return ComputeNodeState.Starting;
+                case "waitingForStartTask":
+                    return ComputeNodeState.WaitingForStartTask;
+                case "startTaskFailed":
+                    return ComputeNodeState.StartTaskFailed;
+                case "unknown":
+                    return ComputeNodeState.Unknown;
+                case "leavingPool":
+                    return ComputeNodeState.LeavingPool;
+                case "offline":
+                    return ComputeNodeState.Offline;
+                case "preempted":
+                    return ComputeNodeState.Preempted;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeUpdateUserHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeUpdateUserHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the ComputeNodeUpdateUserHeaders
         /// class.
         /// </summary>
-        public ComputeNodeUpdateUserHeaders() { }
+        public ComputeNodeUpdateUserHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeUpdateUserHeaders
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public ComputeNodeUpdateUserHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -70,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -80,21 +95,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeUpdateUserOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeUpdateUserOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the ComputeNodeUpdateUserOptions
         /// class.
         /// </summary>
-        public ComputeNodeUpdateUserOptions() { }
+        public ComputeNodeUpdateUserOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeUpdateUserOptions
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public ComputeNodeUpdateUserOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeUser.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ComputeNodeUser.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ComputeNodeUser class.
         /// </summary>
-        public ComputeNodeUser() { }
+        public ComputeNodeUser()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ComputeNodeUser class.
@@ -33,17 +41,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// remote login to the compute node.</param>
         public ComputeNodeUser(string name, bool? isAdmin = default(bool?), System.DateTime? expiryTime = default(System.DateTime?), string password = default(string), string sshPublicKey = default(string))
         {
-            this.Name = name;
-            this.IsAdmin = isAdmin;
-            this.ExpiryTime = expiryTime;
-            this.Password = password;
-            this.SshPublicKey = sshPublicKey;
+            Name = name;
+            IsAdmin = isAdmin;
+            ExpiryTime = expiryTime;
+            Password = password;
+            SshPublicKey = sshPublicKey;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the user name of the account.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
@@ -53,7 +67,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// The default value is false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "isAdmin")]
+        [JsonProperty(PropertyName = "isAdmin")]
         public bool? IsAdmin { get; set; }
 
         /// <summary>
@@ -63,7 +77,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, the default is 1 day from the current time. For Linux
         /// compute nodes, the expiryTime has a precision up to a day.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "expiryTime")]
+        [JsonProperty(PropertyName = "expiryTime")]
         public System.DateTime? ExpiryTime { get; set; }
 
         /// <summary>
@@ -76,7 +90,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Linux compute nodes, the password can optionally be specified along
         /// with the sshPublicKey property.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "password")]
+        [JsonProperty(PropertyName = "password")]
         public string Password { get; set; }
 
         /// <summary>
@@ -90,20 +104,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch service rejects the request; if you are calling the REST API
         /// directly, the HTTP status code is 400 (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "sshPublicKey")]
+        [JsonProperty(PropertyName = "sshPublicKey")]
         public string SshPublicKey { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Name == null)
+            if (Name == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Name");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Name");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/DeleteCertificateError.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/DeleteCertificateError.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the DeleteCertificateError class.
         /// </summary>
-        public DeleteCertificateError() { }
+        public DeleteCertificateError()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the DeleteCertificateError class.
@@ -31,26 +40,32 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// interface.</param>
         /// <param name="values">A list of additional error details related to
         /// the certificate deletion error.</param>
-        public DeleteCertificateError(string code = default(string), string message = default(string), System.Collections.Generic.IList<NameValuePair> values = default(System.Collections.Generic.IList<NameValuePair>))
+        public DeleteCertificateError(string code = default(string), string message = default(string), IList<NameValuePair> values = default(IList<NameValuePair>))
         {
-            this.Code = code;
-            this.Message = message;
-            this.Values = values;
+            Code = code;
+            Message = message;
+            Values = values;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an identifier for the certificate deletion error.
         /// Codes are invariant and are intended to be consumed
         /// programmatically.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [JsonProperty(PropertyName = "code")]
         public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets a message describing the certificate deletion error,
         /// intended to be suitable for display in a user interface.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }
 
         /// <summary>
@@ -63,8 +78,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// resources reference the certificate, the list contains only about
         /// the first hundred.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "values")]
-        public System.Collections.Generic.IList<NameValuePair> Values { get; set; }
+        [JsonProperty(PropertyName = "values")]
+        public IList<NameValuePair> Values { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/DependencyAction.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/DependencyAction.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for DependencyAction.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum DependencyAction
     {
-        [System.Runtime.Serialization.EnumMember(Value = "satisfy")]
+        [EnumMember(Value = "satisfy")]
         Satisfy,
-        [System.Runtime.Serialization.EnumMember(Value = "block")]
+        [EnumMember(Value = "block")]
         Block
+    }
+    internal static class DependencyActionEnumExtension
+    {
+        internal static string ToSerializedValue(this DependencyAction? value)  =>
+            value == null ? null : ((DependencyAction)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this DependencyAction value)
+        {
+            switch( value )
+            {
+                case DependencyAction.Satisfy:
+                    return "satisfy";
+                case DependencyAction.Block:
+                    return "block";
+            }
+            return null;
+        }
+
+        internal static DependencyAction? ParseDependencyAction(this string value)
+        {
+            switch( value )
+            {
+                case "satisfy":
+                    return DependencyAction.Satisfy;
+                case "block":
+                    return DependencyAction.Block;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/DisableComputeNodeSchedulingOption.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/DisableComputeNodeSchedulingOption.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for DisableComputeNodeSchedulingOption.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum DisableComputeNodeSchedulingOption
     {
-        [System.Runtime.Serialization.EnumMember(Value = "requeue")]
+        [EnumMember(Value = "requeue")]
         Requeue,
-        [System.Runtime.Serialization.EnumMember(Value = "terminate")]
+        [EnumMember(Value = "terminate")]
         Terminate,
-        [System.Runtime.Serialization.EnumMember(Value = "taskCompletion")]
+        [EnumMember(Value = "taskCompletion")]
         TaskCompletion
+    }
+    internal static class DisableComputeNodeSchedulingOptionEnumExtension
+    {
+        internal static string ToSerializedValue(this DisableComputeNodeSchedulingOption? value)  =>
+            value == null ? null : ((DisableComputeNodeSchedulingOption)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this DisableComputeNodeSchedulingOption value)
+        {
+            switch( value )
+            {
+                case DisableComputeNodeSchedulingOption.Requeue:
+                    return "requeue";
+                case DisableComputeNodeSchedulingOption.Terminate:
+                    return "terminate";
+                case DisableComputeNodeSchedulingOption.TaskCompletion:
+                    return "taskCompletion";
+            }
+            return null;
+        }
+
+        internal static DisableComputeNodeSchedulingOption? ParseDisableComputeNodeSchedulingOption(this string value)
+        {
+            switch( value )
+            {
+                case "requeue":
+                    return DisableComputeNodeSchedulingOption.Requeue;
+                case "terminate":
+                    return DisableComputeNodeSchedulingOption.Terminate;
+                case "taskCompletion":
+                    return DisableComputeNodeSchedulingOption.TaskCompletion;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/DisableJobOption.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/DisableJobOption.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for DisableJobOption.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum DisableJobOption
     {
-        [System.Runtime.Serialization.EnumMember(Value = "requeue")]
+        [EnumMember(Value = "requeue")]
         Requeue,
-        [System.Runtime.Serialization.EnumMember(Value = "terminate")]
+        [EnumMember(Value = "terminate")]
         Terminate,
-        [System.Runtime.Serialization.EnumMember(Value = "wait")]
+        [EnumMember(Value = "wait")]
         Wait
+    }
+    internal static class DisableJobOptionEnumExtension
+    {
+        internal static string ToSerializedValue(this DisableJobOption? value)  =>
+            value == null ? null : ((DisableJobOption)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this DisableJobOption value)
+        {
+            switch( value )
+            {
+                case DisableJobOption.Requeue:
+                    return "requeue";
+                case DisableJobOption.Terminate:
+                    return "terminate";
+                case DisableJobOption.Wait:
+                    return "wait";
+            }
+            return null;
+        }
+
+        internal static DisableJobOption? ParseDisableJobOption(this string value)
+        {
+            switch( value )
+            {
+                case "requeue":
+                    return DisableJobOption.Requeue;
+                case "terminate":
+                    return DisableJobOption.Terminate;
+                case "wait":
+                    return DisableJobOption.Wait;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ElevationLevel.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ElevationLevel.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for ElevationLevel.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ElevationLevel
     {
-        [System.Runtime.Serialization.EnumMember(Value = "nonAdmin")]
+        [EnumMember(Value = "nonAdmin")]
         NonAdmin,
-        [System.Runtime.Serialization.EnumMember(Value = "admin")]
+        [EnumMember(Value = "admin")]
         Admin
+    }
+    internal static class ElevationLevelEnumExtension
+    {
+        internal static string ToSerializedValue(this ElevationLevel? value)  =>
+            value == null ? null : ((ElevationLevel)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this ElevationLevel value)
+        {
+            switch( value )
+            {
+                case ElevationLevel.NonAdmin:
+                    return "nonAdmin";
+                case ElevationLevel.Admin:
+                    return "admin";
+            }
+            return null;
+        }
+
+        internal static ElevationLevel? ParseElevationLevel(this string value)
+        {
+            switch( value )
+            {
+                case "nonAdmin":
+                    return ElevationLevel.NonAdmin;
+                case "admin":
+                    return ElevationLevel.Admin;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/EnvironmentSetting.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/EnvironmentSetting.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the EnvironmentSetting class.
         /// </summary>
-        public EnvironmentSetting() { }
+        public EnvironmentSetting()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the EnvironmentSetting class.
@@ -27,33 +35,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="value">The value of the environment variable.</param>
         public EnvironmentSetting(string name, string value = default(string))
         {
-            this.Name = name;
-            this.Value = value;
+            Name = name;
+            Value = value;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the name of the environment variable.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the value of the environment variable.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Name == null)
+            if (Name == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Name");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Name");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ErrorCategory.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ErrorCategory.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for ErrorCategory.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum ErrorCategory
     {
-        [System.Runtime.Serialization.EnumMember(Value = "userError")]
+        [EnumMember(Value = "userError")]
         UserError,
-        [System.Runtime.Serialization.EnumMember(Value = "serverError")]
+        [EnumMember(Value = "serverError")]
         ServerError
+    }
+    internal static class ErrorCategoryEnumExtension
+    {
+        internal static string ToSerializedValue(this ErrorCategory? value)  =>
+            value == null ? null : ((ErrorCategory)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this ErrorCategory value)
+        {
+            switch( value )
+            {
+                case ErrorCategory.UserError:
+                    return "userError";
+                case ErrorCategory.ServerError:
+                    return "serverError";
+            }
+            return null;
+        }
+
+        internal static ErrorCategory? ParseErrorCategory(this string value)
+        {
+            switch( value )
+            {
+                case "userError":
+                    return ErrorCategory.UserError;
+                case "serverError":
+                    return ErrorCategory.ServerError;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ErrorMessage.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ErrorMessage.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ErrorMessage class.
         /// </summary>
-        public ErrorMessage() { }
+        public ErrorMessage()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ErrorMessage class.
@@ -27,20 +34,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="value">The text of the message.</param>
         public ErrorMessage(string lang = default(string), string value = default(string))
         {
-            this.Lang = lang;
-            this.Value = value;
+            Lang = lang;
+            Value = value;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the language code of the error message
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lang")]
+        [JsonProperty(PropertyName = "lang")]
         public string Lang { get; set; }
 
         /// <summary>
         /// Gets or sets the text of the message.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ExitCodeMapping.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ExitCodeMapping.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ExitCodeMapping class.
         /// </summary>
-        public ExitCodeMapping() { }
+        public ExitCodeMapping()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ExitCodeMapping class.
@@ -29,34 +37,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the task exits with this exit code.</param>
         public ExitCodeMapping(int code, ExitOptions exitOptions)
         {
-            this.Code = code;
-            this.ExitOptions = exitOptions;
+            Code = code;
+            ExitOptions = exitOptions;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a process exit code.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [JsonProperty(PropertyName = "code")]
         public int Code { get; set; }
 
         /// <summary>
         /// Gets or sets how the Batch service should respond if the task exits
         /// with this exit code.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitOptions")]
+        [JsonProperty(PropertyName = "exitOptions")]
         public ExitOptions ExitOptions { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.ExitOptions == null)
+            if (ExitOptions == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "ExitOptions");
+                throw new ValidationException(ValidationRules.CannotBeNull, "ExitOptions");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ExitCodeRangeMapping.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ExitCodeRangeMapping.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ExitCodeRangeMapping class.
         /// </summary>
-        public ExitCodeRangeMapping() { }
+        public ExitCodeRangeMapping()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ExitCodeRangeMapping class.
@@ -31,41 +39,47 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// (inclusive).</param>
         public ExitCodeRangeMapping(int start, int end, ExitOptions exitOptions)
         {
-            this.Start = start;
-            this.End = end;
-            this.ExitOptions = exitOptions;
+            Start = start;
+            End = end;
+            ExitOptions = exitOptions;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the first exit code in the range.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "start")]
+        [JsonProperty(PropertyName = "start")]
         public int Start { get; set; }
 
         /// <summary>
         /// Gets or sets the last exit code in the range.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
+        [JsonProperty(PropertyName = "end")]
         public int End { get; set; }
 
         /// <summary>
         /// Gets or sets how the Batch service should respond if the task exits
         /// with an exit code in the range start to end (inclusive).
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitOptions")]
+        [JsonProperty(PropertyName = "exitOptions")]
         public ExitOptions ExitOptions { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.ExitOptions == null)
+            if (ExitOptions == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "ExitOptions");
+                throw new ValidationException(ValidationRules.CannotBeNull, "ExitOptions");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ExitConditions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ExitConditions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ExitConditions class.
         /// </summary>
-        public ExitConditions() { }
+        public ExitConditions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ExitConditions class.
@@ -34,34 +43,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="defaultProperty">How the Batch service should respond
         /// if the task fails with an exit condition not covered by any of the
         /// other properties.</param>
-        public ExitConditions(System.Collections.Generic.IList<ExitCodeMapping> exitCodes = default(System.Collections.Generic.IList<ExitCodeMapping>), System.Collections.Generic.IList<ExitCodeRangeMapping> exitCodeRanges = default(System.Collections.Generic.IList<ExitCodeRangeMapping>), ExitOptions preProcessingError = default(ExitOptions), ExitOptions fileUploadError = default(ExitOptions), ExitOptions defaultProperty = default(ExitOptions))
+        public ExitConditions(IList<ExitCodeMapping> exitCodes = default(IList<ExitCodeMapping>), IList<ExitCodeRangeMapping> exitCodeRanges = default(IList<ExitCodeRangeMapping>), ExitOptions preProcessingError = default(ExitOptions), ExitOptions fileUploadError = default(ExitOptions), ExitOptions defaultProperty = default(ExitOptions))
         {
-            this.ExitCodes = exitCodes;
-            this.ExitCodeRanges = exitCodeRanges;
-            this.PreProcessingError = preProcessingError;
-            this.FileUploadError = fileUploadError;
-            this.DefaultProperty = defaultProperty;
+            ExitCodes = exitCodes;
+            ExitCodeRanges = exitCodeRanges;
+            PreProcessingError = preProcessingError;
+            FileUploadError = fileUploadError;
+            DefaultProperty = defaultProperty;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a list of individual task exit codes and how the Batch
         /// service should respond to them.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitCodes")]
-        public System.Collections.Generic.IList<ExitCodeMapping> ExitCodes { get; set; }
+        [JsonProperty(PropertyName = "exitCodes")]
+        public IList<ExitCodeMapping> ExitCodes { get; set; }
 
         /// <summary>
         /// Gets or sets a list of task exit code ranges and how the Batch
         /// service should respond to them.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitCodeRanges")]
-        public System.Collections.Generic.IList<ExitCodeRangeMapping> ExitCodeRanges { get; set; }
+        [JsonProperty(PropertyName = "exitCodeRanges")]
+        public IList<ExitCodeRangeMapping> ExitCodeRanges { get; set; }
 
         /// <summary>
         /// Gets or sets how the Batch service should respond if the task fails
         /// to start due to an error.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "preProcessingError")]
+        [JsonProperty(PropertyName = "preProcessingError")]
         public ExitOptions PreProcessingError { get; set; }
 
         /// <summary>
@@ -73,7 +88,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// exitCodes or exitCodeRanges, and then encountered a file upload
         /// error, then the action specified by the exit code takes precedence.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "fileUploadError")]
+        [JsonProperty(PropertyName = "fileUploadError")]
         public ExitOptions FileUploadError { get; set; }
 
         /// <summary>
@@ -89,7 +104,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// code 0, you must list it explicitly using the exitCodes or
         /// exitCodeRanges collection.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "default")]
+        [JsonProperty(PropertyName = "default")]
         public ExitOptions DefaultProperty { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ExitOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ExitOptions.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ExitOptions class.
         /// </summary>
-        public ExitOptions() { }
+        public ExitOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ExitOptions class.
@@ -32,9 +39,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// performs on tasks that depend on this task.</param>
         public ExitOptions(JobAction? jobAction = default(JobAction?), DependencyAction? dependencyAction = default(DependencyAction?))
         {
-            this.JobAction = jobAction;
-            this.DependencyAction = dependencyAction;
+            JobAction = jobAction;
+            DependencyAction = dependencyAction;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an action to take on the job containing the task, if
@@ -42,14 +55,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// onTaskFailed property is 'performExitOptionsJobAction'.
         /// </summary>
         /// <remarks>
-        /// The default is none for exit code 0 and terminate for all other
-        /// exit conditions. If the job's onTaskFailed property is noAction,
-        /// then specify this property returns an error. The add task request
-        /// fails with an invalid property value error;; if you are calling the
-        /// REST API directly, the HTTP status code is 400 (Bad Request).
-        /// Possible values include: 'none', 'disable', 'terminate'
+        /// Values are:
+        ///
+        /// none - Take no action.
+        /// disable - Disable the job. This is equivalent to calling the
+        /// disable job API, with a disableTasks value of requeue.
+        /// terminate - Terminate the job. The terminateReason in the job's
+        /// executionInfo is set to "TaskFailed". The default is none for exit
+        /// code 0 and terminate for all other exit conditions.
+        ///
+        /// If the job's onTaskFailed property is noAction, then specifying
+        /// this property returns an error and the add task request fails with
+        /// an invalid property value error; if you are calling the REST API
+        /// directly, the HTTP status code is 400 (Bad Request). Possible
+        /// values include: 'none', 'disable', 'terminate'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobAction")]
+        [JsonProperty(PropertyName = "jobAction")]
         public JobAction? JobAction { get; set; }
 
         /// <summary>
@@ -57,15 +78,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// that depend on this task.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
+        /// satisfy - Satisfy the task's dependencies.
+        /// block - Block the task's dependencies.
+        ///
         /// The default is 'satisfy' for exit code 0, and 'block' for all other
         /// exit conditions. If the job's usesTaskDependencies property is set
         /// to false, then specifying the dependencyAction property returns an
-        /// error. The add task request fails with an invalid property value
+        /// erro and the add task request fails with an invalid property value
         /// error; if you are calling the REST API directly, the HTTP status
         /// code is 400  (Bad Request). Possible values include: 'satisfy',
         /// 'block'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "dependencyAction")]
+        [JsonProperty(PropertyName = "dependencyAction")]
         public DependencyAction? DependencyAction { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileDeleteFromComputeNodeHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileDeleteFromComputeNodeHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileDeleteFromComputeNodeHeaders
         /// class.
         /// </summary>
-        public FileDeleteFromComputeNodeHeaders() { }
+        public FileDeleteFromComputeNodeHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileDeleteFromComputeNodeHeaders
@@ -37,16 +44,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public FileDeleteFromComputeNodeHeaders(string clientRequestId = default(string), string requestId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public string ClientRequestId { get; set; }
 
         /// <summary>
@@ -58,7 +71,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public string RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileDeleteFromComputeNodeOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileDeleteFromComputeNodeOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileDeleteFromComputeNodeOptions
         /// class.
         /// </summary>
-        public FileDeleteFromComputeNodeOptions() { }
+        public FileDeleteFromComputeNodeOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileDeleteFromComputeNodeOptions
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public FileDeleteFromComputeNodeOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileDeleteFromTaskHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileDeleteFromTaskHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the FileDeleteFromTaskHeaders class.
         /// </summary>
-        public FileDeleteFromTaskHeaders() { }
+        public FileDeleteFromTaskHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileDeleteFromTaskHeaders class.
@@ -35,16 +42,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public FileDeleteFromTaskHeaders(string clientRequestId = default(string), string requestId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public string ClientRequestId { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public string RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileDeleteFromTaskOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileDeleteFromTaskOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the FileDeleteFromTaskOptions class.
         /// </summary>
-        public FileDeleteFromTaskOptions() { }
+        public FileDeleteFromTaskOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileDeleteFromTaskOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public FileDeleteFromTaskOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetFromComputeNodeHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetFromComputeNodeHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileGetFromComputeNodeHeaders
         /// class.
         /// </summary>
-        public FileGetFromComputeNodeHeaders() { }
+        public FileGetFromComputeNodeHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileGetFromComputeNodeHeaders
@@ -52,24 +61,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="contentLength">The length of the file.</param>
         public FileGetFromComputeNodeHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? ocpCreationTime = default(System.DateTime?), bool? ocpBatchFileIsdirectory = default(bool?), string ocpBatchFileUrl = default(string), string ocpBatchFileMode = default(string), string contentType = default(string), long? contentLength = default(long?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.OcpCreationTime = ocpCreationTime;
-            this.OcpBatchFileIsdirectory = ocpBatchFileIsdirectory;
-            this.OcpBatchFileUrl = ocpBatchFileUrl;
-            this.OcpBatchFileMode = ocpBatchFileMode;
-            this.ContentType = contentType;
-            this.ContentLength = contentLength;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            OcpCreationTime = ocpCreationTime;
+            OcpBatchFileIsdirectory = ocpBatchFileIsdirectory;
+            OcpBatchFileUrl = ocpBatchFileUrl;
+            OcpBatchFileMode = ocpBatchFileMode;
+            ContentType = contentType;
+            ContentLength = contentLength;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -81,7 +96,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -91,51 +106,51 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the file creation time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-creation-time")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "ocp-creation-time")]
         public System.DateTime? OcpCreationTime { get; set; }
 
         /// <summary>
         /// Gets or sets whether the object represents a directory.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-isdirectory")]
+        [JsonProperty(PropertyName = "ocp-batch-file-isdirectory")]
         public bool? OcpBatchFileIsdirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-url")]
+        [JsonProperty(PropertyName = "ocp-batch-file-url")]
         public string OcpBatchFileUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the file mode attribute in octal format.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-mode")]
+        [JsonProperty(PropertyName = "ocp-batch-file-mode")]
         public string OcpBatchFileMode { get; set; }
 
         /// <summary>
         /// Gets or sets the content type of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Content-Type")]
+        [JsonProperty(PropertyName = "Content-Type")]
         public string ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the length of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Content-Length")]
+        [JsonProperty(PropertyName = "Content-Length")]
         public long? ContentLength { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetFromComputeNodeOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetFromComputeNodeOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileGetFromComputeNodeOptions
         /// class.
         /// </summary>
-        public FileGetFromComputeNodeOptions() { }
+        public FileGetFromComputeNodeOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileGetFromComputeNodeOptions
@@ -49,20 +58,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public FileGetFromComputeNodeOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ocpRange = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.OcpRange = ocpRange;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            OcpRange = ocpRange;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -70,14 +85,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -85,15 +100,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
         /// Gets or sets the byte range to be retrieved. The default is to
         /// retrieve the entire file. The format is bytes=startRange-endRange.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string OcpRange { get; set; }
 
         /// <summary>
@@ -102,8 +117,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -112,8 +127,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetFromTaskHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetFromTaskHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the FileGetFromTaskHeaders class.
         /// </summary>
-        public FileGetFromTaskHeaders() { }
+        public FileGetFromTaskHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileGetFromTaskHeaders class.
@@ -50,24 +59,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="contentLength">The length of the file.</param>
         public FileGetFromTaskHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? ocpCreationTime = default(System.DateTime?), bool? ocpBatchFileIsdirectory = default(bool?), string ocpBatchFileUrl = default(string), string ocpBatchFileMode = default(string), string contentType = default(string), long? contentLength = default(long?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.OcpCreationTime = ocpCreationTime;
-            this.OcpBatchFileIsdirectory = ocpBatchFileIsdirectory;
-            this.OcpBatchFileUrl = ocpBatchFileUrl;
-            this.OcpBatchFileMode = ocpBatchFileMode;
-            this.ContentType = contentType;
-            this.ContentLength = contentLength;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            OcpCreationTime = ocpCreationTime;
+            OcpBatchFileIsdirectory = ocpBatchFileIsdirectory;
+            OcpBatchFileUrl = ocpBatchFileUrl;
+            OcpBatchFileMode = ocpBatchFileMode;
+            ContentType = contentType;
+            ContentLength = contentLength;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -79,7 +94,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -89,51 +104,51 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the file creation time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-creation-time")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "ocp-creation-time")]
         public System.DateTime? OcpCreationTime { get; set; }
 
         /// <summary>
         /// Gets or sets whether the object represents a directory.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-isdirectory")]
+        [JsonProperty(PropertyName = "ocp-batch-file-isdirectory")]
         public bool? OcpBatchFileIsdirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-url")]
+        [JsonProperty(PropertyName = "ocp-batch-file-url")]
         public string OcpBatchFileUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the file mode attribute in octal format.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-mode")]
+        [JsonProperty(PropertyName = "ocp-batch-file-mode")]
         public string OcpBatchFileMode { get; set; }
 
         /// <summary>
         /// Gets or sets the content type of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Content-Type")]
+        [JsonProperty(PropertyName = "Content-Type")]
         public string ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the length of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Content-Length")]
+        [JsonProperty(PropertyName = "Content-Length")]
         public long? ContentLength { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetFromTaskOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetFromTaskOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the FileGetFromTaskOptions class.
         /// </summary>
-        public FileGetFromTaskOptions() { }
+        public FileGetFromTaskOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileGetFromTaskOptions class.
@@ -47,20 +56,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public FileGetFromTaskOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ocpRange = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.OcpRange = ocpRange;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            OcpRange = ocpRange;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -68,14 +83,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -83,15 +98,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
         /// Gets or sets the byte range to be retrieved. The default is to
         /// retrieve the entire file. The format is bytes=startRange-endRange.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string OcpRange { get; set; }
 
         /// <summary>
@@ -100,8 +115,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -110,8 +125,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetPropertiesFromComputeNodeHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetPropertiesFromComputeNodeHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// FileGetPropertiesFromComputeNodeHeaders class.
         /// </summary>
-        public FileGetPropertiesFromComputeNodeHeaders() { }
+        public FileGetPropertiesFromComputeNodeHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -52,24 +61,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="contentLength">The length of the file.</param>
         public FileGetPropertiesFromComputeNodeHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? ocpCreationTime = default(System.DateTime?), bool? ocpBatchFileIsdirectory = default(bool?), string ocpBatchFileUrl = default(string), string ocpBatchFileMode = default(string), string contentType = default(string), long? contentLength = default(long?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.OcpCreationTime = ocpCreationTime;
-            this.OcpBatchFileIsdirectory = ocpBatchFileIsdirectory;
-            this.OcpBatchFileUrl = ocpBatchFileUrl;
-            this.OcpBatchFileMode = ocpBatchFileMode;
-            this.ContentType = contentType;
-            this.ContentLength = contentLength;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            OcpCreationTime = ocpCreationTime;
+            OcpBatchFileIsdirectory = ocpBatchFileIsdirectory;
+            OcpBatchFileUrl = ocpBatchFileUrl;
+            OcpBatchFileMode = ocpBatchFileMode;
+            ContentType = contentType;
+            ContentLength = contentLength;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -81,7 +96,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -91,51 +106,51 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the file creation time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-creation-time")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "ocp-creation-time")]
         public System.DateTime? OcpCreationTime { get; set; }
 
         /// <summary>
         /// Gets or sets whether the object represents a directory.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-isdirectory")]
+        [JsonProperty(PropertyName = "ocp-batch-file-isdirectory")]
         public bool? OcpBatchFileIsdirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-url")]
+        [JsonProperty(PropertyName = "ocp-batch-file-url")]
         public string OcpBatchFileUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the file mode attribute in octal format.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-mode")]
+        [JsonProperty(PropertyName = "ocp-batch-file-mode")]
         public string OcpBatchFileMode { get; set; }
 
         /// <summary>
         /// Gets or sets the content type of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Content-Type")]
+        [JsonProperty(PropertyName = "Content-Type")]
         public string ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the length of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Content-Length")]
+        [JsonProperty(PropertyName = "Content-Length")]
         public long? ContentLength { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetPropertiesFromComputeNodeOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetPropertiesFromComputeNodeOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// FileGetPropertiesFromComputeNodeOptions class.
         /// </summary>
-        public FileGetPropertiesFromComputeNodeOptions() { }
+        public FileGetPropertiesFromComputeNodeOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -47,19 +56,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public FileGetPropertiesFromComputeNodeOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -67,14 +82,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -82,8 +97,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -92,8 +107,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -102,8 +117,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetPropertiesFromTaskHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetPropertiesFromTaskHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileGetPropertiesFromTaskHeaders
         /// class.
         /// </summary>
-        public FileGetPropertiesFromTaskHeaders() { }
+        public FileGetPropertiesFromTaskHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileGetPropertiesFromTaskHeaders
@@ -52,24 +61,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="contentLength">The length of the file.</param>
         public FileGetPropertiesFromTaskHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), System.DateTime? ocpCreationTime = default(System.DateTime?), bool? ocpBatchFileIsdirectory = default(bool?), string ocpBatchFileUrl = default(string), string ocpBatchFileMode = default(string), string contentType = default(string), long? contentLength = default(long?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.OcpCreationTime = ocpCreationTime;
-            this.OcpBatchFileIsdirectory = ocpBatchFileIsdirectory;
-            this.OcpBatchFileUrl = ocpBatchFileUrl;
-            this.OcpBatchFileMode = ocpBatchFileMode;
-            this.ContentType = contentType;
-            this.ContentLength = contentLength;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            OcpCreationTime = ocpCreationTime;
+            OcpBatchFileIsdirectory = ocpBatchFileIsdirectory;
+            OcpBatchFileUrl = ocpBatchFileUrl;
+            OcpBatchFileMode = ocpBatchFileMode;
+            ContentType = contentType;
+            ContentLength = contentLength;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -81,7 +96,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -91,51 +106,51 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the file creation time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-creation-time")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "ocp-creation-time")]
         public System.DateTime? OcpCreationTime { get; set; }
 
         /// <summary>
         /// Gets or sets whether the object represents a directory.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-isdirectory")]
+        [JsonProperty(PropertyName = "ocp-batch-file-isdirectory")]
         public bool? OcpBatchFileIsdirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-url")]
+        [JsonProperty(PropertyName = "ocp-batch-file-url")]
         public string OcpBatchFileUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the file mode attribute in octal format.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ocp-batch-file-mode")]
+        [JsonProperty(PropertyName = "ocp-batch-file-mode")]
         public string OcpBatchFileMode { get; set; }
 
         /// <summary>
         /// Gets or sets the content type of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Content-Type")]
+        [JsonProperty(PropertyName = "Content-Type")]
         public string ContentType { get; set; }
 
         /// <summary>
         /// Gets or sets the length of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Content-Length")]
+        [JsonProperty(PropertyName = "Content-Length")]
         public long? ContentLength { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetPropertiesFromTaskOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileGetPropertiesFromTaskOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileGetPropertiesFromTaskOptions
         /// class.
         /// </summary>
-        public FileGetPropertiesFromTaskOptions() { }
+        public FileGetPropertiesFromTaskOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileGetPropertiesFromTaskOptions
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public FileGetPropertiesFromTaskOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -66,14 +81,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -81,8 +96,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -91,8 +106,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -101,8 +116,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromComputeNodeHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromComputeNodeHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileListFromComputeNodeHeaders
         /// class.
         /// </summary>
-        public FileListFromComputeNodeHeaders() { }
+        public FileListFromComputeNodeHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileListFromComputeNodeHeaders
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public FileListFromComputeNodeHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromComputeNodeNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromComputeNodeNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// FileListFromComputeNodeNextOptions class.
         /// </summary>
-        public FileListFromComputeNodeNextOptions() { }
+        public FileListFromComputeNodeNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -35,24 +44,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public FileListFromComputeNodeNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -60,8 +75,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromComputeNodeOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromComputeNodeOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileListFromComputeNodeOptions
         /// class.
         /// </summary>
-        public FileListFromComputeNodeOptions() { }
+        public FileListFromComputeNodeOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileListFromComputeNodeOptions
@@ -41,32 +50,38 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public FileListFromComputeNodeOptions(string filter = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 files can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromTaskHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromTaskHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the FileListFromTaskHeaders class.
         /// </summary>
-        public FileListFromTaskHeaders() { }
+        public FileListFromTaskHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileListFromTaskHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public FileListFromTaskHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromTaskNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromTaskNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the FileListFromTaskNextOptions
         /// class.
         /// </summary>
-        public FileListFromTaskNextOptions() { }
+        public FileListFromTaskNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileListFromTaskNextOptions
@@ -35,24 +44,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public FileListFromTaskNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -60,8 +75,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromTaskOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileListFromTaskOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the FileListFromTaskOptions class.
         /// </summary>
-        public FileListFromTaskOptions() { }
+        public FileListFromTaskOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileListFromTaskOptions class.
@@ -39,32 +48,38 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public FileListFromTaskOptions(string filter = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 files can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -72,14 +87,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -87,8 +102,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileProperties.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/FileProperties.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the FileProperties class.
         /// </summary>
-        public FileProperties() { }
+        public FileProperties()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the FileProperties class.
@@ -32,12 +39,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// format.</param>
         public FileProperties(System.DateTime lastModified, long contentLength, System.DateTime? creationTime = default(System.DateTime?), string contentType = default(string), string fileMode = default(string))
         {
-            this.CreationTime = creationTime;
-            this.LastModified = lastModified;
-            this.ContentLength = contentLength;
-            this.ContentType = contentType;
-            this.FileMode = fileMode;
+            CreationTime = creationTime;
+            LastModified = lastModified;
+            ContentLength = contentLength;
+            ContentType = contentType;
+            FileMode = fileMode;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the file creation time.
@@ -45,25 +58,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// The creation time is not returned for files on Linux compute nodes.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "creationTime")]
+        [JsonProperty(PropertyName = "creationTime")]
         public System.DateTime? CreationTime { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the file was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastModified")]
+        [JsonProperty(PropertyName = "lastModified")]
         public System.DateTime LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the length of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "contentLength")]
+        [JsonProperty(PropertyName = "contentLength")]
         public long ContentLength { get; set; }
 
         /// <summary>
         /// Gets or sets the content type of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "contentType")]
+        [JsonProperty(PropertyName = "contentType")]
         public string ContentType { get; set; }
 
         /// <summary>
@@ -72,13 +85,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// The file mode is returned only for files on Linux compute nodes.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "fileMode")]
+        [JsonProperty(PropertyName = "fileMode")]
         public string FileMode { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ImageReference.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ImageReference.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ImageReference class.
         /// </summary>
-        public ImageReference() { }
+        public ImageReference()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ImageReference class.
@@ -35,11 +43,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Marketplace image.</param>
         public ImageReference(string publisher, string offer, string sku, string version = default(string))
         {
-            this.Publisher = publisher;
-            this.Offer = offer;
-            this.Sku = sku;
-            this.Version = version;
+            Publisher = publisher;
+            Offer = offer;
+            Sku = sku;
+            Version = version;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the publisher of the Azure Virtual Machines
@@ -48,7 +62,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// For example, Canonical or MicrosoftWindowsServer.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "publisher")]
+        [JsonProperty(PropertyName = "publisher")]
         public string Publisher { get; set; }
 
         /// <summary>
@@ -58,7 +72,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// For example, UbuntuServer or WindowsServer.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "offer")]
+        [JsonProperty(PropertyName = "offer")]
         public string Offer { get; set; }
 
         /// <summary>
@@ -68,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// For example, 14.04.0-LTS or 2012-R2-Datacenter.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "sku")]
+        [JsonProperty(PropertyName = "sku")]
         public string Sku { get; set; }
 
         /// <summary>
@@ -79,28 +93,28 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// A value of 'latest' can be specified to select the latest version
         /// of an image. If omitted, the default is 'latest'.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "version")]
+        [JsonProperty(PropertyName = "version")]
         public string Version { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Publisher == null)
+            if (Publisher == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Publisher");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Publisher");
             }
-            if (this.Offer == null)
+            if (Offer == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Offer");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Offer");
             }
-            if (this.Sku == null)
+            if (Sku == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Sku");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Sku");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/InboundEndpoint.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/InboundEndpoint.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the InboundEndpoint class.
         /// </summary>
-        public InboundEndpoint() { }
+        public InboundEndpoint()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the InboundEndpoint class.
@@ -35,18 +43,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// endpoint.</param>
         public InboundEndpoint(string name, InboundEndpointProtocol protocol, string publicIPAddress, string publicFQDN, int frontendPort, int backendPort)
         {
-            this.Name = name;
-            this.Protocol = protocol;
-            this.PublicIPAddress = publicIPAddress;
-            this.PublicFQDN = publicFQDN;
-            this.FrontendPort = frontendPort;
-            this.BackendPort = backendPort;
+            Name = name;
+            Protocol = protocol;
+            PublicIPAddress = publicIPAddress;
+            PublicFQDN = publicFQDN;
+            FrontendPort = frontendPort;
+            BackendPort = backendPort;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the name of the endpoint.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
@@ -55,53 +69,53 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'tcp', 'udp'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "protocol")]
+        [JsonProperty(PropertyName = "protocol")]
         public InboundEndpointProtocol Protocol { get; set; }
 
         /// <summary>
         /// Gets or sets the public IP address of the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "publicIPAddress")]
+        [JsonProperty(PropertyName = "publicIPAddress")]
         public string PublicIPAddress { get; set; }
 
         /// <summary>
         /// Gets or sets the public fully qualified domain name for the compute
         /// node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "publicFQDN")]
+        [JsonProperty(PropertyName = "publicFQDN")]
         public string PublicFQDN { get; set; }
 
         /// <summary>
         /// Gets or sets the public port number of the endpoint.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "frontendPort")]
+        [JsonProperty(PropertyName = "frontendPort")]
         public int FrontendPort { get; set; }
 
         /// <summary>
         /// Gets or sets the backend port number of the endpoint.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "backendPort")]
+        [JsonProperty(PropertyName = "backendPort")]
         public int BackendPort { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Name == null)
+            if (Name == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Name");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Name");
             }
-            if (this.PublicIPAddress == null)
+            if (PublicIPAddress == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "PublicIPAddress");
+                throw new ValidationException(ValidationRules.CannotBeNull, "PublicIPAddress");
             }
-            if (this.PublicFQDN == null)
+            if (PublicFQDN == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "PublicFQDN");
+                throw new ValidationException(ValidationRules.CannotBeNull, "PublicFQDN");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/InboundEndpointProtocol.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/InboundEndpointProtocol.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for InboundEndpointProtocol.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum InboundEndpointProtocol
     {
-        [System.Runtime.Serialization.EnumMember(Value = "tcp")]
+        [EnumMember(Value = "tcp")]
         Tcp,
-        [System.Runtime.Serialization.EnumMember(Value = "udp")]
+        [EnumMember(Value = "udp")]
         Udp
+    }
+    internal static class InboundEndpointProtocolEnumExtension
+    {
+        internal static string ToSerializedValue(this InboundEndpointProtocol? value)  =>
+            value == null ? null : ((InboundEndpointProtocol)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this InboundEndpointProtocol value)
+        {
+            switch( value )
+            {
+                case InboundEndpointProtocol.Tcp:
+                    return "tcp";
+                case InboundEndpointProtocol.Udp:
+                    return "udp";
+            }
+            return null;
+        }
+
+        internal static InboundEndpointProtocol? ParseInboundEndpointProtocol(this string value)
+        {
+            switch( value )
+            {
+                case "tcp":
+                    return InboundEndpointProtocol.Tcp;
+                case "udp":
+                    return InboundEndpointProtocol.Udp;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/InboundNatPool.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/InboundNatPool.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the InboundNATPool class.
         /// </summary>
-        public InboundNATPool() { }
+        public InboundNATPool()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the InboundNATPool class.
@@ -36,15 +46,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// to the backendPort on individual compute nodes.</param>
         /// <param name="networkSecurityGroupRules">A list of network security
         /// group rules that will be applied to the endpoint.</param>
-        public InboundNATPool(string name, InboundEndpointProtocol protocol, int backendPort, int frontendPortRangeStart, int frontendPortRangeEnd, System.Collections.Generic.IList<NetworkSecurityGroupRule> networkSecurityGroupRules = default(System.Collections.Generic.IList<NetworkSecurityGroupRule>))
+        public InboundNATPool(string name, InboundEndpointProtocol protocol, int backendPort, int frontendPortRangeStart, int frontendPortRangeEnd, IList<NetworkSecurityGroupRule> networkSecurityGroupRules = default(IList<NetworkSecurityGroupRule>))
         {
-            this.Name = name;
-            this.Protocol = protocol;
-            this.BackendPort = backendPort;
-            this.FrontendPortRangeStart = frontendPortRangeStart;
-            this.FrontendPortRangeEnd = frontendPortRangeEnd;
-            this.NetworkSecurityGroupRules = networkSecurityGroupRules;
+            Name = name;
+            Protocol = protocol;
+            BackendPort = backendPort;
+            FrontendPortRangeStart = frontendPortRangeStart;
+            FrontendPortRangeEnd = frontendPortRangeEnd;
+            NetworkSecurityGroupRules = networkSecurityGroupRules;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the name of the endpoint.
@@ -56,7 +72,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// and cannot exceed 77 characters.  If any invalid values are
         /// provided the request fails with HTTP status code 400.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
@@ -65,7 +81,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'tcp', 'udp'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "protocol")]
+        [JsonProperty(PropertyName = "protocol")]
         public InboundEndpointProtocol Protocol { get; set; }
 
         /// <summary>
@@ -77,7 +93,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// are reserved. If any reserved values are provided the request fails
         /// with HTTP status code 400.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "backendPort")]
+        [JsonProperty(PropertyName = "backendPort")]
         public int BackendPort { get; set; }
 
         /// <summary>
@@ -91,7 +107,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// distinct and cannot overlap. If any reserved or overlapping values
         /// are provided the request fails with HTTP status code 400.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "frontendPortRangeStart")]
+        [JsonProperty(PropertyName = "frontendPortRangeStart")]
         public int FrontendPortRangeStart { get; set; }
 
         /// <summary>
@@ -106,7 +122,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// overlapping values are provided the request fails with HTTP status
         /// code 400.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "frontendPortRangeEnd")]
+        [JsonProperty(PropertyName = "frontendPortRangeEnd")]
         public int FrontendPortRangeEnd { get; set; }
 
         /// <summary>
@@ -121,24 +137,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// network security group rules is exceeded the request fails with
         /// HTTP status code 400.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "networkSecurityGroupRules")]
-        public System.Collections.Generic.IList<NetworkSecurityGroupRule> NetworkSecurityGroupRules { get; set; }
+        [JsonProperty(PropertyName = "networkSecurityGroupRules")]
+        public IList<NetworkSecurityGroupRule> NetworkSecurityGroupRules { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Name == null)
+            if (Name == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Name");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Name");
             }
-            if (this.NetworkSecurityGroupRules != null)
+            if (NetworkSecurityGroupRules != null)
             {
-                foreach (var element in this.NetworkSecurityGroupRules)
+                foreach (var element in NetworkSecurityGroupRules)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobAction.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobAction.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for JobAction.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum JobAction
     {
-        [System.Runtime.Serialization.EnumMember(Value = "none")]
+        [EnumMember(Value = "none")]
         None,
-        [System.Runtime.Serialization.EnumMember(Value = "disable")]
+        [EnumMember(Value = "disable")]
         Disable,
-        [System.Runtime.Serialization.EnumMember(Value = "terminate")]
+        [EnumMember(Value = "terminate")]
         Terminate
+    }
+    internal static class JobActionEnumExtension
+    {
+        internal static string ToSerializedValue(this JobAction? value)  =>
+            value == null ? null : ((JobAction)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this JobAction value)
+        {
+            switch( value )
+            {
+                case JobAction.None:
+                    return "none";
+                case JobAction.Disable:
+                    return "disable";
+                case JobAction.Terminate:
+                    return "terminate";
+            }
+            return null;
+        }
+
+        internal static JobAction? ParseJobAction(this string value)
+        {
+            switch( value )
+            {
+                case "none":
+                    return JobAction.None;
+                case "disable":
+                    return JobAction.Disable;
+                case "terminate":
+                    return JobAction.Terminate;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobAddHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobAddHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobAddHeaders class.
         /// </summary>
-        public JobAddHeaders() { }
+        public JobAddHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobAddHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobAddHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobAddOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobAddOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobAddOptions class.
         /// </summary>
-        public JobAddOptions() { }
+        public JobAddOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobAddOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobAddOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobAddParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobAddParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobAddParameter class.
         /// </summary>
-        public JobAddParameter() { }
+        public JobAddParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobAddParameter class.
@@ -43,29 +53,33 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// should take when all tasks in the job are in the completed
         /// state.</param>
         /// <param name="onTaskFailure">The action the Batch service should
-        /// take when any task in the job fails. A task is considered to have
-        /// failed if it completes with a non-zero exit code and has exhausted
-        /// its retry count, or if it had a scheduling error.</param>
+        /// take when any task in the job fails.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the job as metadata.</param>
-        /// <param name="usesTaskDependencies">The flag that determines if this
-        /// job will use tasks with dependencies.</param>
-        public JobAddParameter(string id, PoolInformation poolInfo, string displayName = default(string), int? priority = default(int?), JobConstraints constraints = default(JobConstraints), JobManagerTask jobManagerTask = default(JobManagerTask), JobPreparationTask jobPreparationTask = default(JobPreparationTask), JobReleaseTask jobReleaseTask = default(JobReleaseTask), System.Collections.Generic.IList<EnvironmentSetting> commonEnvironmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?), OnTaskFailure? onTaskFailure = default(OnTaskFailure?), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>), bool? usesTaskDependencies = default(bool?))
+        /// <param name="usesTaskDependencies">Whether tasks in the job can
+        /// define dependencies on each other. The default is false.</param>
+        public JobAddParameter(string id, PoolInformation poolInfo, string displayName = default(string), int? priority = default(int?), JobConstraints constraints = default(JobConstraints), JobManagerTask jobManagerTask = default(JobManagerTask), JobPreparationTask jobPreparationTask = default(JobPreparationTask), JobReleaseTask jobReleaseTask = default(JobReleaseTask), IList<EnvironmentSetting> commonEnvironmentSettings = default(IList<EnvironmentSetting>), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?), OnTaskFailure? onTaskFailure = default(OnTaskFailure?), IList<MetadataItem> metadata = default(IList<MetadataItem>), bool? usesTaskDependencies = default(bool?))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.Priority = priority;
-            this.Constraints = constraints;
-            this.JobManagerTask = jobManagerTask;
-            this.JobPreparationTask = jobPreparationTask;
-            this.JobReleaseTask = jobReleaseTask;
-            this.CommonEnvironmentSettings = commonEnvironmentSettings;
-            this.PoolInfo = poolInfo;
-            this.OnAllTasksComplete = onAllTasksComplete;
-            this.OnTaskFailure = onTaskFailure;
-            this.Metadata = metadata;
-            this.UsesTaskDependencies = usesTaskDependencies;
+            Id = id;
+            DisplayName = displayName;
+            Priority = priority;
+            Constraints = constraints;
+            JobManagerTask = jobManagerTask;
+            JobPreparationTask = jobPreparationTask;
+            JobReleaseTask = jobReleaseTask;
+            CommonEnvironmentSettings = commonEnvironmentSettings;
+            PoolInfo = poolInfo;
+            OnAllTasksComplete = onAllTasksComplete;
+            OnTaskFailure = onTaskFailure;
+            Metadata = metadata;
+            UsesTaskDependencies = usesTaskDependencies;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the job within the
@@ -74,9 +88,11 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// The ID can contain any combination of alphanumeric characters
         /// including hyphens and underscores, and cannot contain more than 64
-        /// characters. It is common to use a GUID for the id.
+        /// characters. The ID is case-preserving and case-insensitive (that
+        /// is, you may not have two IDs within an account that differ only by
+        /// case).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -86,7 +102,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The display name need not be unique and can contain any Unicode
         /// characters up to a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
@@ -97,13 +113,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// lowest priority and 1000 being the highest priority. The default
         /// value is 0.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "priority")]
+        [JsonProperty(PropertyName = "priority")]
         public int? Priority { get; set; }
 
         /// <summary>
         /// Gets or sets the execution constraints for the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public JobConstraints Constraints { get; set; }
 
         /// <summary>
@@ -125,7 +141,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// parameter, analyze the contents of that file and submit additional
         /// tasks based on those contents.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobManagerTask")]
+        [JsonProperty(PropertyName = "jobManagerTask")]
         public JobManagerTask JobManagerTask { get; set; }
 
         /// <summary>
@@ -136,7 +152,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Job Preparation task on a compute node before starting any tasks of
         /// that job on that compute node.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobPreparationTask")]
+        [JsonProperty(PropertyName = "jobPreparationTask")]
         public JobPreparationTask JobPreparationTask { get; set; }
 
         /// <summary>
@@ -151,7 +167,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// activities include deleting local files, or shutting down services
         /// that were started as part of job preparation.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobReleaseTask")]
+        [JsonProperty(PropertyName = "jobReleaseTask")]
         public JobReleaseTask JobReleaseTask { get; set; }
 
         /// <summary>
@@ -159,14 +175,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// These environment variables are set for all tasks in the job
         /// (including the Job Manager, Job Preparation and Job Release tasks).
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commonEnvironmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> CommonEnvironmentSettings { get; set; }
+        /// <remarks>
+        /// Individual tasks can override an environment setting specified here
+        /// by specifying the same setting name with a different value.
+        /// </remarks>
+        [JsonProperty(PropertyName = "commonEnvironmentSettings")]
+        public IList<EnvironmentSetting> CommonEnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets the pool on which the Batch service runs the job's
         /// tasks.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolInfo")]
+        [JsonProperty(PropertyName = "poolInfo")]
         public PoolInformation PoolInfo { get; set; }
 
         /// <summary>
@@ -186,16 +206,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// 'AllTasksComplete'. The default is noAction. Possible values
         /// include: 'noAction', 'terminateJob'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "onAllTasksComplete")]
+        [JsonProperty(PropertyName = "onAllTasksComplete")]
         public OnAllTasksComplete? OnAllTasksComplete { get; set; }
 
         /// <summary>
         /// Gets or sets the action the Batch service should take when any task
-        /// in the job fails. A task is considered to have failed if it
-        /// completes with a non-zero exit code and has exhausted its retry
-        /// count, or if it had a scheduling error.
+        /// in the job fails.
         /// </summary>
         /// <remarks>
+        /// A task is considered to have failed if has a failureInfo. A
+        /// failureInfo is set if the task completes with a non-zero exit code
+        /// after exhausting its retry count, or if there was an error starting
+        /// the task, for example due to a resource file download error.
         /// noAction - do nothing. performExitOptionsJobAction - take the
         /// action associated with the task exit condition in the task's
         /// exitConditions collection. (This may still result in no action
@@ -203,7 +225,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// noAction. Possible values include: 'noAction',
         /// 'performExitOptionsJobAction'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "onTaskFailure")]
+        [JsonProperty(PropertyName = "onTaskFailure")]
         public OnTaskFailure? OnTaskFailure { get; set; }
 
         /// <summary>
@@ -214,47 +236,47 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Batch service does not assign any meaning to metadata; it is
         /// solely for the use of user code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag that determines if this job will use tasks
-        /// with dependencies.
+        /// Gets or sets whether tasks in the job can define dependencies on
+        /// each other. The default is false.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "usesTaskDependencies")]
+        [JsonProperty(PropertyName = "usesTaskDependencies")]
         public bool? UsesTaskDependencies { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Id == null)
+            if (Id == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Id");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Id");
             }
-            if (this.PoolInfo == null)
+            if (PoolInfo == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "PoolInfo");
+                throw new ValidationException(ValidationRules.CannotBeNull, "PoolInfo");
             }
-            if (this.JobManagerTask != null)
+            if (JobManagerTask != null)
             {
-                this.JobManagerTask.Validate();
+                JobManagerTask.Validate();
             }
-            if (this.JobPreparationTask != null)
+            if (JobPreparationTask != null)
             {
-                this.JobPreparationTask.Validate();
+                JobPreparationTask.Validate();
             }
-            if (this.JobReleaseTask != null)
+            if (JobReleaseTask != null)
             {
-                this.JobReleaseTask.Validate();
+                JobReleaseTask.Validate();
             }
-            if (this.CommonEnvironmentSettings != null)
+            if (CommonEnvironmentSettings != null)
             {
-                foreach (var element in this.CommonEnvironmentSettings)
+                foreach (var element in CommonEnvironmentSettings)
                 {
                     if (element != null)
                     {
@@ -262,13 +284,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.PoolInfo != null)
+            if (PoolInfo != null)
             {
-                this.PoolInfo.Validate();
+                PoolInfo.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element1 in this.Metadata)
+                foreach (var element1 in Metadata)
                 {
                     if (element1 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobConstraints.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobConstraints.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobConstraints class.
         /// </summary>
-        public JobConstraints() { }
+        public JobConstraints()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobConstraints class.
@@ -30,9 +37,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// code is nonzero.</param>
         public JobConstraints(System.TimeSpan? maxWallClockTime = default(System.TimeSpan?), int? maxTaskRetryCount = default(int?))
         {
-            this.MaxWallClockTime = maxWallClockTime;
-            this.MaxTaskRetryCount = maxTaskRetryCount;
+            MaxWallClockTime = maxWallClockTime;
+            MaxTaskRetryCount = maxTaskRetryCount;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum elapsed time that the job may run,
@@ -45,7 +58,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// this property is not specified, there is no time limit on how long
         /// the job may run.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxWallClockTime")]
+        [JsonProperty(PropertyName = "maxWallClockTime")]
         public System.TimeSpan? MaxWallClockTime { get; set; }
 
         /// <summary>
@@ -61,7 +74,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If the maximum retry count is -1, the Batch service retries tasks
         /// without limit. The default value is 0 (no retries).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxTaskRetryCount")]
+        [JsonProperty(PropertyName = "maxTaskRetryCount")]
         public int? MaxTaskRetryCount { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDeleteHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDeleteHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobDeleteHeaders class.
         /// </summary>
-        public JobDeleteHeaders() { }
+        public JobDeleteHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobDeleteHeaders class.
@@ -35,16 +42,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public JobDeleteHeaders(string clientRequestId = default(string), string requestId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public string ClientRequestId { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public string RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDeleteOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDeleteOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobDeleteOptions class.
         /// </summary>
-        public JobDeleteOptions() { }
+        public JobDeleteOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobDeleteOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobDeleteOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDisableHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDisableHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobDisableHeaders class.
         /// </summary>
-        public JobDisableHeaders() { }
+        public JobDisableHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobDisableHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobDisableHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDisableOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDisableOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobDisableOptions class.
         /// </summary>
-        public JobDisableOptions() { }
+        public JobDisableOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobDisableOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobDisableOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDisableParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobDisableParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobDisableParameter class.
         /// </summary>
-        public JobDisableParameter() { }
+        public JobDisableParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobDisableParameter class.
@@ -27,26 +34,34 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// with the job.</param>
         public JobDisableParameter(DisableJobOption disableTasks)
         {
-            this.DisableTasks = disableTasks;
+            DisableTasks = disableTasks;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets what to do with active tasks associated with the job.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
         /// requeue - Terminate running tasks and requeue them. The tasks will
-        /// run again when the job is enabled. terminate - Terminate running
-        /// tasks. The tasks will not run again. wait - Allow currently running
-        /// tasks to complete. Possible values include: 'requeue', 'terminate',
-        /// 'wait'
+        /// run again when the job is enabled.
+        /// terminate - Terminate running tasks. The tasks will not run again.
+        /// wait - Allow currently running tasks to complete. Possible values
+        /// include: 'requeue', 'terminate', 'wait'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "disableTasks")]
+        [JsonProperty(PropertyName = "disableTasks")]
         public DisableJobOption DisableTasks { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobEnableHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobEnableHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobEnableHeaders class.
         /// </summary>
-        public JobEnableHeaders() { }
+        public JobEnableHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobEnableHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobEnableHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobEnableOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobEnableOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobEnableOptions class.
         /// </summary>
-        public JobEnableOptions() { }
+        public JobEnableOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobEnableOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobEnableOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobExecutionInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobExecutionInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobExecutionInformation class.
         /// </summary>
-        public JobExecutionInformation() { }
+        public JobExecutionInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobExecutionInformation class.
@@ -34,12 +41,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// job ended.</param>
         public JobExecutionInformation(System.DateTime startTime, System.DateTime? endTime = default(System.DateTime?), string poolId = default(string), JobSchedulingError schedulingError = default(JobSchedulingError), string terminateReason = default(string))
         {
-            this.StartTime = startTime;
-            this.EndTime = endTime;
-            this.PoolId = poolId;
-            this.SchedulingError = schedulingError;
-            this.TerminateReason = terminateReason;
+            StartTime = startTime;
+            EndTime = endTime;
+            PoolId = poolId;
+            SchedulingError = schedulingError;
+            TerminateReason = terminateReason;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the start time of the job.
@@ -47,7 +60,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This is the time at which the job was created.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property is set only if the job is in the completed state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endTime")]
+        [JsonProperty(PropertyName = "endTime")]
         public System.DateTime? EndTime { get; set; }
 
         /// <summary>
@@ -69,9 +82,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// when the job was added or updated. That poolInfo element may also
         /// contain a poolId element. If it does, the two IDs are the same. If
         /// it does not, it means the job ran on an auto pool, and this
-        /// property contains the id of that auto pool.
+        /// property contains the ID of that auto pool.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolId")]
+        [JsonProperty(PropertyName = "poolId")]
         public string PoolId { get; set; }
 
         /// <summary>
@@ -81,7 +94,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property is not set if there was no error starting the job.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "schedulingError")]
+        [JsonProperty(PropertyName = "schedulingError")]
         public JobSchedulingError SchedulingError { get; set; }
 
         /// <summary>
@@ -102,20 +115,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// other string is a user-defined reason specified in a call to the
         /// 'Terminate a job' operation.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "terminateReason")]
+        [JsonProperty(PropertyName = "terminateReason")]
         public string TerminateReason { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.SchedulingError != null)
+            if (SchedulingError != null)
             {
-                this.SchedulingError.Validate();
+                SchedulingError.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetAllLifetimeStatisticsHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetAllLifetimeStatisticsHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// JobGetAllLifetimeStatisticsHeaders class.
         /// </summary>
-        public JobGetAllLifetimeStatisticsHeaders() { }
+        public JobGetAllLifetimeStatisticsHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public JobGetAllLifetimeStatisticsHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetAllLifetimeStatisticsOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetAllLifetimeStatisticsOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// JobGetAllLifetimeStatisticsOptions class.
         /// </summary>
-        public JobGetAllLifetimeStatisticsOptions() { }
+        public JobGetAllLifetimeStatisticsOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobGetAllLifetimeStatisticsOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobGetHeaders class.
         /// </summary>
-        public JobGetHeaders() { }
+        public JobGetHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobGetHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public JobGetHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobGetOptions class.
         /// </summary>
-        public JobGetOptions() { }
+        public JobGetOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobGetOptions class.
@@ -54,35 +63,41 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobGetOptions(string select = default(string), string expand = default(string), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Select = select;
-            this.Expand = expand;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Select = select;
+            Expand = expand;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -90,14 +105,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -105,8 +120,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -115,7 +130,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -124,7 +139,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -133,8 +148,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -143,8 +158,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetTaskCountsHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetTaskCountsHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobGetTaskCountsHeaders class.
         /// </summary>
-        public JobGetTaskCountsHeaders() { }
+        public JobGetTaskCountsHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobGetTaskCountsHeaders class.
@@ -35,16 +42,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public JobGetTaskCountsHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetTaskCountsOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobGetTaskCountsOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobGetTaskCountsOptions class.
         /// </summary>
-        public JobGetTaskCountsOptions() { }
+        public JobGetTaskCountsOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobGetTaskCountsOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobGetTaskCountsOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListFromJobScheduleHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListFromJobScheduleHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the JobListFromJobScheduleHeaders
         /// class.
         /// </summary>
-        public JobListFromJobScheduleHeaders() { }
+        public JobListFromJobScheduleHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobListFromJobScheduleHeaders
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public JobListFromJobScheduleHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListFromJobScheduleNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListFromJobScheduleNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the JobListFromJobScheduleNextOptions
         /// class.
         /// </summary>
-        public JobListFromJobScheduleNextOptions() { }
+        public JobListFromJobScheduleNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobListFromJobScheduleNextOptions
@@ -35,24 +44,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobListFromJobScheduleNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -60,8 +75,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListFromJobScheduleOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListFromJobScheduleOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the JobListFromJobScheduleOptions
         /// class.
         /// </summary>
-        public JobListFromJobScheduleOptions() { }
+        public JobListFromJobScheduleOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobListFromJobScheduleOptions
@@ -43,46 +52,52 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobListFromJobScheduleOptions(string filter = default(string), string select = default(string), string expand = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.Select = select;
-            this.Expand = expand;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            Select = select;
+            Expand = expand;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 jobs can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -90,14 +105,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -105,8 +120,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobListHeaders class.
         /// </summary>
-        public JobListHeaders() { }
+        public JobListHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobListHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public JobListHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobListNextOptions class.
         /// </summary>
-        public JobListNextOptions() { }
+        public JobListNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobListNextOptions class.
@@ -33,24 +42,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobListNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -58,8 +73,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobListOptions class.
         /// </summary>
-        public JobListOptions() { }
+        public JobListOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobListOptions class.
@@ -41,46 +50,52 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobListOptions(string filter = default(string), string select = default(string), string expand = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.Select = select;
-            this.Expand = expand;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            Select = select;
+            Expand = expand;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 jobs can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -88,14 +103,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -103,8 +118,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListPreparationAndReleaseTaskStatusHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListPreparationAndReleaseTaskStatusHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// JobListPreparationAndReleaseTaskStatusHeaders class.
         /// </summary>
-        public JobListPreparationAndReleaseTaskStatusHeaders() { }
+        public JobListPreparationAndReleaseTaskStatusHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public JobListPreparationAndReleaseTaskStatusHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListPreparationAndReleaseTaskStatusNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListPreparationAndReleaseTaskStatusNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// JobListPreparationAndReleaseTaskStatusNextOptions class.
         /// </summary>
-        public JobListPreparationAndReleaseTaskStatusNextOptions() { }
+        public JobListPreparationAndReleaseTaskStatusNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -36,24 +45,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobListPreparationAndReleaseTaskStatusNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -61,8 +76,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListPreparationAndReleaseTaskStatusOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobListPreparationAndReleaseTaskStatusOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,13 +26,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// JobListPreparationAndReleaseTaskStatusOptions class.
         /// </summary>
-        public JobListPreparationAndReleaseTaskStatusOptions() { }
+        public JobListPreparationAndReleaseTaskStatusOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
         /// JobListPreparationAndReleaseTaskStatusOptions class.
         /// </summary>
-        /// <param name="filter">An OData $filter clause.</param>
+        /// <param name="filter">An OData $filter clause. To get the status of
+        /// the Job Preparation and Job Release tasks on a specific compute
+        /// node, use "nodeId eq '{desired-node-id}'"</param>
         /// <param name="select">An OData $select clause.</param>
         /// <param name="maxResults">The maximum number of items to return in
         /// the response. A maximum of 1000 tasks can be returned.</param>
@@ -43,39 +54,47 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobListPreparationAndReleaseTaskStatusOptions(string filter = default(string), string select = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.Select = select;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            Select = select;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets an OData $filter clause.
+        /// An initialization method that performs custom operations like setting defaults
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets an OData $filter clause. To get the status of the Job
+        /// Preparation and Job Release tasks on a specific compute node, use
+        /// "nodeId eq '{desired-node-id}'"
+        /// </summary>
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 tasks can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -83,14 +102,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -98,8 +117,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobManagerTask.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobManagerTask.cs
@@ -8,23 +8,49 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
     /// Specifies details of a Job Manager task.
     /// </summary>
+    /// <remarks>
+    /// The Job Manager task is automatically started when the job is created.
+    /// The Batch service tries to schedule the Job Manager task before any
+    /// other tasks in the job. When shrinking a pool, the Batch service tries
+    /// to preserve compute nodes where Job Manager tasks are running for as
+    /// long as possible (that is, nodes running 'normal' tasks are removed
+    /// before nodes running Job Manager tasks). When a Job Manager task fails
+    /// and needs to be restarted, the system tries to schedule it at the
+    /// highest priority. If there are no idle nodes available, the system may
+    /// terminate one of the running tasks in the pool and return it to the
+    /// queue in order to make room for the Job Manager task to restart. Note
+    /// that a Job Manager task in one job does not have priority over tasks in
+    /// other jobs. Across jobs, only job level priorities are observed. For
+    /// example, if a Job Manager in a priority 0 job needs to be restarted, it
+    /// will not displace tasks of a priority 1 job.
+    /// </remarks>
     public partial class JobManagerTask
     {
         /// <summary>
         /// Initializes a new instance of the JobManagerTask class.
         /// </summary>
-        public JobManagerTask() { }
+        public JobManagerTask()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobManagerTask class.
         /// </summary>
         /// <param name="id">A string that uniquely identifies the Job Manager
-        /// taskwithin the job.</param>
+        /// task within the job.</param>
         /// <param name="commandLine">The command line of the Job Manager
         /// task.</param>
         /// <param name="displayName">The display name of the Job Manager
@@ -53,33 +79,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// operations.</param>
         /// <param name="allowLowPriorityNode">Whether the Job Manager task may
         /// run on a low-priority compute node.</param>
-        public JobManagerTask(string id, string commandLine, string displayName = default(string), System.Collections.Generic.IList<ResourceFile> resourceFiles = default(System.Collections.Generic.IList<ResourceFile>), System.Collections.Generic.IList<OutputFile> outputFiles = default(System.Collections.Generic.IList<OutputFile>), System.Collections.Generic.IList<EnvironmentSetting> environmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), TaskConstraints constraints = default(TaskConstraints), bool? killJobOnCompletion = default(bool?), UserIdentity userIdentity = default(UserIdentity), bool? runExclusive = default(bool?), System.Collections.Generic.IList<ApplicationPackageReference> applicationPackageReferences = default(System.Collections.Generic.IList<ApplicationPackageReference>), AuthenticationTokenSettings authenticationTokenSettings = default(AuthenticationTokenSettings), bool? allowLowPriorityNode = default(bool?))
+        public JobManagerTask(string id, string commandLine, string displayName = default(string), IList<ResourceFile> resourceFiles = default(IList<ResourceFile>), IList<OutputFile> outputFiles = default(IList<OutputFile>), IList<EnvironmentSetting> environmentSettings = default(IList<EnvironmentSetting>), TaskConstraints constraints = default(TaskConstraints), bool? killJobOnCompletion = default(bool?), UserIdentity userIdentity = default(UserIdentity), bool? runExclusive = default(bool?), IList<ApplicationPackageReference> applicationPackageReferences = default(IList<ApplicationPackageReference>), AuthenticationTokenSettings authenticationTokenSettings = default(AuthenticationTokenSettings), bool? allowLowPriorityNode = default(bool?))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.CommandLine = commandLine;
-            this.ResourceFiles = resourceFiles;
-            this.OutputFiles = outputFiles;
-            this.EnvironmentSettings = environmentSettings;
-            this.Constraints = constraints;
-            this.KillJobOnCompletion = killJobOnCompletion;
-            this.UserIdentity = userIdentity;
-            this.RunExclusive = runExclusive;
-            this.ApplicationPackageReferences = applicationPackageReferences;
-            this.AuthenticationTokenSettings = authenticationTokenSettings;
-            this.AllowLowPriorityNode = allowLowPriorityNode;
+            Id = id;
+            DisplayName = displayName;
+            CommandLine = commandLine;
+            ResourceFiles = resourceFiles;
+            OutputFiles = outputFiles;
+            EnvironmentSettings = environmentSettings;
+            Constraints = constraints;
+            KillJobOnCompletion = killJobOnCompletion;
+            UserIdentity = userIdentity;
+            RunExclusive = runExclusive;
+            ApplicationPackageReferences = applicationPackageReferences;
+            AuthenticationTokenSettings = authenticationTokenSettings;
+            AllowLowPriorityNode = allowLowPriorityNode;
+            CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets a string that uniquely identifies the Job Manager
-        /// taskwithin the job.
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets a string that uniquely identifies the Job Manager task
+        /// within the job.
         /// </summary>
         /// <remarks>
-        /// The id can contain any combination of alphanumeric characters
+        /// The ID can contain any combination of alphanumeric characters
         /// including hyphens and underscores and cannot contain more than 64
         /// characters.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -89,7 +121,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// It need not be unique and can contain any Unicode characters up to
         /// a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
@@ -102,7 +134,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// should invoke the shell in the command line, for example using "cmd
         /// /c MyCommand" in Windows or "/bin/sh -c MyCommand" in Linux.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commandLine")]
+        [JsonProperty(PropertyName = "commandLine")]
         public string CommandLine { get; set; }
 
         /// <summary>
@@ -113,27 +145,31 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Files listed under this element are located in the task's working
         /// directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resourceFiles")]
-        public System.Collections.Generic.IList<ResourceFile> ResourceFiles { get; set; }
+        [JsonProperty(PropertyName = "resourceFiles")]
+        public IList<ResourceFile> ResourceFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of files that the Batch service will upload
         /// from the compute node after running the command line.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "outputFiles")]
-        public System.Collections.Generic.IList<OutputFile> OutputFiles { get; set; }
+        /// <remarks>
+        /// For multi-instance tasks, the files will only be uploaded from the
+        /// compute node on which the primary task is executed.
+        /// </remarks>
+        [JsonProperty(PropertyName = "outputFiles")]
+        public IList<OutputFile> OutputFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of environment variable settings for the Job
         /// Manager task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "environmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> EnvironmentSettings { get; set; }
+        [JsonProperty(PropertyName = "environmentSettings")]
+        public IList<EnvironmentSetting> EnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets constraints that apply to the Job Manager task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public TaskConstraints Constraints { get; set; }
 
         /// <summary>
@@ -155,7 +191,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// for the job (not to monitor progress), then it is important to set
         /// killJobOnCompletion to false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "killJobOnCompletion")]
+        [JsonProperty(PropertyName = "killJobOnCompletion")]
         public bool? KillJobOnCompletion { get; set; }
 
         /// <summary>
@@ -166,7 +202,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, the task runs as a non-administrative user unique to
         /// the task.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userIdentity")]
+        [JsonProperty(PropertyName = "userIdentity")]
         public UserIdentity UserIdentity { get; set; }
 
         /// <summary>
@@ -181,7 +217,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// limit, so this is only relevant if the node allows multiple
         /// concurrent tasks. The default value is true.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "runExclusive")]
+        [JsonProperty(PropertyName = "runExclusive")]
         public bool? RunExclusive { get; set; }
 
         /// <summary>
@@ -190,15 +226,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// </summary>
         /// <remarks>
         /// Application packages are downloaded and deployed to a shared
-        /// directory, not the task directory. Therefore, if a referenced
-        /// package is already on the compute node, and is up to date, then it
-        /// is not re-downloaded; the existing copy on the compute node is
-        /// used. If a referenced application package cannot be installed, for
-        /// example because the package has been deleted or because download
-        /// failed, the task fails with a scheduling error.
+        /// directory, not the task working directory. Therefore, if a
+        /// referenced package is already on the compute node, and is up to
+        /// date, then it is not re-downloaded; the existing copy on the
+        /// compute node is used. If a referenced application package cannot be
+        /// installed, for example because the package has been deleted or
+        /// because download failed, the task fails.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationPackageReferences")]
-        public System.Collections.Generic.IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
+        [JsonProperty(PropertyName = "applicationPackageReferences")]
+        public IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the settings for an authentication token that the task
@@ -214,7 +250,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// permissions in order to add other tasks to the job, or check the
         /// status of the job or of other tasks under the job.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "authenticationTokenSettings")]
+        [JsonProperty(PropertyName = "authenticationTokenSettings")]
         public AuthenticationTokenSettings AuthenticationTokenSettings { get; set; }
 
         /// <summary>
@@ -224,28 +260,28 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// The default value is false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "allowLowPriorityNode")]
+        [JsonProperty(PropertyName = "allowLowPriorityNode")]
         public bool? AllowLowPriorityNode { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Id == null)
+            if (Id == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Id");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Id");
             }
-            if (this.CommandLine == null)
+            if (CommandLine == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "CommandLine");
+                throw new ValidationException(ValidationRules.CannotBeNull, "CommandLine");
             }
-            if (this.ResourceFiles != null)
+            if (ResourceFiles != null)
             {
-                foreach (var element in this.ResourceFiles)
+                foreach (var element in ResourceFiles)
                 {
                     if (element != null)
                     {
@@ -253,9 +289,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.OutputFiles != null)
+            if (OutputFiles != null)
             {
-                foreach (var element1 in this.OutputFiles)
+                foreach (var element1 in OutputFiles)
                 {
                     if (element1 != null)
                     {
@@ -263,9 +299,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.EnvironmentSettings != null)
+            if (EnvironmentSettings != null)
             {
-                foreach (var element2 in this.EnvironmentSettings)
+                foreach (var element2 in EnvironmentSettings)
                 {
                     if (element2 != null)
                     {
@@ -273,9 +309,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.ApplicationPackageReferences != null)
+            if (ApplicationPackageReferences != null)
             {
-                foreach (var element3 in this.ApplicationPackageReferences)
+                foreach (var element3 in ApplicationPackageReferences)
                 {
                     if (element3 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPatchHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPatchHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobPatchHeaders class.
         /// </summary>
-        public JobPatchHeaders() { }
+        public JobPatchHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobPatchHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobPatchHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPatchOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPatchOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobPatchOptions class.
         /// </summary>
-        public JobPatchOptions() { }
+        public JobPatchOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobPatchOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobPatchOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPatchParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPatchParameter.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobPatchParameter class.
         /// </summary>
-        public JobPatchParameter() { }
+        public JobPatchParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobPatchParameter class.
@@ -33,14 +42,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// job's tasks.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the job as metadata.</param>
-        public JobPatchParameter(int? priority = default(int?), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?), JobConstraints constraints = default(JobConstraints), PoolInformation poolInfo = default(PoolInformation), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>))
+        public JobPatchParameter(int? priority = default(int?), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?), JobConstraints constraints = default(JobConstraints), PoolInformation poolInfo = default(PoolInformation), IList<MetadataItem> metadata = default(IList<MetadataItem>))
         {
-            this.Priority = priority;
-            this.OnAllTasksComplete = onAllTasksComplete;
-            this.Constraints = constraints;
-            this.PoolInfo = poolInfo;
-            this.Metadata = metadata;
+            Priority = priority;
+            OnAllTasksComplete = onAllTasksComplete;
+            Constraints = constraints;
+            PoolInfo = poolInfo;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the priority of the job.
@@ -50,7 +65,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// lowest priority and 1000 being the highest priority. If omitted,
         /// the priority of the job is left unchanged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "priority")]
+        [JsonProperty(PropertyName = "priority")]
         public int? Priority { get; set; }
 
         /// <summary>
@@ -66,7 +81,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// directly, the HTTP status code is 400 (Bad Request). Possible
         /// values include: 'noAction', 'terminateJob'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "onAllTasksComplete")]
+        [JsonProperty(PropertyName = "onAllTasksComplete")]
         public OnAllTasksComplete? OnAllTasksComplete { get; set; }
 
         /// <summary>
@@ -75,7 +90,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// If omitted, the existing execution constraints are left unchanged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public JobConstraints Constraints { get; set; }
 
         /// <summary>
@@ -91,7 +106,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// has a poolLifetimeOption of job. If omitted, the job continues to
         /// run on its current pool.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolInfo")]
+        [JsonProperty(PropertyName = "poolInfo")]
         public PoolInformation PoolInfo { get; set; }
 
         /// <summary>
@@ -101,24 +116,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// If omitted, the existing job metadata is left unchanged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.PoolInfo != null)
+            if (PoolInfo != null)
             {
-                this.PoolInfo.Validate();
+                PoolInfo.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element in this.Metadata)
+                foreach (var element in Metadata)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPreparationAndReleaseTaskExecutionInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPreparationAndReleaseTaskExecutionInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// JobPreparationAndReleaseTaskExecutionInformation class.
         /// </summary>
-        public JobPreparationAndReleaseTaskExecutionInformation() { }
+        public JobPreparationAndReleaseTaskExecutionInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -40,38 +47,44 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// node.</param>
         public JobPreparationAndReleaseTaskExecutionInformation(string poolId = default(string), string nodeId = default(string), string nodeUrl = default(string), JobPreparationTaskExecutionInformation jobPreparationTaskExecutionInfo = default(JobPreparationTaskExecutionInformation), JobReleaseTaskExecutionInformation jobReleaseTaskExecutionInfo = default(JobReleaseTaskExecutionInformation))
         {
-            this.PoolId = poolId;
-            this.NodeId = nodeId;
-            this.NodeUrl = nodeUrl;
-            this.JobPreparationTaskExecutionInfo = jobPreparationTaskExecutionInfo;
-            this.JobReleaseTaskExecutionInfo = jobReleaseTaskExecutionInfo;
+            PoolId = poolId;
+            NodeId = nodeId;
+            NodeUrl = nodeUrl;
+            JobPreparationTaskExecutionInfo = jobPreparationTaskExecutionInfo;
+            JobReleaseTaskExecutionInfo = jobReleaseTaskExecutionInfo;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ID of the pool containing the compute node to
         /// which this entry refers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolId")]
+        [JsonProperty(PropertyName = "poolId")]
         public string PoolId { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the compute node to which this entry refers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeId")]
+        [JsonProperty(PropertyName = "nodeId")]
         public string NodeId { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the compute node to which this entry
         /// refers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeUrl")]
+        [JsonProperty(PropertyName = "nodeUrl")]
         public string NodeUrl { get; set; }
 
         /// <summary>
         /// Gets or sets information about the execution status of the Job
         /// Preparation task on this compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobPreparationTaskExecutionInfo")]
+        [JsonProperty(PropertyName = "jobPreparationTaskExecutionInfo")]
         public JobPreparationTaskExecutionInformation JobPreparationTaskExecutionInfo { get; set; }
 
         /// <summary>
@@ -82,24 +95,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the Job Release task has run on the
         /// node.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobReleaseTaskExecutionInfo")]
+        [JsonProperty(PropertyName = "jobReleaseTaskExecutionInfo")]
         public JobReleaseTaskExecutionInformation JobReleaseTaskExecutionInfo { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.JobPreparationTaskExecutionInfo != null)
+            if (JobPreparationTaskExecutionInfo != null)
             {
-                this.JobPreparationTaskExecutionInfo.Validate();
+                JobPreparationTaskExecutionInfo.Validate();
             }
-            if (this.JobReleaseTaskExecutionInfo != null)
+            if (JobReleaseTaskExecutionInfo != null)
             {
-                this.JobReleaseTaskExecutionInfo.Validate();
+                JobReleaseTaskExecutionInfo.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPreparationTask.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPreparationTask.cs
@@ -8,18 +8,48 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
     /// A Job Preparation task to run before any tasks of the job on any given
     /// compute node.
     /// </summary>
+    /// <remarks>
+    /// You can use Job Preparation to prepare a compute node to run tasks for
+    /// the job. Activities commonly performed in Job Preparation include:
+    /// Downloading common resource files used by all the tasks in the job. The
+    /// Job Preparation task can download these common resource files to the
+    /// shared location on the compute node. (AZ_BATCH_NODE_ROOT_DIR\shared),
+    /// or starting a local service on the compute node so that all tasks of
+    /// that job can communicate with it. If the Job Preparation task fails
+    /// (that is, exhausts its retry count before exiting with exit code 0),
+    /// Batch will not run tasks of this job on the compute node. The node
+    /// remains ineligible to run tasks of this job until it is reimaged. The
+    /// node remains active and can be used for other jobs. The Job Preparation
+    /// task can run multiple times on the same compute node. Therefore, you
+    /// should write the Job Preparation task to handle re-execution. If the
+    /// compute node is rebooted, the Job Preparation task is run again on the
+    /// node before scheduling any other task of the job, if
+    /// rerunOnNodeRebootAfterSuccess is true or if the Job Preparation task
+    /// did not previously complete. If the compute node is reimaged, the Job
+    /// Preparation task is run again before scheduling any task of the job.
+    /// </remarks>
     public partial class JobPreparationTask
     {
         /// <summary>
         /// Initializes a new instance of the JobPreparationTask class.
         /// </summary>
-        public JobPreparationTask() { }
+        public JobPreparationTask()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobPreparationTask class.
@@ -37,23 +67,31 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Preparation task.</param>
         /// <param name="waitForSuccess">Whether the Batch service should wait
         /// for the Job Preparation task to complete successfully before
-        /// scheduling any other tasks of the job on the compute node.</param>
+        /// scheduling any other tasks of the job on the compute node. A Job
+        /// Preparation task has completed successfully if it exits with exit
+        /// code 0.</param>
         /// <param name="userIdentity">The user identity under which the Job
         /// Preparation task runs.</param>
         /// <param name="rerunOnNodeRebootAfterSuccess">Whether the Batch
         /// service should rerun the Job Preparation task after a compute node
         /// reboots.</param>
-        public JobPreparationTask(string commandLine, string id = default(string), System.Collections.Generic.IList<ResourceFile> resourceFiles = default(System.Collections.Generic.IList<ResourceFile>), System.Collections.Generic.IList<EnvironmentSetting> environmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), TaskConstraints constraints = default(TaskConstraints), bool? waitForSuccess = default(bool?), UserIdentity userIdentity = default(UserIdentity), bool? rerunOnNodeRebootAfterSuccess = default(bool?))
+        public JobPreparationTask(string commandLine, string id = default(string), IList<ResourceFile> resourceFiles = default(IList<ResourceFile>), IList<EnvironmentSetting> environmentSettings = default(IList<EnvironmentSetting>), TaskConstraints constraints = default(TaskConstraints), bool? waitForSuccess = default(bool?), UserIdentity userIdentity = default(UserIdentity), bool? rerunOnNodeRebootAfterSuccess = default(bool?))
         {
-            this.Id = id;
-            this.CommandLine = commandLine;
-            this.ResourceFiles = resourceFiles;
-            this.EnvironmentSettings = environmentSettings;
-            this.Constraints = constraints;
-            this.WaitForSuccess = waitForSuccess;
-            this.UserIdentity = userIdentity;
-            this.RerunOnNodeRebootAfterSuccess = rerunOnNodeRebootAfterSuccess;
+            Id = id;
+            CommandLine = commandLine;
+            ResourceFiles = resourceFiles;
+            EnvironmentSettings = environmentSettings;
+            Constraints = constraints;
+            WaitForSuccess = waitForSuccess;
+            UserIdentity = userIdentity;
+            RerunOnNodeRebootAfterSuccess = rerunOnNodeRebootAfterSuccess;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the Job Preparation
@@ -64,13 +102,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// including hyphens and underscores and cannot contain more than 64
         /// characters. If you do not specify this property, the Batch service
         /// assigns a default value of 'jobpreparation'. No other task in the
-        /// job can have the same id as the Job Preparation task. If you try to
+        /// job can have the same ID as the Job Preparation task. If you try to
         /// submit a task with the same id, the Batch service rejects the
         /// request with error code TaskIdSameAsJobPreparationTask; if you are
         /// calling the REST API directly, the HTTP status code is 409
         /// (Conflict).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -83,7 +121,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// should invoke the shell in the command line, for example using "cmd
         /// /c MyCommand" in Windows or "/bin/sh -c MyCommand" in Linux.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commandLine")]
+        [JsonProperty(PropertyName = "commandLine")]
         public string CommandLine { get; set; }
 
         /// <summary>
@@ -94,26 +132,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Files listed under this element are located in the task's working
         /// directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resourceFiles")]
-        public System.Collections.Generic.IList<ResourceFile> ResourceFiles { get; set; }
+        [JsonProperty(PropertyName = "resourceFiles")]
+        public IList<ResourceFile> ResourceFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of environment variable settings for the Job
         /// Preparation task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "environmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> EnvironmentSettings { get; set; }
+        [JsonProperty(PropertyName = "environmentSettings")]
+        public IList<EnvironmentSetting> EnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets constraints that apply to the Job Preparation task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public TaskConstraints Constraints { get; set; }
 
         /// <summary>
         /// Gets or sets whether the Batch service should wait for the Job
         /// Preparation task to complete successfully before scheduling any
-        /// other tasks of the job on the compute node.
+        /// other tasks of the job on the compute node. A Job Preparation task
+        /// has completed successfully if it exits with exit code 0.
         /// </summary>
         /// <remarks>
         /// If true and the Job Preparation task fails on a compute node, the
@@ -129,7 +168,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// new tasks will continue to be scheduled on the node. The default
         /// value is true.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "waitForSuccess")]
+        [JsonProperty(PropertyName = "waitForSuccess")]
         public bool? WaitForSuccess { get; set; }
 
         /// <summary>
@@ -138,9 +177,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// </summary>
         /// <remarks>
         /// If omitted, the task runs as a non-administrative user unique to
-        /// the task.
+        /// the task on Windows nodes, or a a non-administrative user unique to
+        /// the pool on Linux nodes.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userIdentity")]
+        [JsonProperty(PropertyName = "userIdentity")]
         public UserIdentity UserIdentity { get; set; }
 
         /// <summary>
@@ -155,24 +195,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// to behave correctly if run multiple times. The default value is
         /// true.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "rerunOnNodeRebootAfterSuccess")]
+        [JsonProperty(PropertyName = "rerunOnNodeRebootAfterSuccess")]
         public bool? RerunOnNodeRebootAfterSuccess { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.CommandLine == null)
+            if (CommandLine == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "CommandLine");
+                throw new ValidationException(ValidationRules.CannotBeNull, "CommandLine");
             }
-            if (this.ResourceFiles != null)
+            if (ResourceFiles != null)
             {
-                foreach (var element in this.ResourceFiles)
+                foreach (var element in ResourceFiles)
                 {
                     if (element != null)
                     {
@@ -180,9 +220,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.EnvironmentSettings != null)
+            if (EnvironmentSettings != null)
             {
-                foreach (var element1 in this.EnvironmentSettings)
+                foreach (var element1 in EnvironmentSettings)
                 {
                     if (element1 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPreparationTaskExecutionInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPreparationTaskExecutionInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// JobPreparationTaskExecutionInformation class.
         /// </summary>
-        public JobPreparationTaskExecutionInformation() { }
+        public JobPreparationTaskExecutionInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -52,25 +59,32 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="result">The result of the task execution.</param>
         public JobPreparationTaskExecutionInformation(System.DateTime startTime, JobPreparationTaskState state, int retryCount, System.DateTime? endTime = default(System.DateTime?), string taskRootDirectory = default(string), string taskRootDirectoryUrl = default(string), int? exitCode = default(int?), TaskFailureInformation failureInfo = default(TaskFailureInformation), System.DateTime? lastRetryTime = default(System.DateTime?), TaskExecutionResult? result = default(TaskExecutionResult?))
         {
-            this.StartTime = startTime;
-            this.EndTime = endTime;
-            this.State = state;
-            this.TaskRootDirectory = taskRootDirectory;
-            this.TaskRootDirectoryUrl = taskRootDirectoryUrl;
-            this.ExitCode = exitCode;
-            this.FailureInfo = failureInfo;
-            this.RetryCount = retryCount;
-            this.LastRetryTime = lastRetryTime;
-            this.Result = result;
+            StartTime = startTime;
+            EndTime = endTime;
+            State = state;
+            TaskRootDirectory = taskRootDirectory;
+            TaskRootDirectoryUrl = taskRootDirectoryUrl;
+            ExitCode = exitCode;
+            FailureInfo = failureInfo;
+            RetryCount = retryCount;
+            LastRetryTime = lastRetryTime;
+            Result = result;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the time at which the task started running.
         /// </summary>
         /// <remarks>
-        /// Note that every time the task is restarted, this value is updated.
+        /// If the task has been restarted or retried, this is the most recent
+        /// time at which the task started running.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -79,7 +93,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property is set only if the task is in the Completed state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endTime")]
+        [JsonProperty(PropertyName = "endTime")]
         public System.DateTime? EndTime { get; set; }
 
         /// <summary>
@@ -87,13 +101,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
         /// running - the task is currently running (including retrying).
         /// completed - the task has exited with exit code 0, or the task has
         /// exhausted its retry limit, or the Batch service was unable to start
-        /// the task due to scheduling errors. Possible values include:
-        /// 'running', 'completed'
+        /// the task due to task preparation errors (such as resource file
+        /// download failures). Possible values include: 'running', 'completed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public JobPreparationTaskState State { get; set; }
 
         /// <summary>
@@ -101,14 +117,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node. You can use this path to retrieve files created by
         /// the task, such as log files.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskRootDirectory")]
+        [JsonProperty(PropertyName = "taskRootDirectory")]
         public string TaskRootDirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the URL to the root directory of the Job Preparation
         /// task on the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskRootDirectoryUrl")]
+        [JsonProperty(PropertyName = "taskRootDirectoryUrl")]
         public string TaskRootDirectoryUrl { get; set; }
 
         /// <summary>
@@ -125,7 +141,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node operating system, such as when a process is forcibly
         /// terminated.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitCode")]
+        [JsonProperty(PropertyName = "exitCode")]
         public int? ExitCode { get; set; }
 
         /// <summary>
@@ -135,7 +151,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the task is in the completed state and
         /// encountered a failure.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "failureInfo")]
+        [JsonProperty(PropertyName = "failureInfo")]
         public TaskFailureInformation FailureInfo { get; set; }
 
         /// <summary>
@@ -145,7 +161,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// upload errors are not retried. The Batch service will retry the
         /// task up to the limit specified by the constraints.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "retryCount")]
+        /// <remarks>
+        /// Task application failures (non-zero exit code) are retried,
+        /// pre-processing errors (the task could not be run) and file upload
+        /// errors are not retried. The Batch service will retry the task up to
+        /// the limit specified by the constraints.
+        /// </remarks>
+        [JsonProperty(PropertyName = "retryCount")]
         public int RetryCount { get; set; }
 
         /// <summary>
@@ -160,7 +182,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// during a retry, then the startTime is updated but the lastRetryTime
         /// is not.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastRetryTime")]
+        [JsonProperty(PropertyName = "lastRetryTime")]
         public System.DateTime? LastRetryTime { get; set; }
 
         /// <summary>
@@ -171,20 +193,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// found in the failureInfo property. Possible values include:
         /// 'success', 'failure'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "result")]
+        [JsonProperty(PropertyName = "result")]
         public TaskExecutionResult? Result { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.FailureInfo != null)
+            if (FailureInfo != null)
             {
-                this.FailureInfo.Validate();
+                FailureInfo.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPreparationTaskState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobPreparationTaskState.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for JobPreparationTaskState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum JobPreparationTaskState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "running")]
+        [EnumMember(Value = "running")]
         Running,
-        [System.Runtime.Serialization.EnumMember(Value = "completed")]
+        [EnumMember(Value = "completed")]
         Completed
+    }
+    internal static class JobPreparationTaskStateEnumExtension
+    {
+        internal static string ToSerializedValue(this JobPreparationTaskState? value)  =>
+            value == null ? null : ((JobPreparationTaskState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this JobPreparationTaskState value)
+        {
+            switch( value )
+            {
+                case JobPreparationTaskState.Running:
+                    return "running";
+                case JobPreparationTaskState.Completed:
+                    return "completed";
+            }
+            return null;
+        }
+
+        internal static JobPreparationTaskState? ParseJobPreparationTaskState(this string value)
+        {
+            switch( value )
+            {
+                case "running":
+                    return JobPreparationTaskState.Running;
+                case "completed":
+                    return JobPreparationTaskState.Completed;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobReleaseTask.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobReleaseTask.cs
@@ -8,18 +8,47 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
     /// A Job Release task to run on job completion on any compute node where
     /// the job has run.
     /// </summary>
+    /// <remarks>
+    /// The Job Release task runs when the job ends, because of one of the
+    /// following: The user calls the Terminate Job API, or the Delete Job API
+    /// while the job is still active, the job's maximum wall clock time
+    /// constraint is reached, and the job is still active, or the job's Job
+    /// Manager task completed, and the job is configured to terminate when the
+    /// Job Manager completes. The Job Release task runs on each compute node
+    /// where tasks of the job have run and the Job Preparation task ran and
+    /// completed. If you reimage a compute node after it has run the Job
+    /// Preparation task, and the job ends without any further tasks of the job
+    /// running on that compute node (and hence the Job Preparation task does
+    /// not re-run), then the Job Release task does not run on that node. If a
+    /// compute node reboots while the Job Release task is still running, the
+    /// Job Release task runs again when the compute node starts up. The job is
+    /// not marked as complete until all Job Release tasks have completed. The
+    /// Job Release task runs in the background. It does not occupy a
+    /// scheduling slot; that is, it does not count towards the maxTasksPerNode
+    /// limit specified on the pool.
+    /// </remarks>
     public partial class JobReleaseTask
     {
         /// <summary>
         /// Initializes a new instance of the JobReleaseTask class.
         /// </summary>
-        public JobReleaseTask() { }
+        public JobReleaseTask()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobReleaseTask class.
@@ -47,16 +76,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// contents.</param>
         /// <param name="userIdentity">The user identity under which the Job
         /// Release task runs.</param>
-        public JobReleaseTask(string commandLine, string id = default(string), System.Collections.Generic.IList<ResourceFile> resourceFiles = default(System.Collections.Generic.IList<ResourceFile>), System.Collections.Generic.IList<EnvironmentSetting> environmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), System.TimeSpan? maxWallClockTime = default(System.TimeSpan?), System.TimeSpan? retentionTime = default(System.TimeSpan?), UserIdentity userIdentity = default(UserIdentity))
+        public JobReleaseTask(string commandLine, string id = default(string), IList<ResourceFile> resourceFiles = default(IList<ResourceFile>), IList<EnvironmentSetting> environmentSettings = default(IList<EnvironmentSetting>), System.TimeSpan? maxWallClockTime = default(System.TimeSpan?), System.TimeSpan? retentionTime = default(System.TimeSpan?), UserIdentity userIdentity = default(UserIdentity))
         {
-            this.Id = id;
-            this.CommandLine = commandLine;
-            this.ResourceFiles = resourceFiles;
-            this.EnvironmentSettings = environmentSettings;
-            this.MaxWallClockTime = maxWallClockTime;
-            this.RetentionTime = retentionTime;
-            this.UserIdentity = userIdentity;
+            Id = id;
+            CommandLine = commandLine;
+            ResourceFiles = resourceFiles;
+            EnvironmentSettings = environmentSettings;
+            MaxWallClockTime = maxWallClockTime;
+            RetentionTime = retentionTime;
+            UserIdentity = userIdentity;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the Job Release task
@@ -67,12 +102,12 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// including hyphens and underscores and cannot contain more than 64
         /// characters. If you do not specify this property, the Batch service
         /// assigns a default value of 'jobrelease'. No other task in the job
-        /// can have the same id as the Job Release task. If you try to submit
+        /// can have the same ID as the Job Release task. If you try to submit
         /// a task with the same id, the Batch service rejects the request with
         /// error code TaskIdSameAsJobReleaseTask; if you are calling the REST
         /// API directly, the HTTP status code is 409 (Conflict).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -85,7 +120,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// should invoke the shell in the command line, for example using "cmd
         /// /c MyCommand" in Windows or "/bin/sh -c MyCommand" in Linux.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commandLine")]
+        [JsonProperty(PropertyName = "commandLine")]
         public string CommandLine { get; set; }
 
         /// <summary>
@@ -96,15 +131,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Files listed under this element are located in the task's working
         /// directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resourceFiles")]
-        public System.Collections.Generic.IList<ResourceFile> ResourceFiles { get; set; }
+        [JsonProperty(PropertyName = "resourceFiles")]
+        public IList<ResourceFile> ResourceFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of environment variable settings for the Job
         /// Release task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "environmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> EnvironmentSettings { get; set; }
+        [JsonProperty(PropertyName = "environmentSettings")]
+        public IList<EnvironmentSetting> EnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum elapsed time that the Job Release task may
@@ -115,7 +150,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch service rejects it with an error; if you are calling the REST
         /// API directly, the HTTP status code is 400 (Bad Request).
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxWallClockTime")]
+        [JsonProperty(PropertyName = "maxWallClockTime")]
         public System.TimeSpan? MaxWallClockTime { get; set; }
 
         /// <summary>
@@ -127,7 +162,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The default is infinite, i.e. the task directory will be retained
         /// until the compute node is removed or reimaged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "retentionTime")]
+        [JsonProperty(PropertyName = "retentionTime")]
         public System.TimeSpan? RetentionTime { get; set; }
 
         /// <summary>
@@ -138,24 +173,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, the task runs as a non-administrative user unique to
         /// the task.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userIdentity")]
+        [JsonProperty(PropertyName = "userIdentity")]
         public UserIdentity UserIdentity { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.CommandLine == null)
+            if (CommandLine == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "CommandLine");
+                throw new ValidationException(ValidationRules.CannotBeNull, "CommandLine");
             }
-            if (this.ResourceFiles != null)
+            if (ResourceFiles != null)
             {
-                foreach (var element in this.ResourceFiles)
+                foreach (var element in ResourceFiles)
                 {
                     if (element != null)
                     {
@@ -163,9 +198,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.EnvironmentSettings != null)
+            if (EnvironmentSettings != null)
             {
-                foreach (var element1 in this.EnvironmentSettings)
+                foreach (var element1 in EnvironmentSettings)
                 {
                     if (element1 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobReleaseTaskExecutionInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobReleaseTaskExecutionInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,15 +24,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// JobReleaseTaskExecutionInformation class.
         /// </summary>
-        public JobReleaseTaskExecutionInformation() { }
+        public JobReleaseTaskExecutionInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
         /// JobReleaseTaskExecutionInformation class.
         /// </summary>
-        /// <param name="startTime">The time at which the task started running.
-        /// Note that every time the task is restarted, this value is
-        /// updated.</param>
+        /// <param name="startTime">The time at which the task started
+        /// running.</param>
         /// <param name="state">The current state of the Job Release task on
         /// the compute node.</param>
         /// <param name="endTime">The time at which the Job Release task
@@ -45,21 +51,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="result">The result of the task execution.</param>
         public JobReleaseTaskExecutionInformation(System.DateTime startTime, JobReleaseTaskState state, System.DateTime? endTime = default(System.DateTime?), string taskRootDirectory = default(string), string taskRootDirectoryUrl = default(string), int? exitCode = default(int?), TaskFailureInformation failureInfo = default(TaskFailureInformation), TaskExecutionResult? result = default(TaskExecutionResult?))
         {
-            this.StartTime = startTime;
-            this.EndTime = endTime;
-            this.State = state;
-            this.TaskRootDirectory = taskRootDirectory;
-            this.TaskRootDirectoryUrl = taskRootDirectoryUrl;
-            this.ExitCode = exitCode;
-            this.FailureInfo = failureInfo;
-            this.Result = result;
+            StartTime = startTime;
+            EndTime = endTime;
+            State = state;
+            TaskRootDirectory = taskRootDirectory;
+            TaskRootDirectoryUrl = taskRootDirectoryUrl;
+            ExitCode = exitCode;
+            FailureInfo = failureInfo;
+            Result = result;
+            CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets the time at which the task started running. Note that
-        /// every time the task is restarted, this value is updated.
+        /// An initialization method that performs custom operations like setting defaults
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets the time at which the task started running.
+        /// </summary>
+        /// <remarks>
+        /// If the task has been restarted or retried, this is the most recent
+        /// time at which the task started running.
+        /// </remarks>
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property is set only if the task is in the Completed state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endTime")]
+        [JsonProperty(PropertyName = "endTime")]
         public System.DateTime? EndTime { get; set; }
 
         /// <summary>
@@ -76,12 +91,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
         /// running - the task is currently running (including retrying).
         /// completed - the task has exited, or the Batch service was unable to
-        /// start the task due to scheduling errors. Possible values include:
-        /// 'running', 'completed'
+        /// start the task due to task preparation errors (such as resource
+        /// file download failures). Possible values include: 'running',
+        /// 'completed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public JobReleaseTaskState State { get; set; }
 
         /// <summary>
@@ -89,14 +107,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node. You can use this path to retrieve files created by
         /// the task, such as log files.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskRootDirectory")]
+        [JsonProperty(PropertyName = "taskRootDirectory")]
         public string TaskRootDirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the URL to the root directory of the Job Release task
         /// on the compute node.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskRootDirectoryUrl")]
+        [JsonProperty(PropertyName = "taskRootDirectoryUrl")]
         public string TaskRootDirectoryUrl { get; set; }
 
         /// <summary>
@@ -113,7 +131,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// compute node operating system, such as when a process is forcibly
         /// terminated.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitCode")]
+        [JsonProperty(PropertyName = "exitCode")]
         public int? ExitCode { get; set; }
 
         /// <summary>
@@ -123,7 +141,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the task is in the completed state and
         /// encountered a failure.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "failureInfo")]
+        [JsonProperty(PropertyName = "failureInfo")]
         public TaskFailureInformation FailureInfo { get; set; }
 
         /// <summary>
@@ -134,20 +152,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// found in the failureInfo property. Possible values include:
         /// 'success', 'failure'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "result")]
+        [JsonProperty(PropertyName = "result")]
         public TaskExecutionResult? Result { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.FailureInfo != null)
+            if (FailureInfo != null)
             {
-                this.FailureInfo.Validate();
+                FailureInfo.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobReleaseTaskState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobReleaseTaskState.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for JobReleaseTaskState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum JobReleaseTaskState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "running")]
+        [EnumMember(Value = "running")]
         Running,
-        [System.Runtime.Serialization.EnumMember(Value = "completed")]
+        [EnumMember(Value = "completed")]
         Completed
+    }
+    internal static class JobReleaseTaskStateEnumExtension
+    {
+        internal static string ToSerializedValue(this JobReleaseTaskState? value)  =>
+            value == null ? null : ((JobReleaseTaskState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this JobReleaseTaskState value)
+        {
+            switch( value )
+            {
+                case JobReleaseTaskState.Running:
+                    return "running";
+                case JobReleaseTaskState.Completed:
+                    return "completed";
+            }
+            return null;
+        }
+
+        internal static JobReleaseTaskState? ParseJobReleaseTaskState(this string value)
+        {
+            switch( value )
+            {
+                case "running":
+                    return JobReleaseTaskState.Running;
+                case "completed":
+                    return JobReleaseTaskState.Completed;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleAddHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleAddHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleAddHeaders class.
         /// </summary>
-        public JobScheduleAddHeaders() { }
+        public JobScheduleAddHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleAddHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobScheduleAddHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleAddOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleAddOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleAddOptions class.
         /// </summary>
-        public JobScheduleAddOptions() { }
+        public JobScheduleAddOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleAddOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobScheduleAddOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleAddParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleAddParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleAddParameter class.
         /// </summary>
-        public JobScheduleAddParameter() { }
+        public JobScheduleAddParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleAddParameter class.
@@ -34,14 +44,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// schedule.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the schedule as metadata.</param>
-        public JobScheduleAddParameter(string id, Schedule schedule, JobSpecification jobSpecification, string displayName = default(string), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>))
+        public JobScheduleAddParameter(string id, Schedule schedule, JobSpecification jobSpecification, string displayName = default(string), IList<MetadataItem> metadata = default(IList<MetadataItem>))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.Schedule = schedule;
-            this.JobSpecification = jobSpecification;
-            this.Metadata = metadata;
+            Id = id;
+            DisplayName = displayName;
+            Schedule = schedule;
+            JobSpecification = jobSpecification;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the schedule within
@@ -50,11 +66,11 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// The ID can contain any combination of alphanumeric characters
         /// including hyphens and underscores, and cannot contain more than 64
-        /// characters. The id is case-preserving and case-insensitive (that
-        /// is, you may not have two ids within an account that differ only by
+        /// characters. The ID is case-preserving and case-insensitive (that
+        /// is, you may not have two IDs within an account that differ only by
         /// case).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -64,20 +80,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The display name need not be unique and can contain any Unicode
         /// characters up to a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
         /// Gets or sets the schedule according to which jobs will be created.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "schedule")]
+        [JsonProperty(PropertyName = "schedule")]
         public Schedule Schedule { get; set; }
 
         /// <summary>
         /// Gets or sets the details of the jobs to be created on this
         /// schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobSpecification")]
+        [JsonProperty(PropertyName = "jobSpecification")]
         public JobSpecification JobSpecification { get; set; }
 
         /// <summary>
@@ -88,36 +104,36 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Batch service does not assign any meaning to metadata; it is
         /// solely for the use of user code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Id == null)
+            if (Id == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Id");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Id");
             }
-            if (this.Schedule == null)
+            if (Schedule == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Schedule");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Schedule");
             }
-            if (this.JobSpecification == null)
+            if (JobSpecification == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "JobSpecification");
+                throw new ValidationException(ValidationRules.CannotBeNull, "JobSpecification");
             }
-            if (this.JobSpecification != null)
+            if (JobSpecification != null)
             {
-                this.JobSpecification.Validate();
+                JobSpecification.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element in this.Metadata)
+                foreach (var element in Metadata)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleDeleteHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleDeleteHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleDeleteHeaders class.
         /// </summary>
-        public JobScheduleDeleteHeaders() { }
+        public JobScheduleDeleteHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleDeleteHeaders class.
@@ -35,16 +42,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public JobScheduleDeleteHeaders(string clientRequestId = default(string), string requestId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public string ClientRequestId { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public string RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleDeleteOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleDeleteOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleDeleteOptions class.
         /// </summary>
-        public JobScheduleDeleteOptions() { }
+        public JobScheduleDeleteOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleDeleteOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobScheduleDeleteOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleDisableHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleDisableHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleDisableHeaders class.
         /// </summary>
-        public JobScheduleDisableHeaders() { }
+        public JobScheduleDisableHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleDisableHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobScheduleDisableHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleDisableOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleDisableOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleDisableOptions class.
         /// </summary>
-        public JobScheduleDisableOptions() { }
+        public JobScheduleDisableOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleDisableOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobScheduleDisableOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleEnableHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleEnableHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleEnableHeaders class.
         /// </summary>
-        public JobScheduleEnableHeaders() { }
+        public JobScheduleEnableHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleEnableHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobScheduleEnableHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleEnableOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleEnableOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleEnableOptions class.
         /// </summary>
-        public JobScheduleEnableOptions() { }
+        public JobScheduleEnableOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleEnableOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobScheduleEnableOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleExecutionInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleExecutionInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the JobScheduleExecutionInformation
         /// class.
         /// </summary>
-        public JobScheduleExecutionInformation() { }
+        public JobScheduleExecutionInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleExecutionInformation
@@ -33,10 +40,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="endTime">The time at which the schedule ended.</param>
         public JobScheduleExecutionInformation(System.DateTime? nextRunTime = default(System.DateTime?), RecentJob recentJob = default(RecentJob), System.DateTime? endTime = default(System.DateTime?))
         {
-            this.NextRunTime = nextRunTime;
-            this.RecentJob = recentJob;
-            this.EndTime = endTime;
+            NextRunTime = nextRunTime;
+            RecentJob = recentJob;
+            EndTime = endTime;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the next time at which a job will be created under
@@ -48,7 +61,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// disabled, no job will be created at nextRunTime unless the job is
         /// enabled before then.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nextRunTime")]
+        [JsonProperty(PropertyName = "nextRunTime")]
         public System.DateTime? NextRunTime { get; set; }
 
         /// <summary>
@@ -59,7 +72,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is present only if the at least one job has run under
         /// the schedule.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "recentJob")]
+        [JsonProperty(PropertyName = "recentJob")]
         public RecentJob RecentJob { get; set; }
 
         /// <summary>
@@ -69,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the job schedule is in the completed
         /// state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endTime")]
+        [JsonProperty(PropertyName = "endTime")]
         public System.DateTime? EndTime { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleExistsHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleExistsHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleExistsHeaders class.
         /// </summary>
-        public JobScheduleExistsHeaders() { }
+        public JobScheduleExistsHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleExistsHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public JobScheduleExistsHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleExistsOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleExistsOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleExistsOptions class.
         /// </summary>
-        public JobScheduleExistsOptions() { }
+        public JobScheduleExistsOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleExistsOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobScheduleExistsOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleGetHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleGetHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleGetHeaders class.
         /// </summary>
-        public JobScheduleGetHeaders() { }
+        public JobScheduleGetHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleGetHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public JobScheduleGetHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleGetOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleGetOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleGetOptions class.
         /// </summary>
-        public JobScheduleGetOptions() { }
+        public JobScheduleGetOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleGetOptions class.
@@ -54,35 +63,41 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobScheduleGetOptions(string select = default(string), string expand = default(string), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Select = select;
-            this.Expand = expand;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Select = select;
+            Expand = expand;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -90,14 +105,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -105,8 +120,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -115,7 +130,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -124,7 +139,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -133,8 +148,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -143,8 +158,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleListHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleListHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleListHeaders class.
         /// </summary>
-        public JobScheduleListHeaders() { }
+        public JobScheduleListHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleListHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public JobScheduleListHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleListNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleListNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleListNextOptions class.
         /// </summary>
-        public JobScheduleListNextOptions() { }
+        public JobScheduleListNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleListNextOptions class.
@@ -33,24 +42,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobScheduleListNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -58,8 +73,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleListOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleListOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleListOptions class.
         /// </summary>
-        public JobScheduleListOptions() { }
+        public JobScheduleListOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleListOptions class.
@@ -42,46 +51,52 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public JobScheduleListOptions(string filter = default(string), string select = default(string), string expand = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.Select = select;
-            this.Expand = expand;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            Select = select;
+            Expand = expand;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 job schedules can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -89,14 +104,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -104,8 +119,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSchedulePatchHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSchedulePatchHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobSchedulePatchHeaders class.
         /// </summary>
-        public JobSchedulePatchHeaders() { }
+        public JobSchedulePatchHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobSchedulePatchHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobSchedulePatchHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSchedulePatchOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSchedulePatchOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobSchedulePatchOptions class.
         /// </summary>
-        public JobSchedulePatchOptions() { }
+        public JobSchedulePatchOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobSchedulePatchOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobSchedulePatchOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSchedulePatchParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSchedulePatchParameter.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobSchedulePatchParameter class.
         /// </summary>
-        public JobSchedulePatchParameter() { }
+        public JobSchedulePatchParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobSchedulePatchParameter class.
@@ -29,12 +38,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// created on this schedule.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the job schedule as metadata.</param>
-        public JobSchedulePatchParameter(Schedule schedule = default(Schedule), JobSpecification jobSpecification = default(JobSpecification), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>))
+        public JobSchedulePatchParameter(Schedule schedule = default(Schedule), JobSpecification jobSpecification = default(JobSpecification), IList<MetadataItem> metadata = default(IList<MetadataItem>))
         {
-            this.Schedule = schedule;
-            this.JobSpecification = jobSpecification;
-            this.Metadata = metadata;
+            Schedule = schedule;
+            JobSpecification = jobSpecification;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the schedule according to which jobs will be created.
@@ -43,7 +58,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If you do not specify this element, the existing schedule is left
         /// unchanged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "schedule")]
+        [JsonProperty(PropertyName = "schedule")]
         public Schedule Schedule { get; set; }
 
         /// <summary>
@@ -55,7 +70,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// taken place. Any currently active job continues with the older
         /// specification.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobSpecification")]
+        [JsonProperty(PropertyName = "jobSpecification")]
         public JobSpecification JobSpecification { get; set; }
 
         /// <summary>
@@ -66,24 +81,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If you do not specify this element, existing metadata is left
         /// unchanged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.JobSpecification != null)
+            if (JobSpecification != null)
             {
-                this.JobSpecification.Validate();
+                JobSpecification.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element in this.Metadata)
+                foreach (var element in Metadata)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleState.cs
@@ -8,22 +8,70 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for JobScheduleState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum JobScheduleState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "active")]
+        [EnumMember(Value = "active")]
         Active,
-        [System.Runtime.Serialization.EnumMember(Value = "completed")]
+        [EnumMember(Value = "completed")]
         Completed,
-        [System.Runtime.Serialization.EnumMember(Value = "disabled")]
+        [EnumMember(Value = "disabled")]
         Disabled,
-        [System.Runtime.Serialization.EnumMember(Value = "terminating")]
+        [EnumMember(Value = "terminating")]
         Terminating,
-        [System.Runtime.Serialization.EnumMember(Value = "deleting")]
+        [EnumMember(Value = "deleting")]
         Deleting
+    }
+    internal static class JobScheduleStateEnumExtension
+    {
+        internal static string ToSerializedValue(this JobScheduleState? value)  =>
+            value == null ? null : ((JobScheduleState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this JobScheduleState value)
+        {
+            switch( value )
+            {
+                case JobScheduleState.Active:
+                    return "active";
+                case JobScheduleState.Completed:
+                    return "completed";
+                case JobScheduleState.Disabled:
+                    return "disabled";
+                case JobScheduleState.Terminating:
+                    return "terminating";
+                case JobScheduleState.Deleting:
+                    return "deleting";
+            }
+            return null;
+        }
+
+        internal static JobScheduleState? ParseJobScheduleState(this string value)
+        {
+            switch( value )
+            {
+                case "active":
+                    return JobScheduleState.Active;
+                case "completed":
+                    return JobScheduleState.Completed;
+                case "disabled":
+                    return JobScheduleState.Disabled;
+                case "terminating":
+                    return JobScheduleState.Terminating;
+                case "deleting":
+                    return JobScheduleState.Deleting;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleStatistics.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleStatistics.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleStatistics class.
         /// </summary>
-        public JobScheduleStatistics() { }
+        public JobScheduleStatistics()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleStatistics class.
@@ -63,33 +71,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// time is the time to the most recent task execution.)</param>
         public JobScheduleStatistics(string url, System.DateTime startTime, System.DateTime lastUpdateTime, System.TimeSpan userCPUTime, System.TimeSpan kernelCPUTime, System.TimeSpan wallClockTime, long readIOps, long writeIOps, double readIOGiB, double writeIOGiB, long numSucceededTasks, long numFailedTasks, long numTaskRetries, System.TimeSpan waitTime)
         {
-            this.Url = url;
-            this.StartTime = startTime;
-            this.LastUpdateTime = lastUpdateTime;
-            this.UserCPUTime = userCPUTime;
-            this.KernelCPUTime = kernelCPUTime;
-            this.WallClockTime = wallClockTime;
-            this.ReadIOps = readIOps;
-            this.WriteIOps = writeIOps;
-            this.ReadIOGiB = readIOGiB;
-            this.WriteIOGiB = writeIOGiB;
-            this.NumSucceededTasks = numSucceededTasks;
-            this.NumFailedTasks = numFailedTasks;
-            this.NumTaskRetries = numTaskRetries;
-            this.WaitTime = waitTime;
+            Url = url;
+            StartTime = startTime;
+            LastUpdateTime = lastUpdateTime;
+            UserCPUTime = userCPUTime;
+            KernelCPUTime = kernelCPUTime;
+            WallClockTime = wallClockTime;
+            ReadIOps = readIOps;
+            WriteIOps = writeIOps;
+            ReadIOGiB = readIOGiB;
+            WriteIOGiB = writeIOGiB;
+            NumSucceededTasks = numSucceededTasks;
+            NumFailedTasks = numFailedTasks;
+            NumTaskRetries = numTaskRetries;
+            WaitTime = waitTime;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the URL of the statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the start time of the time range covered by the
         /// statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -97,7 +111,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// All statistics are limited to the range between startTime and
         /// lastUpdateTime.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastUpdateTime")]
+        [JsonProperty(PropertyName = "lastUpdateTime")]
         public System.DateTime LastUpdateTime { get; set; }
 
         /// <summary>
@@ -105,7 +119,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// and all compute nodes) consumed by all tasks in all jobs created
         /// under the schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userCPUTime")]
+        [JsonProperty(PropertyName = "userCPUTime")]
         public System.TimeSpan UserCPUTime { get; set; }
 
         /// <summary>
@@ -113,7 +127,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// cores and all compute nodes) consumed by all tasks in all jobs
         /// created under the schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "kernelCPUTime")]
+        [JsonProperty(PropertyName = "kernelCPUTime")]
         public System.TimeSpan KernelCPUTime { get; set; }
 
         /// <summary>
@@ -127,35 +141,35 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If a task was retried, this includes the wall clock time of all the
         /// task retries.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "wallClockTime")]
+        [JsonProperty(PropertyName = "wallClockTime")]
         public System.TimeSpan WallClockTime { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of disk read operations made by all
         /// tasks in all jobs created under the schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "readIOps")]
+        [JsonProperty(PropertyName = "readIOps")]
         public long ReadIOps { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of disk write operations made by all
         /// tasks in all jobs created under the schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "writeIOps")]
+        [JsonProperty(PropertyName = "writeIOps")]
         public long WriteIOps { get; set; }
 
         /// <summary>
         /// Gets or sets the total gibibytes read from disk by all tasks in all
         /// jobs created under the schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "readIOGiB")]
+        [JsonProperty(PropertyName = "readIOGiB")]
         public double ReadIOGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the total gibibytes written to disk by all tasks in
         /// all jobs created under the schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "writeIOGiB")]
+        [JsonProperty(PropertyName = "writeIOGiB")]
         public double WriteIOGiB { get; set; }
 
         /// <summary>
@@ -163,7 +177,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// during the given time range in jobs created under the schedule. A
         /// task completes successfully if it returns exit code 0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "numSucceededTasks")]
+        [JsonProperty(PropertyName = "numSucceededTasks")]
         public long NumSucceededTasks { get; set; }
 
         /// <summary>
@@ -171,14 +185,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// time range in jobs created under the schedule. A task fails if it
         /// exhausts its maximum retry count without returning exit code 0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "numFailedTasks")]
+        [JsonProperty(PropertyName = "numFailedTasks")]
         public long NumFailedTasks { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of retries during the given time
         /// range on all tasks in all jobs created under the schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "numTaskRetries")]
+        [JsonProperty(PropertyName = "numTaskRetries")]
         public long NumTaskRetries { get; set; }
 
         /// <summary>
@@ -192,20 +206,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This value is only reported in the account lifetime statistics; it
         /// is not included in the job statistics.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "waitTime")]
+        [JsonProperty(PropertyName = "waitTime")]
         public System.TimeSpan WaitTime { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Url == null)
+            if (Url == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Url");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Url");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleTerminateHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleTerminateHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the JobScheduleTerminateHeaders
         /// class.
         /// </summary>
-        public JobScheduleTerminateHeaders() { }
+        public JobScheduleTerminateHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleTerminateHeaders
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobScheduleTerminateHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -70,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -80,21 +95,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleTerminateOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleTerminateOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the JobScheduleTerminateOptions
         /// class.
         /// </summary>
-        public JobScheduleTerminateOptions() { }
+        public JobScheduleTerminateOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleTerminateOptions
@@ -54,21 +63,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobScheduleTerminateOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -76,14 +91,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -91,8 +106,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -101,7 +116,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -110,7 +125,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -119,8 +134,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -129,8 +144,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleUpdateHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleUpdateHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleUpdateHeaders class.
         /// </summary>
-        public JobScheduleUpdateHeaders() { }
+        public JobScheduleUpdateHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleUpdateHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobScheduleUpdateHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleUpdateOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleUpdateOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleUpdateOptions class.
         /// </summary>
-        public JobScheduleUpdateOptions() { }
+        public JobScheduleUpdateOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleUpdateOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobScheduleUpdateOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleUpdateParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobScheduleUpdateParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobScheduleUpdateParameter class.
         /// </summary>
-        public JobScheduleUpdateParameter() { }
+        public JobScheduleUpdateParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobScheduleUpdateParameter class.
@@ -29,12 +39,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// this schedule.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the job schedule as metadata.</param>
-        public JobScheduleUpdateParameter(Schedule schedule, JobSpecification jobSpecification, System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>))
+        public JobScheduleUpdateParameter(Schedule schedule, JobSpecification jobSpecification, IList<MetadataItem> metadata = default(IList<MetadataItem>))
         {
-            this.Schedule = schedule;
-            this.JobSpecification = jobSpecification;
-            this.Metadata = metadata;
+            Schedule = schedule;
+            JobSpecification = jobSpecification;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the schedule according to which jobs will be created.
@@ -44,7 +60,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// default schedule: that is, a single job scheduled to run
         /// immediately.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "schedule")]
+        [JsonProperty(PropertyName = "schedule")]
         public Schedule Schedule { get; set; }
 
         /// <summary>
@@ -55,7 +71,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// taken place. Any currently active job continues with the older
         /// specification.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobSpecification")]
+        [JsonProperty(PropertyName = "jobSpecification")]
         public JobSpecification JobSpecification { get; set; }
 
         /// <summary>
@@ -66,32 +82,32 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If you do not specify this element, it takes the default value of
         /// an empty list; in effect, any existing metadata is deleted.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Schedule == null)
+            if (Schedule == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Schedule");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Schedule");
             }
-            if (this.JobSpecification == null)
+            if (JobSpecification == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "JobSpecification");
+                throw new ValidationException(ValidationRules.CannotBeNull, "JobSpecification");
             }
-            if (this.JobSpecification != null)
+            if (JobSpecification != null)
             {
-                this.JobSpecification.Validate();
+                JobSpecification.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element in this.Metadata)
+                foreach (var element in Metadata)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSchedulingError.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSchedulingError.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobSchedulingError class.
         /// </summary>
-        public JobSchedulingError() { }
+        public JobSchedulingError()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobSchedulingError class.
@@ -33,13 +42,19 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// interface.</param>
         /// <param name="details">A list of additional error details related to
         /// the scheduling error.</param>
-        public JobSchedulingError(ErrorCategory category, string code = default(string), string message = default(string), System.Collections.Generic.IList<NameValuePair> details = default(System.Collections.Generic.IList<NameValuePair>))
+        public JobSchedulingError(ErrorCategory category, string code = default(string), string message = default(string), IList<NameValuePair> details = default(IList<NameValuePair>))
         {
-            this.Category = category;
-            this.Code = code;
-            this.Message = message;
-            this.Details = details;
+            Category = category;
+            Code = code;
+            Message = message;
+            Details = details;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the category of the job scheduling error.
@@ -47,34 +62,34 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'userError', 'serverError'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "category")]
+        [JsonProperty(PropertyName = "category")]
         public ErrorCategory Category { get; set; }
 
         /// <summary>
         /// Gets or sets an identifier for the job scheduling error. Codes are
         /// invariant and are intended to be consumed programmatically.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [JsonProperty(PropertyName = "code")]
         public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets a message describing the job scheduling error,
         /// intended to be suitable for display in a user interface.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }
 
         /// <summary>
         /// Gets or sets a list of additional error details related to the
         /// scheduling error.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "details")]
-        public System.Collections.Generic.IList<NameValuePair> Details { get; set; }
+        [JsonProperty(PropertyName = "details")]
+        public IList<NameValuePair> Details { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSpecification.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobSpecification.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobSpecification class.
         /// </summary>
-        public JobSpecification() { }
+        public JobSpecification()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobSpecification class.
@@ -29,16 +39,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// schedule.</param>
         /// <param name="displayName">The display name for jobs created under
         /// this schedule.</param>
-        /// <param name="usesTaskDependencies">The flag that determines if this
-        /// job will use tasks with dependencies.</param>
+        /// <param name="usesTaskDependencies">Whether tasks in the job can
+        /// define dependencies on each other. The default is false.</param>
         /// <param name="onAllTasksComplete">The action the Batch service
         /// should take when all tasks in a job created under this schedule are
         /// in the completed state.</param>
         /// <param name="onTaskFailure">The action the Batch service should
         /// take when any task fails in a job created under this schedule. A
-        /// task is considered to have failed if it completes with a non-zero
-        /// exit code and has exhausted its retry count, or if it had a
-        /// scheduling error.</param>
+        /// task is considered to have failed if it have failed if has a
+        /// failureInfo. A failureInfo is set if the task completes with a
+        /// non-zero exit code after exhausting its retry count, or if there
+        /// was an error starting the task, for example due to a resource file
+        /// download error.</param>
         /// <param name="constraints">The execution constraints for jobs
         /// created under this schedule.</param>
         /// <param name="jobManagerTask">The details of a Job Manager task to
@@ -53,21 +65,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Job Manager, Job Preparation and Job Release tasks).</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// each job created under this schedule as metadata.</param>
-        public JobSpecification(PoolInformation poolInfo, int? priority = default(int?), string displayName = default(string), bool? usesTaskDependencies = default(bool?), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?), OnTaskFailure? onTaskFailure = default(OnTaskFailure?), JobConstraints constraints = default(JobConstraints), JobManagerTask jobManagerTask = default(JobManagerTask), JobPreparationTask jobPreparationTask = default(JobPreparationTask), JobReleaseTask jobReleaseTask = default(JobReleaseTask), System.Collections.Generic.IList<EnvironmentSetting> commonEnvironmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>))
+        public JobSpecification(PoolInformation poolInfo, int? priority = default(int?), string displayName = default(string), bool? usesTaskDependencies = default(bool?), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?), OnTaskFailure? onTaskFailure = default(OnTaskFailure?), JobConstraints constraints = default(JobConstraints), JobManagerTask jobManagerTask = default(JobManagerTask), JobPreparationTask jobPreparationTask = default(JobPreparationTask), JobReleaseTask jobReleaseTask = default(JobReleaseTask), IList<EnvironmentSetting> commonEnvironmentSettings = default(IList<EnvironmentSetting>), IList<MetadataItem> metadata = default(IList<MetadataItem>))
         {
-            this.Priority = priority;
-            this.DisplayName = displayName;
-            this.UsesTaskDependencies = usesTaskDependencies;
-            this.OnAllTasksComplete = onAllTasksComplete;
-            this.OnTaskFailure = onTaskFailure;
-            this.Constraints = constraints;
-            this.JobManagerTask = jobManagerTask;
-            this.JobPreparationTask = jobPreparationTask;
-            this.JobReleaseTask = jobReleaseTask;
-            this.CommonEnvironmentSettings = commonEnvironmentSettings;
-            this.PoolInfo = poolInfo;
-            this.Metadata = metadata;
+            Priority = priority;
+            DisplayName = displayName;
+            UsesTaskDependencies = usesTaskDependencies;
+            OnAllTasksComplete = onAllTasksComplete;
+            OnTaskFailure = onTaskFailure;
+            Constraints = constraints;
+            JobManagerTask = jobManagerTask;
+            JobPreparationTask = jobPreparationTask;
+            JobReleaseTask = jobReleaseTask;
+            CommonEnvironmentSettings = commonEnvironmentSettings;
+            PoolInfo = poolInfo;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the priority of jobs created under this schedule.
@@ -79,7 +97,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the job schedule. You can update a job's priority after it has been
         /// created using by using the update job API.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "priority")]
+        [JsonProperty(PropertyName = "priority")]
         public int? Priority { get; set; }
 
         /// <summary>
@@ -89,14 +107,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The name need not be unique and can contain any Unicode characters
         /// up to a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
-        /// Gets or sets the flag that determines if this job will use tasks
-        /// with dependencies.
+        /// Gets or sets whether tasks in the job can define dependencies on
+        /// each other. The default is false.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "usesTaskDependencies")]
+        [JsonProperty(PropertyName = "usesTaskDependencies")]
         public bool? UsesTaskDependencies { get; set; }
 
         /// <summary>
@@ -113,27 +131,29 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// terminateJob once you have finished adding tasks. The default is
         /// noAction. Possible values include: 'noAction', 'terminateJob'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "onAllTasksComplete")]
+        [JsonProperty(PropertyName = "onAllTasksComplete")]
         public OnAllTasksComplete? OnAllTasksComplete { get; set; }
 
         /// <summary>
         /// Gets or sets the action the Batch service should take when any task
         /// fails in a job created under this schedule. A task is considered to
-        /// have failed if it completes with a non-zero exit code and has
-        /// exhausted its retry count, or if it had a scheduling error.
+        /// have failed if it have failed if has a failureInfo. A failureInfo
+        /// is set if the task completes with a non-zero exit code after
+        /// exhausting its retry count, or if there was an error starting the
+        /// task, for example due to a resource file download error.
         /// </summary>
         /// <remarks>
         /// The default is noAction. Possible values include: 'noAction',
         /// 'performExitOptionsJobAction'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "onTaskFailure")]
+        [JsonProperty(PropertyName = "onTaskFailure")]
         public OnTaskFailure? OnTaskFailure { get; set; }
 
         /// <summary>
         /// Gets or sets the execution constraints for jobs created under this
         /// schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public JobConstraints Constraints { get; set; }
 
         /// <summary>
@@ -147,7 +167,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Manager task when the job is created, and will try to schedule the
         /// Job Manager task before scheduling other tasks in the job.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobManagerTask")]
+        [JsonProperty(PropertyName = "jobManagerTask")]
         public JobManagerTask JobManagerTask { get; set; }
 
         /// <summary>
@@ -159,7 +179,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Job Preparation task on a compute node before starting any tasks of
         /// that job on that compute node.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobPreparationTask")]
+        [JsonProperty(PropertyName = "jobPreparationTask")]
         public JobPreparationTask JobPreparationTask { get; set; }
 
         /// <summary>
@@ -175,7 +195,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// job. The Batch service runs the Job Release task on the compute
         /// nodes that have run the Job Preparation task.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobReleaseTask")]
+        [JsonProperty(PropertyName = "jobReleaseTask")]
         public JobReleaseTask JobReleaseTask { get; set; }
 
         /// <summary>
@@ -188,14 +208,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Individual tasks can override an environment setting specified here
         /// by specifying the same setting name with a different value.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commonEnvironmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> CommonEnvironmentSettings { get; set; }
+        [JsonProperty(PropertyName = "commonEnvironmentSettings")]
+        public IList<EnvironmentSetting> CommonEnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets the pool on which the Batch service runs the tasks of
         /// jobs created under this schedule.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolInfo")]
+        [JsonProperty(PropertyName = "poolInfo")]
         public PoolInformation PoolInfo { get; set; }
 
         /// <summary>
@@ -206,36 +226,36 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Batch service does not assign any meaning to metadata; it is
         /// solely for the use of user code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.PoolInfo == null)
+            if (PoolInfo == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "PoolInfo");
+                throw new ValidationException(ValidationRules.CannotBeNull, "PoolInfo");
             }
-            if (this.JobManagerTask != null)
+            if (JobManagerTask != null)
             {
-                this.JobManagerTask.Validate();
+                JobManagerTask.Validate();
             }
-            if (this.JobPreparationTask != null)
+            if (JobPreparationTask != null)
             {
-                this.JobPreparationTask.Validate();
+                JobPreparationTask.Validate();
             }
-            if (this.JobReleaseTask != null)
+            if (JobReleaseTask != null)
             {
-                this.JobReleaseTask.Validate();
+                JobReleaseTask.Validate();
             }
-            if (this.CommonEnvironmentSettings != null)
+            if (CommonEnvironmentSettings != null)
             {
-                foreach (var element in this.CommonEnvironmentSettings)
+                foreach (var element in CommonEnvironmentSettings)
                 {
                     if (element != null)
                     {
@@ -243,13 +263,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.PoolInfo != null)
+            if (PoolInfo != null)
             {
-                this.PoolInfo.Validate();
+                PoolInfo.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element1 in this.Metadata)
+                foreach (var element1 in Metadata)
                 {
                     if (element1 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobState.cs
@@ -8,26 +8,82 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for JobState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum JobState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "active")]
+        [EnumMember(Value = "active")]
         Active,
-        [System.Runtime.Serialization.EnumMember(Value = "disabling")]
+        [EnumMember(Value = "disabling")]
         Disabling,
-        [System.Runtime.Serialization.EnumMember(Value = "disabled")]
+        [EnumMember(Value = "disabled")]
         Disabled,
-        [System.Runtime.Serialization.EnumMember(Value = "enabling")]
+        [EnumMember(Value = "enabling")]
         Enabling,
-        [System.Runtime.Serialization.EnumMember(Value = "terminating")]
+        [EnumMember(Value = "terminating")]
         Terminating,
-        [System.Runtime.Serialization.EnumMember(Value = "completed")]
+        [EnumMember(Value = "completed")]
         Completed,
-        [System.Runtime.Serialization.EnumMember(Value = "deleting")]
+        [EnumMember(Value = "deleting")]
         Deleting
+    }
+    internal static class JobStateEnumExtension
+    {
+        internal static string ToSerializedValue(this JobState? value)  =>
+            value == null ? null : ((JobState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this JobState value)
+        {
+            switch( value )
+            {
+                case JobState.Active:
+                    return "active";
+                case JobState.Disabling:
+                    return "disabling";
+                case JobState.Disabled:
+                    return "disabled";
+                case JobState.Enabling:
+                    return "enabling";
+                case JobState.Terminating:
+                    return "terminating";
+                case JobState.Completed:
+                    return "completed";
+                case JobState.Deleting:
+                    return "deleting";
+            }
+            return null;
+        }
+
+        internal static JobState? ParseJobState(this string value)
+        {
+            switch( value )
+            {
+                case "active":
+                    return JobState.Active;
+                case "disabling":
+                    return JobState.Disabling;
+                case "disabled":
+                    return JobState.Disabled;
+                case "enabling":
+                    return JobState.Enabling;
+                case "terminating":
+                    return JobState.Terminating;
+                case "completed":
+                    return JobState.Completed;
+                case "deleting":
+                    return JobState.Deleting;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobStatistics.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobStatistics.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobStatistics class.
         /// </summary>
-        public JobStatistics() { }
+        public JobStatistics()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobStatistics class.
@@ -56,33 +64,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// job.</param>
         public JobStatistics(string url, System.DateTime startTime, System.DateTime lastUpdateTime, System.TimeSpan userCPUTime, System.TimeSpan kernelCPUTime, System.TimeSpan wallClockTime, long readIOps, long writeIOps, double readIOGiB, double writeIOGiB, long numSucceededTasks, long numFailedTasks, long numTaskRetries, System.TimeSpan waitTime)
         {
-            this.Url = url;
-            this.StartTime = startTime;
-            this.LastUpdateTime = lastUpdateTime;
-            this.UserCPUTime = userCPUTime;
-            this.KernelCPUTime = kernelCPUTime;
-            this.WallClockTime = wallClockTime;
-            this.ReadIOps = readIOps;
-            this.WriteIOps = writeIOps;
-            this.ReadIOGiB = readIOGiB;
-            this.WriteIOGiB = writeIOGiB;
-            this.NumSucceededTasks = numSucceededTasks;
-            this.NumFailedTasks = numFailedTasks;
-            this.NumTaskRetries = numTaskRetries;
-            this.WaitTime = waitTime;
+            Url = url;
+            StartTime = startTime;
+            LastUpdateTime = lastUpdateTime;
+            UserCPUTime = userCPUTime;
+            KernelCPUTime = kernelCPUTime;
+            WallClockTime = wallClockTime;
+            ReadIOps = readIOps;
+            WriteIOps = writeIOps;
+            ReadIOGiB = readIOGiB;
+            WriteIOGiB = writeIOGiB;
+            NumSucceededTasks = numSucceededTasks;
+            NumFailedTasks = numFailedTasks;
+            NumTaskRetries = numTaskRetries;
+            WaitTime = waitTime;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the URL of the statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the start time of the time range covered by the
         /// statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -90,55 +104,62 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// All statistics are limited to the range between startTime and
         /// lastUpdateTime.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastUpdateTime")]
+        [JsonProperty(PropertyName = "lastUpdateTime")]
         public System.DateTime LastUpdateTime { get; set; }
 
         /// <summary>
         /// Gets or sets the total user mode CPU time (summed across all cores
         /// and all compute nodes) consumed by all tasks in the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userCPUTime")]
+        [JsonProperty(PropertyName = "userCPUTime")]
         public System.TimeSpan UserCPUTime { get; set; }
 
         /// <summary>
         /// Gets or sets the total kernel mode CPU time (summed across all
         /// cores and all compute nodes) consumed by all tasks in the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "kernelCPUTime")]
+        [JsonProperty(PropertyName = "kernelCPUTime")]
         public System.TimeSpan KernelCPUTime { get; set; }
 
         /// <summary>
         /// Gets or sets the total wall clock time of all tasks in the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "wallClockTime")]
+        /// <remarks>
+        /// The wall clock time is the elapsed time from when the task started
+        /// running on a compute node to when it finished (or to the last time
+        /// the statistics were updated, if the task had not finished by then).
+        /// If a task was retried, this includes the wall clock time of all the
+        /// task retries.
+        /// </remarks>
+        [JsonProperty(PropertyName = "wallClockTime")]
         public System.TimeSpan WallClockTime { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of disk read operations made by all
         /// tasks in the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "readIOps")]
+        [JsonProperty(PropertyName = "readIOps")]
         public long ReadIOps { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of disk write operations made by all
         /// tasks in the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "writeIOps")]
+        [JsonProperty(PropertyName = "writeIOps")]
         public long WriteIOps { get; set; }
 
         /// <summary>
         /// Gets or sets the total amount of data in GiB read from disk by all
         /// tasks in the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "readIOGiB")]
+        [JsonProperty(PropertyName = "readIOGiB")]
         public double ReadIOGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the total amount of data in GiB written to disk by all
         /// tasks in the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "writeIOGiB")]
+        [JsonProperty(PropertyName = "writeIOGiB")]
         public double WriteIOGiB { get; set; }
 
         /// <summary>
@@ -148,7 +169,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// A task completes successfully if it returns exit code 0.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "numSucceededTasks")]
+        [JsonProperty(PropertyName = "numSucceededTasks")]
         public long NumSucceededTasks { get; set; }
 
         /// <summary>
@@ -159,14 +180,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// A task fails if it exhausts its maximum retry count without
         /// returning exit code 0.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "numFailedTasks")]
+        [JsonProperty(PropertyName = "numFailedTasks")]
         public long NumFailedTasks { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of retries on all the tasks in the
         /// job during the given time range.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "numTaskRetries")]
+        [JsonProperty(PropertyName = "numTaskRetries")]
         public long NumTaskRetries { get; set; }
 
         /// <summary>
@@ -179,20 +200,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// recent task execution.) This value is only reported in the account
         /// lifetime statistics; it is not included in the job statistics.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "waitTime")]
+        [JsonProperty(PropertyName = "waitTime")]
         public System.TimeSpan WaitTime { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Url == null)
+            if (Url == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Url");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Url");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobTerminateHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobTerminateHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobTerminateHeaders class.
         /// </summary>
-        public JobTerminateHeaders() { }
+        public JobTerminateHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobTerminateHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobTerminateHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobTerminateOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobTerminateOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobTerminateOptions class.
         /// </summary>
-        public JobTerminateOptions() { }
+        public JobTerminateOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobTerminateOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobTerminateOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobTerminateParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobTerminateParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobTerminateParameter class.
         /// </summary>
-        public JobTerminateParameter() { }
+        public JobTerminateParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobTerminateParameter class.
@@ -27,14 +34,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// job's TerminateReason. The default is 'UserTerminate'.</param>
         public JobTerminateParameter(string terminateReason = default(string))
         {
-            this.TerminateReason = terminateReason;
+            TerminateReason = terminateReason;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the text you want to appear as the job's
         /// TerminateReason. The default is 'UserTerminate'.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "terminateReason")]
+        [JsonProperty(PropertyName = "terminateReason")]
         public string TerminateReason { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobUpdateHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobUpdateHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobUpdateHeaders class.
         /// </summary>
-        public JobUpdateHeaders() { }
+        public JobUpdateHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobUpdateHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public JobUpdateHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobUpdateOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobUpdateOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobUpdateOptions class.
         /// </summary>
-        public JobUpdateOptions() { }
+        public JobUpdateOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobUpdateOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public JobUpdateOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobUpdateParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/JobUpdateParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the JobUpdateParameter class.
         /// </summary>
-        public JobUpdateParameter() { }
+        public JobUpdateParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the JobUpdateParameter class.
@@ -33,14 +43,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="onAllTasksComplete">The action the Batch service
         /// should take when all tasks in the job are in the completed
         /// state.</param>
-        public JobUpdateParameter(PoolInformation poolInfo, int? priority = default(int?), JobConstraints constraints = default(JobConstraints), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?))
+        public JobUpdateParameter(PoolInformation poolInfo, int? priority = default(int?), JobConstraints constraints = default(JobConstraints), IList<MetadataItem> metadata = default(IList<MetadataItem>), OnAllTasksComplete? onAllTasksComplete = default(OnAllTasksComplete?))
         {
-            this.Priority = priority;
-            this.Constraints = constraints;
-            this.PoolInfo = poolInfo;
-            this.Metadata = metadata;
-            this.OnAllTasksComplete = onAllTasksComplete;
+            Priority = priority;
+            Constraints = constraints;
+            PoolInfo = poolInfo;
+            Metadata = metadata;
+            OnAllTasksComplete = onAllTasksComplete;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the priority of the job.
@@ -50,7 +66,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// lowest priority and 1000 being the highest priority. If omitted, it
         /// is set to the default value 0.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "priority")]
+        [JsonProperty(PropertyName = "priority")]
         public int? Priority { get; set; }
 
         /// <summary>
@@ -59,7 +75,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// If omitted, the constraints are cleared.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public JobConstraints Constraints { get; set; }
 
         /// <summary>
@@ -74,7 +90,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// keepAlive property can be updated, and then only if the auto pool
         /// has a poolLifetimeOption of job.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolInfo")]
+        [JsonProperty(PropertyName = "poolInfo")]
         public PoolInformation PoolInfo { get; set; }
 
         /// <summary>
@@ -85,8 +101,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, it takes the default value of an empty list; in effect,
         /// any existing metadata is deleted.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Gets or sets the action the Batch service should take when all
@@ -96,30 +112,37 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, the completion behavior is set to noAction. If the
         /// current value is terminateJob, this is an error because a job's
         /// completion behavior may not be changed from terminateJob to
-        /// noAction. Possible values include: 'noAction', 'terminateJob'
+        /// noAction. You may not change the value from terminatejob to
+        /// noaction - that is, once you have engaged automatic job
+        /// termination, you cannot turn it off again. If you try to do this,
+        /// the request fails and Batch returns status code 400 (Bad Request)
+        /// and an 'invalid property value' error response. If you do not
+        /// specify this element in a PUT request, it is equivalent to passing
+        /// noaction. This is an error if the current value is terminatejob.
+        /// Possible values include: 'noAction', 'terminateJob'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "onAllTasksComplete")]
+        [JsonProperty(PropertyName = "onAllTasksComplete")]
         public OnAllTasksComplete? OnAllTasksComplete { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.PoolInfo == null)
+            if (PoolInfo == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "PoolInfo");
+                throw new ValidationException(ValidationRules.CannotBeNull, "PoolInfo");
             }
-            if (this.PoolInfo != null)
+            if (PoolInfo != null)
             {
-                this.PoolInfo.Validate();
+                PoolInfo.Validate();
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element in this.Metadata)
+                foreach (var element in Metadata)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/LinuxUserConfiguration.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/LinuxUserConfiguration.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the LinuxUserConfiguration class.
         /// </summary>
-        public LinuxUserConfiguration() { }
+        public LinuxUserConfiguration()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the LinuxUserConfiguration class.
@@ -29,10 +36,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// account.</param>
         public LinuxUserConfiguration(int? uid = default(int?), int? gid = default(int?), string sshPrivateKey = default(string))
         {
-            this.Uid = uid;
-            this.Gid = gid;
-            this.SshPrivateKey = sshPrivateKey;
+            Uid = uid;
+            Gid = gid;
+            SshPrivateKey = sshPrivateKey;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the user ID of the user account.
@@ -42,7 +55,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// all. If not specified the underlying operating system picks the
         /// uid.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "uid")]
+        [JsonProperty(PropertyName = "uid")]
         public int? Uid { get; set; }
 
         /// <summary>
@@ -53,7 +66,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// all. If not specified the underlying operating system picks the
         /// gid.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "gid")]
+        [JsonProperty(PropertyName = "gid")]
         public int? Gid { get; set; }
 
         /// <summary>
@@ -69,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// password-less SSH is not configured between nodes (no modification
         /// of the user's .ssh directory is done).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "sshPrivateKey")]
+        [JsonProperty(PropertyName = "sshPrivateKey")]
         public string SshPrivateKey { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/MetadataItem.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/MetadataItem.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -22,7 +27,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the MetadataItem class.
         /// </summary>
-        public MetadataItem() { }
+        public MetadataItem()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the MetadataItem class.
@@ -31,37 +39,43 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="value">The value of the metadata item.</param>
         public MetadataItem(string name, string value)
         {
-            this.Name = name;
-            this.Value = value;
+            Name = name;
+            Value = value;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the name of the metadata item.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the value of the metadata item.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Name == null)
+            if (Name == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Name");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Name");
             }
-            if (this.Value == null)
+            if (Value == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Value");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Value");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/MultiInstanceSettings.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/MultiInstanceSettings.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -21,7 +27,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the MultiInstanceSettings class.
         /// </summary>
-        public MultiInstanceSettings() { }
+        public MultiInstanceSettings()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the MultiInstanceSettings class.
@@ -34,17 +43,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="commonResourceFiles">A list of files that the Batch
         /// service will download before running the coordination command
         /// line.</param>
-        public MultiInstanceSettings(int numberOfInstances, string coordinationCommandLine = default(string), System.Collections.Generic.IList<ResourceFile> commonResourceFiles = default(System.Collections.Generic.IList<ResourceFile>))
+        public MultiInstanceSettings(int numberOfInstances, string coordinationCommandLine = default(string), IList<ResourceFile> commonResourceFiles = default(IList<ResourceFile>))
         {
-            this.NumberOfInstances = numberOfInstances;
-            this.CoordinationCommandLine = coordinationCommandLine;
-            this.CommonResourceFiles = commonResourceFiles;
+            NumberOfInstances = numberOfInstances;
+            CoordinationCommandLine = coordinationCommandLine;
+            CommonResourceFiles = commonResourceFiles;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the number of compute nodes required by the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "numberOfInstances")]
+        [JsonProperty(PropertyName = "numberOfInstances")]
         public int NumberOfInstances { get; set; }
 
         /// <summary>
@@ -57,7 +72,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// and verifies that the service is ready to process inter-node
         /// messages.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "coordinationCommandLine")]
+        [JsonProperty(PropertyName = "coordinationCommandLine")]
         public string CoordinationCommandLine { get; set; }
 
         /// <summary>
@@ -68,22 +83,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The difference between common resource files and task resource
         /// files is that common resource files are downloaded for all subtasks
         /// including the primary, whereas task resource files are downloaded
-        /// only for the primary.
+        /// only for the primary. Also note that these resource files are not
+        /// downloaded to the task working directory, but instead are
+        /// downloaded to the task root directory (one directory above the
+        /// working directory).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commonResourceFiles")]
-        public System.Collections.Generic.IList<ResourceFile> CommonResourceFiles { get; set; }
+        [JsonProperty(PropertyName = "commonResourceFiles")]
+        public IList<ResourceFile> CommonResourceFiles { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.CommonResourceFiles != null)
+            if (CommonResourceFiles != null)
             {
-                foreach (var element in this.CommonResourceFiles)
+                foreach (var element in CommonResourceFiles)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NameValuePair.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NameValuePair.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NameValuePair class.
         /// </summary>
-        public NameValuePair() { }
+        public NameValuePair()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NameValuePair class.
@@ -27,20 +34,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="value">The value in the name-value pair.</param>
         public NameValuePair(string name = default(string), string value = default(string))
         {
-            this.Name = name;
-            this.Value = value;
+            Name = name;
+            Value = value;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the name in the name-value pair.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the value in the name-value pair.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
+        [JsonProperty(PropertyName = "value")]
         public string Value { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NetworkConfiguration.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NetworkConfiguration.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NetworkConfiguration class.
         /// </summary>
-        public NetworkConfiguration() { }
+        public NetworkConfiguration()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NetworkConfiguration class.
@@ -31,9 +38,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// on compute nodes in the Batch pool.</param>
         public NetworkConfiguration(string subnetId = default(string), PoolEndpointConfiguration endpointConfiguration = default(PoolEndpointConfiguration))
         {
-            this.SubnetId = subnetId;
-            this.EndpointConfiguration = endpointConfiguration;
+            SubnetId = subnetId;
+            EndpointConfiguration = endpointConfiguration;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ARM resource identifier of the virtual network
@@ -57,9 +70,18 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// denied by an NSG, then the Batch service will set the state of the
         /// compute nodes to unusable. For pools created via
         /// virtualMachineConfiguration the Batch account must have
-        /// poolAllocationMode userSubscription in order to use a VNet.
+        /// poolAllocationMode userSubscription in order to use a VNet. If the
+        /// specified VNet has any associated Network Security Groups (NSG),
+        /// then a few reserved system ports must be enabled for inbound
+        /// communication. For pools created with a virtual machine
+        /// configuration, enable ports 29876 and 29877, as well as port 22 for
+        /// Linux and port 3389 for Windows. For pools created with a cloud
+        /// service configuration, enable ports 10100, 20100, and 30100. Also
+        /// enable outbound connections to Azure Storage on port 443. For more
+        /// details see:
+        /// https://docs.microsoft.com/en-us/azure/batch/batch-api-basics#virtual-network-vnet-and-firewall-configuration
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "subnetId")]
+        [JsonProperty(PropertyName = "subnetId")]
         public string SubnetId { get; set; }
 
         /// <summary>
@@ -70,20 +92,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Pool endpoint configuration is only supported on pools with the
         /// virtualMachineConfiguration property.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endpointConfiguration")]
+        [JsonProperty(PropertyName = "endpointConfiguration")]
         public PoolEndpointConfiguration EndpointConfiguration { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.EndpointConfiguration != null)
+            if (EndpointConfiguration != null)
             {
-                this.EndpointConfiguration.Validate();
+                EndpointConfiguration.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NetworkSecurityGroupRule.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NetworkSecurityGroupRule.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NetworkSecurityGroupRule class.
         /// </summary>
-        public NetworkSecurityGroupRule() { }
+        public NetworkSecurityGroupRule()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NetworkSecurityGroupRule class.
@@ -30,10 +38,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// to match for the rule.</param>
         public NetworkSecurityGroupRule(int priority, NetworkSecurityGroupRuleAccess access, string sourceAddressPrefix)
         {
-            this.Priority = priority;
-            this.Access = access;
-            this.SourceAddressPrefix = sourceAddressPrefix;
+            Priority = priority;
+            Access = access;
+            SourceAddressPrefix = sourceAddressPrefix;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the priority for this rule.
@@ -47,7 +61,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// to 3500. If any reserved or duplicate values are provided the
         /// request fails with HTTP status code 400.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "priority")]
+        [JsonProperty(PropertyName = "priority")]
         public int Priority { get; set; }
 
         /// <summary>
@@ -57,7 +71,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'allow', 'deny'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "access")]
+        [JsonProperty(PropertyName = "access")]
         public NetworkSecurityGroupRuleAccess Access { get; set; }
 
         /// <summary>
@@ -70,20 +84,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// any other values are provided the request fails with HTTP status
         /// code 400.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "sourceAddressPrefix")]
+        [JsonProperty(PropertyName = "sourceAddressPrefix")]
         public string SourceAddressPrefix { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.SourceAddressPrefix == null)
+            if (SourceAddressPrefix == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "SourceAddressPrefix");
+                throw new ValidationException(ValidationRules.CannotBeNull, "SourceAddressPrefix");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NetworkSecurityGroupRuleAccess.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NetworkSecurityGroupRuleAccess.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for NetworkSecurityGroupRuleAccess.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum NetworkSecurityGroupRuleAccess
     {
-        [System.Runtime.Serialization.EnumMember(Value = "allow")]
+        [EnumMember(Value = "allow")]
         Allow,
-        [System.Runtime.Serialization.EnumMember(Value = "deny")]
+        [EnumMember(Value = "deny")]
         Deny
+    }
+    internal static class NetworkSecurityGroupRuleAccessEnumExtension
+    {
+        internal static string ToSerializedValue(this NetworkSecurityGroupRuleAccess? value)  =>
+            value == null ? null : ((NetworkSecurityGroupRuleAccess)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this NetworkSecurityGroupRuleAccess value)
+        {
+            switch( value )
+            {
+                case NetworkSecurityGroupRuleAccess.Allow:
+                    return "allow";
+                case NetworkSecurityGroupRuleAccess.Deny:
+                    return "deny";
+            }
+            return null;
+        }
+
+        internal static NetworkSecurityGroupRuleAccess? ParseNetworkSecurityGroupRuleAccess(this string value)
+        {
+            switch( value )
+            {
+                case "allow":
+                    return NetworkSecurityGroupRuleAccess.Allow;
+                case "deny":
+                    return NetworkSecurityGroupRuleAccess.Deny;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeAgentSku.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeAgentSku.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -24,7 +30,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NodeAgentSku class.
         /// </summary>
-        public NodeAgentSku() { }
+        public NodeAgentSku()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NodeAgentSku class.
@@ -34,17 +43,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// to be compatible with this node agent SKU.</param>
         /// <param name="osType">The type of operating system (e.g. Windows or
         /// Linux) compatible with the node agent SKU.</param>
-        public NodeAgentSku(string id = default(string), System.Collections.Generic.IList<ImageReference> verifiedImageReferences = default(System.Collections.Generic.IList<ImageReference>), OSType? osType = default(OSType?))
+        public NodeAgentSku(string id = default(string), IList<ImageReference> verifiedImageReferences = default(IList<ImageReference>), OSType? osType = default(OSType?))
         {
-            this.Id = id;
-            this.VerifiedImageReferences = verifiedImageReferences;
-            this.OsType = osType;
+            Id = id;
+            VerifiedImageReferences = verifiedImageReferences;
+            OsType = osType;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ID of the node agent SKU.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -55,8 +70,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This collection is not exhaustive (the node agent may be compatible
         /// with other images).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "verifiedImageReferences")]
-        public System.Collections.Generic.IList<ImageReference> VerifiedImageReferences { get; set; }
+        [JsonProperty(PropertyName = "verifiedImageReferences")]
+        public IList<ImageReference> VerifiedImageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the type of operating system (e.g. Windows or Linux)
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'linux', 'windows'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "osType")]
+        [JsonProperty(PropertyName = "osType")]
         public OSType? OsType { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeDisableSchedulingParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeDisableSchedulingParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the NodeDisableSchedulingParameter
         /// class.
         /// </summary>
-        public NodeDisableSchedulingParameter() { }
+        public NodeDisableSchedulingParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NodeDisableSchedulingParameter
@@ -30,18 +37,36 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// node.</param>
         public NodeDisableSchedulingParameter(DisableComputeNodeSchedulingOption? nodeDisableSchedulingOption = default(DisableComputeNodeSchedulingOption?))
         {
-            this.NodeDisableSchedulingOption = nodeDisableSchedulingOption;
+            NodeDisableSchedulingOption = nodeDisableSchedulingOption;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets what to do with currently running tasks when disabling
         /// task scheduling on the compute node.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks.
+        /// The tasks may run again on other compute nodes, or when task
+        /// scheduling is re-enabled on this node. Enter offline state as soon
+        /// as tasks have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again.
+        /// Enter offline state as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete.
+        /// Schedule no new tasks while waiting. Enter offline state when all
+        /// tasks have completed.
+        ///
         /// The default value is requeue. Possible values include: 'requeue',
         /// 'terminate', 'taskCompletion'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeDisableSchedulingOption")]
+        [JsonProperty(PropertyName = "nodeDisableSchedulingOption")]
         public DisableComputeNodeSchedulingOption? NodeDisableSchedulingOption { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeFile.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeFile.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NodeFile class.
         /// </summary>
-        public NodeFile() { }
+        public NodeFile()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NodeFile class.
@@ -30,47 +37,53 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="properties">The file properties.</param>
         public NodeFile(string name = default(string), string url = default(string), bool? isDirectory = default(bool?), FileProperties properties = default(FileProperties))
         {
-            this.Name = name;
-            this.Url = url;
-            this.IsDirectory = isDirectory;
-            this.Properties = properties;
+            Name = name;
+            Url = url;
+            IsDirectory = isDirectory;
+            Properties = properties;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the file path.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the file.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets whether the object represents a directory.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "isDirectory")]
+        [JsonProperty(PropertyName = "isDirectory")]
         public bool? IsDirectory { get; set; }
 
         /// <summary>
         /// Gets or sets the file properties.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "properties")]
+        [JsonProperty(PropertyName = "properties")]
         public FileProperties Properties { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Properties != null)
+            if (Properties != null)
             {
-                this.Properties.Validate();
+                Properties.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeRebootParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeRebootParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NodeRebootParameter class.
         /// </summary>
-        public NodeRebootParameter() { }
+        public NodeRebootParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NodeRebootParameter class.
@@ -27,18 +34,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// what to do with currently running tasks.</param>
         public NodeRebootParameter(ComputeNodeRebootOption? nodeRebootOption = default(ComputeNodeRebootOption?))
         {
-            this.NodeRebootOption = nodeRebootOption;
+            NodeRebootOption = nodeRebootOption;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets when to reboot the compute node and what to do with
         /// currently running tasks.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks.
+        /// The tasks will run again when a node is available. Restart the node
+        /// as soon as tasks have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again.
+        /// Restart the node as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete.
+        /// Schedule no new tasks while waiting. Restart the node when all
+        /// tasks have completed.
+        /// retaineddata - Allow currently running tasks to complete, then wait
+        /// for all task data retention periods to expire. Schedule no new
+        /// tasks while waiting. Restart the node when all task retention
+        /// periods have expired.
+        ///
         /// The default value is requeue. Possible values include: 'requeue',
         /// 'terminate', 'taskCompletion', 'retainedData'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeRebootOption")]
+        [JsonProperty(PropertyName = "nodeRebootOption")]
         public ComputeNodeRebootOption? NodeRebootOption { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeReimageParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeReimageParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NodeReimageParameter class.
         /// </summary>
-        public NodeReimageParameter() { }
+        public NodeReimageParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NodeReimageParameter class.
@@ -27,18 +34,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// and what to do with currently running tasks.</param>
         public NodeReimageParameter(ComputeNodeReimageOption? nodeReimageOption = default(ComputeNodeReimageOption?))
         {
-            this.NodeReimageOption = nodeReimageOption;
+            NodeReimageOption = nodeReimageOption;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets when to reimage the compute node and what to do with
         /// currently running tasks.
         /// </summary>
         /// <remarks>
+        /// Values are:
+        ///
+        /// requeue - Terminate running task processes and requeue the tasks.
+        /// The tasks will run again when a node is available. Reimage the node
+        /// as soon as tasks have been terminated.
+        /// terminate - Terminate running tasks. The tasks will not run again.
+        /// Reimage the node as soon as tasks have been terminated.
+        /// taskcompletion - Allow currently running tasks to complete.
+        /// Schedule no new tasks while waiting. Reimage the node when all
+        /// tasks have completed.
+        /// retaineddata - Allow currently running tasks to complete, then wait
+        /// for all task data retention periods to expire. Schedule no new
+        /// tasks while waiting. Reimage the node when all task retention
+        /// periods have expired.
+        ///
         /// The default value is requeue. Possible values include: 'requeue',
         /// 'terminate', 'taskCompletion', 'retainedData'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeReimageOption")]
+        [JsonProperty(PropertyName = "nodeReimageOption")]
         public ComputeNodeReimageOption? NodeReimageOption { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeRemoveParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeRemoveParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,31 +25,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NodeRemoveParameter class.
         /// </summary>
-        public NodeRemoveParameter() { }
+        public NodeRemoveParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NodeRemoveParameter class.
         /// </summary>
-        /// <param name="nodeList">A list containing the ids of the compute
+        /// <param name="nodeList">A list containing the IDs of the compute
         /// nodes to be removed from the specified pool.</param>
         /// <param name="resizeTimeout">The timeout for removal of compute
         /// nodes to the pool.</param>
         /// <param name="nodeDeallocationOption">Determines what to do with a
         /// node and its running task(s) after it has been selected for
         /// deallocation.</param>
-        public NodeRemoveParameter(System.Collections.Generic.IList<string> nodeList, System.TimeSpan? resizeTimeout = default(System.TimeSpan?), ComputeNodeDeallocationOption? nodeDeallocationOption = default(ComputeNodeDeallocationOption?))
+        public NodeRemoveParameter(IList<string> nodeList, System.TimeSpan? resizeTimeout = default(System.TimeSpan?), ComputeNodeDeallocationOption? nodeDeallocationOption = default(ComputeNodeDeallocationOption?))
         {
-            this.NodeList = nodeList;
-            this.ResizeTimeout = resizeTimeout;
-            this.NodeDeallocationOption = nodeDeallocationOption;
+            NodeList = nodeList;
+            ResizeTimeout = resizeTimeout;
+            NodeDeallocationOption = nodeDeallocationOption;
+            CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets a list containing the ids of the compute nodes to be
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets a list containing the IDs of the compute nodes to be
         /// removed from the specified pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeList")]
-        public System.Collections.Generic.IList<string> NodeList { get; set; }
+        [JsonProperty(PropertyName = "nodeList")]
+        public IList<string> NodeList { get; set; }
 
         /// <summary>
         /// Gets or sets the timeout for removal of compute nodes to the pool.
@@ -53,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// an error; if you are calling the REST API directly, the HTTP status
         /// code is 400 (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resizeTimeout")]
+        [JsonProperty(PropertyName = "resizeTimeout")]
         public System.TimeSpan? ResizeTimeout { get; set; }
 
         /// <summary>
@@ -64,26 +80,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The default value is requeue. Possible values include: 'requeue',
         /// 'terminate', 'taskCompletion', 'retainedData'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeDeallocationOption")]
+        [JsonProperty(PropertyName = "nodeDeallocationOption")]
         public ComputeNodeDeallocationOption? NodeDeallocationOption { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.NodeList == null)
+            if (NodeList == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "NodeList");
+                throw new ValidationException(ValidationRules.CannotBeNull, "NodeList");
             }
-            if (this.NodeList != null)
+            if (NodeList != null)
             {
-                if (this.NodeList.Count > 100)
+                if (NodeList.Count > 100)
                 {
-                    throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.MaxItems, "NodeList", 100);
+                    throw new ValidationException(ValidationRules.MaxItems, "NodeList", 100);
                 }
             }
         }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeUpdateUserParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/NodeUpdateUserParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the NodeUpdateUserParameter class.
         /// </summary>
-        public NodeUpdateUserParameter() { }
+        public NodeUpdateUserParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the NodeUpdateUserParameter class.
@@ -30,10 +37,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// remote login to the compute node.</param>
         public NodeUpdateUserParameter(string password = default(string), System.DateTime? expiryTime = default(System.DateTime?), string sshPublicKey = default(string))
         {
-            this.Password = password;
-            this.ExpiryTime = expiryTime;
-            this.SshPublicKey = sshPublicKey;
+            Password = password;
+            ExpiryTime = expiryTime;
+            SshPublicKey = sshPublicKey;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the password of the account.
@@ -46,7 +59,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// with the sshPublicKey property. If omitted, any existing password
         /// is removed.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "password")]
+        [JsonProperty(PropertyName = "password")]
         public string Password { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, the default is 1 day from the current time. For Linux
         /// compute nodes, the expiryTime has a precision up to a day.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "expiryTime")]
+        [JsonProperty(PropertyName = "expiryTime")]
         public System.DateTime? ExpiryTime { get; set; }
 
         /// <summary>
@@ -71,7 +84,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// directly, the HTTP status code is 400 (Bad Request). If omitted,
         /// any existing SSH public key is removed.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "sshPublicKey")]
+        [JsonProperty(PropertyName = "sshPublicKey")]
         public string SshPublicKey { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OSDisk.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OSDisk.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the OSDisk class.
         /// </summary>
-        public OSDisk() { }
+        public OSDisk()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the OSDisk class.
@@ -27,11 +37,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// URIs.</param>
         /// <param name="caching">The type of caching to enable for the OS
         /// disk.</param>
-        public OSDisk(System.Collections.Generic.IList<string> imageUris, CachingType? caching = default(CachingType?))
+        public OSDisk(IList<string> imageUris, CachingType? caching = default(CachingType?))
         {
-            this.ImageUris = imageUris;
-            this.Caching = caching;
+            ImageUris = imageUris;
+            Caching = caching;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the collection of Virtual Hard Disk (VHD) URIs.
@@ -46,34 +62,38 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the pool. If you do not supply enough VHD URIs, the pool will
         /// partially allocate compute nodes, and a resize error will occur.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "imageUris")]
-        public System.Collections.Generic.IList<string> ImageUris { get; set; }
+        [JsonProperty(PropertyName = "imageUris")]
+        public IList<string> ImageUris { get; set; }
 
         /// <summary>
         /// Gets or sets the type of caching to enable for the OS disk.
         /// </summary>
         /// <remarks>
-        /// none - The caching mode for the disk is not enabled. readOnly - The
-        /// caching mode for the disk is read only. readWrite - The caching
-        /// mode for the disk is read and write. The default value for caching
-        /// is none. For information about the caching options see:
+        /// Values are:
+        ///
+        /// none - The caching mode for the disk is not enabled.
+        /// readOnly - The caching mode for the disk is read only.
+        /// readWrite - The caching mode for the disk is read and write.
+        ///
+        /// The default value for caching is none. For information about the
+        /// caching options see:
         /// https://blogs.msdn.microsoft.com/windowsazurestorage/2012/06/27/exploring-windows-azure-drives-disks-and-images/.
         /// Possible values include: 'none', 'readOnly', 'readWrite'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "caching")]
+        [JsonProperty(PropertyName = "caching")]
         public CachingType? Caching { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.ImageUris == null)
+            if (ImageUris == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "ImageUris");
+                throw new ValidationException(ValidationRules.CannotBeNull, "ImageUris");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OSType.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OSType.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for OSType.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum OSType
     {
-        [System.Runtime.Serialization.EnumMember(Value = "linux")]
+        [EnumMember(Value = "linux")]
         Linux,
-        [System.Runtime.Serialization.EnumMember(Value = "windows")]
+        [EnumMember(Value = "windows")]
         Windows
+    }
+    internal static class OSTypeEnumExtension
+    {
+        internal static string ToSerializedValue(this OSType? value)  =>
+            value == null ? null : ((OSType)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this OSType value)
+        {
+            switch( value )
+            {
+                case OSType.Linux:
+                    return "linux";
+                case OSType.Windows:
+                    return "windows";
+            }
+            return null;
+        }
+
+        internal static OSType? ParseOSType(this string value)
+        {
+            switch( value )
+            {
+                case "linux":
+                    return OSType.Linux;
+                case "windows":
+                    return OSType.Windows;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OnAllTasksComplete.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OnAllTasksComplete.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for OnAllTasksComplete.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum OnAllTasksComplete
     {
-        [System.Runtime.Serialization.EnumMember(Value = "noAction")]
+        [EnumMember(Value = "noAction")]
         NoAction,
-        [System.Runtime.Serialization.EnumMember(Value = "terminateJob")]
+        [EnumMember(Value = "terminateJob")]
         TerminateJob
+    }
+    internal static class OnAllTasksCompleteEnumExtension
+    {
+        internal static string ToSerializedValue(this OnAllTasksComplete? value)  =>
+            value == null ? null : ((OnAllTasksComplete)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this OnAllTasksComplete value)
+        {
+            switch( value )
+            {
+                case OnAllTasksComplete.NoAction:
+                    return "noAction";
+                case OnAllTasksComplete.TerminateJob:
+                    return "terminateJob";
+            }
+            return null;
+        }
+
+        internal static OnAllTasksComplete? ParseOnAllTasksComplete(this string value)
+        {
+            switch( value )
+            {
+                case "noAction":
+                    return OnAllTasksComplete.NoAction;
+                case "terminateJob":
+                    return OnAllTasksComplete.TerminateJob;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OnTaskFailure.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OnTaskFailure.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for OnTaskFailure.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum OnTaskFailure
     {
-        [System.Runtime.Serialization.EnumMember(Value = "noAction")]
+        [EnumMember(Value = "noAction")]
         NoAction,
-        [System.Runtime.Serialization.EnumMember(Value = "performExitOptionsJobAction")]
+        [EnumMember(Value = "performExitOptionsJobAction")]
         PerformExitOptionsJobAction
+    }
+    internal static class OnTaskFailureEnumExtension
+    {
+        internal static string ToSerializedValue(this OnTaskFailure? value)  =>
+            value == null ? null : ((OnTaskFailure)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this OnTaskFailure value)
+        {
+            switch( value )
+            {
+                case OnTaskFailure.NoAction:
+                    return "noAction";
+                case OnTaskFailure.PerformExitOptionsJobAction:
+                    return "performExitOptionsJobAction";
+            }
+            return null;
+        }
+
+        internal static OnTaskFailure? ParseOnTaskFailure(this string value)
+        {
+            switch( value )
+            {
+                case "noAction":
+                    return OnTaskFailure.NoAction;
+                case "performExitOptionsJobAction":
+                    return OnTaskFailure.PerformExitOptionsJobAction;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFile.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFile.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the OutputFile class.
         /// </summary>
-        public OutputFile() { }
+        public OutputFile()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the OutputFile class.
@@ -34,10 +42,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// upload.</param>
         public OutputFile(string filePattern, OutputFileDestination destination, OutputFileUploadOptions uploadOptions)
         {
-            this.FilePattern = filePattern;
-            this.Destination = destination;
-            this.UploadOptions = uploadOptions;
+            FilePattern = filePattern;
+            Destination = destination;
+            UploadOptions = uploadOptions;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a pattern indicating which file(s) to upload.
@@ -62,49 +76,49 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// variables (%var% on Windows or $var on Linux) are expanded prior to
         /// the pattern being applied.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "filePattern")]
+        [JsonProperty(PropertyName = "filePattern")]
         public string FilePattern { get; set; }
 
         /// <summary>
         /// Gets or sets the destination for the output file(s).
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "destination")]
+        [JsonProperty(PropertyName = "destination")]
         public OutputFileDestination Destination { get; set; }
 
         /// <summary>
         /// Gets or sets additional options for the upload operation, including
         /// under what conditions to perform the upload.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "uploadOptions")]
+        [JsonProperty(PropertyName = "uploadOptions")]
         public OutputFileUploadOptions UploadOptions { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.FilePattern == null)
+            if (FilePattern == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "FilePattern");
+                throw new ValidationException(ValidationRules.CannotBeNull, "FilePattern");
             }
-            if (this.Destination == null)
+            if (Destination == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Destination");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Destination");
             }
-            if (this.UploadOptions == null)
+            if (UploadOptions == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "UploadOptions");
+                throw new ValidationException(ValidationRules.CannotBeNull, "UploadOptions");
             }
-            if (this.Destination != null)
+            if (Destination != null)
             {
-                this.Destination.Validate();
+                Destination.Validate();
             }
-            if (this.UploadOptions != null)
+            if (UploadOptions != null)
             {
-                this.UploadOptions.Validate();
+                UploadOptions.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFileBlobContainerDestination.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFileBlobContainerDestination.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// OutputFileBlobContainerDestination class.
         /// </summary>
-        public OutputFileBlobContainerDestination() { }
+        public OutputFileBlobContainerDestination()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -32,9 +40,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the Azure Storage container.</param>
         public OutputFileBlobContainerDestination(string containerUrl, string path = default(string))
         {
-            this.Path = path;
-            this.ContainerUrl = containerUrl;
+            Path = path;
+            ContainerUrl = containerUrl;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the destination blob or virtual directory within the
@@ -50,7 +64,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the root of the container with a blob name matching their file
         /// name.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "path")]
+        [JsonProperty(PropertyName = "path")]
         public string Path { get; set; }
 
         /// <summary>
@@ -61,20 +75,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The URL must include a Shared Access Signature (SAS) granting write
         /// permissions to the container.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "containerUrl")]
+        [JsonProperty(PropertyName = "containerUrl")]
         public string ContainerUrl { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.ContainerUrl == null)
+            if (ContainerUrl == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "ContainerUrl");
+                throw new ValidationException(ValidationRules.CannotBeNull, "ContainerUrl");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFileDestination.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFileDestination.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the OutputFileDestination class.
         /// </summary>
-        public OutputFileDestination() { }
+        public OutputFileDestination()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the OutputFileDestination class.
@@ -27,27 +34,33 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// files are uploaded.</param>
         public OutputFileDestination(OutputFileBlobContainerDestination container = default(OutputFileBlobContainerDestination))
         {
-            this.Container = container;
+            Container = container;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a location in Azure blob storage to which files are
         /// uploaded.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "container")]
+        [JsonProperty(PropertyName = "container")]
         public OutputFileBlobContainerDestination Container { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Container != null)
+            if (Container != null)
             {
-                this.Container.Validate();
+                Container.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFileUploadCondition.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFileUploadCondition.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for OutputFileUploadCondition.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum OutputFileUploadCondition
     {
-        [System.Runtime.Serialization.EnumMember(Value = "taskSuccess")]
+        [EnumMember(Value = "taskSuccess")]
         TaskSuccess,
-        [System.Runtime.Serialization.EnumMember(Value = "taskFailure")]
+        [EnumMember(Value = "taskFailure")]
         TaskFailure,
-        [System.Runtime.Serialization.EnumMember(Value = "taskCompletion")]
+        [EnumMember(Value = "taskCompletion")]
         TaskCompletion
+    }
+    internal static class OutputFileUploadConditionEnumExtension
+    {
+        internal static string ToSerializedValue(this OutputFileUploadCondition? value)  =>
+            value == null ? null : ((OutputFileUploadCondition)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this OutputFileUploadCondition value)
+        {
+            switch( value )
+            {
+                case OutputFileUploadCondition.TaskSuccess:
+                    return "taskSuccess";
+                case OutputFileUploadCondition.TaskFailure:
+                    return "taskFailure";
+                case OutputFileUploadCondition.TaskCompletion:
+                    return "taskCompletion";
+            }
+            return null;
+        }
+
+        internal static OutputFileUploadCondition? ParseOutputFileUploadCondition(this string value)
+        {
+            switch( value )
+            {
+                case "taskSuccess":
+                    return OutputFileUploadCondition.TaskSuccess;
+                case "taskFailure":
+                    return OutputFileUploadCondition.TaskFailure;
+                case "taskCompletion":
+                    return OutputFileUploadCondition.TaskCompletion;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFileUploadOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/OutputFileUploadOptions.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the OutputFileUploadOptions class.
         /// </summary>
-        public OutputFileUploadOptions() { }
+        public OutputFileUploadOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the OutputFileUploadOptions class.
@@ -28,8 +35,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// output file or set of files should be uploaded.</param>
         public OutputFileUploadOptions(OutputFileUploadCondition uploadCondition)
         {
-            this.UploadCondition = uploadCondition;
+            UploadCondition = uploadCondition;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the conditions under which the task output file or set
@@ -39,13 +52,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The default is taskCompletion. Possible values include:
         /// 'taskSuccess', 'taskFailure', 'taskCompletion'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "uploadCondition")]
+        [JsonProperty(PropertyName = "uploadCondition")]
         public OutputFileUploadCondition UploadCondition { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/Page.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/Page.cs
@@ -8,37 +8,45 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Azure;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Defines a page in Azure responses.
     /// </summary>
     /// <typeparam name="T">Type of the page content items</typeparam>
-    [Newtonsoft.Json.JsonObject]
-    public class Page<T> : Microsoft.Rest.Azure.IPage<T>
+    [JsonObject]
+    public class Page<T> : IPage<T>
     {
          /// <summary>
          /// Gets the link to the next page.
          /// </summary>
-         [Newtonsoft.Json.JsonProperty("odata.nextLink")]
-         public System.String NextPageLink { get; private set; }
+         [JsonProperty("odata.nextLink")]
+         public string NextPageLink { get; private set; }
 
-         [Newtonsoft.Json.JsonProperty("value")]
-         private System.Collections.Generic.IList<T> Items{ get; set; }
+         [JsonProperty("value")]
+         private IList<T> Items{ get; set; }
 
          /// <summary>
          /// Returns an enumerator that iterates through the collection.
          /// </summary>
          /// <returns>A an enumerator that can be used to iterate through the collection.</returns>
-         public System.Collections.Generic.IEnumerator<T> GetEnumerator()
+         public IEnumerator<T> GetEnumerator()
          {
-              return (Items == null) ? System.Linq.Enumerable.Empty<T>().GetEnumerator() : Items.GetEnumerator();
+              return Items == null ? System.Linq.Enumerable.Empty<T>().GetEnumerator() : Items.GetEnumerator();
          }
 
          /// <summary>
          /// Returns an enumerator that iterates through the collection.
          /// </summary>
          /// <returns>A an enumerator that can be used to iterate through the collection.</returns>
-         System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+         IEnumerator IEnumerable.GetEnumerator()
          {
              return GetEnumerator();
          }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolAddHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolAddHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolAddHeaders class.
         /// </summary>
-        public PoolAddHeaders() { }
+        public PoolAddHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolAddHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolAddHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolAddOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolAddOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolAddOptions class.
         /// </summary>
-        public PoolAddOptions() { }
+        public PoolAddOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolAddOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolAddOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolAddParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolAddParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolAddParameter class.
         /// </summary>
-        public PoolAddParameter() { }
+        public PoolAddParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolAddParameter class.
@@ -60,36 +70,42 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// pool.</param>
         /// <param name="maxTasksPerNode">The maximum number of tasks that can
         /// run concurrently on a single compute node in the pool.</param>
-        /// <param name="taskSchedulingPolicy">How the Batch service
-        /// distributes tasks between compute nodes in the pool.</param>
+        /// <param name="taskSchedulingPolicy">How tasks are distributed across
+        /// compute nodes in a pool.</param>
         /// <param name="userAccounts">The list of user accounts to be created
         /// on each node in the pool.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the pool as metadata.</param>
-        public PoolAddParameter(string id, string vmSize, string displayName = default(string), CloudServiceConfiguration cloudServiceConfiguration = default(CloudServiceConfiguration), VirtualMachineConfiguration virtualMachineConfiguration = default(VirtualMachineConfiguration), System.TimeSpan? resizeTimeout = default(System.TimeSpan?), int? targetDedicatedNodes = default(int?), int? targetLowPriorityNodes = default(int?), bool? enableAutoScale = default(bool?), string autoScaleFormula = default(string), System.TimeSpan? autoScaleEvaluationInterval = default(System.TimeSpan?), bool? enableInterNodeCommunication = default(bool?), NetworkConfiguration networkConfiguration = default(NetworkConfiguration), StartTask startTask = default(StartTask), System.Collections.Generic.IList<CertificateReference> certificateReferences = default(System.Collections.Generic.IList<CertificateReference>), System.Collections.Generic.IList<ApplicationPackageReference> applicationPackageReferences = default(System.Collections.Generic.IList<ApplicationPackageReference>), System.Collections.Generic.IList<string> applicationLicenses = default(System.Collections.Generic.IList<string>), int? maxTasksPerNode = default(int?), TaskSchedulingPolicy taskSchedulingPolicy = default(TaskSchedulingPolicy), System.Collections.Generic.IList<UserAccount> userAccounts = default(System.Collections.Generic.IList<UserAccount>), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>))
+        public PoolAddParameter(string id, string vmSize, string displayName = default(string), CloudServiceConfiguration cloudServiceConfiguration = default(CloudServiceConfiguration), VirtualMachineConfiguration virtualMachineConfiguration = default(VirtualMachineConfiguration), System.TimeSpan? resizeTimeout = default(System.TimeSpan?), int? targetDedicatedNodes = default(int?), int? targetLowPriorityNodes = default(int?), bool? enableAutoScale = default(bool?), string autoScaleFormula = default(string), System.TimeSpan? autoScaleEvaluationInterval = default(System.TimeSpan?), bool? enableInterNodeCommunication = default(bool?), NetworkConfiguration networkConfiguration = default(NetworkConfiguration), StartTask startTask = default(StartTask), IList<CertificateReference> certificateReferences = default(IList<CertificateReference>), IList<ApplicationPackageReference> applicationPackageReferences = default(IList<ApplicationPackageReference>), IList<string> applicationLicenses = default(IList<string>), int? maxTasksPerNode = default(int?), TaskSchedulingPolicy taskSchedulingPolicy = default(TaskSchedulingPolicy), IList<UserAccount> userAccounts = default(IList<UserAccount>), IList<MetadataItem> metadata = default(IList<MetadataItem>))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.VmSize = vmSize;
-            this.CloudServiceConfiguration = cloudServiceConfiguration;
-            this.VirtualMachineConfiguration = virtualMachineConfiguration;
-            this.ResizeTimeout = resizeTimeout;
-            this.TargetDedicatedNodes = targetDedicatedNodes;
-            this.TargetLowPriorityNodes = targetLowPriorityNodes;
-            this.EnableAutoScale = enableAutoScale;
-            this.AutoScaleFormula = autoScaleFormula;
-            this.AutoScaleEvaluationInterval = autoScaleEvaluationInterval;
-            this.EnableInterNodeCommunication = enableInterNodeCommunication;
-            this.NetworkConfiguration = networkConfiguration;
-            this.StartTask = startTask;
-            this.CertificateReferences = certificateReferences;
-            this.ApplicationPackageReferences = applicationPackageReferences;
-            this.ApplicationLicenses = applicationLicenses;
-            this.MaxTasksPerNode = maxTasksPerNode;
-            this.TaskSchedulingPolicy = taskSchedulingPolicy;
-            this.UserAccounts = userAccounts;
-            this.Metadata = metadata;
+            Id = id;
+            DisplayName = displayName;
+            VmSize = vmSize;
+            CloudServiceConfiguration = cloudServiceConfiguration;
+            VirtualMachineConfiguration = virtualMachineConfiguration;
+            ResizeTimeout = resizeTimeout;
+            TargetDedicatedNodes = targetDedicatedNodes;
+            TargetLowPriorityNodes = targetLowPriorityNodes;
+            EnableAutoScale = enableAutoScale;
+            AutoScaleFormula = autoScaleFormula;
+            AutoScaleEvaluationInterval = autoScaleEvaluationInterval;
+            EnableInterNodeCommunication = enableInterNodeCommunication;
+            NetworkConfiguration = networkConfiguration;
+            StartTask = startTask;
+            CertificateReferences = certificateReferences;
+            ApplicationPackageReferences = applicationPackageReferences;
+            ApplicationLicenses = applicationLicenses;
+            MaxTasksPerNode = maxTasksPerNode;
+            TaskSchedulingPolicy = taskSchedulingPolicy;
+            UserAccounts = userAccounts;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the pool within the
@@ -102,7 +118,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// is, you may not have two pool IDs within an account that differ
         /// only by case).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -112,7 +128,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The display name need not be unique and can contain any Unicode
         /// characters up to a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
@@ -135,7 +151,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// premium storage (STANDARD_GS, STANDARD_DS, and STANDARD_DSV2
         /// series).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "vmSize")]
+        [JsonProperty(PropertyName = "vmSize")]
         public string VmSize { get; set; }
 
         /// <summary>
@@ -147,7 +163,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// property cannot be specified if the Batch account was created with
         /// its poolAllocationMode property set to 'UserSubscription'.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "cloudServiceConfiguration")]
+        [JsonProperty(PropertyName = "cloudServiceConfiguration")]
         public CloudServiceConfiguration CloudServiceConfiguration { get; set; }
 
         /// <summary>
@@ -157,7 +173,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property and cloudServiceConfiguration are mutually exclusive
         /// and one of the properties must be specified.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "virtualMachineConfiguration")]
+        [JsonProperty(PropertyName = "virtualMachineConfiguration")]
         public VirtualMachineConfiguration VirtualMachineConfiguration { get; set; }
 
         /// <summary>
@@ -171,7 +187,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// minutes, the Batch service returns an error; if you are calling the
         /// REST API directly, the HTTP status code is 400 (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resizeTimeout")]
+        [JsonProperty(PropertyName = "resizeTimeout")]
         public System.TimeSpan? ResizeTimeout { get; set; }
 
         /// <summary>
@@ -183,7 +199,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// true. If enableAutoScale is set to false, then you must set either
         /// targetDedicatedNodes, targetLowPriorityNodes, or both.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetDedicatedNodes")]
+        [JsonProperty(PropertyName = "targetDedicatedNodes")]
         public int? TargetDedicatedNodes { get; set; }
 
         /// <summary>
@@ -195,7 +211,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// true. If enableAutoScale is set to false, then you must set either
         /// targetDedicatedNodes, targetLowPriorityNodes, or both.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetLowPriorityNodes")]
+        [JsonProperty(PropertyName = "targetLowPriorityNodes")]
         public int? TargetLowPriorityNodes { get; set; }
 
         /// <summary>
@@ -208,7 +224,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// autoScaleFormula property is required and the pool automatically
         /// resizes according to the formula. The default value is false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "enableAutoScale")]
+        [JsonProperty(PropertyName = "enableAutoScale")]
         public bool? EnableAutoScale { get; set; }
 
         /// <summary>
@@ -225,7 +241,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch pool'
         /// (https://azure.microsoft.com/documentation/articles/batch-automatic-scaling/).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleFormula")]
+        [JsonProperty(PropertyName = "autoScaleFormula")]
         public string AutoScaleFormula { get; set; }
 
         /// <summary>
@@ -239,7 +255,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// an error; if you are calling the REST API directly, the HTTP status
         /// code is 400 (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleEvaluationInterval")]
+        [JsonProperty(PropertyName = "autoScaleEvaluationInterval")]
         public System.TimeSpan? AutoScaleEvaluationInterval { get; set; }
 
         /// <summary>
@@ -252,13 +268,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// may result in the pool not reaching its desired size. The default
         /// value is false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "enableInterNodeCommunication")]
+        [JsonProperty(PropertyName = "enableInterNodeCommunication")]
         public bool? EnableInterNodeCommunication { get; set; }
 
         /// <summary>
         /// Gets or sets the network configuration for the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "networkConfiguration")]
+        [JsonProperty(PropertyName = "networkConfiguration")]
         public NetworkConfiguration NetworkConfiguration { get; set; }
 
         /// <summary>
@@ -269,7 +285,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The task runs when the node is added to the pool or when the node
         /// is restarted.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTask")]
+        [JsonProperty(PropertyName = "startTask")]
         public StartTask StartTask { get; set; }
 
         /// <summary>
@@ -287,15 +303,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// /home/{user-name}/certs) and certificates are placed in that
         /// directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "certificateReferences")]
-        public System.Collections.Generic.IList<CertificateReference> CertificateReferences { get; set; }
+        [JsonProperty(PropertyName = "certificateReferences")]
+        public IList<CertificateReference> CertificateReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the list of application packages to be installed on
         /// each compute node in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationPackageReferences")]
-        public System.Collections.Generic.IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
+        [JsonProperty(PropertyName = "applicationPackageReferences")]
+        public IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the list of application licenses the Batch service
@@ -306,8 +322,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch service application licenses. If a license is requested which
         /// is not supported, pool creation will fail.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationLicenses")]
-        public System.Collections.Generic.IList<string> ApplicationLicenses { get; set; }
+        [JsonProperty(PropertyName = "applicationLicenses")]
+        public IList<string> ApplicationLicenses { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of tasks that can run concurrently
@@ -317,22 +333,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The default value is 1. The maximum value of this setting depends
         /// on the size of the compute nodes in the pool (the vmSize setting).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxTasksPerNode")]
+        [JsonProperty(PropertyName = "maxTasksPerNode")]
         public int? MaxTasksPerNode { get; set; }
 
         /// <summary>
-        /// Gets or sets how the Batch service distributes tasks between
-        /// compute nodes in the pool.
+        /// Gets or sets how tasks are distributed across compute nodes in a
+        /// pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskSchedulingPolicy")]
+        [JsonProperty(PropertyName = "taskSchedulingPolicy")]
         public TaskSchedulingPolicy TaskSchedulingPolicy { get; set; }
 
         /// <summary>
         /// Gets or sets the list of user accounts to be created on each node
         /// in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userAccounts")]
-        public System.Collections.Generic.IList<UserAccount> UserAccounts { get; set; }
+        [JsonProperty(PropertyName = "userAccounts")]
+        public IList<UserAccount> UserAccounts { get; set; }
 
         /// <summary>
         /// Gets or sets a list of name-value pairs associated with the pool as
@@ -342,44 +358,44 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Batch service does not assign any meaning to metadata; it is
         /// solely for the use of user code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Id == null)
+            if (Id == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Id");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Id");
             }
-            if (this.VmSize == null)
+            if (VmSize == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "VmSize");
+                throw new ValidationException(ValidationRules.CannotBeNull, "VmSize");
             }
-            if (this.CloudServiceConfiguration != null)
+            if (CloudServiceConfiguration != null)
             {
-                this.CloudServiceConfiguration.Validate();
+                CloudServiceConfiguration.Validate();
             }
-            if (this.VirtualMachineConfiguration != null)
+            if (VirtualMachineConfiguration != null)
             {
-                this.VirtualMachineConfiguration.Validate();
+                VirtualMachineConfiguration.Validate();
             }
-            if (this.NetworkConfiguration != null)
+            if (NetworkConfiguration != null)
             {
-                this.NetworkConfiguration.Validate();
+                NetworkConfiguration.Validate();
             }
-            if (this.StartTask != null)
+            if (StartTask != null)
             {
-                this.StartTask.Validate();
+                StartTask.Validate();
             }
-            if (this.CertificateReferences != null)
+            if (CertificateReferences != null)
             {
-                foreach (var element in this.CertificateReferences)
+                foreach (var element in CertificateReferences)
                 {
                     if (element != null)
                     {
@@ -387,9 +403,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.ApplicationPackageReferences != null)
+            if (ApplicationPackageReferences != null)
             {
-                foreach (var element1 in this.ApplicationPackageReferences)
+                foreach (var element1 in ApplicationPackageReferences)
                 {
                     if (element1 != null)
                     {
@@ -397,13 +413,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.TaskSchedulingPolicy != null)
+            if (TaskSchedulingPolicy != null)
             {
-                this.TaskSchedulingPolicy.Validate();
+                TaskSchedulingPolicy.Validate();
             }
-            if (this.UserAccounts != null)
+            if (UserAccounts != null)
             {
-                foreach (var element2 in this.UserAccounts)
+                foreach (var element2 in UserAccounts)
                 {
                     if (element2 != null)
                     {
@@ -411,9 +427,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element3 in this.Metadata)
+                foreach (var element3 in Metadata)
                 {
                     if (element3 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolDeleteHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolDeleteHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolDeleteHeaders class.
         /// </summary>
-        public PoolDeleteHeaders() { }
+        public PoolDeleteHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolDeleteHeaders class.
@@ -35,16 +42,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public PoolDeleteHeaders(string clientRequestId = default(string), string requestId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public string ClientRequestId { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public string RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolDeleteOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolDeleteOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolDeleteOptions class.
         /// </summary>
-        public PoolDeleteOptions() { }
+        public PoolDeleteOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolDeleteOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolDeleteOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolDisableAutoScaleHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolDisableAutoScaleHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolDisableAutoScaleHeaders
         /// class.
         /// </summary>
-        public PoolDisableAutoScaleHeaders() { }
+        public PoolDisableAutoScaleHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolDisableAutoScaleHeaders
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolDisableAutoScaleHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -70,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -80,21 +95,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolDisableAutoScaleOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolDisableAutoScaleOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolDisableAutoScaleOptions
         /// class.
         /// </summary>
-        public PoolDisableAutoScaleOptions() { }
+        public PoolDisableAutoScaleOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolDisableAutoScaleOptions
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolDisableAutoScaleOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEnableAutoScaleHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEnableAutoScaleHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolEnableAutoScaleHeaders class.
         /// </summary>
-        public PoolEnableAutoScaleHeaders() { }
+        public PoolEnableAutoScaleHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolEnableAutoScaleHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolEnableAutoScaleHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEnableAutoScaleOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEnableAutoScaleOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolEnableAutoScaleOptions class.
         /// </summary>
-        public PoolEnableAutoScaleOptions() { }
+        public PoolEnableAutoScaleOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolEnableAutoScaleOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolEnableAutoScaleOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEnableAutoScaleParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEnableAutoScaleParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolEnableAutoScaleParameter
         /// class.
         /// </summary>
-        public PoolEnableAutoScaleParameter() { }
+        public PoolEnableAutoScaleParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolEnableAutoScaleParameter
@@ -32,9 +39,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// autoscale formula.</param>
         public PoolEnableAutoScaleParameter(string autoScaleFormula = default(string), System.TimeSpan? autoScaleEvaluationInterval = default(System.TimeSpan?))
         {
-            this.AutoScaleFormula = autoScaleFormula;
-            this.AutoScaleEvaluationInterval = autoScaleEvaluationInterval;
+            AutoScaleFormula = autoScaleFormula;
+            AutoScaleEvaluationInterval = autoScaleEvaluationInterval;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the formula for the desired number of compute nodes in
@@ -48,7 +61,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// an Azure Batch pool
         /// (https://azure.microsoft.com/en-us/documentation/articles/batch-automatic-scaling).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleFormula")]
+        [JsonProperty(PropertyName = "autoScaleFormula")]
         public string AutoScaleFormula { get; set; }
 
         /// <summary>
@@ -66,7 +79,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// evaluation schedule will be started, with its starting time being
         /// the time when this request was issued.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleEvaluationInterval")]
+        [JsonProperty(PropertyName = "autoScaleEvaluationInterval")]
         public System.TimeSpan? AutoScaleEvaluationInterval { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEndpointConfiguration.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEndpointConfiguration.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolEndpointConfiguration class.
         /// </summary>
-        public PoolEndpointConfiguration() { }
+        public PoolEndpointConfiguration()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolEndpointConfiguration class.
@@ -26,10 +36,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="inboundNATPools">A list of inbound NAT pools that can
         /// be used to address specific ports on an individual compute node
         /// externally.</param>
-        public PoolEndpointConfiguration(System.Collections.Generic.IList<InboundNATPool> inboundNATPools)
+        public PoolEndpointConfiguration(IList<InboundNATPool> inboundNATPools)
         {
-            this.InboundNATPools = inboundNATPools;
+            InboundNATPools = inboundNATPools;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a list of inbound NAT pools that can be used to
@@ -40,24 +56,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// maximum number of inbound NAT pools is exceeded the request fails
         /// with HTTP status code 400.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "inboundNATPools")]
-        public System.Collections.Generic.IList<InboundNATPool> InboundNATPools { get; set; }
+        [JsonProperty(PropertyName = "inboundNATPools")]
+        public IList<InboundNATPool> InboundNATPools { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.InboundNATPools == null)
+            if (InboundNATPools == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "InboundNATPools");
+                throw new ValidationException(ValidationRules.CannotBeNull, "InboundNATPools");
             }
-            if (this.InboundNATPools != null)
+            if (InboundNATPools != null)
             {
-                foreach (var element in this.InboundNATPools)
+                foreach (var element in InboundNATPools)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEvaluateAutoScaleHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEvaluateAutoScaleHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolEvaluateAutoScaleHeaders
         /// class.
         /// </summary>
-        public PoolEvaluateAutoScaleHeaders() { }
+        public PoolEvaluateAutoScaleHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolEvaluateAutoScaleHeaders
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolEvaluateAutoScaleHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -70,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -80,21 +95,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEvaluateAutoScaleOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEvaluateAutoScaleOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolEvaluateAutoScaleOptions
         /// class.
         /// </summary>
-        public PoolEvaluateAutoScaleOptions() { }
+        public PoolEvaluateAutoScaleOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolEvaluateAutoScaleOptions
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolEvaluateAutoScaleOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEvaluateAutoScaleParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolEvaluateAutoScaleParameter.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolEvaluateAutoScaleParameter
         /// class.
         /// </summary>
-        public PoolEvaluateAutoScaleParameter() { }
+        public PoolEvaluateAutoScaleParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolEvaluateAutoScaleParameter
@@ -29,8 +37,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// of compute nodes in the pool.</param>
         public PoolEvaluateAutoScaleParameter(string autoScaleFormula)
         {
-            this.AutoScaleFormula = autoScaleFormula;
+            AutoScaleFormula = autoScaleFormula;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the formula for the desired number of compute nodes in
@@ -44,20 +58,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch pool
         /// (https://azure.microsoft.com/en-us/documentation/articles/batch-automatic-scaling).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleFormula")]
+        [JsonProperty(PropertyName = "autoScaleFormula")]
         public string AutoScaleFormula { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.AutoScaleFormula == null)
+            if (AutoScaleFormula == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "AutoScaleFormula");
+                throw new ValidationException(ValidationRules.CannotBeNull, "AutoScaleFormula");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolExistsHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolExistsHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolExistsHeaders class.
         /// </summary>
-        public PoolExistsHeaders() { }
+        public PoolExistsHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolExistsHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public PoolExistsHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolExistsOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolExistsOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolExistsOptions class.
         /// </summary>
-        public PoolExistsOptions() { }
+        public PoolExistsOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolExistsOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolExistsOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolGetAllLifetimeStatisticsHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolGetAllLifetimeStatisticsHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// PoolGetAllLifetimeStatisticsHeaders class.
         /// </summary>
-        public PoolGetAllLifetimeStatisticsHeaders() { }
+        public PoolGetAllLifetimeStatisticsHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public PoolGetAllLifetimeStatisticsHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolGetAllLifetimeStatisticsOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolGetAllLifetimeStatisticsOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the
         /// PoolGetAllLifetimeStatisticsOptions class.
         /// </summary>
-        public PoolGetAllLifetimeStatisticsOptions() { }
+        public PoolGetAllLifetimeStatisticsOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolGetAllLifetimeStatisticsOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolGetHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolGetHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolGetHeaders class.
         /// </summary>
-        public PoolGetHeaders() { }
+        public PoolGetHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolGetHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public PoolGetHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolGetOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolGetOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolGetOptions class.
         /// </summary>
-        public PoolGetOptions() { }
+        public PoolGetOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolGetOptions class.
@@ -54,35 +63,41 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolGetOptions(string select = default(string), string expand = default(string), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Select = select;
-            this.Expand = expand;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Select = select;
+            Expand = expand;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -90,14 +105,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -105,8 +120,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -115,7 +130,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -124,7 +139,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -133,8 +148,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -143,8 +158,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolInformation class.
         /// </summary>
-        public PoolInformation() { }
+        public PoolInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolInformation class.
@@ -30,9 +37,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// job is submitted.</param>
         public PoolInformation(string poolId = default(string), AutoPoolSpecification autoPoolSpecification = default(AutoPoolSpecification))
         {
-            this.PoolId = poolId;
-            this.AutoPoolSpecification = autoPoolSpecification;
+            PoolId = poolId;
+            AutoPoolSpecification = autoPoolSpecification;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ID of an existing pool. All the tasks of the job
@@ -47,7 +60,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// You must specify either the pool ID or the auto pool specification,
         /// but not both.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolId")]
+        [JsonProperty(PropertyName = "poolId")]
         public string PoolId { get; set; }
 
         /// <summary>
@@ -64,20 +77,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// You must specify either the pool ID or the auto pool specification,
         /// but not both.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoPoolSpecification")]
+        [JsonProperty(PropertyName = "autoPoolSpecification")]
         public AutoPoolSpecification AutoPoolSpecification { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.AutoPoolSpecification != null)
+            if (AutoPoolSpecification != null)
             {
-                this.AutoPoolSpecification.Validate();
+                AutoPoolSpecification.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolLifetimeOption.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolLifetimeOption.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for PoolLifetimeOption.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum PoolLifetimeOption
     {
-        [System.Runtime.Serialization.EnumMember(Value = "jobSchedule")]
+        [EnumMember(Value = "jobSchedule")]
         JobSchedule,
-        [System.Runtime.Serialization.EnumMember(Value = "job")]
+        [EnumMember(Value = "job")]
         Job
+    }
+    internal static class PoolLifetimeOptionEnumExtension
+    {
+        internal static string ToSerializedValue(this PoolLifetimeOption? value)  =>
+            value == null ? null : ((PoolLifetimeOption)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this PoolLifetimeOption value)
+        {
+            switch( value )
+            {
+                case PoolLifetimeOption.JobSchedule:
+                    return "jobSchedule";
+                case PoolLifetimeOption.Job:
+                    return "job";
+            }
+            return null;
+        }
+
+        internal static PoolLifetimeOption? ParsePoolLifetimeOption(this string value)
+        {
+            switch( value )
+            {
+                case "jobSchedule":
+                    return PoolLifetimeOption.JobSchedule;
+                case "job":
+                    return PoolLifetimeOption.Job;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolListHeaders class.
         /// </summary>
-        public PoolListHeaders() { }
+        public PoolListHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolListHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public PoolListHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolListNextOptions class.
         /// </summary>
-        public PoolListNextOptions() { }
+        public PoolListNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolListNextOptions class.
@@ -33,24 +42,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolListNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -58,8 +73,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolListOptions class.
         /// </summary>
-        public PoolListOptions() { }
+        public PoolListOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolListOptions class.
@@ -41,46 +50,52 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolListOptions(string filter = default(string), string select = default(string), string expand = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.Select = select;
-            this.Expand = expand;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            Select = select;
+            Expand = expand;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 pools can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -88,14 +103,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -103,8 +118,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListUsageMetricsHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListUsageMetricsHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolListUsageMetricsHeaders
         /// class.
         /// </summary>
-        public PoolListUsageMetricsHeaders() { }
+        public PoolListUsageMetricsHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolListUsageMetricsHeaders
@@ -44,18 +53,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public PoolListUsageMetricsHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -67,7 +82,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -77,14 +92,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListUsageMetricsNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListUsageMetricsNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolListUsageMetricsNextOptions
         /// class.
         /// </summary>
-        public PoolListUsageMetricsNextOptions() { }
+        public PoolListUsageMetricsNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolListUsageMetricsNextOptions
@@ -35,24 +44,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolListUsageMetricsNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -60,8 +75,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListUsageMetricsOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolListUsageMetricsOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolListUsageMetricsOptions
         /// class.
         /// </summary>
-        public PoolListUsageMetricsOptions() { }
+        public PoolListUsageMetricsOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolListUsageMetricsOptions
@@ -52,15 +61,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolListUsageMetricsOptions(System.DateTime? startTime = default(System.DateTime?), System.DateTime? endTime = default(System.DateTime?), string filter = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.StartTime = startTime;
-            this.EndTime = endTime;
-            this.Filter = filter;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            StartTime = startTime;
+            EndTime = endTime;
+            Filter = filter;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the earliest time from which to include metrics. This
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// not specified this defaults to the start time of the last
         /// aggregation interval currently available.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? StartTime { get; set; }
 
         /// <summary>
@@ -77,7 +92,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// specified this defaults to the end time of the last aggregation
         /// interval currently available.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? EndTime { get; set; }
 
         /// <summary>
@@ -85,21 +100,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// response includes all pools that existed in the account in the time
         /// range of the returned aggregation intervals.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 results will be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -107,14 +122,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -122,8 +137,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolPatchHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolPatchHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolPatchHeaders class.
         /// </summary>
-        public PoolPatchHeaders() { }
+        public PoolPatchHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolPatchHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolPatchHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolPatchOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolPatchOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolPatchOptions class.
         /// </summary>
-        public PoolPatchOptions() { }
+        public PoolPatchOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolPatchOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolPatchOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolPatchParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolPatchParameter.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolPatchParameter class.
         /// </summary>
-        public PoolPatchParameter() { }
+        public PoolPatchParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolPatchParameter class.
@@ -32,13 +41,19 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// packages to be installed on each compute node in the pool.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the pool as metadata.</param>
-        public PoolPatchParameter(StartTask startTask = default(StartTask), System.Collections.Generic.IList<CertificateReference> certificateReferences = default(System.Collections.Generic.IList<CertificateReference>), System.Collections.Generic.IList<ApplicationPackageReference> applicationPackageReferences = default(System.Collections.Generic.IList<ApplicationPackageReference>), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>))
+        public PoolPatchParameter(StartTask startTask = default(StartTask), IList<CertificateReference> certificateReferences = default(IList<CertificateReference>), IList<ApplicationPackageReference> applicationPackageReferences = default(IList<ApplicationPackageReference>), IList<MetadataItem> metadata = default(IList<MetadataItem>))
         {
-            this.StartTask = startTask;
-            this.CertificateReferences = certificateReferences;
-            this.ApplicationPackageReferences = applicationPackageReferences;
-            this.Metadata = metadata;
+            StartTask = startTask;
+            CertificateReferences = certificateReferences;
+            ApplicationPackageReferences = applicationPackageReferences;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a task to run on each compute node as it joins the
@@ -46,9 +61,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// node is restarted.
         /// </summary>
         /// <remarks>
+        /// If this element is present, it overwrites any existing start task.
         /// If omitted, any existing start task is left unchanged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTask")]
+        [JsonProperty(PropertyName = "startTask")]
         public StartTask StartTask { get; set; }
 
         /// <summary>
@@ -56,19 +72,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// node in the pool.
         /// </summary>
         /// <remarks>
-        /// If omitted, any existing certificate references are left unchanged.
-        /// For Windows compute nodes, the Batch service installs the
-        /// certificates to the specified certificate store and location. For
-        /// Linux compute nodes, the certificates are stored in a directory
-        /// inside the task working directory and an environment variable
-        /// AZ_BATCH_CERTIFICATES_DIR is supplied to the task to query for this
-        /// location. For certificates with visibility of 'remoteUser', a
-        /// 'certs' directory is created in the user's home directory (e.g.,
-        /// /home/{user-name}/certs) and certificates are placed in that
-        /// directory.
+        /// If this element is present, it replaces any existing certificate
+        /// references configured on the pool. If omitted, any existing
+        /// certificate references are left unchanged. For Windows compute
+        /// nodes, the Batch service installs the certificates to the specified
+        /// certificate store and location. For Linux compute nodes, the
+        /// certificates are stored in a directory inside the task working
+        /// directory and an environment variable AZ_BATCH_CERTIFICATES_DIR is
+        /// supplied to the task to query for this location. For certificates
+        /// with visibility of 'remoteUser', a 'certs' directory is created in
+        /// the user's home directory (e.g., /home/{user-name}/certs) and
+        /// certificates are placed in that directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "certificateReferences")]
-        public System.Collections.Generic.IList<CertificateReference> CertificateReferences { get; set; }
+        [JsonProperty(PropertyName = "certificateReferences")]
+        public IList<CertificateReference> CertificateReferences { get; set; }
 
         /// <summary>
         /// Gets or sets a list of application packages to be installed on each
@@ -84,8 +101,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// omitted, any existing application package references are left
         /// unchanged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationPackageReferences")]
-        public System.Collections.Generic.IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
+        [JsonProperty(PropertyName = "applicationPackageReferences")]
+        public IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets a list of name-value pairs associated with the pool as
@@ -97,24 +114,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// metadata is removed from the pool. If omitted, any existing
         /// metadata is left unchanged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.StartTask != null)
+            if (StartTask != null)
             {
-                this.StartTask.Validate();
+                StartTask.Validate();
             }
-            if (this.CertificateReferences != null)
+            if (CertificateReferences != null)
             {
-                foreach (var element in this.CertificateReferences)
+                foreach (var element in CertificateReferences)
                 {
                     if (element != null)
                     {
@@ -122,9 +139,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.ApplicationPackageReferences != null)
+            if (ApplicationPackageReferences != null)
             {
-                foreach (var element1 in this.ApplicationPackageReferences)
+                foreach (var element1 in ApplicationPackageReferences)
                 {
                     if (element1 != null)
                     {
@@ -132,9 +149,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element2 in this.Metadata)
+                foreach (var element2 in Metadata)
                 {
                     if (element2 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolRemoveNodesHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolRemoveNodesHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolRemoveNodesHeaders class.
         /// </summary>
-        public PoolRemoveNodesHeaders() { }
+        public PoolRemoveNodesHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolRemoveNodesHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolRemoveNodesHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolRemoveNodesOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolRemoveNodesOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolRemoveNodesOptions class.
         /// </summary>
-        public PoolRemoveNodesOptions() { }
+        public PoolRemoveNodesOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolRemoveNodesOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolRemoveNodesOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolResizeHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolResizeHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolResizeHeaders class.
         /// </summary>
-        public PoolResizeHeaders() { }
+        public PoolResizeHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolResizeHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolResizeHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolResizeOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolResizeOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolResizeOptions class.
         /// </summary>
-        public PoolResizeOptions() { }
+        public PoolResizeOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolResizeOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolResizeOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolResizeParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolResizeParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolResizeParameter class.
         /// </summary>
-        public PoolResizeParameter() { }
+        public PoolResizeParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolResizeParameter class.
@@ -35,24 +42,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// decreasing.</param>
         public PoolResizeParameter(int? targetDedicatedNodes = default(int?), int? targetLowPriorityNodes = default(int?), System.TimeSpan? resizeTimeout = default(System.TimeSpan?), ComputeNodeDeallocationOption? nodeDeallocationOption = default(ComputeNodeDeallocationOption?))
         {
-            this.TargetDedicatedNodes = targetDedicatedNodes;
-            this.TargetLowPriorityNodes = targetLowPriorityNodes;
-            this.ResizeTimeout = resizeTimeout;
-            this.NodeDeallocationOption = nodeDeallocationOption;
+            TargetDedicatedNodes = targetDedicatedNodes;
+            TargetLowPriorityNodes = targetLowPriorityNodes;
+            ResizeTimeout = resizeTimeout;
+            NodeDeallocationOption = nodeDeallocationOption;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the desired number of dedicated compute nodes in the
         /// pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetDedicatedNodes")]
+        [JsonProperty(PropertyName = "targetDedicatedNodes")]
         public int? TargetDedicatedNodes { get; set; }
 
         /// <summary>
         /// Gets or sets the desired number of low-priority compute nodes in
         /// the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetLowPriorityNodes")]
+        [JsonProperty(PropertyName = "targetLowPriorityNodes")]
         public int? TargetLowPriorityNodes { get; set; }
 
         /// <summary>
@@ -65,7 +78,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// an error; if you are calling the REST API directly, the HTTP status
         /// code is 400 (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resizeTimeout")]
+        [JsonProperty(PropertyName = "resizeTimeout")]
         public System.TimeSpan? ResizeTimeout { get; set; }
 
         /// <summary>
@@ -76,7 +89,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The default value is requeue. Possible values include: 'requeue',
         /// 'terminate', 'taskCompletion', 'retainedData'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeDeallocationOption")]
+        [JsonProperty(PropertyName = "nodeDeallocationOption")]
         public ComputeNodeDeallocationOption? NodeDeallocationOption { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolSpecification.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolSpecification.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolSpecification class.
         /// </summary>
-        public PoolSpecification() { }
+        public PoolSpecification()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolSpecification class.
@@ -32,8 +42,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// configuration for the pool.</param>
         /// <param name="maxTasksPerNode">The maximum number of tasks that can
         /// run concurrently on a single compute node in the pool.</param>
-        /// <param name="taskSchedulingPolicy">How tasks are distributed among
-        /// compute nodes in the pool.</param>
+        /// <param name="taskSchedulingPolicy">How tasks are distributed across
+        /// compute nodes in a pool.</param>
         /// <param name="resizeTimeout">The timeout for allocation of compute
         /// nodes to the pool.</param>
         /// <param name="targetDedicatedNodes">The desired number of dedicated
@@ -65,29 +75,35 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// on each node in the pool.</param>
         /// <param name="metadata">A list of name-value pairs associated with
         /// the pool as metadata.</param>
-        public PoolSpecification(string vmSize, string displayName = default(string), CloudServiceConfiguration cloudServiceConfiguration = default(CloudServiceConfiguration), VirtualMachineConfiguration virtualMachineConfiguration = default(VirtualMachineConfiguration), int? maxTasksPerNode = default(int?), TaskSchedulingPolicy taskSchedulingPolicy = default(TaskSchedulingPolicy), System.TimeSpan? resizeTimeout = default(System.TimeSpan?), int? targetDedicatedNodes = default(int?), int? targetLowPriorityNodes = default(int?), bool? enableAutoScale = default(bool?), string autoScaleFormula = default(string), System.TimeSpan? autoScaleEvaluationInterval = default(System.TimeSpan?), bool? enableInterNodeCommunication = default(bool?), NetworkConfiguration networkConfiguration = default(NetworkConfiguration), StartTask startTask = default(StartTask), System.Collections.Generic.IList<CertificateReference> certificateReferences = default(System.Collections.Generic.IList<CertificateReference>), System.Collections.Generic.IList<ApplicationPackageReference> applicationPackageReferences = default(System.Collections.Generic.IList<ApplicationPackageReference>), System.Collections.Generic.IList<string> applicationLicenses = default(System.Collections.Generic.IList<string>), System.Collections.Generic.IList<UserAccount> userAccounts = default(System.Collections.Generic.IList<UserAccount>), System.Collections.Generic.IList<MetadataItem> metadata = default(System.Collections.Generic.IList<MetadataItem>))
+        public PoolSpecification(string vmSize, string displayName = default(string), CloudServiceConfiguration cloudServiceConfiguration = default(CloudServiceConfiguration), VirtualMachineConfiguration virtualMachineConfiguration = default(VirtualMachineConfiguration), int? maxTasksPerNode = default(int?), TaskSchedulingPolicy taskSchedulingPolicy = default(TaskSchedulingPolicy), System.TimeSpan? resizeTimeout = default(System.TimeSpan?), int? targetDedicatedNodes = default(int?), int? targetLowPriorityNodes = default(int?), bool? enableAutoScale = default(bool?), string autoScaleFormula = default(string), System.TimeSpan? autoScaleEvaluationInterval = default(System.TimeSpan?), bool? enableInterNodeCommunication = default(bool?), NetworkConfiguration networkConfiguration = default(NetworkConfiguration), StartTask startTask = default(StartTask), IList<CertificateReference> certificateReferences = default(IList<CertificateReference>), IList<ApplicationPackageReference> applicationPackageReferences = default(IList<ApplicationPackageReference>), IList<string> applicationLicenses = default(IList<string>), IList<UserAccount> userAccounts = default(IList<UserAccount>), IList<MetadataItem> metadata = default(IList<MetadataItem>))
         {
-            this.DisplayName = displayName;
-            this.VmSize = vmSize;
-            this.CloudServiceConfiguration = cloudServiceConfiguration;
-            this.VirtualMachineConfiguration = virtualMachineConfiguration;
-            this.MaxTasksPerNode = maxTasksPerNode;
-            this.TaskSchedulingPolicy = taskSchedulingPolicy;
-            this.ResizeTimeout = resizeTimeout;
-            this.TargetDedicatedNodes = targetDedicatedNodes;
-            this.TargetLowPriorityNodes = targetLowPriorityNodes;
-            this.EnableAutoScale = enableAutoScale;
-            this.AutoScaleFormula = autoScaleFormula;
-            this.AutoScaleEvaluationInterval = autoScaleEvaluationInterval;
-            this.EnableInterNodeCommunication = enableInterNodeCommunication;
-            this.NetworkConfiguration = networkConfiguration;
-            this.StartTask = startTask;
-            this.CertificateReferences = certificateReferences;
-            this.ApplicationPackageReferences = applicationPackageReferences;
-            this.ApplicationLicenses = applicationLicenses;
-            this.UserAccounts = userAccounts;
-            this.Metadata = metadata;
+            DisplayName = displayName;
+            VmSize = vmSize;
+            CloudServiceConfiguration = cloudServiceConfiguration;
+            VirtualMachineConfiguration = virtualMachineConfiguration;
+            MaxTasksPerNode = maxTasksPerNode;
+            TaskSchedulingPolicy = taskSchedulingPolicy;
+            ResizeTimeout = resizeTimeout;
+            TargetDedicatedNodes = targetDedicatedNodes;
+            TargetLowPriorityNodes = targetLowPriorityNodes;
+            EnableAutoScale = enableAutoScale;
+            AutoScaleFormula = autoScaleFormula;
+            AutoScaleEvaluationInterval = autoScaleEvaluationInterval;
+            EnableInterNodeCommunication = enableInterNodeCommunication;
+            NetworkConfiguration = networkConfiguration;
+            StartTask = startTask;
+            CertificateReferences = certificateReferences;
+            ApplicationPackageReferences = applicationPackageReferences;
+            ApplicationLicenses = applicationLicenses;
+            UserAccounts = userAccounts;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the display name for the pool.
@@ -96,7 +112,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The display name need not be unique and can contain any Unicode
         /// characters up to a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
@@ -119,7 +135,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// premium storage (STANDARD_GS, STANDARD_DS, and STANDARD_DSV2
         /// series).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "vmSize")]
+        [JsonProperty(PropertyName = "vmSize")]
         public string VmSize { get; set; }
 
         /// <summary>
@@ -135,7 +151,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// account was created with its poolAllocationMode property set to
         /// 'UserSubscription'.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "cloudServiceConfiguration")]
+        [JsonProperty(PropertyName = "cloudServiceConfiguration")]
         public CloudServiceConfiguration CloudServiceConfiguration { get; set; }
 
         /// <summary>
@@ -149,7 +165,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// you are calling the REST API directly, the HTTP status code is 400
         /// (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "virtualMachineConfiguration")]
+        [JsonProperty(PropertyName = "virtualMachineConfiguration")]
         public VirtualMachineConfiguration VirtualMachineConfiguration { get; set; }
 
         /// <summary>
@@ -160,14 +176,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The default value is 1. The maximum value of this setting depends
         /// on the size of the compute nodes in the pool (the vmSize setting).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxTasksPerNode")]
+        [JsonProperty(PropertyName = "maxTasksPerNode")]
         public int? MaxTasksPerNode { get; set; }
 
         /// <summary>
-        /// Gets or sets how tasks are distributed among compute nodes in the
+        /// Gets or sets how tasks are distributed across compute nodes in a
         /// pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskSchedulingPolicy")]
+        [JsonProperty(PropertyName = "taskSchedulingPolicy")]
         public TaskSchedulingPolicy TaskSchedulingPolicy { get; set; }
 
         /// <summary>
@@ -182,7 +198,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// you are calling the REST API directly, the HTTP status code is 400
         /// (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resizeTimeout")]
+        [JsonProperty(PropertyName = "resizeTimeout")]
         public System.TimeSpan? ResizeTimeout { get; set; }
 
         /// <summary>
@@ -194,7 +210,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// true. If enableAutoScale is set to false, then you must set either
         /// targetDedicatedNodes, targetLowPriorityNodes, or both.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetDedicatedNodes")]
+        [JsonProperty(PropertyName = "targetDedicatedNodes")]
         public int? TargetDedicatedNodes { get; set; }
 
         /// <summary>
@@ -206,7 +222,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// true. If enableAutoScale is set to false, then you must set either
         /// targetDedicatedNodes, targetLowPriorityNodes, or both.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetLowPriorityNodes")]
+        [JsonProperty(PropertyName = "targetLowPriorityNodes")]
         public int? TargetLowPriorityNodes { get; set; }
 
         /// <summary>
@@ -219,7 +235,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// autoScaleFormula element is required. The pool automatically
         /// resizes according to the formula. The default value is false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "enableAutoScale")]
+        [JsonProperty(PropertyName = "enableAutoScale")]
         public bool? EnableAutoScale { get; set; }
 
         /// <summary>
@@ -233,7 +249,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// formula is not valid, the Batch service rejects the request with
         /// detailed error information.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleFormula")]
+        [JsonProperty(PropertyName = "autoScaleFormula")]
         public string AutoScaleFormula { get; set; }
 
         /// <summary>
@@ -248,7 +264,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// calling the REST API directly, the HTTP status code is 400 (Bad
         /// Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoScaleEvaluationInterval")]
+        [JsonProperty(PropertyName = "autoScaleEvaluationInterval")]
         public System.TimeSpan? AutoScaleEvaluationInterval { get; set; }
 
         /// <summary>
@@ -261,13 +277,13 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// may result in the pool not reaching its desired size. The default
         /// value is false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "enableInterNodeCommunication")]
+        [JsonProperty(PropertyName = "enableInterNodeCommunication")]
         public bool? EnableInterNodeCommunication { get; set; }
 
         /// <summary>
         /// Gets or sets the network configuration for the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "networkConfiguration")]
+        [JsonProperty(PropertyName = "networkConfiguration")]
         public NetworkConfiguration NetworkConfiguration { get; set; }
 
         /// <summary>
@@ -275,7 +291,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// pool. The task runs when the node is added to the pool or when the
         /// node is restarted.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTask")]
+        [JsonProperty(PropertyName = "startTask")]
         public StartTask StartTask { get; set; }
 
         /// <summary>
@@ -293,15 +309,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// /home/{user-name}/certs) and certificates are placed in that
         /// directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "certificateReferences")]
-        public System.Collections.Generic.IList<CertificateReference> CertificateReferences { get; set; }
+        [JsonProperty(PropertyName = "certificateReferences")]
+        public IList<CertificateReference> CertificateReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the list of application packages to be installed on
         /// each compute node in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationPackageReferences")]
-        public System.Collections.Generic.IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
+        [JsonProperty(PropertyName = "applicationPackageReferences")]
+        public IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the list of application licenses the Batch service
@@ -312,15 +328,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch service application licenses. If a license is requested which
         /// is not supported, pool creation will fail.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationLicenses")]
-        public System.Collections.Generic.IList<string> ApplicationLicenses { get; set; }
+        [JsonProperty(PropertyName = "applicationLicenses")]
+        public IList<string> ApplicationLicenses { get; set; }
 
         /// <summary>
         /// Gets or sets the list of user accounts to be created on each node
         /// in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userAccounts")]
-        public System.Collections.Generic.IList<UserAccount> UserAccounts { get; set; }
+        [JsonProperty(PropertyName = "userAccounts")]
+        public IList<UserAccount> UserAccounts { get; set; }
 
         /// <summary>
         /// Gets or sets a list of name-value pairs associated with the pool as
@@ -330,44 +346,44 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The Batch service does not assign any meaning to metadata; it is
         /// solely for the use of user code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.VmSize == null)
+            if (VmSize == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "VmSize");
+                throw new ValidationException(ValidationRules.CannotBeNull, "VmSize");
             }
-            if (this.CloudServiceConfiguration != null)
+            if (CloudServiceConfiguration != null)
             {
-                this.CloudServiceConfiguration.Validate();
+                CloudServiceConfiguration.Validate();
             }
-            if (this.VirtualMachineConfiguration != null)
+            if (VirtualMachineConfiguration != null)
             {
-                this.VirtualMachineConfiguration.Validate();
+                VirtualMachineConfiguration.Validate();
             }
-            if (this.TaskSchedulingPolicy != null)
+            if (TaskSchedulingPolicy != null)
             {
-                this.TaskSchedulingPolicy.Validate();
+                TaskSchedulingPolicy.Validate();
             }
-            if (this.NetworkConfiguration != null)
+            if (NetworkConfiguration != null)
             {
-                this.NetworkConfiguration.Validate();
+                NetworkConfiguration.Validate();
             }
-            if (this.StartTask != null)
+            if (StartTask != null)
             {
-                this.StartTask.Validate();
+                StartTask.Validate();
             }
-            if (this.CertificateReferences != null)
+            if (CertificateReferences != null)
             {
-                foreach (var element in this.CertificateReferences)
+                foreach (var element in CertificateReferences)
                 {
                     if (element != null)
                     {
@@ -375,9 +391,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.ApplicationPackageReferences != null)
+            if (ApplicationPackageReferences != null)
             {
-                foreach (var element1 in this.ApplicationPackageReferences)
+                foreach (var element1 in ApplicationPackageReferences)
                 {
                     if (element1 != null)
                     {
@@ -385,9 +401,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.UserAccounts != null)
+            if (UserAccounts != null)
             {
-                foreach (var element2 in this.UserAccounts)
+                foreach (var element2 in UserAccounts)
                 {
                     if (element2 != null)
                     {
@@ -395,9 +411,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element3 in this.Metadata)
+                foreach (var element3 in Metadata)
                 {
                     if (element3 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolState.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for PoolState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum PoolState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "active")]
+        [EnumMember(Value = "active")]
         Active,
-        [System.Runtime.Serialization.EnumMember(Value = "deleting")]
+        [EnumMember(Value = "deleting")]
         Deleting,
-        [System.Runtime.Serialization.EnumMember(Value = "upgrading")]
+        [EnumMember(Value = "upgrading")]
         Upgrading
+    }
+    internal static class PoolStateEnumExtension
+    {
+        internal static string ToSerializedValue(this PoolState? value)  =>
+            value == null ? null : ((PoolState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this PoolState value)
+        {
+            switch( value )
+            {
+                case PoolState.Active:
+                    return "active";
+                case PoolState.Deleting:
+                    return "deleting";
+                case PoolState.Upgrading:
+                    return "upgrading";
+            }
+            return null;
+        }
+
+        internal static PoolState? ParsePoolState(this string value)
+        {
+            switch( value )
+            {
+                case "active":
+                    return PoolState.Active;
+                case "deleting":
+                    return PoolState.Deleting;
+                case "upgrading":
+                    return PoolState.Upgrading;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolStatistics.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolStatistics.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolStatistics class.
         /// </summary>
-        public PoolStatistics() { }
+        public PoolStatistics()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolStatistics class.
@@ -36,24 +44,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// consumption by compute nodes in the pool.</param>
         public PoolStatistics(string url, System.DateTime startTime, System.DateTime lastUpdateTime, UsageStatistics usageStats = default(UsageStatistics), ResourceStatistics resourceStats = default(ResourceStatistics))
         {
-            this.Url = url;
-            this.StartTime = startTime;
-            this.LastUpdateTime = lastUpdateTime;
-            this.UsageStats = usageStats;
-            this.ResourceStats = resourceStats;
+            Url = url;
+            StartTime = startTime;
+            LastUpdateTime = lastUpdateTime;
+            UsageStats = usageStats;
+            ResourceStats = resourceStats;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the URL for the statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the start time of the time range covered by the
         /// statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -61,42 +75,42 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// All statistics are limited to the range between startTime and
         /// lastUpdateTime.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastUpdateTime")]
+        [JsonProperty(PropertyName = "lastUpdateTime")]
         public System.DateTime LastUpdateTime { get; set; }
 
         /// <summary>
         /// Gets or sets statistics related to pool usage, such as the amount
         /// of core-time used.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "usageStats")]
+        [JsonProperty(PropertyName = "usageStats")]
         public UsageStatistics UsageStats { get; set; }
 
         /// <summary>
         /// Gets or sets statistics related to resource consumption by compute
         /// nodes in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resourceStats")]
+        [JsonProperty(PropertyName = "resourceStats")]
         public ResourceStatistics ResourceStats { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Url == null)
+            if (Url == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Url");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Url");
             }
-            if (this.UsageStats != null)
+            if (UsageStats != null)
             {
-                this.UsageStats.Validate();
+                UsageStats.Validate();
             }
-            if (this.ResourceStats != null)
+            if (ResourceStats != null)
             {
-                this.ResourceStats.Validate();
+                ResourceStats.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolStopResizeHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolStopResizeHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolStopResizeHeaders class.
         /// </summary>
-        public PoolStopResizeHeaders() { }
+        public PoolStopResizeHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolStopResizeHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolStopResizeHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolStopResizeOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolStopResizeOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolStopResizeOptions class.
         /// </summary>
-        public PoolStopResizeOptions() { }
+        public PoolStopResizeOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolStopResizeOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolStopResizeOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpdatePropertiesHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpdatePropertiesHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolUpdatePropertiesHeaders
         /// class.
         /// </summary>
-        public PoolUpdatePropertiesHeaders() { }
+        public PoolUpdatePropertiesHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolUpdatePropertiesHeaders
@@ -46,19 +55,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolUpdatePropertiesHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -70,7 +85,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -80,21 +95,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpdatePropertiesOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpdatePropertiesOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolUpdatePropertiesOptions
         /// class.
         /// </summary>
-        public PoolUpdatePropertiesOptions() { }
+        public PoolUpdatePropertiesOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolUpdatePropertiesOptions
@@ -38,17 +47,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public PoolUpdatePropertiesOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -56,14 +71,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -71,8 +86,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpdatePropertiesParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpdatePropertiesParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the PoolUpdatePropertiesParameter
         /// class.
         /// </summary>
-        public PoolUpdatePropertiesParameter() { }
+        public PoolUpdatePropertiesParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolUpdatePropertiesParameter
@@ -34,13 +44,19 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="startTask">A task to run on each compute node as it
         /// joins the pool. The task runs when the node is added to the pool or
         /// when the node is restarted.</param>
-        public PoolUpdatePropertiesParameter(System.Collections.Generic.IList<CertificateReference> certificateReferences, System.Collections.Generic.IList<ApplicationPackageReference> applicationPackageReferences, System.Collections.Generic.IList<MetadataItem> metadata, StartTask startTask = default(StartTask))
+        public PoolUpdatePropertiesParameter(IList<CertificateReference> certificateReferences, IList<ApplicationPackageReference> applicationPackageReferences, IList<MetadataItem> metadata, StartTask startTask = default(StartTask))
         {
-            this.StartTask = startTask;
-            this.CertificateReferences = certificateReferences;
-            this.ApplicationPackageReferences = applicationPackageReferences;
-            this.Metadata = metadata;
+            StartTask = startTask;
+            CertificateReferences = certificateReferences;
+            ApplicationPackageReferences = applicationPackageReferences;
+            Metadata = metadata;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a task to run on each compute node as it joins the
@@ -51,7 +67,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If this element is present, it overwrites any existing start task.
         /// If omitted, any existing start task is removed from the pool.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTask")]
+        [JsonProperty(PropertyName = "startTask")]
         public StartTask StartTask { get; set; }
 
         /// <summary>
@@ -59,34 +75,35 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// node in the pool.
         /// </summary>
         /// <remarks>
-        /// If you specify an empty collection, any existing certificate
-        /// references are removed from the pool. For Windows compute nodes,
-        /// the Batch service installs the certificates to the specified
-        /// certificate store and location. For Linux compute nodes, the
-        /// certificates are stored in a directory inside the task working
+        /// This list replaces any existing certificate references configured
+        /// on the pool. If you specify an empty collection, any existing
+        /// certificate references are removed from the pool. For Windows
+        /// compute nodes, the Batch service installs the certificates to the
+        /// specified certificate store and location. For Linux compute nodes,
+        /// the certificates are stored in a directory inside the task working
         /// directory and an environment variable AZ_BATCH_CERTIFICATES_DIR is
         /// supplied to the task to query for this location. For certificates
         /// with visibility of 'remoteUser', a 'certs' directory is created in
         /// the user's home directory (e.g., /home/{user-name}/certs) and
         /// certificates are placed in that directory.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "certificateReferences")]
-        public System.Collections.Generic.IList<CertificateReference> CertificateReferences { get; set; }
+        [JsonProperty(PropertyName = "certificateReferences")]
+        public IList<CertificateReference> CertificateReferences { get; set; }
 
         /// <summary>
         /// Gets or sets a list of application packages to be installed on each
         /// compute node in the pool.
         /// </summary>
         /// <remarks>
-        /// Changes to application package references affect all new compute
-        /// nodes joining the pool, but do not affect compute nodes that are
-        /// already in the pool until they are rebooted or reimaged. The list
-        /// replaces any existing application package references. If omitted,
-        /// or if you specify an empty collection, any existing application
-        /// packages references are removed from the pool.
+        /// The list replaces any existing application package references on
+        /// the pool. Changes to application package references affect all new
+        /// compute nodes joining the pool, but do not affect compute nodes
+        /// that are already in the pool until they are rebooted or reimaged.
+        /// If omitted, or if you specify an empty collection, any existing
+        /// application packages references are removed from the pool.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationPackageReferences")]
-        public System.Collections.Generic.IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
+        [JsonProperty(PropertyName = "applicationPackageReferences")]
+        public IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets a list of name-value pairs associated with the pool as
@@ -97,36 +114,36 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// omitted, or if you specify an empty collection, any existing
         /// metadata is removed from the pool.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "metadata")]
-        public System.Collections.Generic.IList<MetadataItem> Metadata { get; set; }
+        [JsonProperty(PropertyName = "metadata")]
+        public IList<MetadataItem> Metadata { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.CertificateReferences == null)
+            if (CertificateReferences == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "CertificateReferences");
+                throw new ValidationException(ValidationRules.CannotBeNull, "CertificateReferences");
             }
-            if (this.ApplicationPackageReferences == null)
+            if (ApplicationPackageReferences == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "ApplicationPackageReferences");
+                throw new ValidationException(ValidationRules.CannotBeNull, "ApplicationPackageReferences");
             }
-            if (this.Metadata == null)
+            if (Metadata == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Metadata");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Metadata");
             }
-            if (this.StartTask != null)
+            if (StartTask != null)
             {
-                this.StartTask.Validate();
+                StartTask.Validate();
             }
-            if (this.CertificateReferences != null)
+            if (CertificateReferences != null)
             {
-                foreach (var element in this.CertificateReferences)
+                foreach (var element in CertificateReferences)
                 {
                     if (element != null)
                     {
@@ -134,9 +151,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.ApplicationPackageReferences != null)
+            if (ApplicationPackageReferences != null)
             {
-                foreach (var element1 in this.ApplicationPackageReferences)
+                foreach (var element1 in ApplicationPackageReferences)
                 {
                     if (element1 != null)
                     {
@@ -144,9 +161,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.Metadata != null)
+            if (Metadata != null)
             {
-                foreach (var element2 in this.Metadata)
+                foreach (var element2 in Metadata)
                 {
                     if (element2 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpgradeOSHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpgradeOSHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolUpgradeOSHeaders class.
         /// </summary>
-        public PoolUpgradeOSHeaders() { }
+        public PoolUpgradeOSHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolUpgradeOSHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public PoolUpgradeOSHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpgradeOSOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpgradeOSOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolUpgradeOSOptions class.
         /// </summary>
-        public PoolUpgradeOSOptions() { }
+        public PoolUpgradeOSOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolUpgradeOSOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public PoolUpgradeOSOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpgradeOSParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUpgradeOSParameter.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolUpgradeOSParameter class.
         /// </summary>
-        public PoolUpgradeOSParameter() { }
+        public PoolUpgradeOSParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolUpgradeOSParameter class.
@@ -27,27 +35,33 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// installed on the virtual machines in the pool.</param>
         public PoolUpgradeOSParameter(string targetOSVersion)
         {
-            this.TargetOSVersion = targetOSVersion;
+            TargetOSVersion = targetOSVersion;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the Azure Guest OS version to be installed on the
         /// virtual machines in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "targetOSVersion")]
+        [JsonProperty(PropertyName = "targetOSVersion")]
         public string TargetOSVersion { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.TargetOSVersion == null)
+            if (TargetOSVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "TargetOSVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "TargetOSVersion");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUsageMetrics.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/PoolUsageMetrics.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the PoolUsageMetrics class.
         /// </summary>
-        public PoolUsageMetrics() { }
+        public PoolUsageMetrics()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the PoolUsageMetrics class.
@@ -39,34 +47,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// from the pool during this interval, in GiB.</param>
         public PoolUsageMetrics(string poolId, System.DateTime startTime, System.DateTime endTime, string vmSize, double totalCoreHours, double dataIngressGiB, double dataEgressGiB)
         {
-            this.PoolId = poolId;
-            this.StartTime = startTime;
-            this.EndTime = endTime;
-            this.VmSize = vmSize;
-            this.TotalCoreHours = totalCoreHours;
-            this.DataIngressGiB = dataIngressGiB;
-            this.DataEgressGiB = dataEgressGiB;
+            PoolId = poolId;
+            StartTime = startTime;
+            EndTime = endTime;
+            VmSize = vmSize;
+            TotalCoreHours = totalCoreHours;
+            DataIngressGiB = dataIngressGiB;
+            DataEgressGiB = dataEgressGiB;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ID of the pool whose metrics are aggregated in
         /// this entry.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "poolId")]
+        [JsonProperty(PropertyName = "poolId")]
         public string PoolId { get; set; }
 
         /// <summary>
         /// Gets or sets the start time of the aggregation interval covered by
         /// this entry.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
         /// Gets or sets the end time of the aggregation interval covered by
         /// this entry.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endTime")]
+        [JsonProperty(PropertyName = "endTime")]
         public System.DateTime EndTime { get; set; }
 
         /// <summary>
@@ -78,10 +92,11 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Services pools (pools created with cloudServiceConfiguration), see
         /// Sizes for Cloud Services
         /// (http://azure.microsoft.com/documentation/articles/cloud-services-sizes-specs/).
-        /// Batch supports all Cloud Services VM sizes except ExtraSmall, A1V2
-        /// and A2V2. For information about available VM sizes for pools using
-        /// images from the Virtual Machines Marketplace (pools created with
-        /// virtualMachineConfiguration) see Sizes for Virtual Machines (Linux)
+        /// Batch supports all Cloud Services VM sizes except ExtraSmall,
+        /// STANDARD_A1_V2 and STANDARD_A2_V2. For information about available
+        /// VM sizes for pools using images from the Virtual Machines
+        /// Marketplace (pools created with virtualMachineConfiguration) see
+        /// Sizes for Virtual Machines (Linux)
         /// (https://azure.microsoft.com/documentation/articles/virtual-machines-linux-sizes/)
         /// or Sizes for Virtual Machines (Windows)
         /// (https://azure.microsoft.com/documentation/articles/virtual-machines-windows-sizes/).
@@ -89,45 +104,45 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// premium storage (STANDARD_GS, STANDARD_DS, and STANDARD_DSV2
         /// series).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "vmSize")]
+        [JsonProperty(PropertyName = "vmSize")]
         public string VmSize { get; set; }
 
         /// <summary>
         /// Gets or sets the total core hours used in the pool during this
         /// aggregation interval.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "totalCoreHours")]
+        [JsonProperty(PropertyName = "totalCoreHours")]
         public double TotalCoreHours { get; set; }
 
         /// <summary>
         /// Gets or sets the cross data center network ingress to the pool
         /// during this interval, in GiB.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "dataIngressGiB")]
+        [JsonProperty(PropertyName = "dataIngressGiB")]
         public double DataIngressGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the cross data center network egress from the pool
         /// during this interval, in GiB.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "dataEgressGiB")]
+        [JsonProperty(PropertyName = "dataEgressGiB")]
         public double DataEgressGiB { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.PoolId == null)
+            if (PoolId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "PoolId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "PoolId");
             }
-            if (this.VmSize == null)
+            if (VmSize == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "VmSize");
+                throw new ValidationException(ValidationRules.CannotBeNull, "VmSize");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/RecentJob.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/RecentJob.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the RecentJob class.
         /// </summary>
-        public RecentJob() { }
+        public RecentJob()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the RecentJob class.
@@ -27,20 +34,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="url">The URL of the job.</param>
         public RecentJob(string id = default(string), string url = default(string))
         {
-            this.Id = id;
-            this.Url = url;
+            Id = id;
+            Url = url;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ID of the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the job.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ResizeError.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ResizeError.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ResizeError class.
         /// </summary>
-        public ResizeError() { }
+        public ResizeError()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ResizeError class.
@@ -30,33 +39,39 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// intended to be suitable for display in a user interface.</param>
         /// <param name="values">A list of additional error details related to
         /// the pool resize error.</param>
-        public ResizeError(string code = default(string), string message = default(string), System.Collections.Generic.IList<NameValuePair> values = default(System.Collections.Generic.IList<NameValuePair>))
+        public ResizeError(string code = default(string), string message = default(string), IList<NameValuePair> values = default(IList<NameValuePair>))
         {
-            this.Code = code;
-            this.Message = message;
-            this.Values = values;
+            Code = code;
+            Message = message;
+            Values = values;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an identifier for the pool resize error. Codes are
         /// invariant and are intended to be consumed programmatically.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [JsonProperty(PropertyName = "code")]
         public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets a message describing the pool resize error, intended
         /// to be suitable for display in a user interface.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }
 
         /// <summary>
         /// Gets or sets a list of additional error details related to the pool
         /// resize error.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "values")]
-        public System.Collections.Generic.IList<NameValuePair> Values { get; set; }
+        [JsonProperty(PropertyName = "values")]
+        public IList<NameValuePair> Values { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ResourceFile.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ResourceFile.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ResourceFile class.
         /// </summary>
-        public ResourceFile() { }
+        public ResourceFile()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ResourceFile class.
@@ -32,10 +40,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// format.</param>
         public ResourceFile(string blobSource, string filePath, string fileMode = default(string))
         {
-            this.BlobSource = blobSource;
-            this.FilePath = filePath;
-            this.FileMode = fileMode;
+            BlobSource = blobSource;
+            FilePath = filePath;
+            FileMode = fileMode;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the URL of the file within Azure Blob Storage.
@@ -48,14 +62,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// permissions on the blob, or set the ACL for the blob or its
         /// container to allow public access.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "blobSource")]
+        [JsonProperty(PropertyName = "blobSource")]
         public string BlobSource { get; set; }
 
         /// <summary>
         /// Gets or sets the location on the compute node to which to download
         /// the file, relative to the task's working directory.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "filePath")]
+        [JsonProperty(PropertyName = "filePath")]
         public string FilePath { get; set; }
 
         /// <summary>
@@ -68,24 +82,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// property is not specified for a Linux node, then a default value of
         /// 0770 is applied to the file.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "fileMode")]
+        [JsonProperty(PropertyName = "fileMode")]
         public string FileMode { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.BlobSource == null)
+            if (BlobSource == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "BlobSource");
+                throw new ValidationException(ValidationRules.CannotBeNull, "BlobSource");
             }
-            if (this.FilePath == null)
+            if (FilePath == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "FilePath");
+                throw new ValidationException(ValidationRules.CannotBeNull, "FilePath");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ResourceStatistics.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/ResourceStatistics.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the ResourceStatistics class.
         /// </summary>
-        public ResourceStatistics() { }
+        public ResourceStatistics()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the ResourceStatistics class.
@@ -52,26 +59,32 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// network writes across all nodes in the pool.</param>
         public ResourceStatistics(System.DateTime startTime, System.DateTime lastUpdateTime, double avgCPUPercentage, double avgMemoryGiB, double peakMemoryGiB, double avgDiskGiB, double peakDiskGiB, long diskReadIOps, long diskWriteIOps, double diskReadGiB, double diskWriteGiB, double networkReadGiB, double networkWriteGiB)
         {
-            this.StartTime = startTime;
-            this.LastUpdateTime = lastUpdateTime;
-            this.AvgCPUPercentage = avgCPUPercentage;
-            this.AvgMemoryGiB = avgMemoryGiB;
-            this.PeakMemoryGiB = peakMemoryGiB;
-            this.AvgDiskGiB = avgDiskGiB;
-            this.PeakDiskGiB = peakDiskGiB;
-            this.DiskReadIOps = diskReadIOps;
-            this.DiskWriteIOps = diskWriteIOps;
-            this.DiskReadGiB = diskReadGiB;
-            this.DiskWriteGiB = diskWriteGiB;
-            this.NetworkReadGiB = networkReadGiB;
-            this.NetworkWriteGiB = networkWriteGiB;
+            StartTime = startTime;
+            LastUpdateTime = lastUpdateTime;
+            AvgCPUPercentage = avgCPUPercentage;
+            AvgMemoryGiB = avgMemoryGiB;
+            PeakMemoryGiB = peakMemoryGiB;
+            AvgDiskGiB = avgDiskGiB;
+            PeakDiskGiB = peakDiskGiB;
+            DiskReadIOps = diskReadIOps;
+            DiskWriteIOps = diskWriteIOps;
+            DiskReadGiB = diskReadGiB;
+            DiskWriteGiB = diskWriteGiB;
+            NetworkReadGiB = networkReadGiB;
+            NetworkWriteGiB = networkWriteGiB;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the start time of the time range covered by the
         /// statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -79,90 +92,90 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// All statistics are limited to the range between startTime and
         /// lastUpdateTime.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastUpdateTime")]
+        [JsonProperty(PropertyName = "lastUpdateTime")]
         public System.DateTime LastUpdateTime { get; set; }
 
         /// <summary>
         /// Gets or sets the average CPU usage across all nodes in the pool
         /// (percentage per node).
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "avgCPUPercentage")]
+        [JsonProperty(PropertyName = "avgCPUPercentage")]
         public double AvgCPUPercentage { get; set; }
 
         /// <summary>
         /// Gets or sets the average memory usage in GiB across all nodes in
         /// the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "avgMemoryGiB")]
+        [JsonProperty(PropertyName = "avgMemoryGiB")]
         public double AvgMemoryGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the peak memory usage in GiB across all nodes in the
         /// pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "peakMemoryGiB")]
+        [JsonProperty(PropertyName = "peakMemoryGiB")]
         public double PeakMemoryGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the average used disk space in GiB across all nodes in
         /// the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "avgDiskGiB")]
+        [JsonProperty(PropertyName = "avgDiskGiB")]
         public double AvgDiskGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the peak used disk space in GiB across all nodes in
         /// the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "peakDiskGiB")]
+        [JsonProperty(PropertyName = "peakDiskGiB")]
         public double PeakDiskGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of disk read operations across all
         /// nodes in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "diskReadIOps")]
+        [JsonProperty(PropertyName = "diskReadIOps")]
         public long DiskReadIOps { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of disk write operations across all
         /// nodes in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "diskWriteIOps")]
+        [JsonProperty(PropertyName = "diskWriteIOps")]
         public long DiskWriteIOps { get; set; }
 
         /// <summary>
         /// Gets or sets the total amount of data in GiB of disk reads across
         /// all nodes in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "diskReadGiB")]
+        [JsonProperty(PropertyName = "diskReadGiB")]
         public double DiskReadGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the total amount of data in GiB of disk writes across
         /// all nodes in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "diskWriteGiB")]
+        [JsonProperty(PropertyName = "diskWriteGiB")]
         public double DiskWriteGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the total amount of data in GiB of network reads
         /// across all nodes in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "networkReadGiB")]
+        [JsonProperty(PropertyName = "networkReadGiB")]
         public double NetworkReadGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the total amount of data in GiB of network writes
         /// across all nodes in the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "networkWriteGiB")]
+        [JsonProperty(PropertyName = "networkWriteGiB")]
         public double NetworkWriteGiB { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/Schedule.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/Schedule.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the Schedule class.
         /// </summary>
-        public Schedule() { }
+        public Schedule()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the Schedule class.
@@ -38,11 +45,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// time.</param>
         public Schedule(System.DateTime? doNotRunUntil = default(System.DateTime?), System.DateTime? doNotRunAfter = default(System.DateTime?), System.TimeSpan? startWindow = default(System.TimeSpan?), System.TimeSpan? recurrenceInterval = default(System.TimeSpan?))
         {
-            this.DoNotRunUntil = doNotRunUntil;
-            this.DoNotRunAfter = doNotRunAfter;
-            this.StartWindow = startWindow;
-            this.RecurrenceInterval = recurrenceInterval;
+            DoNotRunUntil = doNotRunUntil;
+            DoNotRunAfter = doNotRunAfter;
+            StartWindow = startWindow;
+            RecurrenceInterval = recurrenceInterval;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the earliest time at which any job may be created
@@ -52,7 +65,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If you do not specify a doNotRunUntil time, the schedule becomes
         /// ready to create jobs immediately.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "doNotRunUntil")]
+        [JsonProperty(PropertyName = "doNotRunUntil")]
         public System.DateTime? DoNotRunUntil { get; set; }
 
         /// <summary>
@@ -66,7 +79,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// recurring job schedule, the job schedule will remain active until
         /// you explicitly terminate it.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "doNotRunAfter")]
+        [JsonProperty(PropertyName = "doNotRunAfter")]
         public System.DateTime? DoNotRunAfter { get; set; }
 
         /// <summary>
@@ -86,7 +99,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// rejects the schedule with an error; if you are calling the REST API
         /// directly, the HTTP status code is 400 (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startWindow")]
+        [JsonProperty(PropertyName = "startWindow")]
         public System.TimeSpan? StartWindow { get; set; }
 
         /// <summary>
@@ -113,7 +126,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if you are calling the REST API directly, the HTTP status code is
         /// 400 (Bad Request).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "recurrenceInterval")]
+        [JsonProperty(PropertyName = "recurrenceInterval")]
         public System.TimeSpan? RecurrenceInterval { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/SchedulingState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/SchedulingState.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for SchedulingState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum SchedulingState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "enabled")]
+        [EnumMember(Value = "enabled")]
         Enabled,
-        [System.Runtime.Serialization.EnumMember(Value = "disabled")]
+        [EnumMember(Value = "disabled")]
         Disabled
+    }
+    internal static class SchedulingStateEnumExtension
+    {
+        internal static string ToSerializedValue(this SchedulingState? value)  =>
+            value == null ? null : ((SchedulingState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this SchedulingState value)
+        {
+            switch( value )
+            {
+                case SchedulingState.Enabled:
+                    return "enabled";
+                case SchedulingState.Disabled:
+                    return "disabled";
+            }
+            return null;
+        }
+
+        internal static SchedulingState? ParseSchedulingState(this string value)
+        {
+            switch( value )
+            {
+                case "enabled":
+                    return SchedulingState.Enabled;
+                case "disabled":
+                    return SchedulingState.Disabled;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/StartTask.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/StartTask.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the StartTask class.
         /// </summary>
-        public StartTask() { }
+        public StartTask()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the StartTask class.
@@ -39,15 +49,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// for the start task to complete successfully (that is, to exit with
         /// exit code 0) before scheduling any tasks on the compute
         /// node.</param>
-        public StartTask(string commandLine, System.Collections.Generic.IList<ResourceFile> resourceFiles = default(System.Collections.Generic.IList<ResourceFile>), System.Collections.Generic.IList<EnvironmentSetting> environmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), UserIdentity userIdentity = default(UserIdentity), int? maxTaskRetryCount = default(int?), bool? waitForSuccess = default(bool?))
+        public StartTask(string commandLine, IList<ResourceFile> resourceFiles = default(IList<ResourceFile>), IList<EnvironmentSetting> environmentSettings = default(IList<EnvironmentSetting>), UserIdentity userIdentity = default(UserIdentity), int? maxTaskRetryCount = default(int?), bool? waitForSuccess = default(bool?))
         {
-            this.CommandLine = commandLine;
-            this.ResourceFiles = resourceFiles;
-            this.EnvironmentSettings = environmentSettings;
-            this.UserIdentity = userIdentity;
-            this.MaxTaskRetryCount = maxTaskRetryCount;
-            this.WaitForSuccess = waitForSuccess;
+            CommandLine = commandLine;
+            ResourceFiles = resourceFiles;
+            EnvironmentSettings = environmentSettings;
+            UserIdentity = userIdentity;
+            MaxTaskRetryCount = maxTaskRetryCount;
+            WaitForSuccess = waitForSuccess;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the command line of the start task.
@@ -59,22 +75,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// should invoke the shell in the command line, for example using "cmd
         /// /c MyCommand" in Windows or "/bin/sh -c MyCommand" in Linux.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commandLine")]
+        [JsonProperty(PropertyName = "commandLine")]
         public string CommandLine { get; set; }
 
         /// <summary>
         /// Gets or sets a list of files that the Batch service will download
         /// to the compute node before running the command line.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resourceFiles")]
-        public System.Collections.Generic.IList<ResourceFile> ResourceFiles { get; set; }
+        /// <remarks>
+        /// Files listed under this element are located in the task's working
+        /// directory.
+        /// </remarks>
+        [JsonProperty(PropertyName = "resourceFiles")]
+        public IList<ResourceFile> ResourceFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of environment variable settings for the start
         /// task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "environmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> EnvironmentSettings { get; set; }
+        [JsonProperty(PropertyName = "environmentSettings")]
+        public IList<EnvironmentSetting> EnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets the user identity under which the start task runs.
@@ -83,7 +103,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, the task runs as a non-administrative user unique to
         /// the task.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userIdentity")]
+        [JsonProperty(PropertyName = "userIdentity")]
         public UserIdentity UserIdentity { get; set; }
 
         /// <summary>
@@ -99,7 +119,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// task. If the maximum retry count is -1, the Batch service retries
         /// the task without limit.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxTaskRetryCount")]
+        [JsonProperty(PropertyName = "maxTaskRetryCount")]
         public int? MaxTaskRetryCount { get; set; }
 
         /// <summary>
@@ -113,31 +133,31 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// (maxTaskRetryCount). If the task has still not completed
         /// successfully after all retries, then the Batch service marks the
         /// compute node unusable, and will not schedule tasks to it. This
-        /// condition can be detected via the node state and scheduling error
-        /// detail. If false, the Batch service will not wait for the start
+        /// condition can be detected via the node state and failure info
+        /// details. If false, the Batch service will not wait for the start
         /// task to complete. In this case, other tasks can start executing on
         /// the compute node while the start task is still running; and even if
         /// the start task fails, new tasks will continue to be scheduled on
         /// the node. The default is false.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "waitForSuccess")]
+        [JsonProperty(PropertyName = "waitForSuccess")]
         public bool? WaitForSuccess { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.CommandLine == null)
+            if (CommandLine == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "CommandLine");
+                throw new ValidationException(ValidationRules.CannotBeNull, "CommandLine");
             }
-            if (this.ResourceFiles != null)
+            if (ResourceFiles != null)
             {
-                foreach (var element in this.ResourceFiles)
+                foreach (var element in ResourceFiles)
                 {
                     if (element != null)
                     {
@@ -145,9 +165,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.EnvironmentSettings != null)
+            if (EnvironmentSettings != null)
             {
-                foreach (var element1 in this.EnvironmentSettings)
+                foreach (var element1 in EnvironmentSettings)
                 {
                     if (element1 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/StartTaskInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/StartTaskInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the StartTaskInformation class.
         /// </summary>
-        public StartTaskInformation() { }
+        public StartTaskInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the StartTaskInformation class.
@@ -40,27 +47,36 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="result">The result of the task execution.</param>
         public StartTaskInformation(StartTaskState state, System.DateTime startTime, int retryCount, System.DateTime? endTime = default(System.DateTime?), int? exitCode = default(int?), TaskFailureInformation failureInfo = default(TaskFailureInformation), System.DateTime? lastRetryTime = default(System.DateTime?), TaskExecutionResult? result = default(TaskExecutionResult?))
         {
-            this.State = state;
-            this.StartTime = startTime;
-            this.EndTime = endTime;
-            this.ExitCode = exitCode;
-            this.FailureInfo = failureInfo;
-            this.RetryCount = retryCount;
-            this.LastRetryTime = lastRetryTime;
-            this.Result = result;
+            State = state;
+            StartTime = startTime;
+            EndTime = endTime;
+            ExitCode = exitCode;
+            FailureInfo = failureInfo;
+            RetryCount = retryCount;
+            LastRetryTime = lastRetryTime;
+            Result = result;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the state of the start task on the compute node.
         /// </summary>
         /// <remarks>
-        /// running - The start task is currently running. completed - The
-        /// start task has exited with exit code 0, or the start task has
-        /// failed and the retry limit has reached, or the start task process
-        /// did not run due to scheduling errors. Possible values include:
+        /// Values are:
+        ///
+        /// running - The start task is currently running.
+        /// completed - The start task has exited with exit code 0, or the
+        /// start task has failed and the retry limit has reached, or the start
+        /// task process did not run due to task preparation errors (such as
+        /// resource file download failures). Possible values include:
         /// 'running', 'completed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public StartTaskState State { get; set; }
 
         /// <summary>
@@ -71,7 +87,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// (that is, this is the most recent time at which the start task
         /// started running).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -83,7 +99,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// pending). This element is not present if the start task is
         /// currently running.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endTime")]
+        [JsonProperty(PropertyName = "endTime")]
         public System.DateTime? EndTime { get; set; }
 
         /// <summary>
@@ -100,7 +116,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the start task (due to timeout, or user termination via the API)
         /// you may see an operating system-defined exit code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitCode")]
+        [JsonProperty(PropertyName = "exitCode")]
         public int? ExitCode { get; set; }
 
         /// <summary>
@@ -110,7 +126,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the task is in the completed state and
         /// encountered a failure.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "failureInfo")]
+        [JsonProperty(PropertyName = "failureInfo")]
         public TaskFailureInformation FailureInfo { get; set; }
 
         /// <summary>
@@ -118,13 +134,12 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch service.
         /// </summary>
         /// <remarks>
-        /// The number of times the task has been retried by the Batch service.
         /// Task application failures (non-zero exit code) are retried,
         /// pre-processing errors (the task could not be run) and file upload
         /// errors are not retried. The Batch service will retry the task up to
         /// the limit specified by the constraints.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "retryCount")]
+        [JsonProperty(PropertyName = "retryCount")]
         public int RetryCount { get; set; }
 
         /// <summary>
@@ -139,7 +154,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// rebooted during a retry, then the startTime is updated but the
         /// lastRetryTime is not.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastRetryTime")]
+        [JsonProperty(PropertyName = "lastRetryTime")]
         public System.DateTime? LastRetryTime { get; set; }
 
         /// <summary>
@@ -150,20 +165,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// found in the failureInfo property. Possible values include:
         /// 'success', 'failure'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "result")]
+        [JsonProperty(PropertyName = "result")]
         public TaskExecutionResult? Result { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.FailureInfo != null)
+            if (FailureInfo != null)
             {
-                this.FailureInfo.Validate();
+                FailureInfo.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/StartTaskState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/StartTaskState.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for StartTaskState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum StartTaskState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "running")]
+        [EnumMember(Value = "running")]
         Running,
-        [System.Runtime.Serialization.EnumMember(Value = "completed")]
+        [EnumMember(Value = "completed")]
         Completed
+    }
+    internal static class StartTaskStateEnumExtension
+    {
+        internal static string ToSerializedValue(this StartTaskState? value)  =>
+            value == null ? null : ((StartTaskState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this StartTaskState value)
+        {
+            switch( value )
+            {
+                case StartTaskState.Running:
+                    return "running";
+                case StartTaskState.Completed:
+                    return "completed";
+            }
+            return null;
+        }
+
+        internal static StartTaskState? ParseStartTaskState(this string value)
+        {
+            switch( value )
+            {
+                case "running":
+                    return StartTaskState.Running;
+                case "completed":
+                    return StartTaskState.Completed;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/SubtaskInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/SubtaskInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the SubtaskInformation class.
         /// </summary>
-        public SubtaskInformation() { }
+        public SubtaskInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the SubtaskInformation class.
@@ -45,30 +52,36 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="result">The result of the task execution.</param>
         public SubtaskInformation(int? id = default(int?), ComputeNodeInformation nodeInfo = default(ComputeNodeInformation), System.DateTime? startTime = default(System.DateTime?), System.DateTime? endTime = default(System.DateTime?), int? exitCode = default(int?), TaskFailureInformation failureInfo = default(TaskFailureInformation), SubtaskState? state = default(SubtaskState?), System.DateTime? stateTransitionTime = default(System.DateTime?), SubtaskState? previousState = default(SubtaskState?), System.DateTime? previousStateTransitionTime = default(System.DateTime?), TaskExecutionResult? result = default(TaskExecutionResult?))
         {
-            this.Id = id;
-            this.NodeInfo = nodeInfo;
-            this.StartTime = startTime;
-            this.EndTime = endTime;
-            this.ExitCode = exitCode;
-            this.FailureInfo = failureInfo;
-            this.State = state;
-            this.StateTransitionTime = stateTransitionTime;
-            this.PreviousState = previousState;
-            this.PreviousStateTransitionTime = previousStateTransitionTime;
-            this.Result = result;
+            Id = id;
+            NodeInfo = nodeInfo;
+            StartTime = startTime;
+            EndTime = endTime;
+            ExitCode = exitCode;
+            FailureInfo = failureInfo;
+            State = state;
+            StateTransitionTime = stateTransitionTime;
+            PreviousState = previousState;
+            PreviousStateTransitionTime = previousStateTransitionTime;
+            Result = result;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the ID of the subtask.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public int? Id { get; set; }
 
         /// <summary>
         /// Gets or sets information about the compute node on which the
         /// subtask ran.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeInfo")]
+        [JsonProperty(PropertyName = "nodeInfo")]
         public ComputeNodeInformation NodeInfo { get; set; }
 
         /// <summary>
@@ -76,7 +89,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// subtask has been restarted or retried, this is the most recent time
         /// at which the subtask started running.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime? StartTime { get; set; }
 
         /// <summary>
@@ -85,7 +98,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property is set only if the subtask is in the Completed state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endTime")]
+        [JsonProperty(PropertyName = "endTime")]
         public System.DateTime? EndTime { get; set; }
 
         /// <summary>
@@ -102,7 +115,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// subtask (due to timeout, or user termination via the API) you may
         /// see an operating system-defined exit code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitCode")]
+        [JsonProperty(PropertyName = "exitCode")]
         public int? ExitCode { get; set; }
 
         /// <summary>
@@ -112,7 +125,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the task is in the completed state and
         /// encountered a failure.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "failureInfo")]
+        [JsonProperty(PropertyName = "failureInfo")]
         public TaskFailureInformation FailureInfo { get; set; }
 
         /// <summary>
@@ -121,14 +134,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'preparing', 'running', 'completed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "state")]
+        [JsonProperty(PropertyName = "state")]
         public SubtaskState? State { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the subtask entered its current
         /// state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "stateTransitionTime")]
+        [JsonProperty(PropertyName = "stateTransitionTime")]
         public System.DateTime? StateTransitionTime { get; set; }
 
         /// <summary>
@@ -138,7 +151,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is not set if the subtask is in its initial running
         /// state. Possible values include: 'preparing', 'running', 'completed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousState")]
+        [JsonProperty(PropertyName = "previousState")]
         public SubtaskState? PreviousState { get; set; }
 
         /// <summary>
@@ -149,7 +162,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is not set if the subtask is in its initial running
         /// state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "previousStateTransitionTime")]
+        [JsonProperty(PropertyName = "previousStateTransitionTime")]
         public System.DateTime? PreviousStateTransitionTime { get; set; }
 
         /// <summary>
@@ -160,20 +173,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// found in the failureInfo property. Possible values include:
         /// 'success', 'failure'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "result")]
+        [JsonProperty(PropertyName = "result")]
         public TaskExecutionResult? Result { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.FailureInfo != null)
+            if (FailureInfo != null)
             {
-                this.FailureInfo.Validate();
+                FailureInfo.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/SubtaskState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/SubtaskState.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for SubtaskState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum SubtaskState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "preparing")]
+        [EnumMember(Value = "preparing")]
         Preparing,
-        [System.Runtime.Serialization.EnumMember(Value = "running")]
+        [EnumMember(Value = "running")]
         Running,
-        [System.Runtime.Serialization.EnumMember(Value = "completed")]
+        [EnumMember(Value = "completed")]
         Completed
+    }
+    internal static class SubtaskStateEnumExtension
+    {
+        internal static string ToSerializedValue(this SubtaskState? value)  =>
+            value == null ? null : ((SubtaskState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this SubtaskState value)
+        {
+            switch( value )
+            {
+                case SubtaskState.Preparing:
+                    return "preparing";
+                case SubtaskState.Running:
+                    return "running";
+                case SubtaskState.Completed:
+                    return "completed";
+            }
+            return null;
+        }
+
+        internal static SubtaskState? ParseSubtaskState(this string value)
+        {
+            switch( value )
+            {
+                case "preparing":
+                    return SubtaskState.Preparing;
+                case "running":
+                    return SubtaskState.Running;
+                case "completed":
+                    return SubtaskState.Completed;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddCollectionHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddCollectionHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskAddCollectionHeaders class.
         /// </summary>
-        public TaskAddCollectionHeaders() { }
+        public TaskAddCollectionHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskAddCollectionHeaders class.
@@ -35,16 +42,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public TaskAddCollectionHeaders(string clientRequestId = default(string), string requestId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public string ClientRequestId { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public string RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddCollectionOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddCollectionOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskAddCollectionOptions class.
         /// </summary>
-        public TaskAddCollectionOptions() { }
+        public TaskAddCollectionOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskAddCollectionOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public TaskAddCollectionOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddCollectionParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddCollectionParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,42 +25,58 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskAddCollectionParameter class.
         /// </summary>
-        public TaskAddCollectionParameter() { }
+        public TaskAddCollectionParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskAddCollectionParameter class.
         /// </summary>
         /// <param name="value">The collection of tasks to add.</param>
-        public TaskAddCollectionParameter(System.Collections.Generic.IList<TaskAddParameter> value)
+        public TaskAddCollectionParameter(IList<TaskAddParameter> value)
         {
-            this.Value = value;
+            Value = value;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the collection of tasks to add.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
-        public System.Collections.Generic.IList<TaskAddParameter> Value { get; set; }
+        /// <remarks>
+        /// The total serialized size of this collection must be less than 4MB.
+        /// If it is greater than 4MB (for example if each task has 100's of
+        /// resource files or environment variables), the request will fail
+        /// with code 'RequestBodyTooLarge' and should be retried again with
+        /// fewer tasks.
+        /// </remarks>
+        [JsonProperty(PropertyName = "value")]
+        public IList<TaskAddParameter> Value { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Value == null)
+            if (Value == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Value");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Value");
             }
-            if (this.Value != null)
+            if (Value != null)
             {
-                if (this.Value.Count > 100)
+                if (Value.Count > 100)
                 {
-                    throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.MaxItems, "Value", 100);
+                    throw new ValidationException(ValidationRules.MaxItems, "Value", 100);
                 }
-                foreach (var element in this.Value)
+                foreach (var element in Value)
                 {
                     if (element != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddCollectionResult.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddCollectionResult.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,23 +24,32 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskAddCollectionResult class.
         /// </summary>
-        public TaskAddCollectionResult() { }
+        public TaskAddCollectionResult()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskAddCollectionResult class.
         /// </summary>
         /// <param name="value">The results of the add task collection
         /// operation.</param>
-        public TaskAddCollectionResult(System.Collections.Generic.IList<TaskAddResult> value = default(System.Collections.Generic.IList<TaskAddResult>))
+        public TaskAddCollectionResult(IList<TaskAddResult> value = default(IList<TaskAddResult>))
         {
-            this.Value = value;
+            Value = value;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the results of the add task collection operation.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
-        public System.Collections.Generic.IList<TaskAddResult> Value { get; set; }
+        [JsonProperty(PropertyName = "value")]
+        public IList<TaskAddResult> Value { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskAddHeaders class.
         /// </summary>
-        public TaskAddHeaders() { }
+        public TaskAddHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskAddHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public TaskAddHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskAddOptions class.
         /// </summary>
-        public TaskAddOptions() { }
+        public TaskAddOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskAddOptions class.
@@ -36,17 +45,23 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public TaskAddOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -54,14 +69,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -69,8 +84,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddParameter.cs
@@ -8,6 +8,13 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskAddParameter class.
         /// </summary>
-        public TaskAddParameter() { }
+        public TaskAddParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskAddParameter class.
@@ -55,23 +65,29 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="authenticationTokenSettings">The settings for an
         /// authentication token that the task can use to perform Batch service
         /// operations.</param>
-        public TaskAddParameter(string id, string commandLine, string displayName = default(string), ExitConditions exitConditions = default(ExitConditions), System.Collections.Generic.IList<ResourceFile> resourceFiles = default(System.Collections.Generic.IList<ResourceFile>), System.Collections.Generic.IList<OutputFile> outputFiles = default(System.Collections.Generic.IList<OutputFile>), System.Collections.Generic.IList<EnvironmentSetting> environmentSettings = default(System.Collections.Generic.IList<EnvironmentSetting>), AffinityInformation affinityInfo = default(AffinityInformation), TaskConstraints constraints = default(TaskConstraints), UserIdentity userIdentity = default(UserIdentity), MultiInstanceSettings multiInstanceSettings = default(MultiInstanceSettings), TaskDependencies dependsOn = default(TaskDependencies), System.Collections.Generic.IList<ApplicationPackageReference> applicationPackageReferences = default(System.Collections.Generic.IList<ApplicationPackageReference>), AuthenticationTokenSettings authenticationTokenSettings = default(AuthenticationTokenSettings))
+        public TaskAddParameter(string id, string commandLine, string displayName = default(string), ExitConditions exitConditions = default(ExitConditions), IList<ResourceFile> resourceFiles = default(IList<ResourceFile>), IList<OutputFile> outputFiles = default(IList<OutputFile>), IList<EnvironmentSetting> environmentSettings = default(IList<EnvironmentSetting>), AffinityInformation affinityInfo = default(AffinityInformation), TaskConstraints constraints = default(TaskConstraints), UserIdentity userIdentity = default(UserIdentity), MultiInstanceSettings multiInstanceSettings = default(MultiInstanceSettings), TaskDependencies dependsOn = default(TaskDependencies), IList<ApplicationPackageReference> applicationPackageReferences = default(IList<ApplicationPackageReference>), AuthenticationTokenSettings authenticationTokenSettings = default(AuthenticationTokenSettings))
         {
-            this.Id = id;
-            this.DisplayName = displayName;
-            this.CommandLine = commandLine;
-            this.ExitConditions = exitConditions;
-            this.ResourceFiles = resourceFiles;
-            this.OutputFiles = outputFiles;
-            this.EnvironmentSettings = environmentSettings;
-            this.AffinityInfo = affinityInfo;
-            this.Constraints = constraints;
-            this.UserIdentity = userIdentity;
-            this.MultiInstanceSettings = multiInstanceSettings;
-            this.DependsOn = dependsOn;
-            this.ApplicationPackageReferences = applicationPackageReferences;
-            this.AuthenticationTokenSettings = authenticationTokenSettings;
+            Id = id;
+            DisplayName = displayName;
+            CommandLine = commandLine;
+            ExitConditions = exitConditions;
+            ResourceFiles = resourceFiles;
+            OutputFiles = outputFiles;
+            EnvironmentSettings = environmentSettings;
+            AffinityInfo = affinityInfo;
+            Constraints = constraints;
+            UserIdentity = userIdentity;
+            MultiInstanceSettings = multiInstanceSettings;
+            DependsOn = dependsOn;
+            ApplicationPackageReferences = applicationPackageReferences;
+            AuthenticationTokenSettings = authenticationTokenSettings;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a string that uniquely identifies the task within the
@@ -84,7 +100,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// is, you may not have two IDs within a job that differ only by
         /// case).
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "id")]
+        [JsonProperty(PropertyName = "id")]
         public string Id { get; set; }
 
         /// <summary>
@@ -94,7 +110,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The display name need not be unique and can contain any Unicode
         /// characters up to a maximum length of 1024.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "displayName")]
+        [JsonProperty(PropertyName = "displayName")]
         public string DisplayName { get; set; }
 
         /// <summary>
@@ -110,14 +126,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// command line, for example using "cmd /c MyCommand" in Windows or
         /// "/bin/sh -c MyCommand" in Linux.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "commandLine")]
+        [JsonProperty(PropertyName = "commandLine")]
         public string CommandLine { get; set; }
 
         /// <summary>
         /// Gets or sets how the Batch service should respond when the task
         /// completes.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitConditions")]
+        [JsonProperty(PropertyName = "exitConditions")]
         public ExitConditions ExitConditions { get; set; }
 
         /// <summary>
@@ -129,8 +145,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// downloaded to the compute node on which the primary task is
         /// executed.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "resourceFiles")]
-        public System.Collections.Generic.IList<ResourceFile> ResourceFiles { get; set; }
+        [JsonProperty(PropertyName = "resourceFiles")]
+        public IList<ResourceFile> ResourceFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of files that the Batch service will upload
@@ -140,20 +156,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// For multi-instance tasks, the files will only be uploaded from the
         /// compute node on which the primary task is executed.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "outputFiles")]
-        public System.Collections.Generic.IList<OutputFile> OutputFiles { get; set; }
+        [JsonProperty(PropertyName = "outputFiles")]
+        public IList<OutputFile> OutputFiles { get; set; }
 
         /// <summary>
         /// Gets or sets a list of environment variable settings for the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "environmentSettings")]
-        public System.Collections.Generic.IList<EnvironmentSetting> EnvironmentSettings { get; set; }
+        [JsonProperty(PropertyName = "environmentSettings")]
+        public IList<EnvironmentSetting> EnvironmentSettings { get; set; }
 
         /// <summary>
         /// Gets or sets a locality hint that can be used by the Batch service
         /// to select a compute node on which to start the new task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "affinityInfo")]
+        [JsonProperty(PropertyName = "affinityInfo")]
         public AffinityInformation AffinityInfo { get; set; }
 
         /// <summary>
@@ -164,7 +180,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// maxTaskRetryCount specified for the job, and the maxWallClockTime
         /// and retentionTime are infinite.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public TaskConstraints Constraints { get; set; }
 
         /// <summary>
@@ -174,7 +190,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If omitted, the task runs as a non-administrative user unique to
         /// the task.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userIdentity")]
+        [JsonProperty(PropertyName = "userIdentity")]
         public UserIdentity UserIdentity { get; set; }
 
         /// <summary>
@@ -182,7 +198,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// multi-instance task, and contains information about how to run the
         /// multi-instance task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "multiInstanceSettings")]
+        [JsonProperty(PropertyName = "multiInstanceSettings")]
         public MultiInstanceSettings MultiInstanceSettings { get; set; }
 
         /// <summary>
@@ -196,15 +212,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// present, the request fails with error code
         /// TaskDependenciesNotSpecifiedOnJob.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "dependsOn")]
+        [JsonProperty(PropertyName = "dependsOn")]
         public TaskDependencies DependsOn { get; set; }
 
         /// <summary>
         /// Gets or sets a list of application packages that the Batch service
         /// will deploy to the compute node before running the command line.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "applicationPackageReferences")]
-        public System.Collections.Generic.IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
+        /// <remarks>
+        /// Application packages are downloaded and deployed to a shared
+        /// directory, not the task working directory. Therefore, if a
+        /// referenced package is already on the compute node, and is up to
+        /// date, then it is not re-downloaded; the existing copy on the
+        /// compute node is used. If a referenced application package cannot be
+        /// installed, for example because the package has been deleted or
+        /// because download failed, the task fails.
+        /// </remarks>
+        [JsonProperty(PropertyName = "applicationPackageReferences")]
+        public IList<ApplicationPackageReference> ApplicationPackageReferences { get; set; }
 
         /// <summary>
         /// Gets or sets the settings for an authentication token that the task
@@ -220,28 +245,28 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// permissions in order to add other tasks to the job, or check the
         /// status of the job or of other tasks under the job.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "authenticationTokenSettings")]
+        [JsonProperty(PropertyName = "authenticationTokenSettings")]
         public AuthenticationTokenSettings AuthenticationTokenSettings { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Id == null)
+            if (Id == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Id");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Id");
             }
-            if (this.CommandLine == null)
+            if (CommandLine == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "CommandLine");
+                throw new ValidationException(ValidationRules.CannotBeNull, "CommandLine");
             }
-            if (this.ResourceFiles != null)
+            if (ResourceFiles != null)
             {
-                foreach (var element in this.ResourceFiles)
+                foreach (var element in ResourceFiles)
                 {
                     if (element != null)
                     {
@@ -249,9 +274,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.OutputFiles != null)
+            if (OutputFiles != null)
             {
-                foreach (var element1 in this.OutputFiles)
+                foreach (var element1 in OutputFiles)
                 {
                     if (element1 != null)
                     {
@@ -259,9 +284,9 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.EnvironmentSettings != null)
+            if (EnvironmentSettings != null)
             {
-                foreach (var element2 in this.EnvironmentSettings)
+                foreach (var element2 in EnvironmentSettings)
                 {
                     if (element2 != null)
                     {
@@ -269,17 +294,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
                     }
                 }
             }
-            if (this.AffinityInfo != null)
+            if (AffinityInfo != null)
             {
-                this.AffinityInfo.Validate();
+                AffinityInfo.Validate();
             }
-            if (this.MultiInstanceSettings != null)
+            if (MultiInstanceSettings != null)
             {
-                this.MultiInstanceSettings.Validate();
+                MultiInstanceSettings.Validate();
             }
-            if (this.ApplicationPackageReferences != null)
+            if (ApplicationPackageReferences != null)
             {
-                foreach (var element3 in this.ApplicationPackageReferences)
+                foreach (var element3 in ApplicationPackageReferences)
                 {
                     if (element3 != null)
                     {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddResult.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddResult.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskAddResult class.
         /// </summary>
-        public TaskAddResult() { }
+        public TaskAddResult()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskAddResult class.
@@ -37,67 +45,86 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the task.</param>
         public TaskAddResult(TaskAddStatus status, string taskId, string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string location = default(string), BatchError error = default(BatchError))
         {
-            this.Status = status;
-            this.TaskId = taskId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.Location = location;
-            this.Error = error;
+            Status = status;
+            TaskId = taskId;
+            ETag = eTag;
+            LastModified = lastModified;
+            Location = location;
+            Error = error;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the status of the add task request.
         /// </summary>
         /// <remarks>
-        /// Possible values include: 'success', 'clientError', 'serverError'
+        /// Values are:
+        ///
+        /// success - Task was added successfully.
+        /// clienterror - Task failed to add due to a client error and should
+        /// not be retried without modifying the request as appropriate.
+        /// servererror - Task failed to add due to a server error and can be
+        /// retried without modification. Possible values include: 'success',
+        /// 'clientError', 'serverError'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "status")]
+        [JsonProperty(PropertyName = "status")]
         public TaskAddStatus Status { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the task for which this is the result.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskId")]
+        [JsonProperty(PropertyName = "taskId")]
         public string TaskId { get; set; }
 
         /// <summary>
         /// Gets or sets the ETag of the task, if the task was successfully
         /// added.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "eTag")]
+        /// <remarks>
+        /// You can use this to detect whether the task has changed between
+        /// requests. In particular, you can be pass the ETag with an Update
+        /// Task request to specify that your changes should take effect only
+        /// if nobody else has modified the job in the meantime.
+        /// </remarks>
+        [JsonProperty(PropertyName = "eTag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the last modified time of the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastModified")]
+        [JsonProperty(PropertyName = "lastModified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the URL of the task, if the task was successfully
         /// added.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "location")]
+        [JsonProperty(PropertyName = "location")]
         public string Location { get; set; }
 
         /// <summary>
         /// Gets or sets the error encountered while attempting to add the
         /// task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "error")]
+        [JsonProperty(PropertyName = "error")]
         public BatchError Error { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.TaskId == null)
+            if (TaskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "TaskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "TaskId");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddStatus.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskAddStatus.cs
@@ -8,18 +8,58 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for TaskAddStatus.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum TaskAddStatus
     {
-        [System.Runtime.Serialization.EnumMember(Value = "success")]
+        [EnumMember(Value = "success")]
         Success,
-        [System.Runtime.Serialization.EnumMember(Value = "clientError")]
+        [EnumMember(Value = "clientError")]
         ClientError,
-        [System.Runtime.Serialization.EnumMember(Value = "serverError")]
+        [EnumMember(Value = "serverError")]
         ServerError
+    }
+    internal static class TaskAddStatusEnumExtension
+    {
+        internal static string ToSerializedValue(this TaskAddStatus? value)  =>
+            value == null ? null : ((TaskAddStatus)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this TaskAddStatus value)
+        {
+            switch( value )
+            {
+                case TaskAddStatus.Success:
+                    return "success";
+                case TaskAddStatus.ClientError:
+                    return "clientError";
+                case TaskAddStatus.ServerError:
+                    return "serverError";
+            }
+            return null;
+        }
+
+        internal static TaskAddStatus? ParseTaskAddStatus(this string value)
+        {
+            switch( value )
+            {
+                case "success":
+                    return TaskAddStatus.Success;
+                case "clientError":
+                    return TaskAddStatus.ClientError;
+                case "serverError":
+                    return TaskAddStatus.ServerError;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskConstraints.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskConstraints.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskConstraints class.
         /// </summary>
-        public TaskConstraints() { }
+        public TaskConstraints()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskConstraints class.
@@ -36,10 +43,16 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// code is nonzero.</param>
         public TaskConstraints(System.TimeSpan? maxWallClockTime = default(System.TimeSpan?), System.TimeSpan? retentionTime = default(System.TimeSpan?), int? maxTaskRetryCount = default(int?))
         {
-            this.MaxWallClockTime = maxWallClockTime;
-            this.RetentionTime = retentionTime;
-            this.MaxTaskRetryCount = maxTaskRetryCount;
+            MaxWallClockTime = maxWallClockTime;
+            RetentionTime = retentionTime;
+            MaxTaskRetryCount = maxTaskRetryCount;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum elapsed time that the task may run,
@@ -50,7 +63,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If this is not specified, there is no time limit on how long the
         /// task may run.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxWallClockTime")]
+        [JsonProperty(PropertyName = "maxWallClockTime")]
         public System.TimeSpan? MaxWallClockTime { get; set; }
 
         /// <summary>
@@ -63,7 +76,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The default is infinite, i.e. the task directory will be retained
         /// until the compute node is removed or reimaged.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "retentionTime")]
+        [JsonProperty(PropertyName = "retentionTime")]
         public System.TimeSpan? RetentionTime { get; set; }
 
         /// <summary>
@@ -79,7 +92,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// task. If the maximum retry count is -1, the Batch service retries
         /// the task without limit.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "maxTaskRetryCount")]
+        [JsonProperty(PropertyName = "maxTaskRetryCount")]
         public int? MaxTaskRetryCount { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskCountValidationStatus.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskCountValidationStatus.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for TaskCountValidationStatus.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum TaskCountValidationStatus
     {
-        [System.Runtime.Serialization.EnumMember(Value = "validated")]
+        [EnumMember(Value = "validated")]
         Validated,
-        [System.Runtime.Serialization.EnumMember(Value = "unvalidated")]
+        [EnumMember(Value = "unvalidated")]
         Unvalidated
+    }
+    internal static class TaskCountValidationStatusEnumExtension
+    {
+        internal static string ToSerializedValue(this TaskCountValidationStatus? value)  =>
+            value == null ? null : ((TaskCountValidationStatus)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this TaskCountValidationStatus value)
+        {
+            switch( value )
+            {
+                case TaskCountValidationStatus.Validated:
+                    return "validated";
+                case TaskCountValidationStatus.Unvalidated:
+                    return "unvalidated";
+            }
+            return null;
+        }
+
+        internal static TaskCountValidationStatus? ParseTaskCountValidationStatus(this string value)
+        {
+            switch( value )
+            {
+                case "validated":
+                    return TaskCountValidationStatus.Validated;
+                case "unvalidated":
+                    return TaskCountValidationStatus.Unvalidated;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskCounts.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskCounts.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskCounts class.
         /// </summary>
-        public TaskCounts() { }
+        public TaskCounts()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskCounts class.
@@ -36,69 +43,72 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if its result (found in the executionInfo property) is
         /// 'failure'.</param>
         /// <param name="validationStatus">Whether the task counts have been
-        /// validated. If the validationStatus is unvalidated, then the Batch
-        /// service has not been able to check state counts against the task
-        /// states as reported in the List Tasks API.</param>
+        /// validated.</param>
         public TaskCounts(int active, int running, int completed, int succeeded, int failed, TaskCountValidationStatus validationStatus)
         {
-            this.Active = active;
-            this.Running = running;
-            this.Completed = completed;
-            this.Succeeded = succeeded;
-            this.Failed = failed;
-            this.ValidationStatus = validationStatus;
+            Active = active;
+            Running = running;
+            Completed = completed;
+            Succeeded = succeeded;
+            Failed = failed;
+            ValidationStatus = validationStatus;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the number of tasks in the active state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "active")]
+        [JsonProperty(PropertyName = "active")]
         public int Active { get; set; }
 
         /// <summary>
         /// Gets or sets the number of tasks in the running or preparing state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "running")]
+        [JsonProperty(PropertyName = "running")]
         public int Running { get; set; }
 
         /// <summary>
         /// Gets or sets the number of tasks in the completed state.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "completed")]
+        [JsonProperty(PropertyName = "completed")]
         public int Completed { get; set; }
 
         /// <summary>
         /// Gets or sets the number of tasks which succeeded. A task succeeds
         /// if its result (found in the executionInfo property) is 'success'.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "succeeded")]
+        [JsonProperty(PropertyName = "succeeded")]
         public int Succeeded { get; set; }
 
         /// <summary>
         /// Gets or sets the number of tasks which failed. A task fails if its
         /// result (found in the executionInfo property) is 'failure'.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "failed")]
+        [JsonProperty(PropertyName = "failed")]
         public int Failed { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the task counts have been validated. If the
-        /// validationStatus is unvalidated, then the Batch service has not
-        /// been able to check state counts against the task states as reported
-        /// in the List Tasks API.
+        /// Gets or sets whether the task counts have been validated.
         /// </summary>
         /// <remarks>
-        /// The validationStatus may be unvalidated if the job contains more
-        /// than 200,000 tasks. Possible values include: 'validated',
-        /// 'unvalidated'
+        /// If the validationStatus is unvalidated, then the Batch service has
+        /// not been able to check state counts against the task states as
+        /// reported in the List Tasks API. The validationStatus may be
+        /// unvalidated if the job contains more than 200,000 tasks. Possible
+        /// values include: 'validated', 'unvalidated'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "validationStatus")]
+        [JsonProperty(PropertyName = "validationStatus")]
         public TaskCountValidationStatus ValidationStatus { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskDeleteHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskDeleteHeaders.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskDeleteHeaders class.
         /// </summary>
-        public TaskDeleteHeaders() { }
+        public TaskDeleteHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskDeleteHeaders class.
@@ -35,16 +42,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, and the region that account resides in.</param>
         public TaskDeleteHeaders(string clientRequestId = default(string), string requestId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public string ClientRequestId { get; set; }
 
         /// <summary>
@@ -56,7 +69,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public string RequestId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskDeleteOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskDeleteOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskDeleteOptions class.
         /// </summary>
-        public TaskDeleteOptions() { }
+        public TaskDeleteOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskDeleteOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public TaskDeleteOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskDependencies.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskDependencies.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskDependencies class.
         /// </summary>
-        public TaskDependencies() { }
+        public TaskDependencies()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskDependencies class.
@@ -31,27 +40,40 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="taskIdRanges">The list of task ID ranges that this
         /// task depends on. All tasks in all ranges must complete successfully
         /// before the dependent task can be scheduled.</param>
-        public TaskDependencies(System.Collections.Generic.IList<string> taskIds = default(System.Collections.Generic.IList<string>), System.Collections.Generic.IList<TaskIdRange> taskIdRanges = default(System.Collections.Generic.IList<TaskIdRange>))
+        public TaskDependencies(IList<string> taskIds = default(IList<string>), IList<TaskIdRange> taskIdRanges = default(IList<TaskIdRange>))
         {
-            this.TaskIds = taskIds;
-            this.TaskIdRanges = taskIdRanges;
+            TaskIds = taskIds;
+            TaskIdRanges = taskIdRanges;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the list of task IDs that this task depends on. All
         /// tasks in this list must complete successfully before the dependent
         /// task can be scheduled.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskIds")]
-        public System.Collections.Generic.IList<string> TaskIds { get; set; }
+        /// <remarks>
+        /// The taskIds collection is limited to 64000 characters total (i.e.
+        /// the combined length of all task IDs). If the taskIds collection
+        /// exceeds the maximum length, the Add Task request fails with error
+        /// code TaskDependencyListTooLong. In this case consider using task ID
+        /// ranges instead.
+        /// </remarks>
+        [JsonProperty(PropertyName = "taskIds")]
+        public IList<string> TaskIds { get; set; }
 
         /// <summary>
         /// Gets or sets the list of task ID ranges that this task depends on.
         /// All tasks in all ranges must complete successfully before the
         /// dependent task can be scheduled.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskIdRanges")]
-        public System.Collections.Generic.IList<TaskIdRange> TaskIdRanges { get; set; }
+        [JsonProperty(PropertyName = "taskIdRanges")]
+        public IList<TaskIdRange> TaskIdRanges { get; set; }
 
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskExecutionInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskExecutionInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskExecutionInformation class.
         /// </summary>
-        public TaskExecutionInformation() { }
+        public TaskExecutionInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskExecutionInformation class.
@@ -43,16 +50,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="result">The result of the task execution.</param>
         public TaskExecutionInformation(int retryCount, int requeueCount, System.DateTime? startTime = default(System.DateTime?), System.DateTime? endTime = default(System.DateTime?), int? exitCode = default(int?), TaskFailureInformation failureInfo = default(TaskFailureInformation), System.DateTime? lastRetryTime = default(System.DateTime?), System.DateTime? lastRequeueTime = default(System.DateTime?), TaskExecutionResult? result = default(TaskExecutionResult?))
         {
-            this.StartTime = startTime;
-            this.EndTime = endTime;
-            this.ExitCode = exitCode;
-            this.FailureInfo = failureInfo;
-            this.RetryCount = retryCount;
-            this.LastRetryTime = lastRetryTime;
-            this.RequeueCount = requeueCount;
-            this.LastRequeueTime = lastRequeueTime;
-            this.Result = result;
+            StartTime = startTime;
+            EndTime = endTime;
+            ExitCode = exitCode;
+            FailureInfo = failureInfo;
+            RetryCount = retryCount;
+            LastRetryTime = lastRetryTime;
+            RequeueCount = requeueCount;
+            LastRequeueTime = lastRequeueTime;
+            Result = result;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the time at which the task started running.
@@ -66,7 +79,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// property is present only for tasks that are in the running or
         /// completed state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime? StartTime { get; set; }
 
         /// <summary>
@@ -75,7 +88,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property is set only if the task is in the Completed state.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "endTime")]
+        [JsonProperty(PropertyName = "endTime")]
         public System.DateTime? EndTime { get; set; }
 
         /// <summary>
@@ -92,7 +105,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// task (due to timeout, or user termination via the API) you may see
         /// an operating system-defined exit code.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "exitCode")]
+        [JsonProperty(PropertyName = "exitCode")]
         public int? ExitCode { get; set; }
 
         /// <summary>
@@ -102,7 +115,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is set only if the task is in the completed state and
         /// encountered a failure.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "failureInfo")]
+        [JsonProperty(PropertyName = "failureInfo")]
         public TaskFailureInformation FailureInfo { get; set; }
 
         /// <summary>
@@ -110,13 +123,12 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Batch service.
         /// </summary>
         /// <remarks>
-        /// The number of times the task has been retried by the Batch service.
         /// Task application failures (non-zero exit code) are retried,
         /// pre-processing errors (the task could not be run) and file upload
         /// errors are not retried. The Batch service will retry the task up to
         /// the limit specified by the constraints.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "retryCount")]
+        [JsonProperty(PropertyName = "retryCount")]
         public int RetryCount { get; set; }
 
         /// <summary>
@@ -131,7 +143,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// rebooted during a retry, then the startTime is updated but the
         /// lastRetryTime is not.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastRetryTime")]
+        [JsonProperty(PropertyName = "lastRetryTime")]
         public System.DateTime? LastRetryTime { get; set; }
 
         /// <summary>
@@ -144,7 +156,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// running tasks on the nodes be requeued for execution. This count
         /// tracks how many times the task has been requeued for these reasons.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "requeueCount")]
+        [JsonProperty(PropertyName = "requeueCount")]
         public int RequeueCount { get; set; }
 
         /// <summary>
@@ -154,7 +166,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// This property is set only if the requeueCount is nonzero.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastRequeueTime")]
+        [JsonProperty(PropertyName = "lastRequeueTime")]
         public System.DateTime? LastRequeueTime { get; set; }
 
         /// <summary>
@@ -165,20 +177,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// found in the failureInfo property. Possible values include:
         /// 'success', 'failure'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "result")]
+        [JsonProperty(PropertyName = "result")]
         public TaskExecutionResult? Result { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.FailureInfo != null)
+            if (FailureInfo != null)
             {
-                this.FailureInfo.Validate();
+                FailureInfo.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskExecutionResult.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskExecutionResult.cs
@@ -8,16 +8,52 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for TaskExecutionResult.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum TaskExecutionResult
     {
-        [System.Runtime.Serialization.EnumMember(Value = "success")]
+        [EnumMember(Value = "success")]
         Success,
-        [System.Runtime.Serialization.EnumMember(Value = "failure")]
+        [EnumMember(Value = "failure")]
         Failure
+    }
+    internal static class TaskExecutionResultEnumExtension
+    {
+        internal static string ToSerializedValue(this TaskExecutionResult? value)  =>
+            value == null ? null : ((TaskExecutionResult)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this TaskExecutionResult value)
+        {
+            switch( value )
+            {
+                case TaskExecutionResult.Success:
+                    return "success";
+                case TaskExecutionResult.Failure:
+                    return "failure";
+            }
+            return null;
+        }
+
+        internal static TaskExecutionResult? ParseTaskExecutionResult(this string value)
+        {
+            switch( value )
+            {
+                case "success":
+                    return TaskExecutionResult.Success;
+                case "failure":
+                    return TaskExecutionResult.Failure;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskFailureInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskFailureInformation.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskFailureInformation class.
         /// </summary>
-        public TaskFailureInformation() { }
+        public TaskFailureInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskFailureInformation class.
@@ -30,13 +39,19 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// to be suitable for display in a user interface.</param>
         /// <param name="details">A list of additional details related to the
         /// error.</param>
-        public TaskFailureInformation(ErrorCategory category, string code = default(string), string message = default(string), System.Collections.Generic.IList<NameValuePair> details = default(System.Collections.Generic.IList<NameValuePair>))
+        public TaskFailureInformation(ErrorCategory category, string code = default(string), string message = default(string), IList<NameValuePair> details = default(IList<NameValuePair>))
         {
-            this.Category = category;
-            this.Code = code;
-            this.Message = message;
-            this.Details = details;
+            Category = category;
+            Code = code;
+            Message = message;
+            Details = details;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the category of the task error.
@@ -44,33 +59,33 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// Possible values include: 'userError', 'serverError'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "category")]
+        [JsonProperty(PropertyName = "category")]
         public ErrorCategory Category { get; set; }
 
         /// <summary>
         /// Gets or sets an identifier for the task error. Codes are invariant
         /// and are intended to be consumed programmatically.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "code")]
+        [JsonProperty(PropertyName = "code")]
         public string Code { get; set; }
 
         /// <summary>
         /// Gets or sets a message describing the task error, intended to be
         /// suitable for display in a user interface.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "message")]
+        [JsonProperty(PropertyName = "message")]
         public string Message { get; set; }
 
         /// <summary>
         /// Gets or sets a list of additional details related to the error.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "details")]
-        public System.Collections.Generic.IList<NameValuePair> Details { get; set; }
+        [JsonProperty(PropertyName = "details")]
+        public IList<NameValuePair> Details { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskGetHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskGetHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskGetHeaders class.
         /// </summary>
-        public TaskGetHeaders() { }
+        public TaskGetHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskGetHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public TaskGetHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskGetOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskGetOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskGetOptions class.
         /// </summary>
-        public TaskGetOptions() { }
+        public TaskGetOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskGetOptions class.
@@ -54,35 +63,41 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public TaskGetOptions(string select = default(string), string expand = default(string), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Select = select;
-            this.Expand = expand;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Select = select;
+            Expand = expand;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -90,14 +105,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -105,8 +120,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -115,7 +130,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -124,7 +139,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -133,8 +148,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -143,8 +158,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskIdRange.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskIdRange.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -25,7 +29,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskIdRange class.
         /// </summary>
-        public TaskIdRange() { }
+        public TaskIdRange()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskIdRange class.
@@ -34,26 +41,32 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <param name="end">The last task ID in the range.</param>
         public TaskIdRange(int start, int end)
         {
-            this.Start = start;
-            this.End = end;
+            Start = start;
+            End = end;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the first task ID in the range.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "start")]
+        [JsonProperty(PropertyName = "start")]
         public int Start { get; set; }
 
         /// <summary>
         /// Gets or sets the last task ID in the range.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "end")]
+        [JsonProperty(PropertyName = "end")]
         public int End { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskInformation.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskInformation.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskInformation class.
         /// </summary>
-        public TaskInformation() { }
+        public TaskInformation()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskInformation class.
@@ -34,37 +41,43 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// task.</param>
         public TaskInformation(TaskState taskState, string taskUrl = default(string), string jobId = default(string), string taskId = default(string), int? subtaskId = default(int?), TaskExecutionInformation executionInfo = default(TaskExecutionInformation))
         {
-            this.TaskUrl = taskUrl;
-            this.JobId = jobId;
-            this.TaskId = taskId;
-            this.SubtaskId = subtaskId;
-            this.TaskState = taskState;
-            this.ExecutionInfo = executionInfo;
+            TaskUrl = taskUrl;
+            JobId = jobId;
+            TaskId = taskId;
+            SubtaskId = subtaskId;
+            TaskState = taskState;
+            ExecutionInfo = executionInfo;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the URL of the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskUrl")]
+        [JsonProperty(PropertyName = "taskUrl")]
         public string TaskUrl { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the job to which the task belongs.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "jobId")]
+        [JsonProperty(PropertyName = "jobId")]
         public string JobId { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskId")]
+        [JsonProperty(PropertyName = "taskId")]
         public string TaskId { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the subtask if the task is a multi-instance
         /// task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "subtaskId")]
+        [JsonProperty(PropertyName = "subtaskId")]
         public int? SubtaskId { get; set; }
 
         /// <summary>
@@ -74,26 +87,26 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Possible values include: 'active', 'preparing', 'running',
         /// 'completed'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "taskState")]
+        [JsonProperty(PropertyName = "taskState")]
         public TaskState TaskState { get; set; }
 
         /// <summary>
         /// Gets or sets information about the execution of the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "executionInfo")]
+        [JsonProperty(PropertyName = "executionInfo")]
         public TaskExecutionInformation ExecutionInfo { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.ExecutionInfo != null)
+            if (ExecutionInfo != null)
             {
-                this.ExecutionInfo.Validate();
+                ExecutionInfo.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskListHeaders class.
         /// </summary>
-        public TaskListHeaders() { }
+        public TaskListHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskListHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public TaskListHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListNextOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListNextOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskListNextOptions class.
         /// </summary>
-        public TaskListNextOptions() { }
+        public TaskListNextOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskListNextOptions class.
@@ -33,24 +42,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public TaskListNextOptions(System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the caller-generated request identity, in the form of
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -58,8 +73,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskListOptions class.
         /// </summary>
-        public TaskListOptions() { }
+        public TaskListOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskListOptions class.
@@ -41,46 +50,52 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public TaskListOptions(string filter = default(string), string select = default(string), string expand = default(string), int? maxResults = default(int?), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Filter = filter;
-            this.Select = select;
-            this.Expand = expand;
-            this.MaxResults = maxResults;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Filter = filter;
+            Select = select;
+            Expand = expand;
+            MaxResults = maxResults;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $filter clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Filter { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets an OData $expand clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Expand { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum number of items to return in the response.
         /// A maximum of 1000 tasks can be returned.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? MaxResults { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -88,14 +103,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -103,8 +118,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListSubtasksHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListSubtasksHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskListSubtasksHeaders class.
         /// </summary>
-        public TaskListSubtasksHeaders() { }
+        public TaskListSubtasksHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskListSubtasksHeaders class.
@@ -42,18 +51,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified.</param>
         public TaskListSubtasksHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -65,7 +80,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -75,14 +90,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListSubtasksOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskListSubtasksOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskListSubtasksOptions class.
         /// </summary>
-        public TaskListSubtasksOptions() { }
+        public TaskListSubtasksOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskListSubtasksOptions class.
@@ -37,24 +46,30 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// it explicitly if you are calling the REST API directly.</param>
         public TaskListSubtasksOptions(string select = default(string), int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?))
         {
-            this.Select = select;
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
+            Select = select;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets an OData $select clause.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string Select { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -62,14 +77,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -77,8 +92,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskReactivateHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskReactivateHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskReactivateHeaders class.
         /// </summary>
-        public TaskReactivateHeaders() { }
+        public TaskReactivateHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskReactivateHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public TaskReactivateHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskReactivateOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskReactivateOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskReactivateOptions class.
         /// </summary>
-        public TaskReactivateOptions() { }
+        public TaskReactivateOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskReactivateOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public TaskReactivateOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskSchedulingPolicy.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskSchedulingPolicy.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,31 +22,53 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskSchedulingPolicy class.
         /// </summary>
-        public TaskSchedulingPolicy() { }
+        public TaskSchedulingPolicy()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskSchedulingPolicy class.
         /// </summary>
-        /// <param name="nodeFillType">How tasks should be distributed across
-        /// compute nodes.</param>
+        /// <param name="nodeFillType">How tasks are distributed across compute
+        /// nodes in a pool. Values are:
+        ///
+        /// pack - As many tasks as possible (maxTasksPerNode) should be
+        /// assigned to each node in the pool before any tasks are assigned to
+        /// the next node in the pool.
+        /// spread - Tasks should be assigned evenly across all nodes in the
+        /// pool.</param>
         public TaskSchedulingPolicy(ComputeNodeFillType nodeFillType)
         {
-            this.NodeFillType = nodeFillType;
+            NodeFillType = nodeFillType;
+            CustomInit();
         }
 
         /// <summary>
-        /// Gets or sets how tasks should be distributed across compute nodes.
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets how tasks are distributed across compute nodes in a
+        /// pool. Values are:
+        ///
+        /// pack - As many tasks as possible (maxTasksPerNode) should be
+        /// assigned to each node in the pool before any tasks are assigned to
+        /// the next node in the pool.
+        /// spread - Tasks should be assigned evenly across all nodes in the
+        /// pool.
         /// </summary>
         /// <remarks>
         /// Possible values include: 'spread', 'pack'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeFillType")]
+        [JsonProperty(PropertyName = "nodeFillType")]
         public ComputeNodeFillType NodeFillType { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskState.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskState.cs
@@ -8,20 +8,64 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using System.Runtime;
+    using System.Runtime.Serialization;
 
     /// <summary>
     /// Defines values for TaskState.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(StringEnumConverter))]
     public enum TaskState
     {
-        [System.Runtime.Serialization.EnumMember(Value = "active")]
+        [EnumMember(Value = "active")]
         Active,
-        [System.Runtime.Serialization.EnumMember(Value = "preparing")]
+        [EnumMember(Value = "preparing")]
         Preparing,
-        [System.Runtime.Serialization.EnumMember(Value = "running")]
+        [EnumMember(Value = "running")]
         Running,
-        [System.Runtime.Serialization.EnumMember(Value = "completed")]
+        [EnumMember(Value = "completed")]
         Completed
+    }
+    internal static class TaskStateEnumExtension
+    {
+        internal static string ToSerializedValue(this TaskState? value)  =>
+            value == null ? null : ((TaskState)value).ToSerializedValue();
+
+        internal static string ToSerializedValue(this TaskState value)
+        {
+            switch( value )
+            {
+                case TaskState.Active:
+                    return "active";
+                case TaskState.Preparing:
+                    return "preparing";
+                case TaskState.Running:
+                    return "running";
+                case TaskState.Completed:
+                    return "completed";
+            }
+            return null;
+        }
+
+        internal static TaskState? ParseTaskState(this string value)
+        {
+            switch( value )
+            {
+                case "active":
+                    return TaskState.Active;
+                case "preparing":
+                    return TaskState.Preparing;
+                case "running":
+                    return TaskState.Running;
+                case "completed":
+                    return TaskState.Completed;
+            }
+            return null;
+        }
     }
 }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskStatistics.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskStatistics.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +23,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskStatistics class.
         /// </summary>
-        public TaskStatistics() { }
+        public TaskStatistics()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskStatistics class.
@@ -52,30 +60,36 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// recent task execution.)</param>
         public TaskStatistics(string url, System.DateTime startTime, System.DateTime lastUpdateTime, System.TimeSpan userCPUTime, System.TimeSpan kernelCPUTime, System.TimeSpan wallClockTime, long readIOps, long writeIOps, double readIOGiB, double writeIOGiB, System.TimeSpan waitTime)
         {
-            this.Url = url;
-            this.StartTime = startTime;
-            this.LastUpdateTime = lastUpdateTime;
-            this.UserCPUTime = userCPUTime;
-            this.KernelCPUTime = kernelCPUTime;
-            this.WallClockTime = wallClockTime;
-            this.ReadIOps = readIOps;
-            this.WriteIOps = writeIOps;
-            this.ReadIOGiB = readIOGiB;
-            this.WriteIOGiB = writeIOGiB;
-            this.WaitTime = waitTime;
+            Url = url;
+            StartTime = startTime;
+            LastUpdateTime = lastUpdateTime;
+            UserCPUTime = userCPUTime;
+            KernelCPUTime = kernelCPUTime;
+            WallClockTime = wallClockTime;
+            ReadIOps = readIOps;
+            WriteIOps = writeIOps;
+            ReadIOGiB = readIOGiB;
+            WriteIOGiB = writeIOGiB;
+            WaitTime = waitTime;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the URL of the statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "url")]
+        [JsonProperty(PropertyName = "url")]
         public string Url { get; set; }
 
         /// <summary>
         /// Gets or sets the start time of the time range covered by the
         /// statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -83,21 +97,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// All statistics are limited to the range between startTime and
         /// lastUpdateTime.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastUpdateTime")]
+        [JsonProperty(PropertyName = "lastUpdateTime")]
         public System.DateTime LastUpdateTime { get; set; }
 
         /// <summary>
         /// Gets or sets the total user mode CPU time (summed across all cores
         /// and all compute nodes) consumed by the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "userCPUTime")]
+        [JsonProperty(PropertyName = "userCPUTime")]
         public System.TimeSpan UserCPUTime { get; set; }
 
         /// <summary>
         /// Gets or sets the total kernel mode CPU time (summed across all
         /// cores and all compute nodes) consumed by the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "kernelCPUTime")]
+        [JsonProperty(PropertyName = "kernelCPUTime")]
         public System.TimeSpan KernelCPUTime { get; set; }
 
         /// <summary>
@@ -110,33 +124,33 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// If the task was retried, this includes the wall clock time of all
         /// the task retries.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "wallClockTime")]
+        [JsonProperty(PropertyName = "wallClockTime")]
         public System.TimeSpan WallClockTime { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of disk read operations made by the
         /// task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "readIOps")]
+        [JsonProperty(PropertyName = "readIOps")]
         public long ReadIOps { get; set; }
 
         /// <summary>
         /// Gets or sets the total number of disk write operations made by the
         /// task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "writeIOps")]
+        [JsonProperty(PropertyName = "writeIOps")]
         public long WriteIOps { get; set; }
 
         /// <summary>
         /// Gets or sets the total gibibytes read from disk by the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "readIOGiB")]
+        [JsonProperty(PropertyName = "readIOGiB")]
         public double ReadIOGiB { get; set; }
 
         /// <summary>
         /// Gets or sets the total gibibytes written to disk by the task.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "writeIOGiB")]
+        [JsonProperty(PropertyName = "writeIOGiB")]
         public double WriteIOGiB { get; set; }
 
         /// <summary>
@@ -146,20 +160,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// to failures, the wait time is the time to the most recent task
         /// execution.)
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "waitTime")]
+        [JsonProperty(PropertyName = "waitTime")]
         public System.TimeSpan WaitTime { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Url == null)
+            if (Url == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Url");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Url");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskTerminateHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskTerminateHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskTerminateHeaders class.
         /// </summary>
-        public TaskTerminateHeaders() { }
+        public TaskTerminateHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskTerminateHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public TaskTerminateHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskTerminateOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskTerminateOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskTerminateOptions class.
         /// </summary>
-        public TaskTerminateOptions() { }
+        public TaskTerminateOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskTerminateOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public TaskTerminateOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskUpdateHeaders.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskUpdateHeaders.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskUpdateHeaders class.
         /// </summary>
-        public TaskUpdateHeaders() { }
+        public TaskUpdateHeaders()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskUpdateHeaders class.
@@ -44,19 +53,25 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the request applied.</param>
         public TaskUpdateHeaders(System.Guid? clientRequestId = default(System.Guid?), System.Guid? requestId = default(System.Guid?), string eTag = default(string), System.DateTime? lastModified = default(System.DateTime?), string dataServiceId = default(string))
         {
-            this.ClientRequestId = clientRequestId;
-            this.RequestId = requestId;
-            this.ETag = eTag;
-            this.LastModified = lastModified;
-            this.DataServiceId = dataServiceId;
+            ClientRequestId = clientRequestId;
+            RequestId = requestId;
+            ETag = eTag;
+            LastModified = lastModified;
+            DataServiceId = dataServiceId;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the client-request-id provided by the client during
         /// the request. This will be returned only if the
         /// return-client-request-id parameter was set to true.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "client-request-id")]
+        [JsonProperty(PropertyName = "client-request-id")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
@@ -68,7 +83,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// request was made, the Batch account against which the request was
         /// made, and the region that account resides in.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "request-id")]
+        [JsonProperty(PropertyName = "request-id")]
         public System.Guid? RequestId { get; set; }
 
         /// <summary>
@@ -78,21 +93,21 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the If-Modified-Since, If-Unmodified-Since, If-Match or
         /// If-None-Match headers.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "ETag")]
+        [JsonProperty(PropertyName = "ETag")]
         public string ETag { get; set; }
 
         /// <summary>
         /// Gets or sets the time at which the resource was last modified.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "Last-Modified")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "Last-Modified")]
         public System.DateTime? LastModified { get; set; }
 
         /// <summary>
         /// Gets or sets the OData ID of the resource to which the request
         /// applied.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "DataServiceId")]
+        [JsonProperty(PropertyName = "DataServiceId")]
         public string DataServiceId { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskUpdateOptions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskUpdateOptions.cs
@@ -8,6 +8,12 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Microsoft.Rest.Serialization;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskUpdateOptions class.
         /// </summary>
-        public TaskUpdateOptions() { }
+        public TaskUpdateOptions()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskUpdateOptions class.
@@ -52,21 +61,27 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// modified since the specified time.</param>
         public TaskUpdateOptions(int? timeout = default(int?), System.Guid? clientRequestId = default(System.Guid?), bool? returnClientRequestId = default(bool?), System.DateTime? ocpDate = default(System.DateTime?), string ifMatch = default(string), string ifNoneMatch = default(string), System.DateTime? ifModifiedSince = default(System.DateTime?), System.DateTime? ifUnmodifiedSince = default(System.DateTime?))
         {
-            this.Timeout = timeout;
-            this.ClientRequestId = clientRequestId;
-            this.ReturnClientRequestId = returnClientRequestId;
-            this.OcpDate = ocpDate;
-            this.IfMatch = ifMatch;
-            this.IfNoneMatch = ifNoneMatch;
-            this.IfModifiedSince = ifModifiedSince;
-            this.IfUnmodifiedSince = ifUnmodifiedSince;
+            Timeout = timeout;
+            ClientRequestId = clientRequestId;
+            ReturnClientRequestId = returnClientRequestId;
+            OcpDate = ocpDate;
+            IfMatch = ifMatch;
+            IfNoneMatch = ifNoneMatch;
+            IfModifiedSince = ifModifiedSince;
+            IfUnmodifiedSince = ifUnmodifiedSince;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the maximum time that the server can spend processing
         /// the request, in seconds. The default is 30 seconds.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public int? Timeout { get; set; }
 
         /// <summary>
@@ -74,14 +89,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// a GUID with no decoration such as curly braces, e.g.
         /// 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public System.Guid? ClientRequestId { get; set; }
 
         /// <summary>
         /// Gets or sets whether the server should return the client-request-id
         /// in the response.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public bool? ReturnClientRequestId { get; set; }
 
         /// <summary>
@@ -89,8 +104,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// typically set this to the current system clock time; set it
         /// explicitly if you are calling the REST API directly.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? OcpDate { get; set; }
 
         /// <summary>
@@ -99,7 +114,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service exactly matches the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfMatch { get; set; }
 
         /// <summary>
@@ -108,7 +123,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource's current ETag on the service does not match the
         /// value specified by the client.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonProperty(PropertyName = "")]
         public string IfNoneMatch { get; set; }
 
         /// <summary>
@@ -117,8 +132,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfModifiedSince { get; set; }
 
         /// <summary>
@@ -127,8 +142,8 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// if the resource on the service has not been modified since the
         /// specified time.
         /// </summary>
-        [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
-        [Newtonsoft.Json.JsonProperty(PropertyName = "")]
+        [JsonConverter(typeof(DateTimeRfc1123JsonConverter))]
+        [JsonProperty(PropertyName = "")]
         public System.DateTime? IfUnmodifiedSince { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskUpdateParameter.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/TaskUpdateParameter.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the TaskUpdateParameter class.
         /// </summary>
-        public TaskUpdateParameter() { }
+        public TaskUpdateParameter()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TaskUpdateParameter class.
@@ -27,16 +34,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// task.</param>
         public TaskUpdateParameter(TaskConstraints constraints = default(TaskConstraints))
         {
-            this.Constraints = constraints;
+            Constraints = constraints;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets constraints that apply to this task.
         /// </summary>
         /// <remarks>
-        /// If omitted, the task is given the default constraints.
+        /// If omitted, the task is given the default constraints. For
+        /// multi-instance tasks, updating the retention time applies only to
+        /// the primary task and not subtasks.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "constraints")]
+        [JsonProperty(PropertyName = "constraints")]
         public TaskConstraints Constraints { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/UsageStatistics.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/UsageStatistics.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the UsageStatistics class.
         /// </summary>
-        public UsageStatistics() { }
+        public UsageStatistics()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the UsageStatistics class.
@@ -32,16 +39,22 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// the dedicated compute node cores being part of the pool.</param>
         public UsageStatistics(System.DateTime startTime, System.DateTime lastUpdateTime, System.TimeSpan dedicatedCoreTime)
         {
-            this.StartTime = startTime;
-            this.LastUpdateTime = lastUpdateTime;
-            this.DedicatedCoreTime = dedicatedCoreTime;
+            StartTime = startTime;
+            LastUpdateTime = lastUpdateTime;
+            DedicatedCoreTime = dedicatedCoreTime;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the start time of the time range covered by the
         /// statistics.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "startTime")]
+        [JsonProperty(PropertyName = "startTime")]
         public System.DateTime StartTime { get; set; }
 
         /// <summary>
@@ -49,20 +62,20 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// All statistics are limited to the range between startTime and
         /// lastUpdateTime.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "lastUpdateTime")]
+        [JsonProperty(PropertyName = "lastUpdateTime")]
         public System.DateTime LastUpdateTime { get; set; }
 
         /// <summary>
         /// Gets or sets the aggregated wall-clock time of the dedicated
         /// compute node cores being part of the pool.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "dedicatedCoreTime")]
+        [JsonProperty(PropertyName = "dedicatedCoreTime")]
         public System.TimeSpan DedicatedCoreTime { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="Rest.ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/UserAccount.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/UserAccount.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -19,7 +24,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the UserAccount class.
         /// </summary>
-        public UserAccount() { }
+        public UserAccount()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the UserAccount class.
@@ -32,22 +40,28 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// configuration for the user account.</param>
         public UserAccount(string name, string password, ElevationLevel? elevationLevel = default(ElevationLevel?), LinuxUserConfiguration linuxUserConfiguration = default(LinuxUserConfiguration))
         {
-            this.Name = name;
-            this.Password = password;
-            this.ElevationLevel = elevationLevel;
-            this.LinuxUserConfiguration = linuxUserConfiguration;
+            Name = name;
+            Password = password;
+            ElevationLevel = elevationLevel;
+            LinuxUserConfiguration = linuxUserConfiguration;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the name of the user account.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "name")]
+        [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
 
         /// <summary>
         /// Gets or sets the password for the user account.
         /// </summary>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "password")]
+        [JsonProperty(PropertyName = "password")]
         public string Password { get; set; }
 
         /// <summary>
@@ -59,7 +73,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// operates with full Administrator permissions. The default value is
         /// nonAdmin. Possible values include: 'nonAdmin', 'admin'
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "elevationLevel")]
+        [JsonProperty(PropertyName = "elevationLevel")]
         public ElevationLevel? ElevationLevel { get; set; }
 
         /// <summary>
@@ -70,24 +84,24 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property is ignored if specified on a Windows pool. If not
         /// specified, the user is created with the default options.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "linuxUserConfiguration")]
+        [JsonProperty(PropertyName = "linuxUserConfiguration")]
         public LinuxUserConfiguration LinuxUserConfiguration { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.Name == null)
+            if (Name == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Name");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Name");
             }
-            if (this.Password == null)
+            if (Password == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "Password");
+                throw new ValidationException(ValidationRules.CannotBeNull, "Password");
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/UserIdentity.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/UserIdentity.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -21,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the UserIdentity class.
         /// </summary>
-        public UserIdentity() { }
+        public UserIdentity()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the UserIdentity class.
@@ -32,9 +39,15 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// run.</param>
         public UserIdentity(string userName = default(string), AutoUserSpecification autoUser = default(AutoUserSpecification))
         {
-            this.UserName = userName;
-            this.AutoUser = autoUser;
+            UserName = userName;
+            AutoUser = autoUser;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets the name of the user identity under which the task is
@@ -44,7 +57,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The userName and autoUser properties are mutually exclusive; you
         /// must specify one but not both.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "username")]
+        [JsonProperty(PropertyName = "username")]
         public string UserName { get; set; }
 
         /// <summary>
@@ -54,7 +67,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// The userName and autoUser properties are mutually exclusive; you
         /// must specify one but not both.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "autoUser")]
+        [JsonProperty(PropertyName = "autoUser")]
         public AutoUserSpecification AutoUser { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/VirtualMachineConfiguration.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/VirtualMachineConfiguration.cs
@@ -8,6 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Microsoft.Rest;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -20,7 +25,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// Initializes a new instance of the VirtualMachineConfiguration
         /// class.
         /// </summary>
-        public VirtualMachineConfiguration() { }
+        public VirtualMachineConfiguration()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the VirtualMachineConfiguration
@@ -36,11 +44,17 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// settings on the virtual machine.</param>
         public VirtualMachineConfiguration(string nodeAgentSKUId, ImageReference imageReference = default(ImageReference), OSDisk osDisk = default(OSDisk), WindowsConfiguration windowsConfiguration = default(WindowsConfiguration))
         {
-            this.ImageReference = imageReference;
-            this.OsDisk = osDisk;
-            this.NodeAgentSKUId = nodeAgentSKUId;
-            this.WindowsConfiguration = windowsConfiguration;
+            ImageReference = imageReference;
+            OsDisk = osDisk;
+            NodeAgentSKUId = nodeAgentSKUId;
+            WindowsConfiguration = windowsConfiguration;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets a reference to the Azure Virtual Machines Marketplace
@@ -50,7 +64,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property and osDisk are mutually exclusive and one of the
         /// properties must be specified.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "imageReference")]
+        [JsonProperty(PropertyName = "imageReference")]
         public ImageReference ImageReference { get; set; }
 
         /// <summary>
@@ -62,7 +76,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// 'UserSubscription'. This property and imageReference are mutually
         /// exclusive and one of the properties must be specified.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "osDisk")]
+        [JsonProperty(PropertyName = "osDisk")]
         public OSDisk OsDisk { get; set; }
 
         /// <summary>
@@ -79,7 +93,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// their list of verified image references, see the 'List supported
         /// node agent SKUs' operation.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "nodeAgentSKUId")]
+        [JsonProperty(PropertyName = "nodeAgentSKUId")]
         public string NodeAgentSKUId { get; set; }
 
         /// <summary>
@@ -90,28 +104,28 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// This property must not be specified if the imageReference or osDisk
         /// property specifies a Linux OS image.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "windowsConfiguration")]
+        [JsonProperty(PropertyName = "windowsConfiguration")]
         public WindowsConfiguration WindowsConfiguration { get; set; }
 
         /// <summary>
         /// Validate the object.
         /// </summary>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown if validation fails
         /// </exception>
         public virtual void Validate()
         {
-            if (this.NodeAgentSKUId == null)
+            if (NodeAgentSKUId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "NodeAgentSKUId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "NodeAgentSKUId");
             }
-            if (this.ImageReference != null)
+            if (ImageReference != null)
             {
-                this.ImageReference.Validate();
+                ImageReference.Validate();
             }
-            if (this.OsDisk != null)
+            if (OsDisk != null)
             {
-                this.OsDisk.Validate();
+                OsDisk.Validate();
             }
         }
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/WindowsConfiguration.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/Models/WindowsConfiguration.cs
@@ -8,6 +8,10 @@
 
 namespace Microsoft.Azure.Batch.Protocol.Models
 {
+    using Microsoft.Azure;
+    using Microsoft.Azure.Batch;
+    using Microsoft.Azure.Batch.Protocol;
+    using Newtonsoft.Json;
     using System.Linq;
 
     /// <summary>
@@ -18,7 +22,10 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <summary>
         /// Initializes a new instance of the WindowsConfiguration class.
         /// </summary>
-        public WindowsConfiguration() { }
+        public WindowsConfiguration()
+        {
+          CustomInit();
+        }
 
         /// <summary>
         /// Initializes a new instance of the WindowsConfiguration class.
@@ -27,8 +34,14 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// enabled on the virtual machine.</param>
         public WindowsConfiguration(bool? enableAutomaticUpdates = default(bool?))
         {
-            this.EnableAutomaticUpdates = enableAutomaticUpdates;
+            EnableAutomaticUpdates = enableAutomaticUpdates;
+            CustomInit();
         }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
 
         /// <summary>
         /// Gets or sets whether automatic updates are enabled on the virtual
@@ -37,7 +50,7 @@ namespace Microsoft.Azure.Batch.Protocol.Models
         /// <remarks>
         /// If omitted, the default value is true.
         /// </remarks>
-        [Newtonsoft.Json.JsonProperty(PropertyName = "enableAutomaticUpdates")]
+        [JsonProperty(PropertyName = "enableAutomaticUpdates")]
         public bool? EnableAutomaticUpdates { get; set; }
 
     }

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/PoolOperationsExtensions.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/PoolOperationsExtensions.cs
@@ -8,8 +8,11 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Models;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Extension methods for PoolOperations.
@@ -23,7 +26,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// If you do not specify a $filter clause including a poolId, the response
             /// includes all pools that existed in the account in the time range of the
-            /// returned aggregation intervals.
+            /// returned aggregation intervals. If you do not specify a $filter clause
+            /// including a startTime or endTime these filters default to the start and end
+            /// times of the last aggregation interval currently available; that is, only
+            /// the last aggregation interval is returned.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -31,9 +37,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='poolListUsageMetricsOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<PoolUsageMetrics> ListUsageMetrics(this IPoolOperations operations, PoolListUsageMetricsOptions poolListUsageMetricsOptions = default(PoolListUsageMetricsOptions))
+            public static IPage<PoolUsageMetrics> ListUsageMetrics(this IPoolOperations operations, PoolListUsageMetricsOptions poolListUsageMetricsOptions = default(PoolListUsageMetricsOptions))
             {
-                return ((IPoolOperations)operations).ListUsageMetricsAsync(poolListUsageMetricsOptions).GetAwaiter().GetResult();
+                return operations.ListUsageMetricsAsync(poolListUsageMetricsOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -43,7 +49,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// If you do not specify a $filter clause including a poolId, the response
             /// includes all pools that existed in the account in the time range of the
-            /// returned aggregation intervals.
+            /// returned aggregation intervals. If you do not specify a $filter clause
+            /// including a startTime or endTime these filters default to the start and end
+            /// times of the last aggregation interval currently available; that is, only
+            /// the last aggregation interval is returned.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -54,7 +63,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<PoolUsageMetrics>> ListUsageMetricsAsync(this IPoolOperations operations, PoolListUsageMetricsOptions poolListUsageMetricsOptions = default(PoolListUsageMetricsOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<PoolUsageMetrics>> ListUsageMetricsAsync(this IPoolOperations operations, PoolListUsageMetricsOptions poolListUsageMetricsOptions = default(PoolListUsageMetricsOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListUsageMetricsWithHttpMessagesAsync(poolListUsageMetricsOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -78,7 +87,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolStatistics GetAllLifetimeStatistics(this IPoolOperations operations, PoolGetAllLifetimeStatisticsOptions poolGetAllLifetimeStatisticsOptions = default(PoolGetAllLifetimeStatisticsOptions))
             {
-                return ((IPoolOperations)operations).GetAllLifetimeStatisticsAsync(poolGetAllLifetimeStatisticsOptions).GetAwaiter().GetResult();
+                return operations.GetAllLifetimeStatisticsAsync(poolGetAllLifetimeStatisticsOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -98,7 +107,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolStatistics> GetAllLifetimeStatisticsAsync(this IPoolOperations operations, PoolGetAllLifetimeStatisticsOptions poolGetAllLifetimeStatisticsOptions = default(PoolGetAllLifetimeStatisticsOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolStatistics> GetAllLifetimeStatisticsAsync(this IPoolOperations operations, PoolGetAllLifetimeStatisticsOptions poolGetAllLifetimeStatisticsOptions = default(PoolGetAllLifetimeStatisticsOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetAllLifetimeStatisticsWithHttpMessagesAsync(poolGetAllLifetimeStatisticsOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -125,7 +134,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolAddHeaders Add(this IPoolOperations operations, PoolAddParameter pool, PoolAddOptions poolAddOptions = default(PoolAddOptions))
             {
-                return ((IPoolOperations)operations).AddAsync(pool, poolAddOptions).GetAwaiter().GetResult();
+                return operations.AddAsync(pool, poolAddOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -148,7 +157,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolAddHeaders> AddAsync(this IPoolOperations operations, PoolAddParameter pool, PoolAddOptions poolAddOptions = default(PoolAddOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolAddHeaders> AddAsync(this IPoolOperations operations, PoolAddParameter pool, PoolAddOptions poolAddOptions = default(PoolAddOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.AddWithHttpMessagesAsync(pool, poolAddOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -165,9 +174,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='poolListOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<CloudPool> List(this IPoolOperations operations, PoolListOptions poolListOptions = default(PoolListOptions))
+            public static IPage<CloudPool> List(this IPoolOperations operations, PoolListOptions poolListOptions = default(PoolListOptions))
             {
-                return ((IPoolOperations)operations).ListAsync(poolListOptions).GetAwaiter().GetResult();
+                return operations.ListAsync(poolListOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -182,7 +191,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<CloudPool>> ListAsync(this IPoolOperations operations, PoolListOptions poolListOptions = default(PoolListOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<CloudPool>> ListAsync(this IPoolOperations operations, PoolListOptions poolListOptions = default(PoolListOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListWithHttpMessagesAsync(poolListOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -218,7 +227,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolDeleteHeaders Delete(this IPoolOperations operations, string poolId, PoolDeleteOptions poolDeleteOptions = default(PoolDeleteOptions))
             {
-                return ((IPoolOperations)operations).DeleteAsync(poolId, poolDeleteOptions).GetAwaiter().GetResult();
+                return operations.DeleteAsync(poolId, poolDeleteOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -250,7 +259,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolDeleteHeaders> DeleteAsync(this IPoolOperations operations, string poolId, PoolDeleteOptions poolDeleteOptions = default(PoolDeleteOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolDeleteHeaders> DeleteAsync(this IPoolOperations operations, string poolId, PoolDeleteOptions poolDeleteOptions = default(PoolDeleteOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DeleteWithHttpMessagesAsync(poolId, poolDeleteOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -272,7 +281,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static bool Exists(this IPoolOperations operations, string poolId, PoolExistsOptions poolExistsOptions = default(PoolExistsOptions))
             {
-                return ((IPoolOperations)operations).ExistsAsync(poolId, poolExistsOptions).GetAwaiter().GetResult();
+                return operations.ExistsAsync(poolId, poolExistsOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -290,7 +299,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<bool> ExistsAsync(this IPoolOperations operations, string poolId, PoolExistsOptions poolExistsOptions = default(PoolExistsOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<bool> ExistsAsync(this IPoolOperations operations, string poolId, PoolExistsOptions poolExistsOptions = default(PoolExistsOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ExistsWithHttpMessagesAsync(poolId, poolExistsOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -312,7 +321,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static CloudPool Get(this IPoolOperations operations, string poolId, PoolGetOptions poolGetOptions = default(PoolGetOptions))
             {
-                return ((IPoolOperations)operations).GetAsync(poolId, poolGetOptions).GetAwaiter().GetResult();
+                return operations.GetAsync(poolId, poolGetOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -330,7 +339,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<CloudPool> GetAsync(this IPoolOperations operations, string poolId, PoolGetOptions poolGetOptions = default(PoolGetOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<CloudPool> GetAsync(this IPoolOperations operations, string poolId, PoolGetOptions poolGetOptions = default(PoolGetOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.GetWithHttpMessagesAsync(poolId, poolGetOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -361,7 +370,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolPatchHeaders Patch(this IPoolOperations operations, string poolId, PoolPatchParameter poolPatchParameter, PoolPatchOptions poolPatchOptions = default(PoolPatchOptions))
             {
-                return ((IPoolOperations)operations).PatchAsync(poolId, poolPatchParameter, poolPatchOptions).GetAwaiter().GetResult();
+                return operations.PatchAsync(poolId, poolPatchParameter, poolPatchOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -388,7 +397,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolPatchHeaders> PatchAsync(this IPoolOperations operations, string poolId, PoolPatchParameter poolPatchParameter, PoolPatchOptions poolPatchOptions = default(PoolPatchOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolPatchHeaders> PatchAsync(this IPoolOperations operations, string poolId, PoolPatchParameter poolPatchParameter, PoolPatchOptions poolPatchOptions = default(PoolPatchOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.PatchWithHttpMessagesAsync(poolId, poolPatchParameter, poolPatchOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -410,7 +419,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolDisableAutoScaleHeaders DisableAutoScale(this IPoolOperations operations, string poolId, PoolDisableAutoScaleOptions poolDisableAutoScaleOptions = default(PoolDisableAutoScaleOptions))
             {
-                return ((IPoolOperations)operations).DisableAutoScaleAsync(poolId, poolDisableAutoScaleOptions).GetAwaiter().GetResult();
+                return operations.DisableAutoScaleAsync(poolId, poolDisableAutoScaleOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -428,7 +437,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolDisableAutoScaleHeaders> DisableAutoScaleAsync(this IPoolOperations operations, string poolId, PoolDisableAutoScaleOptions poolDisableAutoScaleOptions = default(PoolDisableAutoScaleOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolDisableAutoScaleHeaders> DisableAutoScaleAsync(this IPoolOperations operations, string poolId, PoolDisableAutoScaleOptions poolDisableAutoScaleOptions = default(PoolDisableAutoScaleOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.DisableAutoScaleWithHttpMessagesAsync(poolId, poolDisableAutoScaleOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -461,7 +470,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolEnableAutoScaleHeaders EnableAutoScale(this IPoolOperations operations, string poolId, PoolEnableAutoScaleParameter poolEnableAutoScaleParameter, PoolEnableAutoScaleOptions poolEnableAutoScaleOptions = default(PoolEnableAutoScaleOptions))
             {
-                return ((IPoolOperations)operations).EnableAutoScaleAsync(poolId, poolEnableAutoScaleParameter, poolEnableAutoScaleOptions).GetAwaiter().GetResult();
+                return operations.EnableAutoScaleAsync(poolId, poolEnableAutoScaleParameter, poolEnableAutoScaleOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -490,7 +499,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolEnableAutoScaleHeaders> EnableAutoScaleAsync(this IPoolOperations operations, string poolId, PoolEnableAutoScaleParameter poolEnableAutoScaleParameter, PoolEnableAutoScaleOptions poolEnableAutoScaleOptions = default(PoolEnableAutoScaleOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolEnableAutoScaleHeaders> EnableAutoScaleAsync(this IPoolOperations operations, string poolId, PoolEnableAutoScaleParameter poolEnableAutoScaleParameter, PoolEnableAutoScaleOptions poolEnableAutoScaleOptions = default(PoolEnableAutoScaleOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.EnableAutoScaleWithHttpMessagesAsync(poolId, poolEnableAutoScaleParameter, poolEnableAutoScaleOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -503,7 +512,8 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </summary>
             /// <remarks>
             /// This API is primarily for validating an autoscale formula, as it simply
-            /// returns the result without applying the formula to the pool.
+            /// returns the result without applying the formula to the pool. The pool must
+            /// have auto scaling enabled in order to evaluate a formula.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -524,7 +534,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static AutoScaleRun EvaluateAutoScale(this IPoolOperations operations, string poolId, string autoScaleFormula, PoolEvaluateAutoScaleOptions poolEvaluateAutoScaleOptions = default(PoolEvaluateAutoScaleOptions))
             {
-                return ((IPoolOperations)operations).EvaluateAutoScaleAsync(poolId, autoScaleFormula, poolEvaluateAutoScaleOptions).GetAwaiter().GetResult();
+                return operations.EvaluateAutoScaleAsync(poolId, autoScaleFormula, poolEvaluateAutoScaleOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -532,7 +542,8 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </summary>
             /// <remarks>
             /// This API is primarily for validating an autoscale formula, as it simply
-            /// returns the result without applying the formula to the pool.
+            /// returns the result without applying the formula to the pool. The pool must
+            /// have auto scaling enabled in order to evaluate a formula.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -554,7 +565,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<AutoScaleRun> EvaluateAutoScaleAsync(this IPoolOperations operations, string poolId, string autoScaleFormula, PoolEvaluateAutoScaleOptions poolEvaluateAutoScaleOptions = default(PoolEvaluateAutoScaleOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<AutoScaleRun> EvaluateAutoScaleAsync(this IPoolOperations operations, string poolId, string autoScaleFormula, PoolEvaluateAutoScaleOptions poolEvaluateAutoScaleOptions = default(PoolEvaluateAutoScaleOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.EvaluateAutoScaleWithHttpMessagesAsync(poolId, autoScaleFormula, poolEvaluateAutoScaleOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -588,7 +599,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolResizeHeaders Resize(this IPoolOperations operations, string poolId, PoolResizeParameter poolResizeParameter, PoolResizeOptions poolResizeOptions = default(PoolResizeOptions))
             {
-                return ((IPoolOperations)operations).ResizeAsync(poolId, poolResizeParameter, poolResizeOptions).GetAwaiter().GetResult();
+                return operations.ResizeAsync(poolId, poolResizeParameter, poolResizeOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -618,7 +629,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolResizeHeaders> ResizeAsync(this IPoolOperations operations, string poolId, PoolResizeParameter poolResizeParameter, PoolResizeOptions poolResizeOptions = default(PoolResizeOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolResizeHeaders> ResizeAsync(this IPoolOperations operations, string poolId, PoolResizeParameter poolResizeParameter, PoolResizeOptions poolResizeOptions = default(PoolResizeOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ResizeWithHttpMessagesAsync(poolId, poolResizeParameter, poolResizeOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -632,9 +643,12 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// This does not restore the pool to its previous state before the resize
             /// operation: it only stops any further changes being made, and the pool
-            /// maintains its current state. A resize operation need not be an explicit
-            /// resize pool request; this API can also be used to halt the initial sizing
-            /// of the pool when it is created.
+            /// maintains its current state. After stopping, the pool stabilizes at the
+            /// number of nodes it was at when the stop operation was done. During the stop
+            /// operation, the pool allocation state changes first to stopping and then to
+            /// steady. A resize operation need not be an explicit resize pool request;
+            /// this API can also be used to halt the initial sizing of the pool when it is
+            /// created.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -647,7 +661,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolStopResizeHeaders StopResize(this IPoolOperations operations, string poolId, PoolStopResizeOptions poolStopResizeOptions = default(PoolStopResizeOptions))
             {
-                return ((IPoolOperations)operations).StopResizeAsync(poolId, poolStopResizeOptions).GetAwaiter().GetResult();
+                return operations.StopResizeAsync(poolId, poolStopResizeOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -656,9 +670,12 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// This does not restore the pool to its previous state before the resize
             /// operation: it only stops any further changes being made, and the pool
-            /// maintains its current state. A resize operation need not be an explicit
-            /// resize pool request; this API can also be used to halt the initial sizing
-            /// of the pool when it is created.
+            /// maintains its current state. After stopping, the pool stabilizes at the
+            /// number of nodes it was at when the stop operation was done. During the stop
+            /// operation, the pool allocation state changes first to stopping and then to
+            /// steady. A resize operation need not be an explicit resize pool request;
+            /// this API can also be used to halt the initial sizing of the pool when it is
+            /// created.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -672,7 +689,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolStopResizeHeaders> StopResizeAsync(this IPoolOperations operations, string poolId, PoolStopResizeOptions poolStopResizeOptions = default(PoolStopResizeOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolStopResizeHeaders> StopResizeAsync(this IPoolOperations operations, string poolId, PoolStopResizeOptions poolStopResizeOptions = default(PoolStopResizeOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.StopResizeWithHttpMessagesAsync(poolId, poolStopResizeOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -703,7 +720,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolUpdatePropertiesHeaders UpdateProperties(this IPoolOperations operations, string poolId, PoolUpdatePropertiesParameter poolUpdatePropertiesParameter, PoolUpdatePropertiesOptions poolUpdatePropertiesOptions = default(PoolUpdatePropertiesOptions))
             {
-                return ((IPoolOperations)operations).UpdatePropertiesAsync(poolId, poolUpdatePropertiesParameter, poolUpdatePropertiesOptions).GetAwaiter().GetResult();
+                return operations.UpdatePropertiesAsync(poolId, poolUpdatePropertiesParameter, poolUpdatePropertiesOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -730,7 +747,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolUpdatePropertiesHeaders> UpdatePropertiesAsync(this IPoolOperations operations, string poolId, PoolUpdatePropertiesParameter poolUpdatePropertiesParameter, PoolUpdatePropertiesOptions poolUpdatePropertiesOptions = default(PoolUpdatePropertiesOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolUpdatePropertiesHeaders> UpdatePropertiesAsync(this IPoolOperations operations, string poolId, PoolUpdatePropertiesParameter poolUpdatePropertiesParameter, PoolUpdatePropertiesOptions poolUpdatePropertiesOptions = default(PoolUpdatePropertiesOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.UpdatePropertiesWithHttpMessagesAsync(poolId, poolUpdatePropertiesParameter, poolUpdatePropertiesOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -752,7 +769,12 @@ namespace Microsoft.Azure.Batch.Protocol
             /// it does not guarantee to do this (particularly on small pools); therefore,
             /// the pool may be temporarily unavailable to run tasks. When this operation
             /// runs, the pool state changes to upgrading. When all compute nodes have
-            /// finished upgrading, the pool state returns to active.
+            /// finished upgrading, the pool state returns to active. While the upgrade is
+            /// in progress, the pool's currentOSVersion reflects the OS version that nodes
+            /// are upgrading from, and targetOSVersion reflects the OS version that nodes
+            /// are upgrading to. Once the upgrade is complete, currentOSVersion is updated
+            /// to reflect the OS version now running on all nodes. This operation can only
+            /// be invoked on pools created with the cloudServiceConfiguration property.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -769,7 +791,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolUpgradeOSHeaders UpgradeOS(this IPoolOperations operations, string poolId, string targetOSVersion, PoolUpgradeOSOptions poolUpgradeOSOptions = default(PoolUpgradeOSOptions))
             {
-                return ((IPoolOperations)operations).UpgradeOSAsync(poolId, targetOSVersion, poolUpgradeOSOptions).GetAwaiter().GetResult();
+                return operations.UpgradeOSAsync(poolId, targetOSVersion, poolUpgradeOSOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -786,7 +808,12 @@ namespace Microsoft.Azure.Batch.Protocol
             /// it does not guarantee to do this (particularly on small pools); therefore,
             /// the pool may be temporarily unavailable to run tasks. When this operation
             /// runs, the pool state changes to upgrading. When all compute nodes have
-            /// finished upgrading, the pool state returns to active.
+            /// finished upgrading, the pool state returns to active. While the upgrade is
+            /// in progress, the pool's currentOSVersion reflects the OS version that nodes
+            /// are upgrading from, and targetOSVersion reflects the OS version that nodes
+            /// are upgrading to. Once the upgrade is complete, currentOSVersion is updated
+            /// to reflect the OS version now running on all nodes. This operation can only
+            /// be invoked on pools created with the cloudServiceConfiguration property.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -804,7 +831,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolUpgradeOSHeaders> UpgradeOSAsync(this IPoolOperations operations, string poolId, string targetOSVersion, PoolUpgradeOSOptions poolUpgradeOSOptions = default(PoolUpgradeOSOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolUpgradeOSHeaders> UpgradeOSAsync(this IPoolOperations operations, string poolId, string targetOSVersion, PoolUpgradeOSOptions poolUpgradeOSOptions = default(PoolUpgradeOSOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.UpgradeOSWithHttpMessagesAsync(poolId, targetOSVersion, poolUpgradeOSOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -834,7 +861,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// </param>
             public static PoolRemoveNodesHeaders RemoveNodes(this IPoolOperations operations, string poolId, NodeRemoveParameter nodeRemoveParameter, PoolRemoveNodesOptions poolRemoveNodesOptions = default(PoolRemoveNodesOptions))
             {
-                return ((IPoolOperations)operations).RemoveNodesAsync(poolId, nodeRemoveParameter, poolRemoveNodesOptions).GetAwaiter().GetResult();
+                return operations.RemoveNodesAsync(poolId, nodeRemoveParameter, poolRemoveNodesOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -860,7 +887,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<PoolRemoveNodesHeaders> RemoveNodesAsync(this IPoolOperations operations, string poolId, NodeRemoveParameter nodeRemoveParameter, PoolRemoveNodesOptions poolRemoveNodesOptions = default(PoolRemoveNodesOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<PoolRemoveNodesHeaders> RemoveNodesAsync(this IPoolOperations operations, string poolId, NodeRemoveParameter nodeRemoveParameter, PoolRemoveNodesOptions poolRemoveNodesOptions = default(PoolRemoveNodesOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.RemoveNodesWithHttpMessagesAsync(poolId, nodeRemoveParameter, poolRemoveNodesOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -875,7 +902,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// If you do not specify a $filter clause including a poolId, the response
             /// includes all pools that existed in the account in the time range of the
-            /// returned aggregation intervals.
+            /// returned aggregation intervals. If you do not specify a $filter clause
+            /// including a startTime or endTime these filters default to the start and end
+            /// times of the last aggregation interval currently available; that is, only
+            /// the last aggregation interval is returned.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -886,9 +916,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='poolListUsageMetricsNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<PoolUsageMetrics> ListUsageMetricsNext(this IPoolOperations operations, string nextPageLink, PoolListUsageMetricsNextOptions poolListUsageMetricsNextOptions = default(PoolListUsageMetricsNextOptions))
+            public static IPage<PoolUsageMetrics> ListUsageMetricsNext(this IPoolOperations operations, string nextPageLink, PoolListUsageMetricsNextOptions poolListUsageMetricsNextOptions = default(PoolListUsageMetricsNextOptions))
             {
-                return ((IPoolOperations)operations).ListUsageMetricsNextAsync(nextPageLink, poolListUsageMetricsNextOptions).GetAwaiter().GetResult();
+                return operations.ListUsageMetricsNextAsync(nextPageLink, poolListUsageMetricsNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -898,7 +928,10 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <remarks>
             /// If you do not specify a $filter clause including a poolId, the response
             /// includes all pools that existed in the account in the time range of the
-            /// returned aggregation intervals.
+            /// returned aggregation intervals. If you do not specify a $filter clause
+            /// including a startTime or endTime these filters default to the start and end
+            /// times of the last aggregation interval currently available; that is, only
+            /// the last aggregation interval is returned.
             /// </remarks>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -912,7 +945,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<PoolUsageMetrics>> ListUsageMetricsNextAsync(this IPoolOperations operations, string nextPageLink, PoolListUsageMetricsNextOptions poolListUsageMetricsNextOptions = default(PoolListUsageMetricsNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<PoolUsageMetrics>> ListUsageMetricsNextAsync(this IPoolOperations operations, string nextPageLink, PoolListUsageMetricsNextOptions poolListUsageMetricsNextOptions = default(PoolListUsageMetricsNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListUsageMetricsNextWithHttpMessagesAsync(nextPageLink, poolListUsageMetricsNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {
@@ -932,9 +965,9 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='poolListNextOptions'>
             /// Additional parameters for the operation
             /// </param>
-            public static Microsoft.Rest.Azure.IPage<CloudPool> ListNext(this IPoolOperations operations, string nextPageLink, PoolListNextOptions poolListNextOptions = default(PoolListNextOptions))
+            public static IPage<CloudPool> ListNext(this IPoolOperations operations, string nextPageLink, PoolListNextOptions poolListNextOptions = default(PoolListNextOptions))
             {
-                return ((IPoolOperations)operations).ListNextAsync(nextPageLink, poolListNextOptions).GetAwaiter().GetResult();
+                return operations.ListNextAsync(nextPageLink, poolListNextOptions).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -952,7 +985,7 @@ namespace Microsoft.Azure.Batch.Protocol
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async System.Threading.Tasks.Task<Microsoft.Rest.Azure.IPage<CloudPool>> ListNextAsync(this IPoolOperations operations, string nextPageLink, PoolListNextOptions poolListNextOptions = default(PoolListNextOptions), System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            public static async Task<IPage<CloudPool>> ListNextAsync(this IPoolOperations operations, string nextPageLink, PoolListNextOptions poolListNextOptions = default(PoolListNextOptions), CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListNextWithHttpMessagesAsync(nextPageLink, poolListNextOptions, null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/TaskOperations.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/GeneratedProtocol/TaskOperations.cs
@@ -8,15 +8,23 @@
 
 namespace Microsoft.Azure.Batch.Protocol
 {
-    using System.Linq;
     using Microsoft.Rest;
     using Microsoft.Rest.Azure;
+    using Microsoft.Rest.Serialization;
     using Models;
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// TaskOperations operations.
     /// </summary>
-    internal partial class TaskOperations : Microsoft.Rest.IServiceOperations<BatchServiceClient>, ITaskOperations
+    internal partial class TaskOperations : IServiceOperations<BatchServiceClient>, ITaskOperations
     {
         /// <summary>
         /// Initializes a new instance of the TaskOperations class.
@@ -33,7 +41,7 @@ namespace Microsoft.Azure.Batch.Protocol
             {
                 throw new System.ArgumentNullException("client");
             }
-            this.Client = client;
+            Client = client;
         }
 
         /// <summary>
@@ -62,7 +70,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -71,23 +79,23 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskAddHeaders>> AddWithHttpMessagesAsync(string jobId, TaskAddParameter task, TaskAddOptions taskAddOptions = default(TaskAddOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<TaskAddHeaders>> AddWithHttpMessagesAsync(string jobId, TaskAddParameter task, TaskAddOptions taskAddOptions = default(TaskAddOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (task == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "task");
+                throw new ValidationException(ValidationRules.CannotBeNull, "task");
             }
             if (task != null)
             {
                 task.Validate();
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (taskAddOptions != null)
@@ -110,12 +118,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = taskAddOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("task", task);
                 tracingParameters.Add("timeout", timeout);
@@ -123,42 +131,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Add", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Add", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -166,7 +174,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -174,7 +182,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -182,7 +190,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -202,28 +210,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(task != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(task, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(task, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 201)
@@ -232,21 +240,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -256,7 +264,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskAddHeaders>();
+            var _result = new AzureOperationHeaderResponse<TaskAddHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -265,20 +273,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskAddHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskAddHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -306,10 +314,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -318,15 +326,15 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudTask>,TaskListHeaders>> ListWithHttpMessagesAsync(string jobId, TaskListOptions taskListOptions = default(TaskListOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<CloudTask>,TaskListHeaders>> ListWithHttpMessagesAsync(string jobId, TaskListOptions taskListOptions = default(TaskListOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string filter = default(string);
             if (taskListOptions != null)
@@ -369,12 +377,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = taskListOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("filter", filter);
                 tracingParameters.Add("select", select);
@@ -385,16 +393,16 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "List", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (filter != null)
             {
@@ -410,33 +418,33 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (maxResults != null)
             {
-                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(maxResults, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("maxresults={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(maxResults, Client.SerializationSettings).Trim('"'))));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -444,7 +452,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -452,7 +460,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -460,7 +468,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -479,23 +487,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -504,21 +512,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -528,7 +536,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudTask>,TaskListHeaders>();
+            var _result = new AzureOperationResponse<IPage<CloudTask>,TaskListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -541,34 +549,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<CloudTask>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<CloudTask>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -583,15 +591,22 @@ namespace Microsoft.Azure.Batch.Protocol
         /// the request, the request may have been partially or fully processed, or not
         /// at all. In such cases, the user should re-issue the request. Note that it
         /// is up to the user to correctly handle failures when re-issuing a request.
-        /// For example, you should use the same task ids during a retry so that if the
+        /// For example, you should use the same task IDs during a retry so that if the
         /// prior operation succeeded, the retry will not create extra tasks
-        /// unexpectedly.
+        /// unexpectedly. If the response contains any tasks which failed to add, a
+        /// client can retry the request. In a retry, it is most efficient to resubmit
+        /// only tasks that failed to add, and to omit tasks that were successfully
+        /// added on the first attempt.
         /// </remarks>
         /// <param name='jobId'>
         /// The ID of the job to which the task collection is to be added.
         /// </param>
         /// <param name='value'>
-        /// The collection of tasks to add.
+        /// The collection of tasks to add. The total serialized size of this
+        /// collection must be less than 4MB. If it is greater than 4MB (for example if
+        /// each task has 100's of resource files or environment variables), the
+        /// request will fail with code 'RequestBodyTooLarge' and should be retried
+        /// again with fewer tasks.
         /// </param>
         /// <param name='taskAddCollectionOptions'>
         /// Additional parameters for the operation
@@ -605,10 +620,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -617,25 +632,25 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<TaskAddCollectionResult,TaskAddCollectionHeaders>> AddCollectionWithHttpMessagesAsync(string jobId, System.Collections.Generic.IList<TaskAddParameter> value, TaskAddCollectionOptions taskAddCollectionOptions = default(TaskAddCollectionOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<TaskAddCollectionResult,TaskAddCollectionHeaders>> AddCollectionWithHttpMessagesAsync(string jobId, IList<TaskAddParameter> value, TaskAddCollectionOptions taskAddCollectionOptions = default(TaskAddCollectionOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             if (value == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "value");
+                throw new ValidationException(ValidationRules.CannotBeNull, "value");
             }
             if (value != null)
             {
                 if (value.Count > 100)
                 {
-                    throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.MaxItems, "value", 100);
+                    throw new ValidationException(ValidationRules.MaxItems, "value", 100);
                 }
                 foreach (var element in value)
                 {
@@ -671,12 +686,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 taskCollection.Value = value;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("timeout", timeout);
                 tracingParameters.Add("clientRequestId", clientRequestId);
@@ -684,42 +699,42 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("taskCollection", taskCollection);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "AddCollection", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "AddCollection", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/addtaskcollection").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -727,7 +742,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -735,7 +750,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -743,7 +758,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -763,28 +778,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(taskCollection != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(taskCollection, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(taskCollection, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -793,21 +808,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -817,7 +832,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<TaskAddCollectionResult,TaskAddCollectionHeaders>();
+            var _result = new AzureOperationResponse<TaskAddCollectionResult,TaskAddCollectionHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -830,34 +845,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<TaskAddCollectionResult>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<TaskAddCollectionResult>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskAddCollectionHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskAddCollectionHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -890,7 +905,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -899,19 +914,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobId, string taskId, TaskDeleteOptions taskDeleteOptions = default(TaskDeleteOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<TaskDeleteHeaders>> DeleteWithHttpMessagesAsync(string jobId, string taskId, TaskDeleteOptions taskDeleteOptions = default(TaskDeleteOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (taskDeleteOptions != null)
@@ -954,12 +969,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = taskDeleteOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("timeout", timeout);
@@ -971,43 +986,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Delete", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Delete", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("DELETE");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("DELETE");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1015,7 +1030,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1023,7 +1038,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1031,7 +1046,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1055,7 +1070,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1063,7 +1078,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1082,23 +1097,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1107,21 +1122,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1131,7 +1146,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskDeleteHeaders>();
+            var _result = new AzureOperationHeaderResponse<TaskDeleteHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1140,20 +1155,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskDeleteHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskDeleteHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1184,10 +1199,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1196,19 +1211,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudTask,TaskGetHeaders>> GetWithHttpMessagesAsync(string jobId, string taskId, TaskGetOptions taskGetOptions = default(TaskGetOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<CloudTask,TaskGetHeaders>> GetWithHttpMessagesAsync(string jobId, string taskId, TaskGetOptions taskGetOptions = default(TaskGetOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string select = default(string);
             if (taskGetOptions != null)
@@ -1261,12 +1276,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = taskGetOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("select", select);
@@ -1280,17 +1295,17 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Get", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (select != null)
             {
@@ -1302,29 +1317,29 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1332,7 +1347,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1340,7 +1355,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1348,7 +1363,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1372,7 +1387,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1380,7 +1395,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1399,23 +1414,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1424,21 +1439,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1448,7 +1463,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<CloudTask,TaskGetHeaders>();
+            var _result = new AzureOperationResponse<CloudTask,TaskGetHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1461,34 +1476,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<CloudTask>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<CloudTask>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskGetHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskGetHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1504,7 +1519,8 @@ namespace Microsoft.Azure.Batch.Protocol
         /// </param>
         /// <param name='constraints'>
         /// Constraints that apply to this task. If omitted, the task is given the
-        /// default constraints.
+        /// default constraints. For multi-instance tasks, updating the retention time
+        /// applies only to the primary task and not subtasks.
         /// </param>
         /// <param name='taskUpdateOptions'>
         /// Additional parameters for the operation
@@ -1518,7 +1534,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1527,19 +1543,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobId, string taskId, TaskConstraints constraints = default(TaskConstraints), TaskUpdateOptions taskUpdateOptions = default(TaskUpdateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<TaskUpdateHeaders>> UpdateWithHttpMessagesAsync(string jobId, string taskId, TaskConstraints constraints = default(TaskConstraints), TaskUpdateOptions taskUpdateOptions = default(TaskUpdateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (taskUpdateOptions != null)
@@ -1587,12 +1603,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 taskUpdateParameter.Constraints = constraints;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("timeout", timeout);
@@ -1605,43 +1621,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("taskUpdateParameter", taskUpdateParameter);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Update", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Update", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("PUT");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("PUT");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1649,7 +1665,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1657,7 +1673,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1665,7 +1681,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -1689,7 +1705,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -1697,7 +1713,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1717,28 +1733,28 @@ namespace Microsoft.Azure.Batch.Protocol
             string _requestContent = null;
             if(taskUpdateParameter != null)
             {
-                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(taskUpdateParameter, this.Client.SerializationSettings);
-                _httpRequest.Content = new System.Net.Http.StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _requestContent = SafeJsonConvert.SerializeObject(taskUpdateParameter, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
                 _httpRequest.Content.Headers.ContentType =System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; odata=minimalmetadata; charset=utf-8");
             }
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1747,21 +1763,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -1771,7 +1787,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskUpdateHeaders>();
+            var _result = new AzureOperationHeaderResponse<TaskUpdateHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -1780,20 +1796,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskUpdateHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskUpdateHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -1824,10 +1840,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -1836,19 +1852,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<CloudTaskListSubtasksResult,TaskListSubtasksHeaders>> ListSubtasksWithHttpMessagesAsync(string jobId, string taskId, TaskListSubtasksOptions taskListSubtasksOptions = default(TaskListSubtasksOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<CloudTaskListSubtasksResult,TaskListSubtasksHeaders>> ListSubtasksWithHttpMessagesAsync(string jobId, string taskId, TaskListSubtasksOptions taskListSubtasksOptions = default(TaskListSubtasksOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             string select = default(string);
             if (taskListSubtasksOptions != null)
@@ -1876,12 +1892,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = taskListSubtasksOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("select", select);
@@ -1890,17 +1906,17 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListSubtasks", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListSubtasks", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}/subtasksinfo").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (select != null)
             {
@@ -1908,29 +1924,29 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -1938,7 +1954,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -1946,7 +1962,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -1954,7 +1970,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -1973,23 +1989,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -1998,21 +2014,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2022,7 +2038,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<CloudTaskListSubtasksResult,TaskListSubtasksHeaders>();
+            var _result = new AzureOperationResponse<CloudTaskListSubtasksResult,TaskListSubtasksHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2035,34 +2051,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<CloudTaskListSubtasksResult>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<CloudTaskListSubtasksResult>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskListSubtasksHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskListSubtasksHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2094,7 +2110,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2103,19 +2119,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobId, string taskId, TaskTerminateOptions taskTerminateOptions = default(TaskTerminateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<TaskTerminateHeaders>> TerminateWithHttpMessagesAsync(string jobId, string taskId, TaskTerminateOptions taskTerminateOptions = default(TaskTerminateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (taskTerminateOptions != null)
@@ -2158,12 +2174,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = taskTerminateOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("timeout", timeout);
@@ -2175,43 +2191,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Terminate", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Terminate", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}/terminate").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2219,7 +2235,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2227,7 +2243,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2235,7 +2251,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -2259,7 +2275,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -2267,7 +2283,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2286,23 +2302,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 204)
@@ -2311,21 +2327,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2335,7 +2351,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskTerminateHeaders>();
+            var _result = new AzureOperationHeaderResponse<TaskTerminateHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2344,35 +2360,37 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskTerminateHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskTerminateHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
 
         /// <summary>
-        /// Reactivates the specified task.
+        /// Reactivates a task, allowing it to run again even if its retry count has
+        /// been exhausted.
         /// </summary>
         /// <remarks>
         /// Reactivation makes a task eligible to be retried again up to its maximum
         /// retry count. The task's state is changed to active. As the task is no
-        /// longer in the completed state, any previous exit code or scheduling error
-        /// is no longer available after reactivation. This will fail for tasks that
-        /// are not completed or that previously completed successfully (with an exit
-        /// code of 0). Additionally, this will fail if the job has completed (or is
-        /// terminating or deleting).
+        /// longer in the completed state, any previous exit code or failure
+        /// information is no longer available after reactivation. Each time a task is
+        /// reactivated, its retry count is reset to 0. Reactivation will fail for
+        /// tasks that are not completed or that previously completed successfully
+        /// (with an exit code of 0). Additionally, it will fail if the job has
+        /// completed (or is terminating or deleting).
         /// </remarks>
         /// <param name='jobId'>
         /// The ID of the job containing the task.
@@ -2392,7 +2410,7 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2401,19 +2419,19 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskReactivateHeaders>> ReactivateWithHttpMessagesAsync(string jobId, string taskId, TaskReactivateOptions taskReactivateOptions = default(TaskReactivateOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationHeaderResponse<TaskReactivateHeaders>> ReactivateWithHttpMessagesAsync(string jobId, string taskId, TaskReactivateOptions taskReactivateOptions = default(TaskReactivateOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (jobId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "jobId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "jobId");
             }
             if (taskId == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "taskId");
+                throw new ValidationException(ValidationRules.CannotBeNull, "taskId");
             }
-            if (this.Client.ApiVersion == null)
+            if (Client.ApiVersion == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "this.Client.ApiVersion");
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.ApiVersion");
             }
             int? timeout = default(int?);
             if (taskReactivateOptions != null)
@@ -2456,12 +2474,12 @@ namespace Microsoft.Azure.Batch.Protocol
                 ifUnmodifiedSince = taskReactivateOptions.IfUnmodifiedSince;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("jobId", jobId);
                 tracingParameters.Add("taskId", taskId);
                 tracingParameters.Add("timeout", timeout);
@@ -2473,43 +2491,43 @@ namespace Microsoft.Azure.Batch.Protocol
                 tracingParameters.Add("ifModifiedSince", ifModifiedSince);
                 tracingParameters.Add("ifUnmodifiedSince", ifUnmodifiedSince);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "Reactivate", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "Reactivate", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = this.Client.BaseUri.AbsoluteUri;
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
             var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "jobs/{jobId}/tasks/{taskId}/reactivate").ToString();
             _url = _url.Replace("{jobId}", System.Uri.EscapeDataString(jobId));
             _url = _url.Replace("{taskId}", System.Uri.EscapeDataString(taskId));
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
-            if (this.Client.ApiVersion != null)
+            List<string> _queryParameters = new List<string>();
+            if (Client.ApiVersion != null)
             {
-                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(this.Client.ApiVersion)));
+                _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
             }
             if (timeout != null)
             {
-                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(timeout, this.Client.SerializationSettings).Trim('"'))));
+                _queryParameters.Add(string.Format("timeout={0}", System.Uri.EscapeDataString(SafeJsonConvert.SerializeObject(timeout, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("POST");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2517,7 +2535,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2525,7 +2543,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2533,7 +2551,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifMatch != null)
             {
@@ -2557,7 +2575,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Modified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifModifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Modified-Since", SafeJsonConvert.SerializeObject(ifModifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
             if (ifUnmodifiedSince != null)
             {
@@ -2565,7 +2583,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("If-Unmodified-Since");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("If-Unmodified-Since", SafeJsonConvert.SerializeObject(ifUnmodifiedSince, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2584,23 +2602,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 204)
@@ -2609,21 +2627,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2633,7 +2651,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationHeaderResponse<TaskReactivateHeaders>();
+            var _result = new AzureOperationHeaderResponse<TaskReactivateHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2642,20 +2660,20 @@ namespace Microsoft.Azure.Batch.Protocol
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskReactivateHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskReactivateHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }
@@ -2683,10 +2701,10 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <exception cref="BatchErrorException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
-        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// <exception cref="SerializationException">
         /// Thrown when unable to deserialize the response
         /// </exception>
-        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// <exception cref="ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
         /// <exception cref="System.ArgumentNullException">
@@ -2695,11 +2713,11 @@ namespace Microsoft.Azure.Batch.Protocol
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudTask>,TaskListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, TaskListNextOptions taskListNextOptions = default(TaskListNextOptions), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async Task<AzureOperationResponse<IPage<CloudTask>,TaskListHeaders>> ListNextWithHttpMessagesAsync(string nextPageLink, TaskListNextOptions taskListNextOptions = default(TaskListNextOptions), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (nextPageLink == null)
             {
-                throw new Microsoft.Rest.ValidationException(Microsoft.Rest.ValidationRules.CannotBeNull, "nextPageLink");
+                throw new ValidationException(ValidationRules.CannotBeNull, "nextPageLink");
             }
             System.Guid? clientRequestId = default(System.Guid?);
             if (taskListNextOptions != null)
@@ -2717,44 +2735,44 @@ namespace Microsoft.Azure.Batch.Protocol
                 ocpDate = taskListNextOptions.OcpDate;
             }
             // Tracing
-            bool _shouldTrace = Microsoft.Rest.ServiceClientTracing.IsEnabled;
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
             string _invocationId = null;
             if (_shouldTrace)
             {
-                _invocationId = Microsoft.Rest.ServiceClientTracing.NextInvocationId.ToString();
-                System.Collections.Generic.Dictionary<string, object> tracingParameters = new System.Collections.Generic.Dictionary<string, object>();
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("nextPageLink", nextPageLink);
                 tracingParameters.Add("clientRequestId", clientRequestId);
                 tracingParameters.Add("returnClientRequestId", returnClientRequestId);
                 tracingParameters.Add("ocpDate", ocpDate);
                 tracingParameters.Add("cancellationToken", cancellationToken);
-                Microsoft.Rest.ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
+                ServiceClientTracing.Enter(_invocationId, this, "ListNext", tracingParameters);
             }
             // Construct URL
             string _url = "{nextLink}";
             _url = _url.Replace("{nextLink}", nextPageLink);
-            System.Collections.Generic.List<string> _queryParameters = new System.Collections.Generic.List<string>();
+            List<string> _queryParameters = new List<string>();
             if (_queryParameters.Count > 0)
             {
                 _url += (_url.Contains("?") ? "&" : "?") + string.Join("&", _queryParameters);
             }
             // Create HTTP transport objects
-            var _httpRequest = new System.Net.Http.HttpRequestMessage();
-            System.Net.Http.HttpResponseMessage _httpResponse = null;
-            _httpRequest.Method = new System.Net.Http.HttpMethod("GET");
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("GET");
             _httpRequest.RequestUri = new System.Uri(_url);
             // Set Headers
-            if (this.Client.GenerateClientRequestId != null && this.Client.GenerateClientRequestId.Value)
+            if (Client.GenerateClientRequestId != null && Client.GenerateClientRequestId.Value)
             {
                 _httpRequest.Headers.TryAddWithoutValidation("client-request-id", System.Guid.NewGuid().ToString());
             }
-            if (this.Client.AcceptLanguage != null)
+            if (Client.AcceptLanguage != null)
             {
                 if (_httpRequest.Headers.Contains("accept-language"))
                 {
                     _httpRequest.Headers.Remove("accept-language");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("accept-language", this.Client.AcceptLanguage);
+                _httpRequest.Headers.TryAddWithoutValidation("accept-language", Client.AcceptLanguage);
             }
             if (clientRequestId != null)
             {
@@ -2762,7 +2780,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(clientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("client-request-id", SafeJsonConvert.SerializeObject(clientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (returnClientRequestId != null)
             {
@@ -2770,7 +2788,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("return-client-request-id");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(returnClientRequestId, this.Client.SerializationSettings).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("return-client-request-id", SafeJsonConvert.SerializeObject(returnClientRequestId, Client.SerializationSettings).Trim('"'));
             }
             if (ocpDate != null)
             {
@@ -2778,7 +2796,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 {
                     _httpRequest.Headers.Remove("ocp-date");
                 }
-                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(ocpDate, new Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter()).Trim('"'));
+                _httpRequest.Headers.TryAddWithoutValidation("ocp-date", SafeJsonConvert.SerializeObject(ocpDate, new DateTimeRfc1123JsonConverter()).Trim('"'));
             }
 
 
@@ -2797,23 +2815,23 @@ namespace Microsoft.Azure.Batch.Protocol
             // Serialize Request
             string _requestContent = null;
             // Set Credentials
-            if (this.Client.Credentials != null)
+            if (Client.Credentials != null)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                await this.Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             }
             // Send Request
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
             }
             cancellationToken.ThrowIfCancellationRequested();
-            _httpResponse = await this.Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
             }
-            System.Net.HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
             cancellationToken.ThrowIfCancellationRequested();
             string _responseContent = null;
             if ((int)_statusCode != 200)
@@ -2822,21 +2840,21 @@ namespace Microsoft.Azure.Batch.Protocol
                 try
                 {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    BatchError _errorBody =  Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, this.Client.DeserializationSettings);
+                    BatchError _errorBody =  SafeJsonConvert.DeserializeObject<BatchError>(_responseContent, Client.DeserializationSettings);
                     if (_errorBody != null)
                     {
                         ex.Body = _errorBody;
                     }
                 }
-                catch (Newtonsoft.Json.JsonException)
+                catch (JsonException)
                 {
                     // Ignore the exception
                 }
-                ex.Request = new Microsoft.Rest.HttpRequestMessageWrapper(_httpRequest, _requestContent);
-                ex.Response = new Microsoft.Rest.HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
                 if (_shouldTrace)
                 {
-                    Microsoft.Rest.ServiceClientTracing.Error(_invocationId, ex);
+                    ServiceClientTracing.Error(_invocationId, ex);
                 }
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
@@ -2846,7 +2864,7 @@ namespace Microsoft.Azure.Batch.Protocol
                 throw ex;
             }
             // Create Result
-            var _result = new Microsoft.Rest.Azure.AzureOperationResponse<Microsoft.Rest.Azure.IPage<CloudTask>,TaskListHeaders>();
+            var _result = new AzureOperationResponse<IPage<CloudTask>,TaskListHeaders>();
             _result.Request = _httpRequest;
             _result.Response = _httpResponse;
             if (_httpResponse.Headers.Contains("request-id"))
@@ -2859,34 +2877,34 @@ namespace Microsoft.Azure.Batch.Protocol
                 _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
                 try
                 {
-                    _result.Body = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Page<CloudTask>>(_responseContent, this.Client.DeserializationSettings);
+                    _result.Body = SafeJsonConvert.DeserializeObject<Page<CloudTask>>(_responseContent, Client.DeserializationSettings);
                 }
-                catch (Newtonsoft.Json.JsonException ex)
+                catch (JsonException ex)
                 {
                     _httpRequest.Dispose();
                     if (_httpResponse != null)
                     {
                         _httpResponse.Dispose();
                     }
-                    throw new Microsoft.Rest.SerializationException("Unable to deserialize the response.", _responseContent, ex);
+                    throw new SerializationException("Unable to deserialize the response.", _responseContent, ex);
                 }
             }
             try
             {
-                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskListHeaders>(Newtonsoft.Json.JsonSerializer.Create(this.Client.DeserializationSettings));
+                _result.Headers = _httpResponse.GetHeadersAsJson().ToObject<TaskListHeaders>(JsonSerializer.Create(Client.DeserializationSettings));
             }
-            catch (Newtonsoft.Json.JsonException ex)
+            catch (JsonException ex)
             {
                 _httpRequest.Dispose();
                 if (_httpResponse != null)
                 {
                     _httpResponse.Dispose();
                 }
-                throw new Microsoft.Rest.SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
+                throw new SerializationException("Unable to deserialize the headers.", _httpResponse.GetHeadersAsJson().ToString(), ex);
             }
             if (_shouldTrace)
             {
-                Microsoft.Rest.ServiceClientTracing.Exit(_invocationId, _result);
+                ServiceClientTracing.Exit(_invocationId, _result);
             }
             return _result;
         }

--- a/src/SDKs/Batch/DataPlane/fixup.ps1
+++ b/src/SDKs/Batch/DataPlane/fixup.ps1
@@ -1,0 +1,8 @@
+foreach($f in (Get-ChildItem ".\Azure.Batch\GeneratedProtocol" -Filter *Operations.cs) + (Get-ChildItem ".\Azure.Batch\GeneratedProtocol" -Filter *OperationsExtensions.cs))
+{
+    # (Get-Content $f.FullName -Raw).replace('using Microsoft.Azure;`n', '').replace('using Microsoft.Azure.Batch;`n', '') | Set-Content $f.FullName
+    $text = [string]::Join("`n", (Get-Content $f.FullName))
+    $text = [regex]::Replace($text, " *using Microsoft.Azure;`n", "", "Singleline")
+    $text = [regex]::Replace($text, " *using Microsoft.Azure.Batch;`n", "", "Singleline")
+    [IO.File]::WriteAllText($f.FullName, $text)
+}

--- a/src/SDKs/Batch/DataPlane/generate.cmd
+++ b/src/SDKs/Batch/DataPlane/generate.cmd
@@ -5,3 +5,6 @@
 
 @echo off
 call %~dp0..\..\..\..\tools\generate.cmd batch/data-plane %*
+
+:: This is a stop-gap until https://github.com/Azure/autorest/issues/2558 is fixed
+powershell .\fixup.ps1

--- a/src/SDKs/_metadata/batch_data-plane.txt
+++ b/src/SDKs/_metadata/batch_data-plane.txt
@@ -1,0 +1,10 @@
+2017-08-31 16:55:15 UTC
+
+1) azure-rest-api-specs repository information
+GitHub user: Azure
+Branch:      current
+Commit:      21a810b65e7faed64040acf6cb0435ced80e6005
+
+2) AutoRest information
+Requested version: latest
+Latest version:    1.2.2


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
