### PR TITLE
Avoid throwing exception when  deserializing from empty queues (Issue 3709)

### DIFF
--- a/src/ServiceManagement/HDInsight/Microsoft.Hadoop.Avro/Container/StreamReader.cs
+++ b/src/ServiceManagement/HDInsight/Microsoft.Hadoop.Avro/Container/StreamReader.cs
@@ -117,8 +117,20 @@ namespace Microsoft.Hadoop.Avro.Container
             }
 
             int objectCount = this.decoder.DecodeInt();
+            
+            if (objectCount == 0)
+            {
+                return false;
+            }
+
             int blockSize = this.decoder.DecodeInt();
             this.current = new AvroBufferReaderBlock<T>(this.serializer, this.codec, this.decoder.DecodeFixed(blockSize), objectCount);
+ 			
+            if (this.header.SyncMarker.Length == 0)
+            {
+                return false;
+            }
+            
             var marker = this.decoder.DecodeFixed(this.header.SyncMarker.Length);
             if (!marker.SequenceEqual(this.header.SyncMarker))
             {


### PR DESCRIPTION
Proposed fix for issue: https://github.com/Azure/azure-sdk-for-net/issues/3709

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
