### PR TITLE
Update ADF tests to latest resource manager client

### DIFF
--- a/src/SDKs/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
+++ b/src/SDKs/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
@@ -29,5 +29,6 @@
   <ItemGroup>
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Update="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="1.7.2" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
   </ItemGroup>
 </Project>

--- a/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/DataFactoryScenarioTests.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/DataFactoryScenarioTests.cs
@@ -6,6 +6,7 @@ using DataFactory.Tests.Utils;
 using Microsoft.Azure.Management.DataFactory;
 using Microsoft.Azure.Management.DataFactory.Models;
 using Microsoft.Rest.Azure;
+using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
 using System;
 using System.Linq;
 using System.Net;
@@ -24,34 +25,34 @@ namespace DataFactory.Tests.ScenarioTests
 
             Func<DataFactoryManagementClient, Task> action = async (client) =>
             {
-                AzureOperationResponse<Factory> createResponse = await client.Factories.CreateOrUpdateWithHttpMessagesAsync(ResourceGroupName, DataFactoryName, expectedFactory);
-                this.ValidateFactory(createResponse.Body);
+                AzureOperationResponse<Factory> createResponse = await client.Factories.CreateOrUpdateWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName, expectedFactory);
+                this.ValidateFactory(createResponse.Body, this.DataFactoryName);
                 Assert.Equal(HttpStatusCode.OK, createResponse.Response.StatusCode);
 
-                AzureOperationResponse<Factory> getResponse = await client.Factories.GetWithHttpMessagesAsync(ResourceGroupName, DataFactoryName);
-                this.ValidateFactory(getResponse.Body);
+                AzureOperationResponse<Factory> getResponse = await client.Factories.GetWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName);
+                this.ValidateFactory(getResponse.Body, this.DataFactoryName);
                 Assert.Equal(HttpStatusCode.OK, getResponse.Response.StatusCode);
 
-                AzureOperationResponse<IPage<Factory>> listByResourceGroupResponse = await client.Factories.ListByResourceGroupWithHttpMessagesAsync(ResourceGroupName);
-                this.ValidateFactory(listByResourceGroupResponse.Body.First());
+                AzureOperationResponse<IPage<Factory>> listByResourceGroupResponse = await client.Factories.ListByResourceGroupWithHttpMessagesAsync(this.ResourceGroupName);
+                this.ValidateFactory(listByResourceGroupResponse.Body.First(), this.DataFactoryName);
                 Assert.Equal(HttpStatusCode.OK, listByResourceGroupResponse.Response.StatusCode);
             };
 
             Func<DataFactoryManagementClient, Task> finallyAction = async (client) =>
             {
-                AzureOperationResponse deleteResponse = await client.Factories.DeleteWithHttpMessagesAsync(ResourceGroupName, DataFactoryName);
+                AzureOperationResponse deleteResponse = await client.Factories.DeleteWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName);
                 Assert.Equal(HttpStatusCode.OK, deleteResponse.Response.StatusCode);
 
-                deleteResponse = await client.Factories.DeleteWithHttpMessagesAsync(ResourceGroupName, DataFactoryName);
+                deleteResponse = await client.Factories.DeleteWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName);
                 Assert.Equal(HttpStatusCode.NoContent, deleteResponse.Response.StatusCode);
             };
 
             await this.RunTest(action, finallyAction);
         }
 
-        private void ValidateFactory(Factory actualFactory)
+        private void ValidateFactory(Factory actualFactory, string expectedFactoryName)
         {
-            Assert.Equal(DataFactoryName, actualFactory.Name);
+            Assert.Equal(expectedFactoryName, actualFactory.Name);
             Assert.Equal(FactoryLocation, actualFactory.Location);
             Assert.Equal("Succeeded", actualFactory.ProvisioningState);
         }

--- a/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/LinkedServiceScenarioTests.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/LinkedServiceScenarioTests.cs
@@ -31,27 +31,27 @@ namespace DataFactory.Tests.ScenarioTests
 
             Func<DataFactoryManagementClient, Task> action = async (client) =>
             {
-                client.Factories.CreateOrUpdate(ResourceGroupName, DataFactoryName, new Factory(location: FactoryLocation));
+                client.Factories.CreateOrUpdate(this.ResourceGroupName, this.DataFactoryName, new Factory(location: FactoryLocation));
 
-                AzureOperationResponse<LinkedServiceResource> createResponse = await client.LinkedServices.CreateOrUpdateWithHttpMessagesAsync(ResourceGroupName, DataFactoryName, linkedServiceName, expectedLinkedService);
+                AzureOperationResponse<LinkedServiceResource> createResponse = await client.LinkedServices.CreateOrUpdateWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName, linkedServiceName, expectedLinkedService);
                 this.ValidateLinkedService(expectedLinkedService, createResponse.Body, linkedServiceName);
                 Assert.Equal(HttpStatusCode.OK, createResponse.Response.StatusCode);
 
-                AzureOperationResponse<LinkedServiceResource> getResponse = await client.LinkedServices.GetWithHttpMessagesAsync(ResourceGroupName, DataFactoryName, linkedServiceName);
+                AzureOperationResponse<LinkedServiceResource> getResponse = await client.LinkedServices.GetWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName, linkedServiceName);
                 this.ValidateLinkedService(expectedLinkedService, getResponse.Body, linkedServiceName);
                 Assert.Equal(HttpStatusCode.OK, getResponse.Response.StatusCode);
 
