### PR TITLE
Add linked service scenario test (resolves #3726)

### DIFF
--- a/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/LinkedServiceScenarioTests.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/LinkedServiceScenarioTests.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using DataFactory.Tests.Utils;
+using Microsoft.Azure.Management.DataFactory;
+using Microsoft.Azure.Management.DataFactory.Models;
+using Microsoft.Rest.Azure;
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace DataFactory.Tests.ScenarioTests
+{
+    public class LinkedServiceScenarioTests : ScenarioTestBase<LinkedServiceScenarioTests>
+    {
+        [Fact]
+        [Trait(TraitName.TestType, TestType.Scenario)]
+        public async Task LinkedServiceCrud()
+        {
+            string linkedServiceName = "TestDataLakeStore";
+            var expectedLinkedService = new LinkedServiceResource()
+            {
+                Properties = new AzureDataLakeStoreLinkedService()
+                {
+                    DataLakeStoreUri = "adl://test.azuredatalakestore.net/"
+                }
+            };
+
+            Func<DataFactoryManagementClient, Task> action = async (client) =>
+            {
+                client.Factories.CreateOrUpdate(ResourceGroupName, DataFactoryName, new Factory(location: FactoryLocation));
+
+                AzureOperationResponse<LinkedServiceResource> createResponse = await client.LinkedServices.CreateOrUpdateWithHttpMessagesAsync(ResourceGroupName, DataFactoryName, linkedServiceName, expectedLinkedService);
+                this.ValidateLinkedService(expectedLinkedService, createResponse.Body, linkedServiceName);
+                Assert.Equal(HttpStatusCode.OK, createResponse.Response.StatusCode);
+
+                AzureOperationResponse<LinkedServiceResource> getResponse = await client.LinkedServices.GetWithHttpMessagesAsync(ResourceGroupName, DataFactoryName, linkedServiceName);
+                this.ValidateLinkedService(expectedLinkedService, getResponse.Body, linkedServiceName);
+                Assert.Equal(HttpStatusCode.OK, getResponse.Response.StatusCode);
+
+                AzureOperationResponse<IPage<LinkedServiceResource>> listResponse = await client.LinkedServices.ListByFactoryWithHttpMessagesAsync(ResourceGroupName, DataFactoryName);
+                this.ValidateLinkedService(expectedLinkedService, listResponse.Body.First(), linkedServiceName);
+                Assert.Equal(HttpStatusCode.OK, listResponse.Response.StatusCode);
+
+                AzureOperationResponse deleteResponse = await client.LinkedServices.DeleteWithHttpMessagesAsync(ResourceGroupName, DataFactoryName, linkedServiceName);
+                Assert.Equal(HttpStatusCode.OK, deleteResponse.Response.StatusCode);
+            };
+
+            Func<DataFactoryManagementClient, Task> finallyAction = async (client) =>
+            {
+                await client.Factories.DeleteAsync(ResourceGroupName, DataFactoryName);
+            };
+
+            await this.RunTest(action, finallyAction);
+        }
+
+        private void ValidateLinkedService(LinkedServiceResource expected, LinkedServiceResource actual, string expectedName)
+        {
+            this.ValidateSubResource(actual, expectedName, "linkedservices");
+            Assert.IsType<AzureDataLakeStoreLinkedService>(actual.Properties);
+            Assert.Equal(((AzureDataLakeStoreLinkedService)expected.Properties).DataLakeStoreUri, ((AzureDataLakeStoreLinkedService)actual.Properties).DataLakeStoreUri);
+        }
+    }
+}

--- a/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/PipelineRunScenarioTests.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/PipelineRunScenarioTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Azure.Management.DataFactory;
 using Microsoft.Azure.Management.DataFactory.Models;
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace DataFactory.Tests.ScenarioTests
@@ -15,11 +16,11 @@ namespace DataFactory.Tests.ScenarioTests
     {
         [Fact]
         [Trait(TraitName.TestType, TestType.Scenario)]
-        public void CancelPipelineRun()
+        public async Task CancelPipelineRun()
         {
             var expectedFactory = new Factory(location: FactoryLocation);
 
-            Action<DataFactoryManagementClient> action = async (client) =>
+            Func<DataFactoryManagementClient, Task> action = async (client) =>
             {
                 Factory createResponse = client.Factories.CreateOrUpdate(ResourceGroupName, DataFactoryName, expectedFactory);
                 ErrorResponseException exception = await Assert.ThrowsAsync<ErrorResponseException>(async () =>
@@ -30,11 +31,11 @@ namespace DataFactory.Tests.ScenarioTests
                 Assert.Equal(exception.Response.StatusCode, HttpStatusCode.BadRequest);
             };
 
-            Action<DataFactoryManagementClient> finallyAction = (client) =>
+            Func<DataFactoryManagementClient, Task> finallyAction = async (client) =>
             {
-                client.Factories.Delete(ResourceGroupName, DataFactoryName);
+                await client.Factories.DeleteAsync(ResourceGroupName, DataFactoryName);
             };
-            this.RunTest(action, finallyAction);
+            await this.RunTest(action, finallyAction);
         }
     }
 }

--- a/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.DataFactoryScenarioTests/DataFactoryCrud.json
+++ b/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.DataFactoryScenarioTests/DataFactoryCrud.json
@@ -13,7 +13,7 @@
           "31"
         ],
         "x-ms-client-request-id": [
-          "ccc12cc7-9c24-457d-8c23-f6f0a67a11d1"
+          "89e695dc-61ed-4bf9-8158-822c8c7a20d7"
         ],
         "accept-language": [
           "en-US"
@@ -23,7 +23,7 @@
           "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-11T18:05:17.8196041Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-18T17:20:05.4558261Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -35,7 +35,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 11 Oct 2017 18:05:26 GMT"
+          "Wed, 18 Oct 2017 17:20:03 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -50,7 +50,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "4aff2f3a-da68-47c8-bf58-09bbd1fb0147"
+          "89e695dc-61ed-4bf9-8158-822c8c7a20d7"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,13 +62,13 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1134"
+          "1105"
         ],
         "x-ms-correlation-request-id": [
-          "7a17a3b9-ef1c-4c93-8eae-f398d85a78d2"
+          "83784228-fe6f-44d8-9a07-a4d42da62c92"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20171011T180526Z:7a17a3b9-ef1c-4c93-8eae-f398d85a78d2"
+          "NORTHEUROPE:20171018T172004Z:83784228-fe6f-44d8-9a07-a4d42da62c92"
         ]
       },
       "StatusCode": 200
