### PR TITLE
Update Batch supporting assemblies

### DIFF
--- a/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/AzureBatchFileConventions.csproj
+++ b/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/AzureBatchFileConventions.csproj
@@ -8,7 +8,7 @@ by task and job id and the type of output.
     </Description>
     <AssemblyTitle>Microsoft Azure Batch File Conventions</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Batch.Conventions.Files</AssemblyName>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.1.0</VersionPrefix>
     <PackageTags>Microsoft, Azure, Batch, windowsazureofficial</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <PackageReleaseNotes>
@@ -35,7 +35,7 @@ Updated dependent libraries.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Batch" Version="[7.0.0,8.0.0)" />
+    <PackageReference Include="Azure.Batch" Version="[8.0.0,9.0.0)" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.1.1" />
   </ItemGroup>
 

--- a/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("A convention-based library for saving and retrieving Azure Batch task output files.")]
 
 [assembly: AssemblyVersion("3.0.0.0")] 
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.1.0.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/AzureBatchFileConventions.Tests.csproj
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/AzureBatchFileConventions.Tests.csproj
@@ -23,7 +23,6 @@
     <OutputPath>bin\$(Configuration)\</OutputPath>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Batch" Version="7.0.0" />
     <PackageReference Include="FsCheck.Xunit" Version="2.9.0-rc3" />
     <PackageReference Include="NSubstitute" Version="2.0.3" />
     <PackageReference Include="xunit" Version="2.3.0-beta1-build3642" />

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/AssemblyAttributes.cs
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/AssemblyAttributes.cs
@@ -20,8 +20,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft.Azure.Batch.FileStaging")]
 [assembly: AssemblyDescription("Client library for uploading resource files for tasks in the Azure Batch service.")]
 
-[assembly: AssemblyVersion("7.0.0.0")]
-[assembly: AssemblyFileVersion("7.0.0.0")]
+[assembly: AssemblyVersion("8.0.0.0")]
+[assembly: AssemblyFileVersion("8.0.0.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/Batch.FileStaging.csproj
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/Batch.FileStaging.csproj
@@ -8,7 +8,7 @@ Visit our home page for more detail - http://azure.microsoft.com/services/batch/
 For technical overview, see http://azure.microsoft.com/documentation/articles/batch-technical-overview/.
 
 API reference can be found at http://go.microsoft.com/fwlink/?LinkId=717949.</Description>
-    <VersionPrefix>7.0.0</VersionPrefix>
+    <VersionPrefix>8.0.0</VersionPrefix>
     <DefineConstants>$(DefineConstants);CODESIGN</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Microsoft.Azure.Batch.FileStaging</AssemblyName>
@@ -34,7 +34,7 @@ API reference can be found at http://go.microsoft.com/fwlink/?LinkId=717949.</De
 
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" Version="8.1.1" />
-    <PackageReference Include="Azure.Batch" Version="[7.0.1,8.0.0)" />
+    <PackageReference Include="Azure.Batch" Version="[8.0.0,9.0.0)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Web" />


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