-                AzureOperationResponse<IPage<LinkedServiceResource>> listResponse = await client.LinkedServices.ListByFactoryWithHttpMessagesAsync(ResourceGroupName, DataFactoryName);
+                AzureOperationResponse<IPage<LinkedServiceResource>> listResponse = await client.LinkedServices.ListByFactoryWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName);
                 this.ValidateLinkedService(expectedLinkedService, listResponse.Body.First(), linkedServiceName);
                 Assert.Equal(HttpStatusCode.OK, listResponse.Response.StatusCode);
 
-                AzureOperationResponse deleteResponse = await client.LinkedServices.DeleteWithHttpMessagesAsync(ResourceGroupName, DataFactoryName, linkedServiceName);
+                AzureOperationResponse deleteResponse = await client.LinkedServices.DeleteWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName, linkedServiceName);
                 Assert.Equal(HttpStatusCode.OK, deleteResponse.Response.StatusCode);
             };
 
             Func<DataFactoryManagementClient, Task> finallyAction = async (client) =>
             {
-                await client.Factories.DeleteAsync(ResourceGroupName, DataFactoryName);
+                await client.Factories.DeleteAsync(this.ResourceGroupName, this.DataFactoryName);
             };
 
             await this.RunTest(action, finallyAction);
@@ -59,7 +59,7 @@ namespace DataFactory.Tests.ScenarioTests
 
         private void ValidateLinkedService(LinkedServiceResource expected, LinkedServiceResource actual, string expectedName)
         {
-            this.ValidateSubResource(actual, expectedName, "linkedservices");
+            this.ValidateSubResource(actual, this.DataFactoryName, expectedName, "linkedservices");
             Assert.IsType<AzureDataLakeStoreLinkedService>(actual.Properties);
             Assert.Equal(((AzureDataLakeStoreLinkedService)expected.Properties).DataLakeStoreUri, ((AzureDataLakeStoreLinkedService)actual.Properties).DataLakeStoreUri);
         }

--- a/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/PipelineRunScenarioTests.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/ScenarioTests/PipelineRunScenarioTests.cs
@@ -5,6 +5,7 @@
 using DataFactory.Tests.Utils;
 using Microsoft.Azure.Management.DataFactory;
 using Microsoft.Azure.Management.DataFactory.Models;
+using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
 using System;
 using System.Net;
 using System.Threading.Tasks;