@@ -80,7 +80,7 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "a61d9ce4-8db6-414e-abf2-56b6d92c48cd"
+          "567de79a-1dee-44ce-b9ce-6be90c2e9669"
         ],
         "accept-language": [
           "en-US"
@@ -90,7 +90,7 @@
           "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-11T18:05:17.8196041Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-18T17:20:05.4558261Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -102,7 +102,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 11 Oct 2017 18:05:29 GMT"
+          "Wed, 18 Oct 2017 17:20:03 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -117,7 +117,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "2a201819-702c-4230-9f02-6b55725f891a"
+          "567de79a-1dee-44ce-b9ce-6be90c2e9669"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -129,13 +129,13 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14740"
+          "14613"
         ],
         "x-ms-correlation-request-id": [
-          "6bad86c9-4ceb-4bd8-953f-d4708be7a264"
+          "695e8eff-3415-4e44-ae4e-005447f3080a"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20171011T180530Z:6bad86c9-4ceb-4bd8-953f-d4708be7a264"
+          "NORTHEUROPE:20171018T172004Z:695e8eff-3415-4e44-ae4e-005447f3080a"
         ]
       },
       "StatusCode": 200
@@ -147,7 +147,7 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "12eb2527-80ac-4266-8114-33389f4862f9"
+          "143acece-2241-417e-8f35-0ce41fdae9b4"
         ],
         "accept-language": [
           "en-US"
@@ -157,7 +157,7 @@
           "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"sdktestingfactory\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"loggingStorageAccountKey\": \"**********\",\r\n        \"createTime\": \"2017-10-11T18:05:17.8196041Z\",\r\n        \"version\": \"2017-09-01-preview\"\r\n      },\r\n      \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n      \"type\": \"Microsoft.DataFactory/factories\",\r\n      \"location\": \"East US 2\"\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"sdktestingfactory\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"loggingStorageAccountKey\": \"**********\",\r\n        \"createTime\": \"2017-10-18T17:20:05.4558261Z\",\r\n        \"version\": \"2017-09-01-preview\"\r\n      },\r\n      \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n      \"type\": \"Microsoft.DataFactory/factories\",\r\n      \"location\": \"East US 2\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -169,7 +169,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 11 Oct 2017 18:05:29 GMT"
+          "Wed, 18 Oct 2017 17:20:04 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -184,7 +184,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "b2858e9d-e52b-47b2-b3fc-e6b276b2f59e"
+          "143acece-2241-417e-8f35-0ce41fdae9b4"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -196,13 +196,13 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14739"
+          "14612"
         ],
         "x-ms-correlation-request-id": [
-          "f4667a02-1925-4eb4-9a3e-c53bd8bd1f13"
+          "ade0054b-0ccd-4e0f-a100-4383cd5e520d"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20171011T180530Z:f4667a02-1925-4eb4-9a3e-c53bd8bd1f13"
+          "NORTHEUROPE:20171018T172004Z:ade0054b-0ccd-4e0f-a100-4383cd5e520d"
         ]
       },
       "StatusCode": 200
