### PR TITLE
[Monitor] Increasing nuget package and dll version to unblock publication of the SDK.

### DIFF
--- a/src/SDKs/Monitor/Management.Monitor/Microsoft.Azure.Management.Monitor.csproj
+++ b/src/SDKs/Monitor/Management.Monitor/Microsoft.Azure.Management.Monitor.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Microsoft Azure Monitor Library</Description>
     <AssemblyName>Microsoft.Azure.Management.Monitor</AssemblyName>
-    <Version>0.17.0-preview</Version>
+    <Version>0.18.0-preview</Version>
     <PackageId>Microsoft.Azure.Management.Monitor</PackageId>
     <PackageTags>Management.Monitor;Management.Monitoring;metrics;alerts;autoscale;activityLogs;events;operations;logs</PackageTags>
     <PackageReleaseNotes>See https://aka.ms/azure-sdk-for-net/monitor/changelog for release notes.</PackageReleaseNotes>

--- a/src/SDKs/Monitor/Management.Monitor/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Monitor/Management.Monitor/Properties/AssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Azure Monitor Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Monitor operations.")]
 
-[assembly: AssemblyVersion("0.17.0.0")]
-[assembly: AssemblyFileVersion("0.17.0.0")]
+[assembly: AssemblyVersion("0.18.0.0")]
+[assembly: AssemblyFileVersion("0.18.0.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Increasing nuget package and dll version from 0.17.0 to 0.18.0 to unblock publication of the SDK.
 The code was generated using the latest merged version of the Swagger spec (Azure/azure-rest-api-specs#1693)

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