@@ -18,14 +19,12 @@ namespace DataFactory.Tests.ScenarioTests
         [Trait(TraitName.TestType, TestType.Scenario)]
         public async Task CancelPipelineRun()
         {
-            var expectedFactory = new Factory(location: FactoryLocation);
-
             Func<DataFactoryManagementClient, Task> action = async (client) =>
             {
-                Factory createResponse = client.Factories.CreateOrUpdate(ResourceGroupName, DataFactoryName, expectedFactory);
+                Factory createResponse = client.Factories.CreateOrUpdate(this.ResourceGroupName, this.DataFactoryName, new Factory(location: FactoryLocation));
                 ErrorResponseException exception = await Assert.ThrowsAsync<ErrorResponseException>(async () =>
                 {
-                    await client.Factories.CancelPipelineRunWithHttpMessagesAsync(ResourceGroupName, DataFactoryName, "efbe5443-9879-4495-94a6-4d7c394133ad");
+                    await client.Factories.CancelPipelineRunWithHttpMessagesAsync(this.ResourceGroupName, this.DataFactoryName, "efbe5443-9879-4495-94a6-4d7c394133ad");
                 });
 
                 Assert.Equal(exception.Response.StatusCode, HttpStatusCode.BadRequest);
@@ -33,7 +32,7 @@ namespace DataFactory.Tests.ScenarioTests
 
             Func<DataFactoryManagementClient, Task> finallyAction = async (client) =>
             {
-                await client.Factories.DeleteAsync(ResourceGroupName, DataFactoryName);
+                await client.Factories.DeleteAsync(this.ResourceGroupName, this.DataFactoryName);
             };
             await this.RunTest(action, finallyAction);
         }

--- a/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.DataFactoryScenarioTests/DataFactoryCrud.json
+++ b/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.DataFactoryScenarioTests/DataFactoryCrud.json
@@ -1,8 +1,8 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourcegroups/sdktestingadfrg2102?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlZ3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzIxMDI/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
       "RequestHeaders": {
@@ -13,17 +13,78 @@
           "31"
         ],
         "x-ms-client-request-id": [
-          "89e695dc-61ed-4bf9-8158-822c8c7a20d7"
+          "56e836ac-ac9e-465d-a39d-c4a9a2afb0a2"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-18T17:20:05.4558261Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102\",\r\n  \"name\": \"sdktestingadfrg2102\",\r\n  \"location\": \"eastus2\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "192"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:03:55 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1168"
+        ],
+        "x-ms-request-id": [
+          "b3259ec1-2477-4f35-987b-c0136101dbea"
+        ],
+        "x-ms-correlation-request-id": [
+          "b3259ec1-2477-4f35-987b-c0136101dbea"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230356Z:b3259ec1-2477-4f35-987b-c0136101dbea"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102/providers/Microsoft.DataFactory/factories/sdktestingfactory4067?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzIxMDIvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk0MDY3P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "31"
+        ],
+        "x-ms-client-request-id": [
+          "fd07b2e6-fddc-4821-afc8-5bf6eab1ad83"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory4067\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-31T23:03:59.479058Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102/providers/Microsoft.DataFactory/factories/sdktestingfactory4067\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -35,7 +96,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:20:03 GMT"
+          "Tue, 31 Oct 2017 23:03:59 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -50,7 +111,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "89e695dc-61ed-4bf9-8158-822c8c7a20d7"
+          "fd07b2e6-fddc-4821-afc8-5bf6eab1ad83"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,35 +123,35 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1105"
+          "1169"
         ],
         "x-ms-correlation-request-id": [
-          "83784228-fe6f-44d8-9a07-a4d42da62c92"
+          "705462c6-f342-4bf3-8688-d0ba4c43f0d3"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T172004Z:83784228-fe6f-44d8-9a07-a4d42da62c92"
+          "CENTRALUS:20171031T230400Z:705462c6-f342-4bf3-8688-d0ba4c43f0d3"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102/providers/Microsoft.DataFactory/factories/sdktestingfactory4067?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzIxMDIvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk0MDY3P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "567de79a-1dee-44ce-b9ce-6be90c2e9669"
+          "a9f7f02c-e9d5-4bc8-ad69-73726c22dadb"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-18T17:20:05.4558261Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
+      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory4067\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-31T23:03:59.479058Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102/providers/Microsoft.DataFactory/factories/sdktestingfactory4067\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -102,7 +163,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:20:03 GMT"
+          "Tue, 31 Oct 2017 23:03:59 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -117,7 +178,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "567de79a-1dee-44ce-b9ce-6be90c2e9669"
+          "a9f7f02c-e9d5-4bc8-ad69-73726c22dadb"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -129,35 +190,35 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14613"
+          "14875"
         ],
         "x-ms-correlation-request-id": [
-          "695e8eff-3415-4e44-ae4e-005447f3080a"
+          "af941882-30ce-456e-b53a-84461a33dd12"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T172004Z:695e8eff-3415-4e44-ae4e-005447f3080a"
+          "CENTRALUS:20171031T230400Z:af941882-30ce-456e-b53a-84461a33dd12"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXM/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102/providers/Microsoft.DataFactory/factories?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzIxMDIvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXM/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "143acece-2241-417e-8f35-0ce41fdae9b4"
+          "5ed51c00-c1d8-4fba-8abf-f896d1cfa48c"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"sdktestingfactory\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"loggingStorageAccountKey\": \"**********\",\r\n        \"createTime\": \"2017-10-18T17:20:05.4558261Z\",\r\n        \"version\": \"2017-09-01-preview\"\r\n      },\r\n      \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n      \"type\": \"Microsoft.DataFactory/factories\",\r\n      \"location\": \"East US 2\"\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": \"sdktestingfactory4067\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\",\r\n        \"loggingStorageAccountKey\": \"**********\",\r\n        \"createTime\": \"2017-10-31T23:03:59.479058Z\",\r\n        \"version\": \"2017-09-01-preview\"\r\n      },\r\n      \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102/providers/Microsoft.DataFactory/factories/sdktestingfactory4067\",\r\n      \"type\": \"Microsoft.DataFactory/factories\",\r\n      \"location\": \"East US 2\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -169,7 +230,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:20:04 GMT"
+          "Tue, 31 Oct 2017 23:04:00 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -184,7 +245,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "143acece-2241-417e-8f35-0ce41fdae9b4"
+          "5ed51c00-c1d8-4fba-8abf-f896d1cfa48c"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -196,32 +257,32 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14612"
+          "14874"
         ],
         "x-ms-correlation-request-id": [
-          "ade0054b-0ccd-4e0f-a100-4383cd5e520d"
+          "3bac07e9-d8a2-46c0-ae34-754e02b1dfb9"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T172004Z:ade0054b-0ccd-4e0f-a100-4383cd5e520d"
+          "CENTRALUS:20171031T230400Z:3bac07e9-d8a2-46c0-ae34-754e02b1dfb9"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102/providers/Microsoft.DataFactory/factories/sdktestingfactory4067?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzIxMDIvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk0MDY3P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "3d947086-6019-4f45-bd92-149007bfed98"
+          "f526ae1d-256b-46d1-8f77-0bb6301265eb"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
       "ResponseBody": "",
@@ -236,7 +297,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:20:05 GMT"
+          "Tue, 31 Oct 2017 23:04:02 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -245,7 +306,7 @@
           "Microsoft-IIS/8.5"
         ],
         "x-ms-request-id": [
-          "3d947086-6019-4f45-bd92-149007bfed98"
+          "f526ae1d-256b-46d1-8f77-0bb6301265eb"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -257,32 +318,32 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1104"
+          "1168"
         ],
         "x-ms-correlation-request-id": [
-          "78fd5e2a-b409-4f34-a03d-55c1a518627e"
+          "2fcf4fd7-623d-488c-b479-a7b597fe758a"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T172005Z:78fd5e2a-b409-4f34-a03d-55c1a518627e"
+          "CENTRALUS:20171031T230402Z:2fcf4fd7-623d-488c-b479-a7b597fe758a"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg2102/providers/Microsoft.DataFactory/factories/sdktestingfactory4067?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzIxMDIvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk0MDY3P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "6efde5aa-c7bd-4694-9228-e51b158f836e"
+          "240f302b-d9de-4f63-8105-5be52c050760"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
       "ResponseBody": "",
@@ -294,31 +355,244 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:20:05 GMT"
+          "Tue, 31 Oct 2017 23:04:02 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1103"
+          "1167"
         ],
         "x-ms-request-id": [
-          "efd118eb-e05a-4e7d-89a2-392c52eb2399"
+          "8c291d50-6c77-49a8-95a8-f2c2906296a5"
         ],
         "x-ms-correlation-request-id": [
-          "efd118eb-e05a-4e7d-89a2-392c52eb2399"
+          "8c291d50-6c77-49a8-95a8-f2c2906296a5"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T172006Z:efd118eb-e05a-4e7d-89a2-392c52eb2399"
+          "CENTRALUS:20171031T230403Z:8c291d50-6c77-49a8-95a8-f2c2906296a5"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ]
       },
       "StatusCode": 204
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourcegroups/sdktestingadfrg2102?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlZ3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzIxMDI/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "e8f5b090-cf13-495d-9000-079e045c2865"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:04:04 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkcyMTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1167"
+        ],
+        "x-ms-request-id": [
+          "e4c5f8f9-9307-4f02-8220-33feba3a61ef"
+        ],
+        "x-ms-correlation-request-id": [
+          "e4c5f8f9-9307-4f02-8220-33feba3a61ef"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230404Z:e4c5f8f9-9307-4f02-8220-33feba3a61ef"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkcyMTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrY3lNVEF5TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:04:20 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkcyMTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14888"
+        ],
+        "x-ms-request-id": [
+          "9ec6f51a-8b9c-4b81-a0c8-65c76472db4f"
+        ],
+        "x-ms-correlation-request-id": [
+          "9ec6f51a-8b9c-4b81-a0c8-65c76472db4f"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230420Z:9ec6f51a-8b9c-4b81-a0c8-65c76472db4f"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkcyMTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrY3lNVEF5TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:04:35 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkcyMTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14887"
+        ],
+        "x-ms-request-id": [
+          "a0e0fc45-8789-4e4d-ad7c-ac19677cda96"
+        ],
+        "x-ms-correlation-request-id": [
+          "a0e0fc45-8789-4e4d-ad7c-ac19677cda96"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230435Z:a0e0fc45-8789-4e4d-ad7c-ac19677cda96"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkcyMTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrY3lNVEF5TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:04:50 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14886"
+        ],
+        "x-ms-request-id": [
+          "8ebb6126-c80c-4e4d-a353-38c1688c6003"
+        ],
+        "x-ms-correlation-request-id": [
+          "8ebb6126-c80c-4e4d-a353-38c1688c6003"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230450Z:8ebb6126-c80c-4e4d-a353-38c1688c6003"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
     }
   ],
