### PR TITLE
Adding Extensible enum type

### DIFF
--- a/src/SdkCommon/ClientRuntime.sln
+++ b/src/SdkCommon/ClientRuntime.sln
@@ -1,13 +1,27 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26214.0
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{FC756A84-660A-4917-85D0-0BBFB19FF71C}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Tracing.Tests", "Test\ClientRuntime.Tracing.Tests\Microsoft.Rest.ClientRuntime.Tracing.Tests.csproj", "{05A3BD74-8C1B-457B-A85A-35C7B393449E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Azure.Authentication", "ClientRuntime.Azure.Authentication\Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj", "{C98D5F13-997C-4555-9547-A997CC8A95A9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Etw", "ClientRuntime.Etw\Microsoft.Rest.ClientRuntime.Etw.csproj", "{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Log4Net", "ClientRuntime.Log4Net\Microsoft.Rest.ClientRuntime.Log4Net.csproj", "{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Tests", "ClientRuntime\ClientRuntime.Tests\Microsoft.Rest.ClientRuntime.Tests.csproj", "{582890B6-B962-4852-8420-1D7BB68E41E8}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Azure.Tests", "ClientRuntime.Azure\ClientRuntime.Azure.Tests\Microsoft.Rest.ClientRuntime.Azure.Tests.csproj", "{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Azure", "ClientRuntime.Azure\ClientRuntime.Azure\Microsoft.Rest.ClientRuntime.Azure.csproj", "{E67D3C1A-67CA-4315-918E-ADD2108AC66D}"
+EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime", "ClientRuntime\ClientRuntime\Microsoft.Rest.ClientRuntime.csproj", "{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientRuntime.E2E.Tests", "Test\ClientRuntime.E2E.Tests\ClientRuntime.E2E.Tests.csproj", "{87980F3C-A993-4620-B43A-07A174DB852E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,19 +29,50 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{05A3BD74-8C1B-457B-A85A-35C7B393449E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{05A3BD74-8C1B-457B-A85A-35C7B393449E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{05A3BD74-8C1B-457B-A85A-35C7B393449E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{05A3BD74-8C1B-457B-A85A-35C7B393449E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C98D5F13-997C-4555-9547-A997CC8A95A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C98D5F13-997C-4555-9547-A997CC8A95A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C98D5F13-997C-4555-9547-A997CC8A95A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C98D5F13-997C-4555-9547-A997CC8A95A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}.Release|Any CPU.Build.0 = Release|Any CPU
 		{582890B6-B962-4852-8420-1D7BB68E41E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{582890B6-B962-4852-8420-1D7BB68E41E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{582890B6-B962-4852-8420-1D7BB68E41E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{582890B6-B962-4852-8420-1D7BB68E41E8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E67D3C1A-67CA-4315-918E-ADD2108AC66D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E67D3C1A-67CA-4315-918E-ADD2108AC66D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E67D3C1A-67CA-4315-918E-ADD2108AC66D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E67D3C1A-67CA-4315-918E-ADD2108AC66D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{87980F3C-A993-4620-B43A-07A174DB852E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{87980F3C-A993-4620-B43A-07A174DB852E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{87980F3C-A993-4620-B43A-07A174DB852E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{87980F3C-A993-4620-B43A-07A174DB852E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
+		{05A3BD74-8C1B-457B-A85A-35C7B393449E} = {FC756A84-660A-4917-85D0-0BBFB19FF71C}
 		{582890B6-B962-4852-8420-1D7BB68E41E8} = {FC756A84-660A-4917-85D0-0BBFB19FF71C}
+		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA} = {FC756A84-660A-4917-85D0-0BBFB19FF71C}
+		{87980F3C-A993-4620-B43A-07A174DB852E} = {FC756A84-660A-4917-85D0-0BBFB19FF71C}
 	EndGlobalSection
 EndGlobal

--- a/src/SdkCommon/ClientRuntime.sln
+++ b/src/SdkCommon/ClientRuntime.sln
@@ -1,27 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26403.7
+VisualStudioVersion = 15.0.26214.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test", "Test", "{FC756A84-660A-4917-85D0-0BBFB19FF71C}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Tracing.Tests", "Test\ClientRuntime.Tracing.Tests\Microsoft.Rest.ClientRuntime.Tracing.Tests.csproj", "{05A3BD74-8C1B-457B-A85A-35C7B393449E}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Azure.Authentication", "ClientRuntime.Azure.Authentication\Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj", "{C98D5F13-997C-4555-9547-A997CC8A95A9}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Etw", "ClientRuntime.Etw\Microsoft.Rest.ClientRuntime.Etw.csproj", "{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Log4Net", "ClientRuntime.Log4Net\Microsoft.Rest.ClientRuntime.Log4Net.csproj", "{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Tests", "ClientRuntime\ClientRuntime.Tests\Microsoft.Rest.ClientRuntime.Tests.csproj", "{582890B6-B962-4852-8420-1D7BB68E41E8}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Azure.Tests", "ClientRuntime.Azure\ClientRuntime.Azure.Tests\Microsoft.Rest.ClientRuntime.Azure.Tests.csproj", "{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime.Azure", "ClientRuntime.Azure\ClientRuntime.Azure\Microsoft.Rest.ClientRuntime.Azure.csproj", "{E67D3C1A-67CA-4315-918E-ADD2108AC66D}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Rest.ClientRuntime", "ClientRuntime\ClientRuntime\Microsoft.Rest.ClientRuntime.csproj", "{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClientRuntime.E2E.Tests", "Test\ClientRuntime.E2E.Tests\ClientRuntime.E2E.Tests.csproj", "{87980F3C-A993-4620-B43A-07A174DB852E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -29,50 +15,19 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{05A3BD74-8C1B-457B-A85A-35C7B393449E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{05A3BD74-8C1B-457B-A85A-35C7B393449E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{05A3BD74-8C1B-457B-A85A-35C7B393449E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{05A3BD74-8C1B-457B-A85A-35C7B393449E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C98D5F13-997C-4555-9547-A997CC8A95A9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C98D5F13-997C-4555-9547-A997CC8A95A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C98D5F13-997C-4555-9547-A997CC8A95A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C98D5F13-997C-4555-9547-A997CC8A95A9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{1A2DAD3B-3AA1-4075-85F8-9C92CB43DC36}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5056FF5C-10C7-4CD4-920C-1E1DFEEBD100}.Release|Any CPU.Build.0 = Release|Any CPU
 		{582890B6-B962-4852-8420-1D7BB68E41E8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{582890B6-B962-4852-8420-1D7BB68E41E8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{582890B6-B962-4852-8420-1D7BB68E41E8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{582890B6-B962-4852-8420-1D7BB68E41E8}.Release|Any CPU.Build.0 = Release|Any CPU
-		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E67D3C1A-67CA-4315-918E-ADD2108AC66D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E67D3C1A-67CA-4315-918E-ADD2108AC66D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{E67D3C1A-67CA-4315-918E-ADD2108AC66D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{E67D3C1A-67CA-4315-918E-ADD2108AC66D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8DEE788-A658-4C1F-ACC4-866CDE9315BB}.Release|Any CPU.Build.0 = Release|Any CPU
-		{87980F3C-A993-4620-B43A-07A174DB852E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{87980F3C-A993-4620-B43A-07A174DB852E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{87980F3C-A993-4620-B43A-07A174DB852E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{87980F3C-A993-4620-B43A-07A174DB852E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
-		{05A3BD74-8C1B-457B-A85A-35C7B393449E} = {FC756A84-660A-4917-85D0-0BBFB19FF71C}
 		{582890B6-B962-4852-8420-1D7BB68E41E8} = {FC756A84-660A-4917-85D0-0BBFB19FF71C}
-		{140E67AC-EBC9-4CD7-9884-D0C63358C9CA} = {FC756A84-660A-4917-85D0-0BBFB19FF71C}
-		{87980F3C-A993-4620-B43A-07A174DB852E} = {FC756A84-660A-4917-85D0-0BBFB19FF71C}
 	EndGlobalSection
 EndGlobal

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ExtensibleEnumTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ExtensibleEnumTests.cs
@@ -25,15 +25,17 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             Assert.True(serialObj.Contains("Friday"));
 
             // Deserialization test
-            var serializedMovieTic = "{\"Price\":11.5,\"Day\":\"Weekday\",\"MovieName\":\"DEF\"}";
+            var serializedMovieTic = "{\"Price\":11.5,\"Day\":\"Weekday\",\"MovieName\":\"DEF\", \"Tax\":\"1.1\"}";
             var deserializeSettings = new JsonSerializerSettings() {
                 ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
                 NullValueHandling = NullValueHandling.Ignore
             };
+            System.Console.WriteLine(TaxAmount.One);
             var deserialized = JsonConvert.DeserializeObject<MovieTicket>(serializedMovieTic);
             Assert.Equal(deserialized.Price, 11.50);
             Assert.Equal(deserialized.MovieName, "DEF");
             Assert.Equal(deserialized.Day, (DaysOfWeekExtensibleEnum)"Weekday");
+            Assert.Equal(deserialized.Tax, "1");
 
             var day1 = DaysOfWeekExtensibleEnum.Saturday;
             DaysOfWeekExtensibleEnum day2 = "Monday";
@@ -42,6 +44,14 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             DaysOfWeekExtensibleEnum day3 = "Weekday";
             DaysOfWeekExtensibleEnum day4 = "Weekday";
             Assert.True(day4 == day3);
+
+            TaxAmount tax1 = "2.2";
+            Assert.Equal(TaxAmount.Two, tax1);
+
+            TaxAmount tax2 = "3.5";
+            Assert.NotEqual(TaxAmount.Three, tax2);
+
+            Assert.Equal(TaxAmount.Two, (TaxAmount)"2");
         }
 
         [Fact]

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ExtensibleEnumTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ExtensibleEnumTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+using Microsoft.Rest.ClientRuntime.Tests.Resources;
+using Microsoft.Rest.Serialization;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Microsoft.Rest.ClientRuntime.Tests
+{
+    [Collection("ExtensibleEnums Tests")]
+    public class ExtensibleEnumTests
+    {
+        [Fact]
+        public void ExtensibleEnumsTests()
+        {
+            // Serialization test
+            var serializeSettings = new JsonSerializerSettings();
+            serializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+            serializeSettings.ContractResolver = new ReadOnlyJsonContractResolver();
+            var movieTic = new MovieTicket() { Day = DaysOfWeekExtensibleEnum.Friday, MovieName = "ABC", Price = 13.50 };
+            var serialObj = JsonConvert.SerializeObject(movieTic);
+            Assert.NotNull(serialObj);
+            Assert.True(serialObj.Contains("Friday"));
+
+            // Deserialization test
+            var serializedMovieTic = "{\"Price\":11.5,\"Day\":\"Weekday\",\"MovieName\":\"DEF\"}";
+            var deserializeSettings = new JsonSerializerSettings();
+            deserializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
+            deserializeSettings.NullValueHandling = NullValueHandling.Ignore;
+            var deserialized = JsonConvert.DeserializeObject<MovieTicket>(serializedMovieTic);
+            Assert.Equal(deserialized.Price, 11.50);
+            Assert.Equal(deserialized.MovieName, "DEF");
+            Assert.Equal(deserialized.Day, (DaysOfWeekExtensibleEnum)"Weekday");
+
+            var day1 = DaysOfWeekExtensibleEnum.Saturday;
+            DaysOfWeekExtensibleEnum day2 = "Monday";
+            Assert.False(day1 == DaysOfWeekExtensibleEnum.Monday);
+
+            DaysOfWeekExtensibleEnum day3 = "Weekday";
+            DaysOfWeekExtensibleEnum day4 = "Weekday";
+            Assert.True(day4 == day3);
+        }
+
+        [Fact]
+        public void CanConvertEnumToString()
+        {
+            Assert.Equal("a", TestEnum.A.ToString());
+            Assert.Equal("b", TestEnum.B.ToString());
+            Assert.Equal("b", ((TestEnum)"b").ToString());
+            Assert.Equal("c", ((TestEnum)"c").ToString());
+
+            Assert.Equal("a", TestEnum.A.ToString());
+            Assert.Equal("b", TestEnum.B.ToString());
+            Assert.Equal("c", ((TestEnum)"c").ToString());
+        }
+
+        public void CanGetHashCode()
+        {
+            TestEnum.A.GetHashCode();
+        }
+
+        [Fact]
+        public void CanCompareForEquality()
+        {
+            var aAlias = TestEnum.A;    // Resolve compiler warning
+            Assert.True(TestEnum.A.Equals(TestEnum.A));
+            Assert.True(TestEnum.A.Equals((object)TestEnum.A));
+            Assert.True(aAlias == TestEnum.A);
+            Assert.False(aAlias != TestEnum.A);
+
+            Assert.False(TestEnum.A.Equals(TestEnum.B));
+            Assert.False(TestEnum.A.Equals((object)TestEnum.B));
+            Assert.False(TestEnum.A == TestEnum.B);
+            Assert.True(TestEnum.A != TestEnum.B);
+
+            Assert.False(TestEnum.A.Equals((TestEnum)"c"));
+            Assert.False(TestEnum.A.Equals((object)(TestEnum)"c"));
+            Assert.False(TestEnum.A == (TestEnum)"c");
+            Assert.True(TestEnum.A != (TestEnum)"c");
+
+            Assert.True(((TestEnum)"a").Equals(TestEnum.A));
+            Assert.True(((TestEnum)"a").Equals((object)TestEnum.A));
+            Assert.True(((TestEnum)"a") == TestEnum.A);
+            Assert.False(((TestEnum)"a") != TestEnum.A);
+
+            Assert.True(TestEnum.Special(TestEnum.A).Equals(TestEnum.Special(TestEnum.A)));
+            Assert.True(TestEnum.Special(TestEnum.A).Equals((object)TestEnum.Special(TestEnum.A)));
+            Assert.True(TestEnum.Special(TestEnum.A) == TestEnum.Special(TestEnum.A));
+            Assert.False(TestEnum.Special(TestEnum.A) != TestEnum.Special(TestEnum.A));
+
+            Assert.False(TestEnum.Special(TestEnum.A).Equals(TestEnum.Special(TestEnum.B)));
+            Assert.False(TestEnum.Special(TestEnum.A).Equals((object)TestEnum.Special(TestEnum.B)));
+            Assert.False(TestEnum.Special(TestEnum.A) == TestEnum.Special(TestEnum.B));
+            Assert.True(TestEnum.Special(TestEnum.A) != TestEnum.Special(TestEnum.B));
+        }
+
+        [Fact]
+        public void CannotCompareDifferentEnumsForEquality()
+        {
+            Assert.False(TestEnum.A.Equals((TestEnum2)"A"));
+            Assert.False(TestEnum.A.Equals((TestEnum2)"A"));
+        }
+
+        private class TestEnum : ExtensibleEnum<TestEnum, string>
+        {
+
+            private TestEnum(string value):base(value)
+            {
+            }
+
+            public static implicit operator TestEnum(string value) => _valueMap.GetOrAdd(value, (v)=>new TestEnum(v));
+
+            public static readonly TestEnum A = "a";
+            public static readonly TestEnum B = "b";
+            public static TestEnum Special(TestEnum baseEnum) => $"Special({baseEnum})";
+        }
+
+        private class TestEnum2 : ExtensibleEnum<TestEnum2, string>
+        {
+            public static implicit operator TestEnum2(string value) => _valueMap.GetOrAdd(value, (v) => new TestEnum2(v));
+
+            private TestEnum2(string name) : base(name) { }
+            
+        }
+
+    }
+}

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ExtensibleEnumTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ExtensibleEnumTests.cs
@@ -14,9 +14,11 @@ namespace Microsoft.Rest.ClientRuntime.Tests
         public void ExtensibleEnumsTests()
         {
             // Serialization test
-            var serializeSettings = new JsonSerializerSettings();
-            serializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
-            serializeSettings.ContractResolver = new ReadOnlyJsonContractResolver();
+            var serializeSettings = new JsonSerializerSettings()
+            {
+                ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
+                ContractResolver = new ReadOnlyJsonContractResolver()
+            };
             var movieTic = new MovieTicket() { Day = DaysOfWeekExtensibleEnum.Friday, MovieName = "ABC", Price = 13.50 };
             var serialObj = JsonConvert.SerializeObject(movieTic);
             Assert.NotNull(serialObj);
@@ -24,9 +26,10 @@ namespace Microsoft.Rest.ClientRuntime.Tests
 
             // Deserialization test
             var serializedMovieTic = "{\"Price\":11.5,\"Day\":\"Weekday\",\"MovieName\":\"DEF\"}";
-            var deserializeSettings = new JsonSerializerSettings();
-            deserializeSettings.ReferenceLoopHandling = ReferenceLoopHandling.Serialize;
-            deserializeSettings.NullValueHandling = NullValueHandling.Ignore;
+            var deserializeSettings = new JsonSerializerSettings() {
+                ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
+                NullValueHandling = NullValueHandling.Ignore
+            };
             var deserialized = JsonConvert.DeserializeObject<MovieTicket>(serializedMovieTic);
             Assert.Equal(deserialized.Price, 11.50);
             Assert.Equal(deserialized.MovieName, "DEF");

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Resources/MovieTicket.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Resources/MovieTicket.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
 
     internal class DaysOfWeekExtensibleEnum : Microsoft.Rest.ExtensibleEnum<DaysOfWeekExtensibleEnum, string>
     {
-        private DaysOfWeekExtensibleEnum(string value):base(value)
+        private DaysOfWeekExtensibleEnum(string value) : base(value)
         {
         }
 
@@ -28,22 +28,38 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
         /// DaysOfWeekExtensibleEnum.
         /// </summary>
         /// <param name="value">string to convert.</param>
-        public static implicit operator DaysOfWeekExtensibleEnum(string value) => _valueMap.GetOrAdd(value, (v) => new DaysOfWeekExtensibleEnum(v));
+        public static implicit operator DaysOfWeekExtensibleEnum(string value) => Create(value);
+
+        public static DaysOfWeekExtensibleEnum Create(string value) => _valueMap.GetOrAdd(value, (v) => new DaysOfWeekExtensibleEnum(v));
 
     }
 
-    public sealed class IntEnum : Microsoft.Rest.ExtensibleEnum<IntEnum, string>
+    public sealed class TaxAmount : Microsoft.Rest.ExtensibleEnum<TaxAmount, string>
     {
-        private IntEnum(string value) : base(value)
+        private TaxAmount(string value) : base(value)
         {
         }
-        public static readonly IntEnum One = "1";
-        public static readonly IntEnum Two = "2";
-        public static readonly IntEnum Three = "3";
-        /*
-        static
+
+        public static readonly TaxAmount One = "1";
+        public static readonly TaxAmount Two = "2";
+        public static readonly TaxAmount Three = "3";
+
+        public static implicit operator TaxAmount(string value) => Create(value);
+
+        public static TaxAmount Create(string value)
         {
-            AllowedValuesMap = new Dictionary<string, IntEnum>();
+            System.Console.Error.WriteLine("we're trying to deserialize "+value);
+            if (AllowedValuesMap.ContainsKey(value))
+            {
+                return AllowedValuesMap[value];
+            }
+
+            return _valueMap.GetOrAdd(value, (v) => new TaxAmount(v));
+        }
+
+        static TaxAmount()
+        {
+            AllowedValuesMap = new Dictionary<string, TaxAmount>();
             AllowedValuesMap.Add("1.1", One);
             AllowedValuesMap.Add("1.2", One);
             AllowedValuesMap.Add("1.3", One);
@@ -52,24 +68,10 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
             AllowedValuesMap.Add("3.1", Three);
             AllowedValuesMap.Add("3.3", Three);
         }
-        */
-    /// <summary>
-    /// Defines ctor/explicit conversion from value type to IntEnum.
-    /// </summary>
-    /// <param name="value">string to convert.</param>
-    public static implicit operator IntEnum(string value)
-    {
-        if (AllowedValuesMap.ContainsKey(value))
-        {
-            return AllowedValuesMap[value];
-        }
-
-        return _valueMap.GetOrAdd(value, (v) => new IntEnum(v));
+        
     }
 
-}
-
-internal class MovieTicket
+    internal class MovieTicket
     {
         public double Price { get; set; }
 
@@ -77,6 +79,8 @@ internal class MovieTicket
         public DaysOfWeekExtensibleEnum Day { get; set; }
 
         public string MovieName { get; set; }
+
+        public TaxAmount Tax { get; set; }
 
     }
 }

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Resources/MovieTicket.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Resources/MovieTicket.cs
@@ -4,6 +4,7 @@
 
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace Microsoft.Rest.ClientRuntime.Tests.Resources
 {
@@ -31,7 +32,44 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Resources
 
     }
 
-    internal class MovieTicket
+    public sealed class IntEnum : Microsoft.Rest.ExtensibleEnum<IntEnum, string>
+    {
+        private IntEnum(string value) : base(value)
+        {
+        }
+        public static readonly IntEnum One = "1";
+        public static readonly IntEnum Two = "2";
+        public static readonly IntEnum Three = "3";
+        /*
+        static
+        {
+            AllowedValuesMap = new Dictionary<string, IntEnum>();
+            AllowedValuesMap.Add("1.1", One);
+            AllowedValuesMap.Add("1.2", One);
+            AllowedValuesMap.Add("1.3", One);
+            AllowedValuesMap.Add("2.1", Two);
+            AllowedValuesMap.Add("2.2", Two);
+            AllowedValuesMap.Add("3.1", Three);
+            AllowedValuesMap.Add("3.3", Three);
+        }
+        */
+    /// <summary>
+    /// Defines ctor/explicit conversion from value type to IntEnum.
+    /// </summary>
+    /// <param name="value">string to convert.</param>
+    public static implicit operator IntEnum(string value)
+    {
+        if (AllowedValuesMap.ContainsKey(value))
+        {
+            return AllowedValuesMap[value];
+        }
+
+        return _valueMap.GetOrAdd(value, (v) => new IntEnum(v));
+    }
+
+}
+
+internal class MovieTicket
     {
         public double Price { get; set; }
 

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Resources/MovieTicket.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Resources/MovieTicket.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Newtonsoft.Json;
+using System;
+
+namespace Microsoft.Rest.ClientRuntime.Tests.Resources
+{
+
+    internal class DaysOfWeekExtensibleEnum : Microsoft.Rest.ExtensibleEnum<DaysOfWeekExtensibleEnum, string>
+    {
+        private DaysOfWeekExtensibleEnum(string value):base(value)
+        {
+        }
+
+        public static readonly DaysOfWeekExtensibleEnum Monday = "Monday";
+        public static readonly DaysOfWeekExtensibleEnum Tuesday = "Tuesday";
+        public static readonly DaysOfWeekExtensibleEnum Wednesday = "Wednesday";
+        public static readonly DaysOfWeekExtensibleEnum Thursday = "Thursday";
+        public static readonly DaysOfWeekExtensibleEnum Friday = "Friday";
+        public static readonly DaysOfWeekExtensibleEnum Saturday = "Saturday";
+        public static readonly DaysOfWeekExtensibleEnum Sunday = "Sunday";
+
+        /// <summary>
+        /// Defines ctor/explicit conversion from value type to
+        /// DaysOfWeekExtensibleEnum.
+        /// </summary>
+        /// <param name="value">string to convert.</param>
+        public static implicit operator DaysOfWeekExtensibleEnum(string value) => _valueMap.GetOrAdd(value, (v) => new DaysOfWeekExtensibleEnum(v));
+
+    }
+
+    internal class MovieTicket
+    {
+        public double Price { get; set; }
+
+        [JsonConverter(typeof(Serialization.ExtensibleEnumConverter<DaysOfWeekExtensibleEnum, string>))]
+        public DaysOfWeekExtensibleEnum Day { get; set; }
+
+        public string MovieName { get; set; }
+
+    }
+}

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/ExtensibleEnum.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/ExtensibleEnum.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Rest
+{
+    using System.Collections.Concurrent;
+
+    /// <summary>
+    /// Abstract base class for types that act like enums, but can be extended with arbitrary string values.
+    /// </summary>
+    public abstract class ExtensibleEnum<T, V> 
+    {
+        protected static readonly ConcurrentDictionary<V, T> _valueMap = new ConcurrentDictionary<V, T>();
+
+        protected readonly V _value;
+
+        /// <summary>
+        /// Initializes a new instance of the ExtensibleEnum class.
+        /// </summary>
+        /// <param value="value">The value for this instance of the extensible enumeration.</param>
+        protected ExtensibleEnum(V value)
+        {
+            _value = value;
+        }
+        
+        /// <summary>
+        /// Defines explicit conversion from ExtensibleEnum to string.
+        /// </summary>
+        /// <param val="val">ExtensibleEnum to convert.</param>
+        /// <returns>The ExtensibleEnum as a string.</returns>
+        public static explicit operator V(ExtensibleEnum<T, V> val) => val._value;
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return _value.GetHashCode();
+        }
+
+        /// <summary>
+        /// Returns a string representation of the ExtensibleEnum.
+        /// </summary>
+        /// <returns>The ExtensibleEnum as a string.</returns>
+        public override string ToString()
+        {
+            return _value.ToString();
+        }
+        
+    }
+}

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/ExtensibleEnum.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/ExtensibleEnum.cs
@@ -5,11 +5,12 @@
 namespace Microsoft.Rest
 {
     using System.Collections.Concurrent;
+    using System.Collections.Generic;
 
     /// <summary>
     /// Abstract base class for types that act like enums, but can be extended with arbitrary string values.
     /// </summary>
-    public abstract class ExtensibleEnum<T, V> 
+    public abstract class ExtensibleEnum<T, V> where T : ExtensibleEnum<T, V>
     {
         protected static readonly ConcurrentDictionary<V, T> _valueMap = new ConcurrentDictionary<V, T>();
 
@@ -23,7 +24,12 @@ namespace Microsoft.Rest
         {
             _value = value;
         }
-        
+
+        /// <summary>
+        /// Static map to store allowed values for enums        
+        /// ///</summary>
+        public static Dictionary<T, V> AllowedValuesMap { get; protected set; }
+
         /// <summary>
         /// Defines explicit conversion from ExtensibleEnum to string.
         /// </summary>

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/ExtensibleEnum.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/ExtensibleEnum.cs
@@ -27,15 +27,15 @@ namespace Microsoft.Rest
 
         /// <summary>
         /// Static map to store allowed values for enums        
-        /// ///</summary>
-        public static Dictionary<T, V> AllowedValuesMap { get; protected set; }
-
+        ///</summary>
+        public static Dictionary<V, T> AllowedValuesMap { get; protected set; } = new Dictionary<V, T>();
+        
         /// <summary>
         /// Defines explicit conversion from ExtensibleEnum to string.
         /// </summary>
         /// <param val="val">ExtensibleEnum to convert.</param>
         /// <returns>The ExtensibleEnum as a string.</returns>
-        public static explicit operator V(ExtensibleEnum<T, V> val) => val._value;
+        public static implicit operator V(ExtensibleEnum<T, V> val) => val._value;
 
         /// <inheritdoc />
         public override int GetHashCode()

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/Serialization/EnumConverterBase.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/Serialization/EnumConverterBase.cs
@@ -1,0 +1,127 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Microsoft.Rest.ClientRuntime.Serialization
+{
+    /// <summary>
+    /// Base class for custom JsonConverters.
+    /// </summary>
+    public abstract class EnumConverterBase : JsonConverter
+    {
+        /// <summary>
+        /// Asserts that the given JSON reader is positioned on a token with the expected type. Optionally asserts
+        /// that the value of the token matches a given expected value. If any of the assertions fail, this method
+        /// throws a JsonSerializationException. Otherwise, this method attempts to advance the JSON reader to the
+        /// next position.
+        /// </summary>
+        /// <param name="reader">The JSON reader.</param>
+        /// <param name="expectedToken">The JSON token on which the reader is expected to be positioned.</param>
+        /// <param name="expectedValue">Optional; The expected value of the current JSON token.</param>
+        protected void ExpectAndAdvance(JsonReader reader, JsonToken expectedToken, object expectedValue = null)
+        {
+            ExpectAndAdvance<object>(reader, expectedToken, expectedValue);
+        }
+
+        /// <summary>
+        /// Asserts that the given JSON reader is positioned on a token with the expected type and retrieves the value
+        /// of the token, if any. Optionally asserts that the value of the token matches a given expected value. If
+        /// any of the assertions fail, this method throws a JsonSerializationException. Otherwise, this method
+        /// attempts to advance the JSON reader to the next position.
+        /// </summary>
+        /// <typeparam name="TValue">The expected type of the value of the current JSON token.</typeparam>
+        /// <param name="reader">The JSON reader.</param>
+        /// <param name="expectedToken">The JSON token on which the reader is expected to be positioned.</param>
+        /// <param name="expectedValue">Optional; The expected value of the current JSON token.</param>
+        /// <returns>
+        /// The value of the JSON token before advancing the reader, or default(TValue) if the token has no value.
+        /// </returns>
+        protected TValue ExpectAndAdvance<TValue>(JsonReader reader, JsonToken expectedToken, object expectedValue = null)
+        {
+            TValue result = Expect<TValue>(reader, expectedToken, expectedValue);
+            Advance(reader);
+            return result;
+        }
+
+        /// <summary>
+        /// Asserts that the given JSON reader is positioned on a token with the expected type. Optionally asserts
+        /// that the value of the token matches a given expected value. If any of the assertions fail, this method
+        /// throws a JsonSerializationException.
+        /// </summary>
+        /// <param name="reader">The JSON reader.</param>
+        /// <param name="expectedToken">The JSON token on which the reader is expected to be positioned.</param>
+        /// <param name="expectedValue">Optional; The expected value of the current JSON token.</param>
+        protected void Expect(JsonReader reader, JsonToken expectedToken, object expectedValue = null)
+        {
+            Expect<object>(reader, expectedToken, expectedValue);
+        }
+
+        /// <summary>
+        /// Asserts that the given JSON reader is positioned on a token with the expected type and retrieves the value
+        /// of the token, if any. Optionally asserts that the value of the token matches a given expected value. If
+        /// any of the assertions fail, this method throws a JsonSerializationException.
+        /// </summary>
+        /// <typeparam name="TValue">The expected type of the value of the current JSON token.</typeparam>
+        /// <param name="reader">The JSON reader.</param>
+        /// <param name="expectedToken">The JSON token on which the reader is expected to be positioned.</param>
+        /// <param name="expectedValue">Optional; The expected value of the current JSON token.</param>
+        /// <returns>
+        /// The value of the current JSON token, or default(TValue) if the current token has no value.
+        /// </returns>
+        protected TValue Expect<TValue>(JsonReader reader, JsonToken expectedToken, object expectedValue = null)
+        {
+            if (reader.TokenType != expectedToken)
+            {
+                throw new JsonSerializationException(
+                    String.Format("Deserialization failed. Expected token: '{0}'", expectedToken));
+            }
+
+            if (expectedValue != null && (reader.Value == null || !reader.Value.Equals(expectedValue)))
+            {
+                string message =
+                    String.Format(
+                        "Deserialization failed. Expected value: '{0}'. Actual: '{1}'",
+                        expectedValue,
+                        reader.Value);
+
+                throw new JsonSerializationException(message);
+            }
+
+            TValue result = default(TValue);
+
+            if (reader.Value != null)
+            {
+                if (!typeof(TValue).GetTypeInfo().IsAssignableFrom(reader.ValueType.GetTypeInfo()))
+                {
+                    string message =
+                        String.Format(
+                            "Deserialization failed. Value '{0}' is not of expected type '{1}'.",
+                            reader.Value,
+                            typeof(TValue));
+
+                    throw new JsonSerializationException(message);
+                }
+
+                result = (TValue)reader.Value;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Advances the given JSON reader, or throws a JsonSerializationException if it cannot be advanced.
+        /// </summary>
+        /// <param name="reader">The JSON reader to advance.</param>
+        protected void Advance(JsonReader reader)
+        {
+            if (!reader.Read())
+            {
+                throw new JsonSerializationException("Deserialization failed. Unexpected end of input.");
+            }
+        }
+    }
+}

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/Serialization/ExtensibleEnumConverter.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/Serialization/ExtensibleEnumConverter.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using System.Reflection;
+using Newtonsoft.Json;
+
+namespace Microsoft.Rest.ClientRuntime.Serialization
+{
+    /// <summary>
+    /// Serializes and deserializes "extensible enums" to and from JSON. Extensible enums are like enumerations in
+    /// that they have well-known values, but they are extensible with new values and the values are based on strings
+    /// instead of integers.
+    /// </summary>
+    public class ExtensibleEnumConverter<T,V> : EnumConverterBase where T : ExtensibleEnum<T,V>
+    {
+        /// <summary>
+        /// Delegate type for a factory method that creates or looks up an ExtensibleEnum instance from a given string.
+        /// </summary>
+        /// <typeparam name="T">The type of ExtensibleEnum returned.</typeparam>
+        /// <param name="name">The enum value to look up or create.</param>
+        /// <returns>An instance of type T.</returns>
+        public delegate T ExtensibleEnumValueFactory<T,V>(V value) where T : ExtensibleEnum<T,V>;
+
+        private ExtensibleEnumValueFactory<T, V> _enumValueFactory;
+
+        /// <summary>
+        /// Initializes a new instance of the ExtensibleEnumConverter class.
+        /// </summary>
+        public ExtensibleEnumConverter() : this("Create") { }
+
+        /// <summary>
+        /// Initializes a new instance of the ExtensibleEnumConverter class.
+        /// </summary>
+        /// <param name="factoryMethodName">
+        /// The name of a public static method that creates an instance of type T given a string value; Default is
+        /// "Create".
+        /// </param>
+        public ExtensibleEnumConverter(string factoryMethodName)
+        {
+            if (factoryMethodName == null)
+            {
+                throw new ArgumentNullException(factoryMethodName, "factoryMethodName");
+            }
+            
+            MethodInfo method = typeof(T).GetTypeInfo().GetDeclaredMethod(factoryMethodName);
+
+            const string MessageFormat =
+                "No method named '{0}' could be found that is convertible to ExtensibleEnumValueFactory<{1}>.";
+            if (method == null)
+            {
+                throw new ArgumentException(String.Format(MessageFormat, factoryMethodName, typeof(T).Name), "factoryMethodName");
+            }
+            
+            _enumValueFactory =
+                (ExtensibleEnumValueFactory<T, V>)method.CreateDelegate(typeof(ExtensibleEnumValueFactory<T, V>));
+        }
+
+        /// <summary>
+        /// Indicates whether this converter can serialize or deserialize objects of the given type.
+        /// </summary>
+        /// <param name="objectType">The type to test against.</param>
+        /// <returns>true if objectType derives from ExtensibleEnum, false otherwise.</returns>
+        public override bool CanConvert(Type objectType)
+        {
+            return typeof(T).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+        }
+
+        /// <summary>
+        /// Deserializes a string into an ExtensibleEnum.
+        /// </summary>
+        /// <param name="reader">The JSON reader.</param>
+        /// <param name="objectType">Ignored by this method.</param>
+        /// <param name="existingValue">Ignored by this method.</param>
+        /// <param name="serializer">Ignored by this method.</param>
+        /// <returns>An instance of type T, or null if the current JSON token is null.</returns>
+        public override object ReadJson(
+            JsonReader reader,
+            Type objectType,
+            object existingValue,
+            JsonSerializer serializer)
+        {
+            // Check for null first.
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            return _enumValueFactory(Expect<V>(reader, reader.TokenType));
+        }
+        
+        /// <summary>
+        /// Serializes an ExtensibleEnum to a JSON string.
+        /// </summary>
+        /// <param name="writer">The JSON writer.</param>
+        /// <param name="value">The value to serialize.</param>
+        /// <param name="serializer">Ignored by this method.</param>
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString());
+        }
+    }
+}


### PR DESCRIPTION
Addressing https://github.com/Azure/autorest/issues/1591
Adding ExtensibleEnums type and related serialization/deserialization logic to ClientRuntime
Most of the code is derived from the solution implemented by  @brjohnstmsft 


<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
