### PR TITLE
[Storage] rename SKUs to Skus

### DIFF
--- a/src/SDKs/Storage/Management.Storage/Generated/ISKUsOperations.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/ISKUsOperations.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Azure.Management.Storage
     using System.Threading.Tasks;
 
     /// <summary>
-    /// SKUsOperations operations.
+    /// SkusOperations operations.
     /// </summary>
-    public partial interface ISKUsOperations
+    public partial interface ISkusOperations
     {
         /// <summary>
         /// Lists the available SKUs supported by Microsoft.Storage for given

--- a/src/SDKs/Storage/Management.Storage/Generated/IStorageManagementClient.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/IStorageManagementClient.cs
@@ -76,9 +76,9 @@ namespace Microsoft.Azure.Management.Storage
         IOperations Operations { get; }
 
         /// <summary>
-        /// Gets the ISKUsOperations.
+        /// Gets the ISkusOperations.
         /// </summary>
-        ISKUsOperations SKUs { get; }
+        ISkusOperations Skus { get; }
 
         /// <summary>
         /// Gets the IStorageAccountsOperations.

--- a/src/SDKs/Storage/Management.Storage/Generated/SKUsOperations.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/SKUsOperations.cs
@@ -23,12 +23,12 @@ namespace Microsoft.Azure.Management.Storage
     using System.Threading.Tasks;
 
     /// <summary>
-    /// SKUsOperations operations.
+    /// SkusOperations operations.
     /// </summary>
-    internal partial class SKUsOperations : IServiceOperations<StorageManagementClient>, ISKUsOperations
+    internal partial class SkusOperations : IServiceOperations<StorageManagementClient>, ISkusOperations
     {
         /// <summary>
-        /// Initializes a new instance of the SKUsOperations class.
+        /// Initializes a new instance of the SkusOperations class.
         /// </summary>
         /// <param name='client'>
         /// Reference to the service client.
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Management.Storage
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        internal SKUsOperations(StorageManagementClient client)
+        internal SkusOperations(StorageManagementClient client)
         {
             if (client == null)
             {

--- a/src/SDKs/Storage/Management.Storage/Generated/SKUsOperationsExtensions.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/SKUsOperationsExtensions.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Azure.Management.Storage
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Extension methods for SKUsOperations.
+    /// Extension methods for SkusOperations.
     /// </summary>
-    public static partial class SKUsOperationsExtensions
+    public static partial class SkusOperationsExtensions
     {
             /// <summary>
             /// Lists the available SKUs supported by Microsoft.Storage for given
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Management.Storage
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
-            public static IEnumerable<Sku> List(this ISKUsOperations operations)
+            public static IEnumerable<Sku> List(this ISkusOperations operations)
             {
                 return operations.ListAsync().GetAwaiter().GetResult();
             }
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Management.Storage
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<IEnumerable<Sku>> ListAsync(this ISKUsOperations operations, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<IEnumerable<Sku>> ListAsync(this ISkusOperations operations, CancellationToken cancellationToken = default(CancellationToken))
             {
                 using (var _result = await operations.ListWithHttpMessagesAsync(null, cancellationToken).ConfigureAwait(false))
                 {

--- a/src/SDKs/Storage/Management.Storage/Generated/StorageManagementClient.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/StorageManagementClient.cs
@@ -81,9 +81,9 @@ namespace Microsoft.Azure.Management.Storage
         public virtual IOperations Operations { get; private set; }
 
         /// <summary>
-        /// Gets the ISKUsOperations.
+        /// Gets the ISkusOperations.
         /// </summary>
-        public virtual ISKUsOperations SKUs { get; private set; }
+        public virtual ISkusOperations Skus { get; private set; }
 
         /// <summary>
         /// Gets the IStorageAccountsOperations.
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.Management.Storage
         private void Initialize()
         {
             Operations = new Operations(this);
-            SKUs = new SKUsOperations(this);
+            Skus = new SkusOperations(this);
             StorageAccounts = new StorageAccountsOperations(this);
             Usage = new UsageOperations(this);
             BaseUri = new System.Uri("https://management.azure.com");

--- a/src/SDKs/Storage/Management.Storage/Microsoft.Azure.Management.Storage.csproj
+++ b/src/SDKs/Storage/Management.Storage/Microsoft.Azure.Management.Storage.csproj
@@ -6,6 +6,7 @@
     <AssemblyName>Microsoft.Azure.Management.Storage</AssemblyName>
     <Version>7.0.0-preview</Version>
     <PackageTags>Microsoft Azure Storage management;Storage;Storage management</PackageTags>
+    <PackageReleaseNotes>See https://aka.ms/asdotnetsdkchangelog for release notes.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/Storage/Storage.Tests/Tests/StorageAccountTests.cs
+++ b/src/SDKs/Storage/Storage.Tests/Tests/StorageAccountTests.cs
@@ -1547,7 +1547,7 @@ namespace Storage.Tests
                 var resourcesClient = StorageManagementTestUtilities.GetResourceManagementClient(context, handler);
                 var storageMgmtClient = StorageManagementTestUtilities.GetStorageManagementClient(context, handler);
 
-                var skulist = storageMgmtClient.SKUs.List();
+                var skulist = storageMgmtClient.Skus.List();
                 Assert.NotNull(skulist);
                 Assert.Equal(@"storageAccounts", skulist.ElementAt(0).ResourceType);
                 Assert.NotNull(skulist.ElementAt(0).Name);

--- a/src/SDKs/Storage/changelog.md
+++ b/src/SDKs/Storage/changelog.md
@@ -1,0 +1,12 @@
+## Microsoft.Azure.Management.Storage release notes
+
+### Changes in 7.0.0-preview
+
+**Breaking changes**
+
+- When updating storage virtual networks, NetworkRuleSet is used instead of NetworkAcl.
+
+**Notes**
+
+- When updating storage virtual networks, virtualNetworkResourceId is limited to be resource ID of a subnet.
+- Added Skus.list() operation, which could list all the available skus for the subscription. 

--- a/src/SDKs/_metadata/storage_resource-manager.txt
+++ b/src/SDKs/_metadata/storage_resource-manager.txt
@@ -1,9 +1,9 @@
-2017-08-31 08:01:39 UTC
+2017-09-12 04:04:03 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure
 Branch:      current
-Commit:      21a810b65e7faed64040acf6cb0435ced80e6005
+Commit:      b3f4823378bab4812792ad0b90da6e8a8385a2f1
 
 2) AutoRest information
 Requested version: latest


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

Fixed bad names in swagger for python SDK, which affect other SDKs.
Since 7.0.0 haven't released yet, this will not break current experience for customers.

https://github.com/Azure/azure-rest-api-specs/pull/1650

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