-  "Names": {},
+  "Names": {
+    "RunTest": [
+      "sdktestingadfrg2102",
+      "sdktestingfactory4067"
+    ]
+  },
   "Variables": {
     "SubscriptionId": "876407bb-5bd3-45c4-9c07-cd74a964b2fc"
   }

--- a/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.LinkedServiceScenarioTests/LinkedServiceCrud.json
+++ b/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.LinkedServiceScenarioTests/LinkedServiceCrud.json
@@ -1,8 +1,8 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourcegroups/sdktestingadfrg6600?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlZ3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzY2MDA/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
       "RequestHeaders": {
@@ -13,17 +13,78 @@
           "31"
         ],
         "x-ms-client-request-id": [
-          "6b1d8c76-9e14-4409-a347-759d808929fd"
+          "44481083-10ed-4e40-8b99-f2ded8738408"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-18T17:09:01.2495452Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600\",\r\n  \"name\": \"sdktestingadfrg6600\",\r\n  \"location\": \"eastus2\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "192"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:02:04 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1161"
+        ],
+        "x-ms-request-id": [
+          "8b64e625-efca-47cd-b95e-628d70b65c1e"
+        ],
+        "x-ms-correlation-request-id": [
+          "8b64e625-efca-47cd-b95e-628d70b65c1e"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230204Z:8b64e625-efca-47cd-b95e-628d70b65c1e"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzY2MDAvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkzMDIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "31"
+        ],
+        "x-ms-client-request-id": [
+          "e2b55069-2ad1-41ed-8b88-8daa28200901"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory3021\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-31T23:02:06.5290172Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -35,7 +96,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:08:59 GMT"
+          "Tue, 31 Oct 2017 23:02:06 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -50,7 +111,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "6b1d8c76-9e14-4409-a347-759d808929fd"
+          "e2b55069-2ad1-41ed-8b88-8daa28200901"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,20 +123,20 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1113"
+          "1172"
         ],
         "x-ms-correlation-request-id": [
-          "dc012cec-cd82-4a82-a8da-d333aba94740"
+          "009020d6-6f65-41c4-9f01-41df276be8d8"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T170900Z:dc012cec-cd82-4a82-a8da-d333aba94740"
+          "CENTRALUS:20171031T230207Z:009020d6-6f65-41c4-9f01-41df276be8d8"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvbGlua2Vkc2VydmljZXMvVGVzdERhdGFMYWtlU3RvcmU/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzY2MDAvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkzMDIxL2xpbmtlZHNlcnZpY2VzL1Rlc3REYXRhTGFrZVN0b3JlP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"properties\": {\r\n    \"type\": \"AzureDataLakeStore\",\r\n    \"typeProperties\": {\r\n      \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n    }\r\n  }\r\n}",
       "RequestHeaders": {
@@ -86,17 +147,17 @@
           "159"
         ],
         "x-ms-client-request-id": [
-          "3b6d42b5-be24-40d3-b0fd-75e4bf41d912"
+          "8399768a-e353-4d63-a41d-39641af94caa"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore\",\r\n  \"name\": \"TestDataLakeStore\",\r\n  \"properties\": {\r\n    \"type\": \"AzureDataLakeStore\",\r\n    \"typeProperties\": {\r\n      \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n    }\r\n  },\r\n  \"etag\": \"a0014c71-0000-0000-0000-59e78aae0000\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021/linkedservices/TestDataLakeStore\",\r\n  \"name\": \"TestDataLakeStore\",\r\n  \"properties\": {\r\n    \"type\": \"AzureDataLakeStore\",\r\n    \"typeProperties\": {\r\n      \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n    }\r\n  },\r\n  \"etag\": \"9a00b2ca-0000-0000-0000-59f900ef0000\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -108,7 +169,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:09:01 GMT"
+          "Tue, 31 Oct 2017 23:02:08 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -123,7 +184,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "3b6d42b5-be24-40d3-b0fd-75e4bf41d912"
+          "8399768a-e353-4d63-a41d-39641af94caa"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -135,35 +196,35 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1112"
+          "1171"
         ],
         "x-ms-correlation-request-id": [
-          "00e06ea2-113b-421b-b5d8-76b0cdf1dd90"
+          "cc8cf895-969b-4aef-8269-403e983181a8"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T170901Z:00e06ea2-113b-421b-b5d8-76b0cdf1dd90"
+          "CENTRALUS:20171031T230208Z:cc8cf895-969b-4aef-8269-403e983181a8"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvbGlua2Vkc2VydmljZXMvVGVzdERhdGFMYWtlU3RvcmU/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzY2MDAvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkzMDIxL2xpbmtlZHNlcnZpY2VzL1Rlc3REYXRhTGFrZVN0b3JlP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "2c3b659d-58ba-4187-ab25-ce49edf76dda"
+          "1ed5580c-61b1-4ec9-93c9-d8ef2a16913d"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore\",\r\n  \"name\": \"TestDataLakeStore\",\r\n  \"properties\": {\r\n    \"type\": \"AzureDataLakeStore\",\r\n    \"typeProperties\": {\r\n      \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n    }\r\n  },\r\n  \"etag\": \"a0014c71-0000-0000-0000-59e78aae0000\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021/linkedservices/TestDataLakeStore\",\r\n  \"name\": \"TestDataLakeStore\",\r\n  \"properties\": {\r\n    \"type\": \"AzureDataLakeStore\",\r\n    \"typeProperties\": {\r\n      \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n    }\r\n  },\r\n  \"etag\": \"9a00b2ca-0000-0000-0000-59f900ef0000\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -175,7 +236,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:09:02 GMT"
+          "Tue, 31 Oct 2017 23:02:08 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -190,7 +251,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "2c3b659d-58ba-4187-ab25-ce49edf76dda"
+          "1ed5580c-61b1-4ec9-93c9-d8ef2a16913d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -202,35 +263,35 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14709"
+          "14891"
         ],
         "x-ms-correlation-request-id": [
-          "e909cf19-5646-46ae-b96a-dbb530ff4737"
+          "68d7a771-cda3-49ba-b66e-107eeb8b9dec"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T170902Z:e909cf19-5646-46ae-b96a-dbb530ff4737"
+          "CENTRALUS:20171031T230208Z:68d7a771-cda3-49ba-b66e-107eeb8b9dec"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvbGlua2Vkc2VydmljZXM/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021/linkedservices?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzY2MDAvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkzMDIxL2xpbmtlZHNlcnZpY2VzP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "09a18d00-17ca-4075-9414-4052370d76b3"
+          "a3a49640-c8c1-4a6d-b6e7-ed8fb7b98f7f"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore\",\r\n      \"name\": \"TestDataLakeStore\",\r\n      \"properties\": {\r\n        \"type\": \"AzureDataLakeStore\",\r\n        \"typeProperties\": {\r\n          \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n        }\r\n      },\r\n      \"etag\": \"a0014c71-0000-0000-0000-59e78aae0000\"\r\n    }\r\n  ]\r\n}",
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021/linkedservices/TestDataLakeStore\",\r\n      \"name\": \"TestDataLakeStore\",\r\n      \"properties\": {\r\n        \"type\": \"AzureDataLakeStore\",\r\n        \"typeProperties\": {\r\n          \"dataLakeStoreUri\": \"adl://test.azuredatalakestore.net/\"\r\n        }\r\n      },\r\n      \"etag\": \"9a00b2ca-0000-0000-0000-59f900ef0000\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -242,7 +303,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:09:02 GMT"
+          "Tue, 31 Oct 2017 23:02:08 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -257,7 +318,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "09a18d00-17ca-4075-9414-4052370d76b3"
+          "a3a49640-c8c1-4a6d-b6e7-ed8fb7b98f7f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -269,32 +330,32 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14708"
+          "14890"
         ],
         "x-ms-correlation-request-id": [
-          "af553f63-d531-45da-8fd4-93e2cc733e51"
+          "7f573856-cce2-4544-9a4d-747ce67c36d2"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T170902Z:af553f63-d531-45da-8fd4-93e2cc733e51"
+          "CENTRALUS:20171031T230208Z:7f573856-cce2-4544-9a4d-747ce67c36d2"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvbGlua2Vkc2VydmljZXMvVGVzdERhdGFMYWtlU3RvcmU/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021/linkedservices/TestDataLakeStore?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzY2MDAvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkzMDIxL2xpbmtlZHNlcnZpY2VzL1Rlc3REYXRhTGFrZVN0b3JlP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "e161bb18-3daa-47fe-b173-38a8f376527c"
+          "256eb772-38cd-4b06-a515-01778f1ab224"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
       "ResponseBody": "",
@@ -309,7 +370,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:09:02 GMT"
+          "Tue, 31 Oct 2017 23:02:08 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -318,7 +379,7 @@
           "Microsoft-IIS/8.5"
         ],
         "x-ms-request-id": [
-          "e161bb18-3daa-47fe-b173-38a8f376527c"
+          "256eb772-38cd-4b06-a515-01778f1ab224"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -330,32 +391,32 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1111"
+          "1170"
         ],
         "x-ms-correlation-request-id": [
-          "30222ba4-a673-4afa-a074-32a1221e47f3"
+          "02b8cd47-2725-4ecf-a598-e30c2602d33c"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T170903Z:30222ba4-a673-4afa-a074-32a1221e47f3"
+          "CENTRALUS:20171031T230208Z:02b8cd47-2725-4ecf-a598-e30c2602d33c"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg6600/providers/Microsoft.DataFactory/factories/sdktestingfactory3021?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzY2MDAvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkzMDIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "6ea90f1a-7b45-42a1-8f35-f95e061a0a45"
+          "9be7246f-226c-422b-b19f-a4dbbe47c26f"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
       "ResponseBody": "",
@@ -370,7 +431,7 @@
           "no-cache"
         ],
         "Date": [
-          "Wed, 18 Oct 2017 17:09:04 GMT"
+          "Tue, 31 Oct 2017 23:02:10 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -379,7 +440,7 @@
           "Microsoft-IIS/8.5"
         ],
         "x-ms-request-id": [
-          "6ea90f1a-7b45-42a1-8f35-f95e061a0a45"
+          "9be7246f-226c-422b-b19f-a4dbbe47c26f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -391,19 +452,232 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1110"
+          "1169"
         ],
         "x-ms-correlation-request-id": [
-          "9f89c5a9-e580-4e3c-bab2-76b3d7e97436"
+          "049918d1-acdd-4c3c-875c-2f423652976b"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20171018T170904Z:9f89c5a9-e580-4e3c-bab2-76b3d7e97436"
+          "CENTRALUS:20171031T230210Z:049918d1-acdd-4c3c-875c-2f423652976b"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourcegroups/sdktestingadfrg6600?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlZ3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzY2MDA/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "b5bf3f87-6d23-42c5-a3a8-a6478cd90dcd"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:02:11 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc2NjAwLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1160"
+        ],
+        "x-ms-request-id": [
+          "bd35d0b6-1cb0-41e5-98ce-9ac7a830241b"
+        ],
+        "x-ms-correlation-request-id": [
+          "bd35d0b6-1cb0-41e5-98ce-9ac7a830241b"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230211Z:bd35d0b6-1cb0-41e5-98ce-9ac7a830241b"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc2NjAwLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrYzJOakF3TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:02:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc2NjAwLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14868"
+        ],
+        "x-ms-request-id": [
+          "1826eee4-56cd-4886-973f-9ef78f3dd447"
+        ],
+        "x-ms-correlation-request-id": [
+          "1826eee4-56cd-4886-973f-9ef78f3dd447"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230227Z:1826eee4-56cd-4886-973f-9ef78f3dd447"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc2NjAwLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrYzJOakF3TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:02:41 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc2NjAwLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14867"
+        ],
+        "x-ms-request-id": [
+          "dfee1570-faf3-4c3f-a886-dec790765629"
+        ],
+        "x-ms-correlation-request-id": [
+          "dfee1570-faf3-4c3f-a886-dec790765629"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230242Z:dfee1570-faf3-4c3f-a886-dec790765629"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc2NjAwLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrYzJOakF3TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:02:57 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14866"
+        ],
+        "x-ms-request-id": [
+          "e9d1a23d-7289-4b6a-a15d-9aa102828608"
+        ],
+        "x-ms-correlation-request-id": [
+          "e9d1a23d-7289-4b6a-a15d-9aa102828608"
+        ],
+        "x-ms-routing-request-id": [
+          "CENTRALUS:20171031T230257Z:e9d1a23d-7289-4b6a-a15d-9aa102828608"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
         ]
       },
       "StatusCode": 200
     }
   ],