@@ -214,7 +214,7 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "bf2f6c61-8a27-486a-9439-4124cf50b1c9"
+          "3d947086-6019-4f45-bd92-149007bfed98"
         ],
         "accept-language": [
           "en-US"
@@ -236,7 +236,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 11 Oct 2017 18:05:34 GMT"
+          "Wed, 18 Oct 2017 17:20:05 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -245,7 +245,7 @@
           "Microsoft-IIS/8.5"
         ],
         "x-ms-request-id": [
-          "dec4559d-6f11-490f-9b98-70817ec6dc4c"
+          "3d947086-6019-4f45-bd92-149007bfed98"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -257,16 +257,65 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1131"
+          "1104"
         ],
         "x-ms-correlation-request-id": [
-          "06d8f20a-0a2e-4ab2-87f5-895545f25e0a"
+          "78fd5e2a-b409-4f34-a03d-55c1a518627e"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20171011T180534Z:06d8f20a-0a2e-4ab2-87f5-895545f25e0a"
+          "NORTHEUROPE:20171018T172005Z:78fd5e2a-b409-4f34-a03d-55c1a518627e"
         ]
       },
       "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "6efde5aa-c7bd-4694-9228-e51b158f836e"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 18 Oct 2017 17:20:05 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1103"
+        ],
+        "x-ms-request-id": [
+          "efd118eb-e05a-4e7d-89a2-392c52eb2399"
+        ],
+        "x-ms-correlation-request-id": [
+          "efd118eb-e05a-4e7d-89a2-392c52eb2399"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171018T172006Z:efd118eb-e05a-4e7d-89a2-392c52eb2399"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 204
     }
   ],
   "Names": {},

