### PR TITLE
Clean invalid characters in user user agent string version

### DIFF
--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ServiceClientTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ServiceClientTests.cs
@@ -224,7 +224,24 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             Assert.True(testProduct.Product.Name.Equals(testProductName));
             Assert.True(testProduct.Product.Version.Equals(testProductVersion));
         }
-        
+
+        [Fact]
+        public void AddUserAgentInfoWithIllegalCharacters()
+        {
+            string testProductName = "TestProduct";
+            string testProductVersion = "1.0.0.0 (Microsoft)";
+
+            string expectedProductVersion = "1.0.0.0Microsoft";
+
+            FakeServiceClient fakeClient = new FakeServiceClient(new FakeHttpHandler());
+            fakeClient.SetUserAgent(testProductName, testProductVersion);
+            HttpResponseMessage response = fakeClient.DoStuffSync();
+            HttpHeaderValueCollection<ProductInfoHeaderValue> userAgentValueCollection = fakeClient.HttpClient.DefaultRequestHeaders.UserAgent;
+
+            var testProduct = userAgentValueCollection.Where<ProductInfoHeaderValue>((p) => p.Product.Name.Equals(testProductName)).FirstOrDefault<ProductInfoHeaderValue>();
+            Assert.Equal(expectedProductVersion, testProduct.Product.Version);
+        }
+
 #if FullNetFx
         [Fact]
         public void VerifyOsInfoInUserAgent()
@@ -247,7 +264,7 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             string sampleProd = "SampleProdName";
             string newSampleProd = "NewSampleProdName";
             string spChars = "*()!@#$%^&";
-            string sampleVersion = "1.*.0.*";
+            string sampleVersion = "1..0.";
 
             FakeServiceClient fakeClient = new FakeServiceClient(new FakeHttpHandler());
             fakeClient.SetUserAgent(string.Concat(sampleProd, spChars));

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/ServiceClient.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/ServiceClient.cs
@@ -472,8 +472,9 @@ namespace Microsoft.Rest
             if (!_disposed && HttpClient != null)
             {
                 MergeUserAgentInfo(DefaultUserAgentInfoList);
-                string cleanedProductName = CleanUserAgentInfoEntry(productName);                
-                HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(cleanedProductName, version));
+                string cleanedProductName = CleanUserAgentInfoEntry(productName);
+                string cleanedVersionString = CleanUserAgentInfoEntry(version);
+                HttpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue(cleanedProductName, cleanedVersionString));
                 return true;
             }
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->
This pull request fixes the exception being thrown when the assembly version has special characters like parenthesis. 

```
System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation. ---> System.FormatException: The format of value '1.0.0(MyAssemblyInfo)' is invalid.
   at System.Net.Http.Headers.HeaderUtilities.CheckValidToken(String value, String parameterName)
   at System.Net.Http.Headers.ProductHeaderValue..ctor(String name, String version)
   at Microsoft.Rest.ServiceClient`1.SetUserAgent(String productName, String version)
   at Microsoft.Azure.Management.ResourceManager.ResourceManagementClient..ctor(Uri baseUri, DelegatingHandler[] handlers)
```
This happens because `Microsoft.Azure.Management.ResourceManager.ResourceManagementClient` uses the assembly's version as the version for constructing the user agent string. If the assembly version has special characters, it is rejected with exception while constructing an instance of `System.Net.Http.Headers.ProductHeaderValue` due to the run of CheckValidToken method against the string in `System.Net.Http.Headers.HeaderUtilities`.

This fix adds a cleanup for version strings in a user agent, to accept the same character set as accepted by user agent string. Examples of updated versions:

| Input version | Output version |
| -------------- | ---------------- |
| 1.0.0(Microsoft) | 1.0.0Microsoft |
| 1.\*.\* | 1.. |

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