-  "Names": {},
+  "Names": {
+    "RunTest": [
+      "sdktestingadfrg6600",
+      "sdktestingfactory3021"
+    ]
+  },
   "Variables": {
     "SubscriptionId": "876407bb-5bd3-45c4-9c07-cd74a964b2fc"
   }

--- a/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.PipelineRunScenarioTests/CancelPipelineRun.json
+++ b/src/SDKs/DataFactory/DataFactory.Tests/SessionRecords/DataFactory.Tests.ScenarioTests.PipelineRunScenarioTests/CancelPipelineRun.json
@@ -1,8 +1,8 @@
 {
   "Entries": [
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourcegroups/sdktestingadfrg7502?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlZ3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzc1MDI/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
       "RequestHeaders": {
@@ -13,17 +13,78 @@
           "31"
         ],
         "x-ms-client-request-id": [
-          "ec063b24-d99a-431c-93d1-be186f1e589a"
+          "06b8ceb3-f7a6-48ab-a123-4cc54b697299"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-23T22:54:46.6895471Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg7502\",\r\n  \"name\": \"sdktestingadfrg7502\",\r\n  \"location\": \"eastus2\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "192"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:19:00 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1125"
+        ],
+        "x-ms-request-id": [
+          "c7c1f4ae-b19c-4d1d-83a2-d2dc736e2f62"
+        ],
+        "x-ms-correlation-request-id": [
+          "c7c1f4ae-b19c-4d1d-83a2-d2dc736e2f62"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171031T231900Z:c7c1f4ae-b19c-4d1d-83a2-d2dc736e2f62"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg7502/providers/Microsoft.DataFactory/factories/sdktestingfactory5185?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzc1MDIvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk1MTg1P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "31"
+        ],
+        "x-ms-client-request-id": [
+          "788a3192-5f2e-4d44-a110-45d59d8506f9"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"name\": \"sdktestingfactory5185\",\r\n  \"tags\": {},\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"loggingStorageAccountKey\": \"**********\",\r\n    \"createTime\": \"2017-10-31T23:19:04.6338736Z\",\r\n    \"version\": \"2017-09-01-preview\"\r\n  },\r\n  \"id\": \"/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg7502/providers/Microsoft.DataFactory/factories/sdktestingfactory5185\",\r\n  \"type\": \"Microsoft.DataFactory/factories\",\r\n  \"location\": \"East US 2\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -35,7 +96,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 23 Oct 2017 22:54:47 GMT"
+          "Tue, 31 Oct 2017 23:19:04 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -50,7 +111,7 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "ec063b24-d99a-431c-93d1-be186f1e589a"
+          "788a3192-5f2e-4d44-a110-45d59d8506f9"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,32 +123,32 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1161"
+          "1150"
         ],
         "x-ms-correlation-request-id": [
-          "8ad253e4-0fc8-48a5-8fa6-99522cb9b4f1"
+          "062a4c44-7807-4f8e-a69a-6b60a0c451f9"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20171023T225448Z:8ad253e4-0fc8-48a5-8fa6-99522cb9b4f1"
+          "NORTHEUROPE:20171031T231904Z:062a4c44-7807-4f8e-a69a-6b60a0c451f9"
         ]
       },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory/cancelpipelinerun/efbe5443-9879-4495-94a6-4d7c394133ad?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3RvcnkvY2FuY2VscGlwZWxpbmVydW4vZWZiZTU0NDMtOTg3OS00NDk1LTk0YTYtNGQ3YzM5NDEzM2FkP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg7502/providers/Microsoft.DataFactory/factories/sdktestingfactory5185/cancelpipelinerun/efbe5443-9879-4495-94a6-4d7c394133ad?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzc1MDIvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk1MTg1L2NhbmNlbHBpcGVsaW5lcnVuL2VmYmU1NDQzLTk4NzktNDQ5NS05NGE2LTRkN2MzOTQxMzNhZD9hcGktdmVyc2lvbj0yMDE3LTA5LTAxLXByZXZpZXc=",
       "RequestMethod": "POST",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "53fa59fa-ab09-41a7-82cc-f89f40b5fdca"
+          "025e02ae-b7f2-4250-a7de-08b83cdfcc78"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
       "ResponseBody": "{\r\n  \"code\": \"BadRequest\",\r\n  \"message\": \"Pipeline run does not exist\",\r\n  \"target\": \"cancelPipelineRun/efbe5443-9879-4495-94a6-4d7c394133ad\"\r\n}",
@@ -105,7 +166,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 23 Oct 2017 22:54:48 GMT"
+          "Tue, 31 Oct 2017 23:19:05 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -114,7 +175,7 @@
           "Microsoft-IIS/8.5"
         ],
         "x-ms-request-id": [
-          "53fa59fa-ab09-41a7-82cc-f89f40b5fdca"
+          "025e02ae-b7f2-4250-a7de-08b83cdfcc78"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -126,32 +187,32 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1160"
+          "1149"
         ],
         "x-ms-correlation-request-id": [
-          "dc88bc3e-72da-4364-9584-c6538dbdd807"
+          "ddcf1a85-83db-4db9-a53d-bbb2ff464db6"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20171023T225448Z:dc88bc3e-72da-4364-9584-c6538dbdd807"
+          "NORTHEUROPE:20171031T231905Z:ddcf1a85-83db-4db9-a53d-bbb2ff464db6"
         ]
       },
       "StatusCode": 400
     },
     {
-      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktesting/providers/Microsoft.DataFactory/factories/sdktestingfactory?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmcvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk/YXBpLXZlcnNpb249MjAxNy0wOS0wMS1wcmV2aWV3",
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourceGroups/sdktestingadfrg7502/providers/Microsoft.DataFactory/factories/sdktestingfactory5185?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlR3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzc1MDIvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhRmFjdG9yeS9mYWN0b3JpZXMvc2RrdGVzdGluZ2ZhY3Rvcnk1MTg1P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "6cf48abf-126f-4ca7-b575-5e553808afc1"
+          "66ad9694-adcd-433a-a845-8949283718aa"
         ],
         "accept-language": [
           "en-US"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.0.0"
+          "Microsoft.Azure.Management.DataFactory.DataFactoryManagementClient/0.2.1.0"
         ]
       },
       "ResponseBody": "",