--- a/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.LinkedServiceScenarioTests/LinkedServiceCrud.json
+++ b/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.LinkedServiceScenarioTests/LinkedServiceCrud.json
@@ -1,0 +1,410 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "31"
+        ],
+        "x-ms-client-request-id": [
+          "6b1d8c76-9e14-4409-a347-759d808929fd"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-18T17:09:01.2495452Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 18 Oct 2017 17:08:59 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "6b1d8c76-9e14-4409-a347-759d808929fd"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1113"
+        ],
+        "x-ms-correlation-request-id": [
+          "dc012cec-cd82-4a82-a8da-d333aba94740"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171018T170900Z:dc012cec-cd82-4a82-a8da-d333aba94740"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvbGlua2Vkc2VydmljZXMvVGVzdERhdGFMYWtlU3RvcmU/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"type\": \"AzureDataLakeStore\",\r\n    \"typeProperties\": {\r\n      \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n    }\r\n  }\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "159"
+        ],
+        "x-ms-client-request-id": [
+          "3b6d42b5-be24-40d3-b0fd-75e4bf41d912"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore\",\r\n  \"name\": \"TestDataLakeStore\",\r\n  \"properties\": {\r\n    \"type\": \"AzureDataLakeStore\",\r\n    \"typeProperties\": {\r\n      \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n    }\r\n  },\r\n  \"etag\": \"a0014c71-0000-0000-0000-59e78aae0000\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 18 Oct 2017 17:09:01 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "3b6d42b5-be24-40d3-b0fd-75e4bf41d912"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1112"
+        ],
+        "x-ms-correlation-request-id": [
+          "00e06ea2-113b-421b-b5d8-76b0cdf1dd90"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171018T170901Z:00e06ea2-113b-421b-b5d8-76b0cdf1dd90"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvbGlua2Vkc2VydmljZXMvVGVzdERhdGFMYWtlU3RvcmU/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "2c3b659d-58ba-4187-ab25-ce49edf76dda"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore\",\r\n  \"name\": \"TestDataLakeStore\",\r\n  \"properties\": {\r\n    \"type\": \"AzureDataLakeStore\",\r\n    \"typeProperties\": {\r\n      \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n    }\r\n  },\r\n  \"etag\": \"a0014c71-0000-0000-0000-59e78aae0000\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 18 Oct 2017 17:09:02 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "2c3b659d-58ba-4187-ab25-ce49edf76dda"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14709"
+        ],
+        "x-ms-correlation-request-id": [
+          "e909cf19-5646-46ae-b96a-dbb530ff4737"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171018T170902Z:e909cf19-5646-46ae-b96a-dbb530ff4737"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvbGlua2Vkc2VydmljZXM/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "09a18d00-17ca-4075-9414-4052370d76b3"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore\",\r\n      \"name\": \"TestDataLakeStore\",\r\n      \"properties\": {\r\n        \"type\": \"AzureDataLakeStore\",\r\n        \"typeProperties\": {\r\n          \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n        }\r\n      },\r\n      \"etag\": \"a0014c71-0000-0000-0000-59e78aae0000\"\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 18 Oct 2017 17:09:02 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-request-id": [
+          "09a18d00-17ca-4075-9414-4052370d76b3"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14708"
+        ],
+        "x-ms-correlation-request-id": [
+          "af553f63-d531-45da-8fd4-93e2cc733e51"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171018T170902Z:af553f63-d531-45da-8fd4-93e2cc733e51"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvbGlua2Vkc2VydmljZXMvVGVzdERhdGFMYWtlU3RvcmU/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "e161bb18-3daa-47fe-b173-38a8f376527c"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 18 Oct 2017 17:09:02 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "x-ms-request-id": [
+          "e161bb18-3daa-47fe-b173-38a8f376527c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1111"
+        ],
+        "x-ms-correlation-request-id": [
+          "30222ba4-a673-4afa-a074-32a1221e47f3"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171018T170903Z:30222ba4-a673-4afa-a074-32a1221e47f3"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "6ea90f1a-7b45-42a1-8f35-f95e061a0a45"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Wed, 18 Oct 2017 17:09:04 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Server": [
+          "Microsoft-IIS/8.5"
+        ],
+        "x-ms-request-id": [
+          "6ea90f1a-7b45-42a1-8f35-f95e061a0a45"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1110"
+        ],
+        "x-ms-correlation-request-id": [
+          "9f89c5a9-e580-4e3c-bab2-76b3d7e97436"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171018T170904Z:9f89c5a9-e580-4e3c-bab2-76b3d7e97436"
+        ]
+      },
+      "StatusCode": 200
+    }
+  ],
+  "Names": {},
+  "Variables": {
+    "SubscriptionId": "876407bb-5bd3-45c4-9c07-cd74a964b2fc"
+  }
+}


### PR DESCRIPTION

## Description

Add linked service scenario test (resolves #3726)

  * Adds a simple CRUD test for linked services
  * Also change all tests to check for proper HTTP response codes on
    each API call

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
