### PR TITLE
Enable more approaches of credential storing for Dynamics LinkedService

### DIFF
--- a/src/SDKs/DataFactory/DataFactory.Tests/JsonSamples/LinkedServiceJsonSamples.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/JsonSamples/LinkedServiceJsonSamples.cs
@@ -547,7 +547,7 @@ namespace DataFactory.Tests.JsonSamples
 }";
 
         [JsonSample]
-        public const string DynamicsLinkedService = @"
+        public const string DynamicsLinkedService_AKV = @"
 {
     name: ""Test-Dynamics-LinkedService"",
     properties:
@@ -563,13 +563,36 @@ namespace DataFactory.Tests.JsonSamples
             authenticationType : ""Office365"", 
             username : ""fakeuser@contoso.com"",
             password : { 
-                        type : ""AzureKeyVaultSecret"", 
-                        secretName : ""fakeSecretName"", 
-                        store: { 
-                            type : ""LinkedServiceReference"", 
-                            referenceName : ""AKVLinkedService"" 
-                        } 
-                    }
+                type : ""AzureKeyVaultSecret"", 
+                secretName : ""fakeSecretName"", 
+                store: { 
+                    type : ""LinkedServiceReference"", 
+                    referenceName : ""AKVLinkedService"" 
+                } 
+            }
+        }
+    }
+}";
+
+        [JsonSample]
+        public const string DynamicsLinkedService = @"
+{
+    name: ""LinkedService-Dynamics"",
+    properties:
+    {
+        type: ""Dynamics"",
+        typeProperties: {
+            deploymentType: ""Online"",
+            authenticationType: ""Office365"",
+            hostName: ""hostname.com"",
+            port: 12345,
+            organizationName: ""contoso"",
+            username: ""fakeuser@contoso.com"",
+            password: {
+                value : ""fakepassword"",
+                type : ""SecureString""
+            },
+            encryptedCredential : ""fake credential""
         }
     }
 }";

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsLinkedService.cs
@@ -27,7 +27,6 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         public DynamicsLinkedService()
         {
-            Password = new AzureKeyVaultSecretReference();
             CustomInit();
         }
 
@@ -44,8 +43,6 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// resultType string).</param>
         /// <param name="username">User name to access the Dynamics instance.
         /// Type: string (or Expression with resultType string).</param>
-        /// <param name="password">Password to access the Dynamics
-        /// instance.</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="hostName">The host name of the on-premises Dynamics
@@ -61,7 +58,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// required for online when there are more than one Dynamics instances
         /// associated with the user. Type: string (or Expression with
         /// resultType string).</param>
-        public DynamicsLinkedService(object deploymentType, object authenticationType, object username, AzureKeyVaultSecretReference password, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object hostName = default(object), object port = default(object), object organizationName = default(object))
+        /// <param name="password">Password to access the Dynamics
+        /// instance.</param>
+        /// <param name="encryptedCredential">The encrypted credential used for
+        /// authentication. Credentials are encrypted using the integration
+        /// runtime credential manager. Type: string (or Expression with
+        /// resultType string).</param>
+        public DynamicsLinkedService(object deploymentType, object authenticationType, object username, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object hostName = default(object), object port = default(object), object organizationName = default(object), SecretBase password = default(SecretBase), object encryptedCredential = default(object))
             : base(connectVia, description)
         {
             DeploymentType = deploymentType;
@@ -71,6 +74,7 @@ namespace Microsoft.Azure.Management.DataFactory.Models
             AuthenticationType = authenticationType;
             Username = username;
             Password = password;
+            EncryptedCredential = encryptedCredential;
             CustomInit();
         }
 
@@ -132,7 +136,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Gets or sets password to access the Dynamics instance.
         /// </summary>
         [JsonProperty(PropertyName = "typeProperties.password")]
-        public AzureKeyVaultSecretReference Password { get; set; }
+        public SecretBase Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the encrypted credential used for authentication.
+        /// Credentials are encrypted using the integration runtime credential
+        /// manager. Type: string (or Expression with resultType string).
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.encryptedCredential")]
+        public object EncryptedCredential { get; set; }
 
         /// <summary>
         /// Validate the object.
@@ -154,14 +166,6 @@ namespace Microsoft.Azure.Management.DataFactory.Models
             if (Username == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "Username");
-            }
-            if (Password == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "Password");
-            }
-            if (Password != null)
-            {
-                Password.Validate();
             }
         }
     }

--- a/src/SDKs/DataFactory/Management.DataFactory/changelog.md
+++ b/src/SDKs/DataFactory/Management.DataFactory/changelog.md
@@ -6,6 +6,7 @@
   * Add SAP Cloud For Customer Source
   * Add SAP Cloud For Customer Dataset
   * Add SAP Cloud For Customer Sink
+  * Support providing a Dynamics password as a SecureString, a secret in Azure Key Vault, or as an encrypted credential.
 
 ## Version 0.2.1-preview
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Currently Dynamics LinkedService only supports storing credentials in Azure Key Vault.
After this change, it can support storing encrypted credentials in ADF metadata store or storing encrypted credentials in Self-Hosted IR. (These two are totally aligned with other connectors).

Internal Code Review: http://codeflow/extensions/launcher.html?server=https:%2f%2fmsdata.visualstudio.com%2fdefaultcollection&projectId=13ee5071-298b-4fbc-863a-5ffe8c09e915&reviewId=78690&projectshortname=Azure Data Factory

Swagger PR got merged:
https://github.com/Azure/azure-rest-api-specs/pull/1994

---

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