@@ -166,7 +227,7 @@
           "no-cache"
         ],
         "Date": [
-          "Mon, 23 Oct 2017 22:54:50 GMT"
+          "Tue, 31 Oct 2017 23:19:06 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -175,7 +236,7 @@
           "Microsoft-IIS/8.5"
         ],
         "x-ms-request-id": [
-          "6cf48abf-126f-4ca7-b575-5e553808afc1"
+          "66ad9694-adcd-433a-a845-8949283718aa"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -187,19 +248,232 @@
           "ASP.NET"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1167"
+          "1148"
         ],
         "x-ms-correlation-request-id": [
-          "4b224df3-b6fe-40a2-a5b6-baed7e6ef576"
+          "fb59acf1-167b-47eb-8db2-9c4c9d116e90"
         ],
         "x-ms-routing-request-id": [
-          "CENTRALUS:20171023T225450Z:4b224df3-b6fe-40a2-a5b6-baed7e6ef576"
+          "NORTHEUROPE:20171031T231907Z:fb59acf1-167b-47eb-8db2-9c4c9d116e90"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/resourcegroups/sdktestingadfrg7502?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL3Jlc291cmNlZ3JvdXBzL3Nka3Rlc3RpbmdhZGZyZzc1MDI/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "f644ff2f-77ce-4e8b-a3cb-d44379a298e2"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:19:07 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc3NTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1124"
+        ],
+        "x-ms-request-id": [
+          "aafe6dcd-4962-425c-bc2e-93c966b279e6"
+        ],
+        "x-ms-correlation-request-id": [
+          "aafe6dcd-4962-425c-bc2e-93c966b279e6"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171031T231908Z:aafe6dcd-4962-425c-bc2e-93c966b279e6"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc3NTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrYzNOVEF5TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:19:22 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc3NTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14761"
+        ],
+        "x-ms-request-id": [
+          "17575308-4b34-4a12-b555-36872bebb903"
+        ],
+        "x-ms-correlation-request-id": [
+          "17575308-4b34-4a12-b555-36872bebb903"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171031T231923Z:17575308-4b34-4a12-b555-36872bebb903"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc3NTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrYzNOVEF5TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:19:38 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://api-dogfood.resources.windows-int.net/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc3NTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10"
+        ],
+        "Retry-After": [
+          "15"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14760"
+        ],
+        "x-ms-request-id": [
+          "3f352fcf-fba8-4a2c-8c37-5e1832ee890c"
+        ],
+        "x-ms-correlation-request-id": [
+          "3f352fcf-fba8-4a2c-8c37-5e1832ee890c"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171031T231938Z:3f352fcf-fba8-4a2c-8c37-5e1832ee890c"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/876407bb-5bd3-45c4-9c07-cd74a964b2fc/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1TREtURVNUSU5HQURGUkc3NTAyLUVBU1RVUzIiLCJqb2JMb2NhdGlvbiI6ImVhc3R1czIifQ?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvODc2NDA3YmItNWJkMy00NWM0LTljMDctY2Q3NGE5NjRiMmZjL29wZXJhdGlvbnJlc3VsdHMvZXlKcWIySkpaQ0k2SWxKRlUwOVZVa05GUjFKUFZWQkVSVXhGVkVsUFRrcFBRaTFUUkV0VVJWTlVTVTVIUVVSR1VrYzNOVEF5TFVWQlUxUlZVeklpTENKcWIySk1iMk5oZEdsdmJpSTZJbVZoYzNSMWN6SWlmUT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25211.01",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 31 Oct 2017 23:19:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14759"
+        ],
+        "x-ms-request-id": [
+          "3d868ab9-6227-45d2-bef2-17e63bbf4932"
+        ],
+        "x-ms-correlation-request-id": [
+          "3d868ab9-6227-45d2-bef2-17e63bbf4932"
+        ],
+        "x-ms-routing-request-id": [
+          "NORTHEUROPE:20171031T231953Z:3d868ab9-6227-45d2-bef2-17e63bbf4932"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
         ]
       },
       "StatusCode": 200
     }
   ],
-  "Names": {},
+  "Names": {
+    "RunTest": [
+      "sdktestingadfrg7502",
+      "sdktestingfactory5185"
+    ]
+  },
   "Variables": {
     "SubscriptionId": "876407bb-5bd3-45c4-9c07-cd74a964b2fc"
   }


### PR DESCRIPTION
## Description

Update ADF tests to latest resource manager client

  * Tests now use Microsoft.Azure.Management.ResourceManager version
    1.6.0-preview
  * Modify all tests to create and delete a resource group
  * resolves #3726

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
