### PR TITLE
[DataFactory] Adding additionalProperties to roundtrip new properties

### DIFF
--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Activity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Activity.cs
@@ -33,10 +33,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the Activity class.
         /// </summary>
         /// <param name="name">Activity name.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
-        public Activity(string name, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>))
+        public Activity(string name, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>))
         {
+            AdditionalProperties = additionalProperties;
             Name = name;
             Description = description;
             DependsOn = dependsOn;
@@ -47,6 +50,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets activity name.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ActivityDependency.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ActivityDependency.cs
@@ -35,8 +35,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="activity">Activity name.</param>
         /// <param name="dependencyConditions">Match-Condition for the
         /// dependency.</param>
-        public ActivityDependency(string activity, IList<string> dependencyConditions)
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
+        public ActivityDependency(string activity, IList<string> dependencyConditions, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>))
         {
+            AdditionalProperties = additionalProperties;
             Activity = activity;
             DependencyConditions = dependencyConditions;
             CustomInit();
@@ -46,6 +49,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets activity name.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ActivityPolicy.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ActivityPolicy.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Microsoft.Rest;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -30,6 +32,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ActivityPolicy class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="timeout">Specifies the timeout for the activity to
         /// run. The default timeout is 7 days. Type: string (or Expression
         /// with resultType string), pattern:
@@ -39,8 +43,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// 0.</param>
         /// <param name="retryIntervalInSeconds">Interval between each retry
         /// attempt (in seconds). The default is 30 sec.</param>
-        public ActivityPolicy(object timeout = default(object), object retry = default(object), int? retryIntervalInSeconds = default(int?))
+        public ActivityPolicy(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object timeout = default(object), object retry = default(object), int? retryIntervalInSeconds = default(int?))
         {
+            AdditionalProperties = additionalProperties;
             Timeout = timeout;
             Retry = retry;
             RetryIntervalInSeconds = retryIntervalInSeconds;
@@ -51,6 +56,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets specifies the timeout for the activity to run. The

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ActivityRun.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ActivityRun.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ActivityRun class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="pipelineName">The name of the pipeline.</param>
         /// <param name="pipelineRunId">The id of the pipeline run.</param>
         /// <param name="activityName">The name of the activity.</param>
@@ -46,8 +50,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="input">The input for the activity.</param>
         /// <param name="output">The output for the activity.</param>
         /// <param name="error">The error if any from the activity run.</param>
-        public ActivityRun(string pipelineName = default(string), string pipelineRunId = default(string), string activityName = default(string), string activityType = default(string), string activityRunId = default(string), string linkedServiceName = default(string), string status = default(string), System.DateTime? activityRunStart = default(System.DateTime?), System.DateTime? activityRunEnd = default(System.DateTime?), int? durationInMs = default(int?), object input = default(object), object output = default(object), object error = default(object))
+        public ActivityRun(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string pipelineName = default(string), string pipelineRunId = default(string), string activityName = default(string), string activityType = default(string), string activityRunId = default(string), string linkedServiceName = default(string), string status = default(string), System.DateTime? activityRunStart = default(System.DateTime?), System.DateTime? activityRunEnd = default(System.DateTime?), int? durationInMs = default(int?), object input = default(object), object output = default(object), object error = default(object))
         {
+            AdditionalProperties = additionalProperties;
             PipelineName = pipelineName;
             PipelineRunId = pipelineRunId;
             ActivityName = activityName;
@@ -68,6 +73,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets the name of the pipeline.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonMWSLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonMWSLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -41,6 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="sellerID">The Amazon seller ID.</param>
         /// <param name="accessKeyId">The access key id used to access
         /// data.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="mwsAuthToken">The Amazon MWS authentication
@@ -59,8 +63,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AmazonMWSLinkedService(object endpoint, object marketplaceID, object sellerID, object accessKeyId, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase mwsAuthToken = default(SecretBase), SecretBase secretKey = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AmazonMWSLinkedService(object endpoint, object marketplaceID, object sellerID, object accessKeyId, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase mwsAuthToken = default(SecretBase), SecretBase secretKey = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Endpoint = endpoint;
             MarketplaceID = marketplaceID;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonMWSObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonMWSObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the AmazonMWSObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public AmazonMWSObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public AmazonMWSObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonMWSSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonMWSSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AmazonMWSSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public AmazonMWSSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public AmazonMWSSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonRedshiftLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonRedshiftLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -40,6 +42,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="database">The database name of the Amazon Redshift
         /// source. Type: string (or Expression with resultType
         /// string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="username">The username of the Amazon Redshift source.
@@ -54,8 +58,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AmazonRedshiftLinkedService(object server, object database, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object username = default(object), SecureString password = default(SecureString), object port = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AmazonRedshiftLinkedService(object server, object database, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object username = default(object), SecureString password = default(SecureString), object port = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             Username = username;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonRedshiftSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonRedshiftSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AmazonRedshiftSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -41,8 +45,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// unload. With this, data from Amazon Redshift source will be
         /// unloaded into S3 first and then copied into the targeted sink from
         /// the interim S3.</param>
-        public AmazonRedshiftSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object), RedshiftUnloadSettings redshiftUnloadSettings = default(RedshiftUnloadSettings))
-            : base(sourceRetryCount, sourceRetryWait)
+        public AmazonRedshiftSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object), RedshiftUnloadSettings redshiftUnloadSettings = default(RedshiftUnloadSettings))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             RedshiftUnloadSettings = redshiftUnloadSettings;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonS3Dataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonS3Dataset.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="bucketName">The name of the Amazon S3 bucket. Type:
         /// string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -54,8 +56,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="format">The format of files.</param>
         /// <param name="compression">The data compression method used for the
         /// Amazon S3 object.</param>
-        public AmazonS3Dataset(LinkedServiceReference linkedServiceName, object bucketName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object key = default(object), object prefix = default(object), object version = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), DatasetCompression compression = default(DatasetCompression))
-            : base(linkedServiceName, description, structure, parameters)
+        public AmazonS3Dataset(LinkedServiceReference linkedServiceName, object bucketName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object key = default(object), object prefix = default(object), object version = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), DatasetCompression compression = default(DatasetCompression))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             BucketName = bucketName;
             Key = key;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonS3LinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AmazonS3LinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,6 +35,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AmazonS3LinkedService class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="accessKeyId">The access key identifier of the Amazon
@@ -44,8 +48,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AmazonS3LinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object accessKeyId = default(object), SecureString secretAccessKey = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AmazonS3LinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object accessKeyId = default(object), SecureString secretAccessKey = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             AccessKeyId = accessKeyId;
             SecretAccessKey = secretAccessKey;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AvroFormat.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AvroFormat.cs
@@ -10,6 +10,8 @@
 
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -28,12 +30,14 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AvroFormat class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="serializer">Serializer. Type: string (or Expression
         /// with resultType string).</param>
         /// <param name="deserializer">Deserializer. Type: string (or
         /// Expression with resultType string).</param>
-        public AvroFormat(object serializer = default(object), object deserializer = default(object))
-            : base(serializer, deserializer)
+        public AvroFormat(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object serializer = default(object), object deserializer = default(object))
+            : base(additionalProperties, serializer, deserializer)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureBatchLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureBatchLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -42,6 +44,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Expression with resultType string).</param>
         /// <param name="linkedServiceName">The Azure Storage linked service
         /// reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="accessKey">The Azure Batch account access key.</param>
@@ -49,8 +53,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureBatchLinkedService(object accountName, object batchUri, object poolName, LinkedServiceReference linkedServiceName, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecureString accessKey = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureBatchLinkedService(object accountName, object batchUri, object poolName, LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecureString accessKey = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             AccountName = accountName;
             AccessKey = accessKey;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureBlobDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureBlobDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the AzureBlobDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -51,8 +53,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="format">The format of the Azure Blob storage.</param>
         /// <param name="compression">The data compression method used for the
         /// blob storage.</param>
-        public AzureBlobDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object folderPath = default(object), object tableRootLocation = default(object), object fileName = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), DatasetCompression compression = default(DatasetCompression))
-            : base(linkedServiceName, description, structure, parameters)
+        public AzureBlobDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object folderPath = default(object), object tableRootLocation = default(object), object fileName = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), DatasetCompression compression = default(DatasetCompression))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             FolderPath = folderPath;
             TableRootLocation = tableRootLocation;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeAnalyticsLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeAnalyticsLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -40,6 +42,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="tenant">The name or ID of the tenant to which the
         /// service principal belongs. Type: string (or Expression with
         /// resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="servicePrincipalId">The ID of the application used to
@@ -60,8 +64,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureDataLakeAnalyticsLinkedService(object accountName, object tenant, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object servicePrincipalId = default(object), SecureString servicePrincipalKey = default(SecureString), object subscriptionId = default(object), object resourceGroupName = default(object), object dataLakeAnalyticsUri = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureDataLakeAnalyticsLinkedService(object accountName, object tenant, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object servicePrincipalId = default(object), SecureString servicePrincipalKey = default(SecureString), object subscriptionId = default(object), object resourceGroupName = default(object), object dataLakeAnalyticsUri = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             AccountName = accountName;
             ServicePrincipalId = servicePrincipalId;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeStoreDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeStoreDataset.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="folderPath">Path to the folder in the Azure Data Lake
         /// Store. Type: string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -49,8 +51,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="format">The format of the Data Lake Store.</param>
         /// <param name="compression">The data compression method used for the
         /// item(s) in the Azure Data Lake Store.</param>
-        public AzureDataLakeStoreDataset(LinkedServiceReference linkedServiceName, object folderPath, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object fileName = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), DatasetCompression compression = default(DatasetCompression))
-            : base(linkedServiceName, description, structure, parameters)
+        public AzureDataLakeStoreDataset(LinkedServiceReference linkedServiceName, object folderPath, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object fileName = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), DatasetCompression compression = default(DatasetCompression))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             FolderPath = folderPath;
             FileName = fileName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeStoreLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeStoreLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="dataLakeStoreUri">Data Lake Store service URI. Type:
         /// string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="servicePrincipalId">The ID of the application used to
@@ -59,8 +63,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureDataLakeStoreLinkedService(object dataLakeStoreUri, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object servicePrincipalId = default(object), SecureString servicePrincipalKey = default(SecureString), object tenant = default(object), object accountName = default(object), object subscriptionId = default(object), object resourceGroupName = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureDataLakeStoreLinkedService(object dataLakeStoreUri, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object servicePrincipalId = default(object), SecureString servicePrincipalKey = default(SecureString), object tenant = default(object), object accountName = default(object), object subscriptionId = default(object), object resourceGroupName = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             DataLakeStoreUri = dataLakeStoreUri;
             ServicePrincipalId = servicePrincipalId;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeStoreSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeStoreSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzureDataLakeStoreSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="copyBehavior">The type of copy behavior for copy sink.
         /// Possible values include: 'PreserveHierarchy', 'FlattenHierarchy',
         /// 'MergeFiles'</param>
-        public AzureDataLakeStoreSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string copyBehavior = default(string))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public AzureDataLakeStoreSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string copyBehavior = default(string))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             CopyBehavior = copyBehavior;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeStoreSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureDataLakeStoreSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzureDataLakeStoreSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -37,8 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="recursive">If true, files under the folder path will
         /// be read recursively. Default is true. Type: boolean (or Expression
         /// with resultType boolean).</param>
-        public AzureDataLakeStoreSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object recursive = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public AzureDataLakeStoreSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object recursive = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Recursive = recursive;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureKeyVaultLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureKeyVaultLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -36,10 +38,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="baseUrl">The base URL of the Azure Key Vault. e.g.
         /// https://myakv.vault.azure.net Type: string (or Expression with
         /// resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
-        public AzureKeyVaultLinkedService(object baseUrl, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string))
-            : base(connectVia, description)
+        public AzureKeyVaultLinkedService(object baseUrl, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string))
+            : base(additionalProperties, connectVia, description)
         {
             BaseUrl = baseUrl;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMLBatchExecutionActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMLBatchExecutionActivity.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// class.
         /// </summary>
         /// <param name="name">Activity name.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -57,8 +59,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// objects specifying the input Blob locations.. This information will
         /// be passed in the WebServiceInputs property of the Azure ML batch
         /// execution request.</param>
-        public AzureMLBatchExecutionActivity(string name, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IDictionary<string, object> globalParameters = default(IDictionary<string, object>), IDictionary<string, AzureMLWebServiceFile> webServiceOutputs = default(IDictionary<string, AzureMLWebServiceFile>), IDictionary<string, AzureMLWebServiceFile> webServiceInputs = default(IDictionary<string, AzureMLWebServiceFile>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public AzureMLBatchExecutionActivity(string name, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IDictionary<string, object> globalParameters = default(IDictionary<string, object>), IDictionary<string, AzureMLWebServiceFile> webServiceOutputs = default(IDictionary<string, AzureMLWebServiceFile>), IDictionary<string, AzureMLWebServiceFile> webServiceInputs = default(IDictionary<string, AzureMLWebServiceFile>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             GlobalParameters = globalParameters;
             WebServiceOutputs = webServiceOutputs;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMLLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMLLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -38,6 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// resultType string).</param>
         /// <param name="apiKey">The API key for accessing the Azure ML model
         /// endpoint.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="updateResourceEndpoint">The Update Resource REST URL
@@ -57,8 +61,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureMLLinkedService(object mlEndpoint, SecureString apiKey, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object updateResourceEndpoint = default(object), object servicePrincipalId = default(object), SecureString servicePrincipalKey = default(SecureString), object tenant = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureMLLinkedService(object mlEndpoint, SecureString apiKey, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object updateResourceEndpoint = default(object), object servicePrincipalId = default(object), SecureString servicePrincipalKey = default(SecureString), object tenant = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             MlEndpoint = mlEndpoint;
             ApiKey = apiKey;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMLUpdateResourceActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMLUpdateResourceActivity.cs
@@ -49,12 +49,14 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// trainedModelLinkedService to represent the .ilearner file that will
         /// be uploaded by the update operation.  Type: string (or Expression
         /// with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="policy">Activity policy.</param>
-        public AzureMLUpdateResourceActivity(string name, object trainedModelName, LinkedServiceReference trainedModelLinkedServiceName, object trainedModelFilePath, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public AzureMLUpdateResourceActivity(string name, object trainedModelName, LinkedServiceReference trainedModelLinkedServiceName, object trainedModelFilePath, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             TrainedModelName = trainedModelName;
             TrainedModelLinkedServiceName = trainedModelLinkedServiceName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMySqlLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMySqlLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -34,14 +36,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the AzureMySqlLinkedService class.
         /// </summary>
         /// <param name="connectionString">The connection string.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="encryptedCredential">The encrypted credential used for
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureMySqlLinkedService(SecureString connectionString, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureMySqlLinkedService(SecureString connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMySqlSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMySqlSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzureMySqlSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">Database query. Type: string (or Expression
         /// with resultType string).</param>
-        public AzureMySqlSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public AzureMySqlSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMySqlTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureMySqlTableDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the AzureMySqlTableDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -44,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="parameters">Parameters for dataset.</param>
         /// <param name="tableName">The Azure MySQL database table name. Type:
         /// string (or Expression with resultType string).</param>
-        public AzureMySqlTableDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object tableName = default(object))
-            : base(linkedServiceName, description, structure, parameters)
+        public AzureMySqlTableDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object tableName = default(object))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TableName = tableName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzurePostgreSqlLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzurePostgreSqlLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the AzurePostgreSqlLinkedService
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="connectionString">An ODBC connection string.</param>
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzurePostgreSqlLinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzurePostgreSqlLinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzurePostgreSqlSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzurePostgreSqlSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzurePostgreSqlSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public AzurePostgreSqlSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public AzurePostgreSqlSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzurePostgreSqlTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzurePostgreSqlTableDataset.cs
@@ -36,13 +36,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public AzurePostgreSqlTableDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public AzurePostgreSqlTableDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureQueueSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureQueueSink.cs
@@ -10,6 +10,8 @@
 
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -28,6 +30,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzureQueueSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -38,8 +42,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="sinkRetryWait">Sink retry wait. Type: string (or
         /// Expression with resultType string), pattern:
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
-        public AzureQueueSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public AzureQueueSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSearchIndexDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSearchIndexDataset.cs
@@ -39,13 +39,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="indexName">The name of the Azure Search Index. Type:
         /// string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public AzureSearchIndexDataset(LinkedServiceReference linkedServiceName, object indexName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public AzureSearchIndexDataset(LinkedServiceReference linkedServiceName, object indexName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             IndexName = indexName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSearchIndexSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSearchIndexSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzureSearchIndexSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="writeBehavior">Specify the write behavior when
         /// upserting documents into Azure Search Index. Possible values
         /// include: 'Merge', 'Upload'</param>
-        public AzureSearchIndexSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string writeBehavior = default(string))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public AzureSearchIndexSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string writeBehavior = default(string))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             WriteBehavior = writeBehavior;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSearchLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSearchLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="url">URL for Azure Search service. Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="key">Admin Key for Azure Search service</param>
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureSearchLinkedService(object url, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecureString key = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureSearchLinkedService(object url, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecureString key = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Url = url;
             Key = key;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDWLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDWLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -34,14 +36,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the AzureSqlDWLinkedService class.
         /// </summary>
         /// <param name="connectionString">The connection string.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="encryptedCredential">The encrypted credential used for
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureSqlDWLinkedService(SecureString connectionString, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureSqlDWLinkedService(SecureString connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDWTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDWTableDataset.cs
@@ -40,13 +40,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="tableName">The table name of the Azure SQL Data
         /// Warehouse. Type: string (or Expression with resultType
         /// string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public AzureSqlDWTableDataset(LinkedServiceReference linkedServiceName, object tableName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public AzureSqlDWTableDataset(LinkedServiceReference linkedServiceName, object tableName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TableName = tableName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDatabaseLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDatabaseLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -36,14 +38,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// class.
         /// </summary>
         /// <param name="connectionString">The connection string.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="encryptedCredential">The encrypted credential used for
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureSqlDatabaseLinkedService(SecureString connectionString, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureSqlDatabaseLinkedService(SecureString connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlTableDataset.cs
@@ -39,13 +39,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="tableName">The table name of the Azure SQL database.
         /// Type: string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public AzureSqlTableDataset(LinkedServiceReference linkedServiceName, object tableName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public AzureSqlTableDataset(LinkedServiceReference linkedServiceName, object tableName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TableName = tableName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureStorageLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureStorageLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,6 +35,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzureStorageLinkedService class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="connectionString">The connection string. It is
@@ -43,8 +47,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureStorageLinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecureString connectionString = default(SecureString), SecureString sasUri = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public AzureStorageLinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecureString connectionString = default(SecureString), SecureString sasUri = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             SasUri = sasUri;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureTableDataset.cs
@@ -39,13 +39,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="tableName">The table name of the Azure Table storage.
         /// Type: string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public AzureTableDataset(LinkedServiceReference linkedServiceName, object tableName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public AzureTableDataset(LinkedServiceReference linkedServiceName, object tableName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TableName = tableName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureTableSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureTableSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzureTableSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -48,8 +52,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// string (or Expression with resultType string).</param>
         /// <param name="azureTableInsertType">Azure Table insert type. Type:
         /// string (or Expression with resultType string).</param>
-        public AzureTableSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object azureTableDefaultPartitionKeyValue = default(object), object azureTablePartitionKeyName = default(object), object azureTableRowKeyName = default(object), object azureTableInsertType = default(object))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public AzureTableSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object azureTableDefaultPartitionKeyValue = default(object), object azureTablePartitionKeyName = default(object), object azureTableRowKeyName = default(object), object azureTableInsertType = default(object))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             AzureTableDefaultPartitionKeyValue = azureTableDefaultPartitionKeyValue;
             AzureTablePartitionKeyName = azureTablePartitionKeyName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureTableSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureTableSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the AzureTableSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -39,8 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="azureTableSourceIgnoreTableNotFound">Azure Table
         /// source ignore table not found. Type: boolean (or Expression with
         /// resultType boolean).</param>
-        public AzureTableSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object azureTableSourceQuery = default(object), object azureTableSourceIgnoreTableNotFound = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public AzureTableSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object azureTableSourceQuery = default(object), object azureTableSourceIgnoreTableNotFound = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             AzureTableSourceQuery = azureTableSourceQuery;
             AzureTableSourceIgnoreTableNotFound = azureTableSourceIgnoreTableNotFound;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/BlobSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/BlobSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the BlobSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -49,8 +53,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="copyBehavior">The type of copy behavior for copy sink.
         /// Possible values include: 'PreserveHierarchy', 'FlattenHierarchy',
         /// 'MergeFiles'</param>
-        public BlobSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object blobWriterOverwriteFiles = default(object), object blobWriterDateTimeFormat = default(object), object blobWriterAddHeader = default(object), string copyBehavior = default(string))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public BlobSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object blobWriterOverwriteFiles = default(object), object blobWriterDateTimeFormat = default(object), object blobWriterAddHeader = default(object), string copyBehavior = default(string))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             BlobWriterOverwriteFiles = blobWriterOverwriteFiles;
             BlobWriterDateTimeFormat = blobWriterDateTimeFormat;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/BlobSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/BlobSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the BlobSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="recursive">If true, files under the folder path will
         /// be read recursively. Default is true. Type: boolean (or Expression
         /// with resultType boolean).</param>
-        public BlobSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object treatEmptyAsNull = default(object), object skipHeaderLineCount = default(object), object recursive = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public BlobSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object treatEmptyAsNull = default(object), object skipHeaderLineCount = default(object), object recursive = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             TreatEmptyAsNull = treatEmptyAsNull;
             SkipHeaderLineCount = skipHeaderLineCount;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/BlobTrigger.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/BlobTrigger.cs
@@ -34,6 +34,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the BlobTrigger class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Trigger description.</param>
         /// <param name="runtimeState">Indicates if trigger is running or not.
         /// Updated when Start/Stop APIs are called on the Trigger. Possible
@@ -45,8 +47,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// handle when it is triggered.</param>
         /// <param name="linkedService">The Azure Storage linked service
         /// reference.</param>
-        public BlobTrigger(string description = default(string), string runtimeState = default(string), IList<TriggerPipelineReference> pipelines = default(IList<TriggerPipelineReference>), string folderPath = default(string), int? maxConcurrency = default(int?), LinkedServiceReference linkedService = default(LinkedServiceReference))
-            : base(description, runtimeState, pipelines)
+        public BlobTrigger(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), string runtimeState = default(string), IList<TriggerPipelineReference> pipelines = default(IList<TriggerPipelineReference>), string folderPath = default(string), int? maxConcurrency = default(int?), LinkedServiceReference linkedService = default(LinkedServiceReference))
+            : base(additionalProperties, description, runtimeState, pipelines)
         {
             FolderPath = folderPath;
             MaxConcurrency = maxConcurrency;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CassandraLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CassandraLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="host">Host name for connection. Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="authenticationType">AuthenticationType to be used for
@@ -49,8 +53,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public CassandraLinkedService(object host, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object authenticationType = default(object), object port = default(object), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public CassandraLinkedService(object host, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object authenticationType = default(object), object port = default(object), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             AuthenticationType = authenticationType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CassandraSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CassandraSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the CassandraSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -45,8 +49,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// default value is 'ONE'. It is case-insensitive. Possible values
         /// include: 'ALL', 'EACH_QUORUM', 'QUORUM', 'LOCAL_QUORUM', 'ONE',
         /// 'TWO', 'THREE', 'LOCAL_ONE', 'SERIAL', 'LOCAL_SERIAL'</param>
-        public CassandraSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object), string consistencyLevel = default(string))
-            : base(sourceRetryCount, sourceRetryWait)
+        public CassandraSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object), string consistencyLevel = default(string))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             ConsistencyLevel = consistencyLevel;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CassandraTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CassandraTableDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the CassandraTableDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -46,8 +48,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Type: string (or Expression with resultType string).</param>
         /// <param name="keyspace">The keyspace of the Cassandra database.
         /// Type: string (or Expression with resultType string).</param>
-        public CassandraTableDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object tableName = default(object), object keyspace = default(object))
-            : base(linkedServiceName, description, structure, parameters)
+        public CassandraTableDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object tableName = default(object), object keyspace = default(object))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TableName = tableName;
             Keyspace = keyspace;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ConcurLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ConcurLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Management.</param>
         /// <param name="username">The user name that you use to access Concur
         /// Service.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="password">The password corresponding to the user name
@@ -54,8 +58,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public ConcurLinkedService(object clientId, object username, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase password = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public ConcurLinkedService(object clientId, object username, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase password = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ClientId = clientId;
             Username = username;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ConcurObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ConcurObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ConcurObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public ConcurObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public ConcurObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ConcurSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ConcurSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ConcurSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public ConcurSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public ConcurSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ControlActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ControlActivity.cs
@@ -34,10 +34,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ControlActivity class.
         /// </summary>
         /// <param name="name">Activity name.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
-        public ControlActivity(string name, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>))
-            : base(name, description, dependsOn)
+        public ControlActivity(string name, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>))
+            : base(name, additionalProperties, description, dependsOn)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CopyActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CopyActivity.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="name">Activity name.</param>
         /// <param name="source">Copy activity source.</param>
         /// <param name="sink">Copy activity sink.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -64,8 +66,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// row settings when EnableSkipIncompatibleRow is true.</param>
         /// <param name="inputs">List of inputs for the activity.</param>
         /// <param name="outputs">List of outputs for the activity.</param>
-        public CopyActivity(string name, CopySource source, CopySink sink, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), CopyTranslator translator = default(CopyTranslator), object enableStaging = default(object), StagingSettings stagingSettings = default(StagingSettings), object parallelCopies = default(object), object cloudDataMovementUnits = default(object), object enableSkipIncompatibleRow = default(object), RedirectIncompatibleRowSettings redirectIncompatibleRowSettings = default(RedirectIncompatibleRowSettings), IList<DatasetReference> inputs = default(IList<DatasetReference>), IList<DatasetReference> outputs = default(IList<DatasetReference>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public CopyActivity(string name, CopySource source, CopySink sink, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), CopyTranslator translator = default(CopyTranslator), object enableStaging = default(object), StagingSettings stagingSettings = default(StagingSettings), object parallelCopies = default(object), object cloudDataMovementUnits = default(object), object enableSkipIncompatibleRow = default(object), RedirectIncompatibleRowSettings redirectIncompatibleRowSettings = default(RedirectIncompatibleRowSettings), IList<DatasetReference> inputs = default(IList<DatasetReference>), IList<DatasetReference> outputs = default(IList<DatasetReference>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             Source = source;
             Sink = sink;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CopySink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CopySink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the CopySink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -39,8 +43,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="sinkRetryWait">Sink retry wait. Type: string (or
         /// Expression with resultType string), pattern:
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
-        public CopySink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object))
+        public CopySink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object))
         {
+            AdditionalProperties = additionalProperties;
             WriteBatchSize = writeBatchSize;
             WriteBatchTimeout = writeBatchTimeout;
             SinkRetryCount = sinkRetryCount;
@@ -52,6 +57,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets write batch size. Type: integer (or Expression with

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CopySource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CopySource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,13 +31,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the CopySource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
         /// Expression with resultType string), pattern:
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
-        public CopySource(object sourceRetryCount = default(object), object sourceRetryWait = default(object))
+        public CopySource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object))
         {
+            AdditionalProperties = additionalProperties;
             SourceRetryCount = sourceRetryCount;
             SourceRetryWait = sourceRetryWait;
             CustomInit();
@@ -45,6 +50,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets source retry count. Type: integer (or Expression with

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CopyTranslator.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CopyTranslator.cs
@@ -10,6 +10,9 @@
 
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -25,11 +28,28 @@ namespace Microsoft.Azure.Management.DataFactory.Models
             CustomInit();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the CopyTranslator class.
+        /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
+        public CopyTranslator(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>))
+        {
+            AdditionalProperties = additionalProperties;
+            CustomInit();
+        }
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
     }
 }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CosmosDbLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CosmosDbLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -34,14 +36,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the CosmosDbLinkedService class.
         /// </summary>
         /// <param name="connectionString">The connection string.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="encryptedCredential">The encrypted credential used for
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public CosmosDbLinkedService(SecureString connectionString, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public CosmosDbLinkedService(SecureString connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CouchbaseLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CouchbaseLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,6 +35,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the CouchbaseLinkedService class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="connectionString">An ODBC connection string.</param>
@@ -40,8 +44,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public CouchbaseLinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public CouchbaseLinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CouchbaseSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CouchbaseSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the CouchbaseSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public CouchbaseSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public CouchbaseSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CouchbaseTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CouchbaseTableDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the CouchbaseTableDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public CouchbaseTableDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public CouchbaseTableDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CustomActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CustomActivity.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="name">Activity name.</param>
         /// <param name="command">Command for custom activity Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -51,8 +53,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// is no restriction on the keys or values that can be used. The user
         /// specified custom activity has the full responsibility to consume
         /// and interpret the content defined.</param>
-        public CustomActivity(string name, object command, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), LinkedServiceReference resourceLinkedService = default(LinkedServiceReference), object folderPath = default(object), CustomActivityReferenceObject referenceObjects = default(CustomActivityReferenceObject), IDictionary<string, object> extendedProperties = default(IDictionary<string, object>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public CustomActivity(string name, object command, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), LinkedServiceReference resourceLinkedService = default(LinkedServiceReference), object folderPath = default(object), CustomActivityReferenceObject referenceObjects = default(CustomActivityReferenceObject), IDictionary<string, object> extendedProperties = default(IDictionary<string, object>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             Command = command;
             ResourceLinkedService = resourceLinkedService;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CustomDataSourceLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CustomDataSourceLinkedService.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Microsoft.Rest;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,10 +37,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="typeProperties">Custom linked service
         /// properties.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
-        public CustomDataSourceLinkedService(object typeProperties, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string))
-            : base(connectVia, description)
+        public CustomDataSourceLinkedService(object typeProperties, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string))
+            : base(additionalProperties, connectVia, description)
         {
             TypeProperties = typeProperties;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CustomDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/CustomDataset.cs
@@ -35,13 +35,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="typeProperties">Custom dataset properties.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public CustomDataset(LinkedServiceReference linkedServiceName, object typeProperties, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public CustomDataset(LinkedServiceReference linkedServiceName, object typeProperties, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TypeProperties = typeProperties;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DataLakeAnalyticsUSQLActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DataLakeAnalyticsUSQLActivity.cs
@@ -44,6 +44,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// resultType string).</param>
         /// <param name="scriptLinkedService">Script linked service
         /// reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -62,8 +64,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="compilationMode">Compilation mode of U-SQL. Must be
         /// one of these values : Semantic, Full and SingleBox. Type: string
         /// (or Expression with resultType string).</param>
-        public DataLakeAnalyticsUSQLActivity(string name, object scriptPath, LinkedServiceReference scriptLinkedService, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), object degreeOfParallelism = default(object), object priority = default(object), IDictionary<string, object> parameters = default(IDictionary<string, object>), object runtimeVersion = default(object), object compilationMode = default(object))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public DataLakeAnalyticsUSQLActivity(string name, object scriptPath, LinkedServiceReference scriptLinkedService, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), object degreeOfParallelism = default(object), object priority = default(object), IDictionary<string, object> parameters = default(IDictionary<string, object>), object runtimeVersion = default(object), object compilationMode = default(object))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             ScriptPath = scriptPath;
             ScriptLinkedService = scriptLinkedService;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Dataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Dataset.cs
@@ -35,13 +35,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the Dataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public Dataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+        public Dataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
         {
+            AdditionalProperties = additionalProperties;
             Description = description;
             Structure = structure;
             LinkedServiceName = linkedServiceName;
@@ -53,6 +56,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets dataset description.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetBZip2Compression.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetBZip2Compression.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -27,6 +29,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
             CustomInit();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the DatasetBZip2Compression class.
+        /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
+        public DatasetBZip2Compression(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>))
+            : base(additionalProperties)
+        {
+            CustomInit();
+        }
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetCompression.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetCompression.cs
@@ -10,6 +10,9 @@
 
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
+    using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -25,11 +28,28 @@ namespace Microsoft.Azure.Management.DataFactory.Models
             CustomInit();
         }
 
+        /// <summary>
+        /// Initializes a new instance of the DatasetCompression class.
+        /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
+        public DatasetCompression(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>))
+        {
+            AdditionalProperties = additionalProperties;
+            CustomInit();
+        }
 
         /// <summary>
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
     }
 }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetDeflateCompression.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetDeflateCompression.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -30,9 +32,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DatasetDeflateCompression class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="level">The Deflate compression level. Possible values
         /// include: 'Optimal', 'Fastest'</param>
-        public DatasetDeflateCompression(string level = default(string))
+        public DatasetDeflateCompression(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string level = default(string))
+            : base(additionalProperties)
         {
             Level = level;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetGZipCompression.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetGZipCompression.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -30,9 +32,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DatasetGZipCompression class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="level">The GZip compression level. Possible values
         /// include: 'Optimal', 'Fastest'</param>
-        public DatasetGZipCompression(string level = default(string))
+        public DatasetGZipCompression(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string level = default(string))
+            : base(additionalProperties)
         {
             Level = level;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetStorageFormat.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetStorageFormat.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,12 +31,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DatasetStorageFormat class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="serializer">Serializer. Type: string (or Expression
         /// with resultType string).</param>
         /// <param name="deserializer">Deserializer. Type: string (or
         /// Expression with resultType string).</param>
-        public DatasetStorageFormat(object serializer = default(object), object deserializer = default(object))
+        public DatasetStorageFormat(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object serializer = default(object), object deserializer = default(object))
         {
+            AdditionalProperties = additionalProperties;
             Serializer = serializer;
             Deserializer = deserializer;
             CustomInit();
@@ -44,6 +49,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets serializer. Type: string (or Expression with

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetZipDeflateCompression.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DatasetZipDeflateCompression.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -32,9 +34,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the DatasetZipDeflateCompression
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="level">The ZipDeflate compression level. Possible
         /// values include: 'Optimal', 'Fastest'</param>
-        public DatasetZipDeflateCompression(string level = default(string))
+        public DatasetZipDeflateCompression(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string level = default(string))
+            : base(additionalProperties)
         {
             Level = level;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Db2LinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Db2LinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Expression with resultType string).</param>
         /// <param name="database">Database name for connection. Type: string
         /// (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="schema">Schema name for connection. Type: string (or
@@ -50,8 +54,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public Db2LinkedService(object server, object database, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), string authenticationType = default(string), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public Db2LinkedService(object server, object database, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), string authenticationType = default(string), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             Database = database;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DocumentDbCollectionDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DocumentDbCollectionDataset.cs
@@ -41,13 +41,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="collectionName">Document Database collection name.
         /// Type: string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public DocumentDbCollectionDataset(LinkedServiceReference linkedServiceName, object collectionName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public DocumentDbCollectionDataset(LinkedServiceReference linkedServiceName, object collectionName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CollectionName = collectionName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DocumentDbCollectionSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DocumentDbCollectionSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DocumentDbCollectionSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="nestingSeparator">Nested properties separator. Default
         /// is . (dot). Type: string (or Expression with resultType
         /// string).</param>
-        public DocumentDbCollectionSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object nestingSeparator = default(object))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public DocumentDbCollectionSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object nestingSeparator = default(object))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             NestingSeparator = nestingSeparator;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DocumentDbCollectionSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DocumentDbCollectionSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DocumentDbCollectionSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -38,8 +42,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// with resultType string).</param>
         /// <param name="nestingSeparator">Nested properties separator. Type:
         /// string (or Expression with resultType string).</param>
-        public DocumentDbCollectionSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object), object nestingSeparator = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public DocumentDbCollectionSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object), object nestingSeparator = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             NestingSeparator = nestingSeparator;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DrillLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DrillLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,6 +35,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DrillLinkedService class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="connectionString">An ODBC connection string.</param>
@@ -40,8 +44,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public DrillLinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public DrillLinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DrillSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DrillSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DrillSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public DrillSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public DrillSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DrillTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DrillTableDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the DrillTableDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public DrillTableDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public DrillTableDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsEntityDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsEntityDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the DynamicsEntityDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -44,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="parameters">Parameters for dataset.</param>
         /// <param name="entityName">The logical name of the entity. Type:
         /// string (or Expression with resultType string).</param>
-        public DynamicsEntityDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object entityName = default(object))
-            : base(linkedServiceName, description, structure, parameters)
+        public DynamicsEntityDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object entityName = default(object))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             EntityName = entityName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -43,6 +45,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// resultType string).</param>
         /// <param name="username">User name to access the Dynamics instance.
         /// Type: string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="hostName">The host name of the on-premises Dynamics
@@ -64,8 +68,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public DynamicsLinkedService(object deploymentType, object authenticationType, object username, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object hostName = default(object), object port = default(object), object organizationName = default(object), SecretBase password = default(SecretBase), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public DynamicsLinkedService(object deploymentType, object authenticationType, object username, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object hostName = default(object), object port = default(object), object organizationName = default(object), SecretBase password = default(SecretBase), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             DeploymentType = deploymentType;
             HostName = hostName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DynamicsSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -43,8 +47,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// null values from input dataset (except key fields) during write
         /// operation. Default is false. Type: boolean (or Expression with
         /// resultType boolean).</param>
-        public DynamicsSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object ignoreNullValues = default(object))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public DynamicsSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object ignoreNullValues = default(object))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             IgnoreNullValues = ignoreNullValues;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/DynamicsSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the DynamicsSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -37,8 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="query">FetchXML is a proprietary query language that
         /// is used in Microsoft Dynamics (online &amp; on-premises). Type:
         /// string (or Expression with resultType string).</param>
-        public DynamicsSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public DynamicsSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/EloquaLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/EloquaLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// eloqua.example.com)</param>
         /// <param name="username">The site name and user name of your Eloqua
         /// account in the form: sitename/username. (i.e. Eloqua/Alice)</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="password">The password corresponding to the user
@@ -54,8 +58,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public EloquaLinkedService(object endpoint, object username, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase password = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public EloquaLinkedService(object endpoint, object username, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase password = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Endpoint = endpoint;
             Username = username;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/EloquaObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/EloquaObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the EloquaObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public EloquaObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public EloquaObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/EloquaSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/EloquaSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the EloquaSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public EloquaSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public EloquaSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ExecutePipelineActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ExecutePipelineActivity.cs
@@ -38,14 +38,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="name">Activity name.</param>
         /// <param name="pipeline">Pipeline reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="parameters">Pipeline parameters.</param>
         /// <param name="waitOnCompletion">Defines whether activity execution
         /// will wait for the dependent pipeline execution to finish. Default
         /// is false.</param>
-        public ExecutePipelineActivity(string name, PipelineReference pipeline, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), IDictionary<string, object> parameters = default(IDictionary<string, object>), bool? waitOnCompletion = default(bool?))
-            : base(name, description, dependsOn)
+        public ExecutePipelineActivity(string name, PipelineReference pipeline, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), IDictionary<string, object> parameters = default(IDictionary<string, object>), bool? waitOnCompletion = default(bool?))
+            : base(name, additionalProperties, description, dependsOn)
         {
             Pipeline = pipeline;
             Parameters = parameters;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ExecutionActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ExecutionActivity.cs
@@ -33,12 +33,14 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ExecutionActivity class.
         /// </summary>
         /// <param name="name">Activity name.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="policy">Activity policy.</param>
-        public ExecutionActivity(string name, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy))
-            : base(name, description, dependsOn)
+        public ExecutionActivity(string name, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy))
+            : base(name, additionalProperties, description, dependsOn)
         {
             LinkedServiceName = linkedServiceName;
             Policy = policy;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Factory.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Factory.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="type">The resource type.</param>
         /// <param name="location">The resource location.</param>
         /// <param name="tags">The resource tags.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="identity">Managed service identity of the
         /// factory.</param>
         /// <param name="provisioningState">Factory provisioning state, example
@@ -46,9 +48,10 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="createTime">Time the factory was created in ISO8601
         /// format.</param>
         /// <param name="version">Version of the factory.</param>
-        public Factory(string id = default(string), string name = default(string), string type = default(string), string location = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), FactoryIdentity identity = default(FactoryIdentity), string provisioningState = default(string), System.DateTime? createTime = default(System.DateTime?), string version = default(string))
+        public Factory(string id = default(string), string name = default(string), string type = default(string), string location = default(string), IDictionary<string, string> tags = default(IDictionary<string, string>), IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), FactoryIdentity identity = default(FactoryIdentity), string provisioningState = default(string), System.DateTime? createTime = default(System.DateTime?), string version = default(string))
             : base(id, name, type, location, tags)
         {
+            AdditionalProperties = additionalProperties;
             Identity = identity;
             ProvisioningState = provisioningState;
             CreateTime = createTime;
@@ -60,6 +63,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets managed service identity of the factory.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FileServerLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FileServerLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="host">Host name of the server. Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="userId">User ID to logon the server. Type: string (or
@@ -44,8 +48,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public FileServerLinkedService(object host, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object userId = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public FileServerLinkedService(object host, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object userId = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             UserId = userId;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FileShareDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FileShareDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the FileShareDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -52,8 +54,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// string (or Expression with resultType string).</param>
         /// <param name="compression">The data compression method used for the
         /// file system.</param>
-        public FileShareDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object folderPath = default(object), object fileName = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), object fileFilter = default(object), DatasetCompression compression = default(DatasetCompression))
-            : base(linkedServiceName, description, structure, parameters)
+        public FileShareDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object folderPath = default(object), object fileName = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), object fileFilter = default(object), DatasetCompression compression = default(DatasetCompression))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             FolderPath = folderPath;
             FileName = fileName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FileSystemSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FileSystemSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the FileSystemSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="copyBehavior">The type of copy behavior for copy sink.
         /// Possible values include: 'PreserveHierarchy', 'FlattenHierarchy',
         /// 'MergeFiles'</param>
-        public FileSystemSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string copyBehavior = default(string))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public FileSystemSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string copyBehavior = default(string))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             CopyBehavior = copyBehavior;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FileSystemSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FileSystemSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the FileSystemSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -37,8 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="recursive">If true, files under the folder path will
         /// be read recursively. Default is true. Type: boolean (or Expression
         /// with resultType boolean).</param>
-        public FileSystemSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object recursive = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public FileSystemSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object recursive = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Recursive = recursive;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ForEachActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ForEachActivity.cs
@@ -40,12 +40,14 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="name">Activity name.</param>
         /// <param name="items">Collection to iterate.</param>
         /// <param name="activities">List of activities to execute .</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="isSequential">Should the loop be executed in sequence
         /// or in parallel (max 20)</param>
-        public ForEachActivity(string name, Expression items, IList<Activity> activities, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), bool? isSequential = default(bool?))
-            : base(name, description, dependsOn)
+        public ForEachActivity(string name, Expression items, IList<Activity> activities, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), bool? isSequential = default(bool?))
+            : base(name, additionalProperties, description, dependsOn)
         {
             IsSequential = isSequential;
             Items = items;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FtpServerLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/FtpServerLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="host">Host name of the FTP server. Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="port">The TCP port number that the FTP server uses to
@@ -57,8 +61,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// the FTP server SSL certificate when connect over SSL/TLS channel.
         /// Default value is true. Type: boolean (or Expression with resultType
         /// boolean).</param>
-        public FtpServerLinkedService(object host, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object), object enableSsl = default(object), object enableServerCertificateValidation = default(object))
-            : base(connectVia, description)
+        public FtpServerLinkedService(object host, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object), object enableSsl = default(object), object enableServerCertificateValidation = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             Port = port;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GetMetadataActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GetMetadataActivity.cs
@@ -39,14 +39,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="name">Activity name.</param>
         /// <param name="dataset">GetMetadata activity dataset
         /// reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="policy">Activity policy.</param>
         /// <param name="fieldList">Fields of metadata to get from
         /// dataset.</param>
-        public GetMetadataActivity(string name, DatasetReference dataset, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<object> fieldList = default(IList<object>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public GetMetadataActivity(string name, DatasetReference dataset, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<object> fieldList = default(IList<object>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             Dataset = dataset;
             FieldList = fieldList;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GoogleBigQueryLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GoogleBigQueryLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -41,6 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// mechanism used for authentication. ServiceAuthentication can only
         /// be used on self-hosted IR. Possible values include:
         /// 'ServiceAuthentication', 'UserAuthentication'</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="additionalProjects">A comma-separated list of public
@@ -69,8 +73,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public GoogleBigQueryLinkedService(object project, string authenticationType, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object additionalProjects = default(object), object requestGoogleDriveScope = default(object), SecretBase refreshToken = default(SecretBase), object email = default(object), object keyFilePath = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public GoogleBigQueryLinkedService(object project, string authenticationType, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object additionalProjects = default(object), object requestGoogleDriveScope = default(object), SecretBase refreshToken = default(SecretBase), object email = default(object), object keyFilePath = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Project = project;
             AdditionalProjects = additionalProjects;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GoogleBigQueryObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GoogleBigQueryObjectDataset.cs
@@ -36,13 +36,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public GoogleBigQueryObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public GoogleBigQueryObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GoogleBigQuerySource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GoogleBigQuerySource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the GoogleBigQuerySource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public GoogleBigQuerySource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public GoogleBigQuerySource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GreenplumLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GreenplumLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,6 +35,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the GreenplumLinkedService class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="connectionString">An ODBC connection string.</param>
@@ -40,8 +44,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public GreenplumLinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public GreenplumLinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GreenplumSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GreenplumSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the GreenplumSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public GreenplumSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public GreenplumSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GreenplumTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/GreenplumTableDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the GreenplumTableDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public GreenplumTableDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public GreenplumTableDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HBaseLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HBaseLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -38,6 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="authenticationType">The authentication mechanism to
         /// use to connect to the HBase server. Possible values include:
         /// 'Anonymous', 'Basic'</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="port">The TCP port that the HBase instance uses to
@@ -66,8 +70,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public HBaseLinkedService(object host, string authenticationType, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), object httpPath = default(object), object username = default(object), SecretBase password = default(SecretBase), object enableSsl = default(object), object trustedCertPath = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public HBaseLinkedService(object host, string authenticationType, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), object httpPath = default(object), object username = default(object), SecretBase password = default(SecretBase), object enableSsl = default(object), object trustedCertPath = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             Port = port;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HBaseObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HBaseObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the HBaseObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public HBaseObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public HBaseObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HBaseSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HBaseSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the HBaseSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public HBaseSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public HBaseSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightHiveActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightHiveActivity.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the HDInsightHiveActivity class.
         /// </summary>
         /// <param name="name">Activity name.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -52,8 +54,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// reference.</param>
         /// <param name="defines">Allows user to specify defines for Hive job
         /// request.</param>
-        public HDInsightHiveActivity(string name, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<LinkedServiceReference> storageLinkedServices = default(IList<LinkedServiceReference>), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), object scriptPath = default(object), LinkedServiceReference scriptLinkedService = default(LinkedServiceReference), IDictionary<string, object> defines = default(IDictionary<string, object>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public HDInsightHiveActivity(string name, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<LinkedServiceReference> storageLinkedServices = default(IList<LinkedServiceReference>), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), object scriptPath = default(object), LinkedServiceReference scriptLinkedService = default(LinkedServiceReference), IDictionary<string, object> defines = default(IDictionary<string, object>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             StorageLinkedServices = storageLinkedServices;
             Arguments = arguments;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="clusterUri">HDInsight cluster URI. Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="userName">HDInsight cluster user name. Type: string
@@ -48,8 +52,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public HDInsightLinkedService(object clusterUri, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object userName = default(object), SecureString password = default(SecureString), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), LinkedServiceReference hcatalogLinkedServiceName = default(LinkedServiceReference), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public HDInsightLinkedService(object clusterUri, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object userName = default(object), SecureString password = default(SecureString), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), LinkedServiceReference hcatalogLinkedServiceName = default(LinkedServiceReference), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ClusterUri = clusterUri;
             UserName = userName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightMapReduceActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightMapReduceActivity.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// with resultType string).</param>
         /// <param name="jarFilePath">Jar path. Type: string (or Expression
         /// with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -55,8 +57,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="jarLibs">Jar libs.</param>
         /// <param name="defines">Allows user to specify defines for the
         /// MapReduce job request.</param>
-        public HDInsightMapReduceActivity(string name, object className, object jarFilePath, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<LinkedServiceReference> storageLinkedServices = default(IList<LinkedServiceReference>), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), LinkedServiceReference jarLinkedService = default(LinkedServiceReference), IList<object> jarLibs = default(IList<object>), IDictionary<string, object> defines = default(IDictionary<string, object>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public HDInsightMapReduceActivity(string name, object className, object jarFilePath, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<LinkedServiceReference> storageLinkedServices = default(IList<LinkedServiceReference>), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), LinkedServiceReference jarLinkedService = default(LinkedServiceReference), IList<object> jarLibs = default(IList<object>), IDictionary<string, object> defines = default(IDictionary<string, object>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             StorageLinkedServices = storageLinkedServices;
             Arguments = arguments;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightOnDemandLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightOnDemandLinkedService.cs
@@ -60,6 +60,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="clusterResourceGroup">The resource group where the
         /// cluster belongs. Type: string (or Expression with resultType
         /// string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="servicePrincipalId">The service principal id for the
@@ -113,8 +115,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public HDInsightOnDemandLinkedService(object clusterSize, object timeToLive, object version, LinkedServiceReference linkedServiceName, object hostSubscriptionId, object tenant, object clusterResourceGroup, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object servicePrincipalId = default(object), SecureString servicePrincipalKey = default(SecureString), object clusterNamePrefix = default(object), object clusterUserName = default(object), SecureString clusterPassword = default(SecureString), object clusterSshUserName = default(object), SecureString clusterSshPassword = default(SecureString), IList<LinkedServiceReference> additionalLinkedServiceNames = default(IList<LinkedServiceReference>), LinkedServiceReference hcatalogLinkedServiceName = default(LinkedServiceReference), object clusterType = default(object), object sparkVersion = default(object), object coreConfiguration = default(object), object hBaseConfiguration = default(object), object hdfsConfiguration = default(object), object hiveConfiguration = default(object), object mapReduceConfiguration = default(object), object oozieConfiguration = default(object), object stormConfiguration = default(object), object yarnConfiguration = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public HDInsightOnDemandLinkedService(object clusterSize, object timeToLive, object version, LinkedServiceReference linkedServiceName, object hostSubscriptionId, object tenant, object clusterResourceGroup, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object servicePrincipalId = default(object), SecureString servicePrincipalKey = default(SecureString), object clusterNamePrefix = default(object), object clusterUserName = default(object), SecureString clusterPassword = default(SecureString), object clusterSshUserName = default(object), SecureString clusterSshPassword = default(SecureString), IList<LinkedServiceReference> additionalLinkedServiceNames = default(IList<LinkedServiceReference>), LinkedServiceReference hcatalogLinkedServiceName = default(LinkedServiceReference), object clusterType = default(object), object sparkVersion = default(object), object coreConfiguration = default(object), object hBaseConfiguration = default(object), object hdfsConfiguration = default(object), object hiveConfiguration = default(object), object mapReduceConfiguration = default(object), object oozieConfiguration = default(object), object stormConfiguration = default(object), object yarnConfiguration = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ClusterSize = clusterSize;
             TimeToLive = timeToLive;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightPigActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightPigActivity.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the HDInsightPigActivity class.
         /// </summary>
         /// <param name="name">Activity name.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -52,8 +54,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// reference.</param>
         /// <param name="defines">Allows user to specify defines for Pig job
         /// request.</param>
-        public HDInsightPigActivity(string name, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<LinkedServiceReference> storageLinkedServices = default(IList<LinkedServiceReference>), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), object scriptPath = default(object), LinkedServiceReference scriptLinkedService = default(LinkedServiceReference), IDictionary<string, object> defines = default(IDictionary<string, object>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public HDInsightPigActivity(string name, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<LinkedServiceReference> storageLinkedServices = default(IList<LinkedServiceReference>), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), object scriptPath = default(object), LinkedServiceReference scriptLinkedService = default(LinkedServiceReference), IDictionary<string, object> defines = default(IDictionary<string, object>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             StorageLinkedServices = storageLinkedServices;
             Arguments = arguments;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightSparkActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightSparkActivity.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="entryFilePath">The relative path to the root folder of
         /// the code/package to be executed. Type: string (or Expression with
         /// resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -59,8 +61,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// the job. Type: string (or Expression with resultType
         /// string).</param>
         /// <param name="sparkConfig">Spark configuration property.</param>
-        public HDInsightSparkActivity(string name, object rootPath, object entryFilePath, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), LinkedServiceReference sparkJobLinkedService = default(LinkedServiceReference), string className = default(string), object proxyUser = default(object), IDictionary<string, object> sparkConfig = default(IDictionary<string, object>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public HDInsightSparkActivity(string name, object rootPath, object entryFilePath, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), LinkedServiceReference sparkJobLinkedService = default(LinkedServiceReference), string className = default(string), object proxyUser = default(object), IDictionary<string, object> sparkConfig = default(IDictionary<string, object>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             RootPath = rootPath;
             EntryFilePath = entryFilePath;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightStreamingActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HDInsightStreamingActivity.cs
@@ -46,6 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// with resultType string).</param>
         /// <param name="filePaths">Paths to streaming job files. Can be
         /// directories.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -64,8 +66,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// values.</param>
         /// <param name="defines">Allows user to specify defines for streaming
         /// job request.</param>
-        public HDInsightStreamingActivity(string name, object mapper, object reducer, object input, object output, IList<object> filePaths, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<LinkedServiceReference> storageLinkedServices = default(IList<LinkedServiceReference>), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), LinkedServiceReference fileLinkedService = default(LinkedServiceReference), object combiner = default(object), IList<object> commandEnvironment = default(IList<object>), IDictionary<string, object> defines = default(IDictionary<string, object>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public HDInsightStreamingActivity(string name, object mapper, object reducer, object input, object output, IList<object> filePaths, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IList<LinkedServiceReference> storageLinkedServices = default(IList<LinkedServiceReference>), IList<object> arguments = default(IList<object>), string getDebugInfo = default(string), LinkedServiceReference fileLinkedService = default(LinkedServiceReference), object combiner = default(object), IList<object> commandEnvironment = default(IList<object>), IDictionary<string, object> defines = default(IDictionary<string, object>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             StorageLinkedServices = storageLinkedServices;
             Arguments = arguments;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HdfsLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HdfsLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -36,6 +38,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="url">The URL of the HDFS service endpoint, e.g.
         /// http://myhostname:50070/webhdfs/v1 . Type: string (or Expression
         /// with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="authenticationType">Type of authentication used to
@@ -48,8 +52,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="userName">User name for Windows authentication. Type:
         /// string (or Expression with resultType string).</param>
         /// <param name="password">Password for Windows authentication.</param>
-        public HdfsLinkedService(object url, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object authenticationType = default(object), object encryptedCredential = default(object), object userName = default(object), SecureString password = default(SecureString))
-            : base(connectVia, description)
+        public HdfsLinkedService(object url, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object authenticationType = default(object), object encryptedCredential = default(object), object userName = default(object), SecureString password = default(SecureString))
+            : base(additionalProperties, connectVia, description)
         {
             Url = url;
             AuthenticationType = authenticationType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HdfsSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HdfsSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the HdfsSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -39,8 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// with resultType boolean).</param>
         /// <param name="distcpSettings">Specifies Distcp-related
         /// settings.</param>
-        public HdfsSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object recursive = default(object), DistcpSettings distcpSettings = default(DistcpSettings))
-            : base(sourceRetryCount, sourceRetryWait)
+        public HdfsSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object recursive = default(object), DistcpSettings distcpSettings = default(DistcpSettings))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Recursive = recursive;
             DistcpSettings = distcpSettings;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HiveLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HiveLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -40,6 +42,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// access the Hive server. Possible values include: 'Anonymous',
         /// 'Username', 'UsernameAndPassword',
         /// 'WindowsAzureHDInsightService'</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="port">The TCP port that the Hive server uses to listen
@@ -83,8 +87,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public HiveLinkedService(object host, string authenticationType, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), string serverType = default(string), string thriftTransportProtocol = default(string), object serviceDiscoveryMode = default(object), object zooKeeperNameSpace = default(object), object useNativeQuery = default(object), object username = default(object), SecretBase password = default(SecretBase), object httpPath = default(object), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public HiveLinkedService(object host, string authenticationType, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), string serverType = default(string), string thriftTransportProtocol = default(string), object serviceDiscoveryMode = default(object), object zooKeeperNameSpace = default(object), object useNativeQuery = default(object), object username = default(object), SecretBase password = default(SecretBase), object httpPath = default(object), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             Port = port;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HiveObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HiveObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the HiveObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public HiveObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public HiveObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HiveSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HiveSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the HiveSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public HiveSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public HiveSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HttpDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HttpDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the HttpDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -57,8 +59,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="format">The format of files.</param>
         /// <param name="compression">The data compression method used on
         /// files.</param>
-        public HttpDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object relativeUrl = default(object), object requestMethod = default(object), object requestBody = default(object), object additionalHeaders = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), DatasetCompression compression = default(DatasetCompression))
-            : base(linkedServiceName, description, structure, parameters)
+        public HttpDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object relativeUrl = default(object), object requestMethod = default(object), object requestBody = default(object), object additionalHeaders = default(object), DatasetStorageFormat format = default(DatasetStorageFormat), DatasetCompression compression = default(DatasetCompression))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             RelativeUrl = relativeUrl;
             RequestMethod = requestMethod;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HttpLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HttpLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -36,6 +38,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="url">The base URL of the HTTP endpoint, e.g.
         /// http://www.microsoft.com. Type: string (or Expression with
         /// resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="authenticationType">The authentication type to be used
@@ -63,8 +67,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="enableServerCertificateValidation">If true, validate
         /// the HTTPS server SSL certificate. Default value is true. Type:
         /// boolean (or Expression with resultType boolean).</param>
-        public HttpLinkedService(object url, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object embeddedCertData = default(object), object certThumbprint = default(object), object encryptedCredential = default(object), object enableServerCertificateValidation = default(object))
-            : base(connectVia, description)
+        public HttpLinkedService(object url, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object embeddedCertData = default(object), object certThumbprint = default(object), object encryptedCredential = default(object), object enableServerCertificateValidation = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Url = url;
             AuthenticationType = authenticationType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HttpSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HttpSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the HttpSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -39,8 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// equivalent to System.Net.HttpWebRequest.Timeout. Type: string (or
         /// Expression with resultType string), pattern:
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
-        public HttpSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object httpRequestTimeout = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public HttpSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object httpRequestTimeout = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             HttpRequestTimeout = httpRequestTimeout;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HubspotLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HubspotLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="clientId">The client ID associated with your Hubspot
         /// application.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="clientSecret">The client secret associated with your
@@ -56,8 +60,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public HubspotLinkedService(object clientId, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase clientSecret = default(SecretBase), SecretBase accessToken = default(SecretBase), SecretBase refreshToken = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public HubspotLinkedService(object clientId, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase clientSecret = default(SecretBase), SecretBase accessToken = default(SecretBase), SecretBase refreshToken = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ClientId = clientId;
             ClientSecret = clientSecret;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HubspotObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HubspotObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the HubspotObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public HubspotObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public HubspotObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HubspotSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/HubspotSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the HubspotSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public HubspotSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public HubspotSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IfConditionActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IfConditionActivity.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Boolean. This is used to determine the block of activities
         /// (ifTrueActivities or ifFalseActivities) that will be
         /// executed.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="ifTrueActivities">List of activities to execute if
@@ -51,8 +53,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="ifFalseActivities">List of activities to execute if
         /// expression is evaluated to false. This is an optional property and
         /// if not provided, the activity will exit without any action.</param>
-        public IfConditionActivity(string name, Expression expression, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), IList<Activity> ifTrueActivities = default(IList<Activity>), IList<Activity> ifFalseActivities = default(IList<Activity>))
-            : base(name, description, dependsOn)
+        public IfConditionActivity(string name, Expression expression, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), IList<Activity> ifTrueActivities = default(IList<Activity>), IList<Activity> ifFalseActivities = default(IList<Activity>))
+            : base(name, additionalProperties, description, dependsOn)
         {
             Expression = expression;
             IfTrueActivities = ifTrueActivities;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ImpalaLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ImpalaLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -38,6 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="authenticationType">The authentication type to use.
         /// Possible values include: 'Anonymous', 'SASLUsername',
         /// 'UsernameAndPassword'</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="port">The TCP port that the Impala server uses to
@@ -68,8 +72,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public ImpalaLinkedService(object host, string authenticationType, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), object username = default(object), SecretBase password = default(SecretBase), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public ImpalaLinkedService(object host, string authenticationType, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), object username = default(object), SecretBase password = default(SecretBase), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             Port = port;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ImpalaObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ImpalaObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ImpalaObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public ImpalaObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public ImpalaObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ImpalaSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ImpalaSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ImpalaSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public ImpalaSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public ImpalaSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntime.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntime.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -30,9 +32,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the IntegrationRuntime class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Integration runtime description.</param>
-        public IntegrationRuntime(string description = default(string))
+        public IntegrationRuntime(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string))
         {
+            AdditionalProperties = additionalProperties;
             Description = description;
             CustomInit();
         }
@@ -41,6 +46,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets integration runtime description.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeComputeProperties.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeComputeProperties.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Microsoft.Rest;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -32,6 +34,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the
         /// IntegrationRuntimeComputeProperties class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="location">The location for managed integration
         /// runtime. The supported regions could be found on
         /// https://docs.microsoft.com/en-us/azure/data-factory/data-factory-data-movement-activities</param>
@@ -43,8 +47,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// executions count per node for managed integration runtime.</param>
         /// <param name="vNetProperties">VNet properties for managed
         /// integration runtime.</param>
-        public IntegrationRuntimeComputeProperties(string location = default(string), string nodeSize = default(string), int? numberOfNodes = default(int?), int? maxParallelExecutionsPerNode = default(int?), IntegrationRuntimeVNetProperties vNetProperties = default(IntegrationRuntimeVNetProperties))
+        public IntegrationRuntimeComputeProperties(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string location = default(string), string nodeSize = default(string), int? numberOfNodes = default(int?), int? maxParallelExecutionsPerNode = default(int?), IntegrationRuntimeVNetProperties vNetProperties = default(IntegrationRuntimeVNetProperties))
         {
+            AdditionalProperties = additionalProperties;
             Location = location;
             NodeSize = nodeSize;
             NumberOfNodes = numberOfNodes;
@@ -57,6 +62,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the location for managed integration runtime. The

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeConnectionInfo.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeConnectionInfo.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -32,6 +34,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the IntegrationRuntimeConnectionInfo
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="serviceToken">The token generated in service. Callers
         /// use this token to authenticate to integration runtime.</param>
         /// <param name="identityCertThumbprint">The integration runtime SSL
@@ -45,8 +49,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// runtime.</param>
         /// <param name="isIdentityCertExprired">Whether the identity
         /// certificate is expired.</param>
-        public IntegrationRuntimeConnectionInfo(string serviceToken = default(string), string identityCertThumbprint = default(string), string hostServiceUri = default(string), string version = default(string), string publicKey = default(string), bool? isIdentityCertExprired = default(bool?))
+        public IntegrationRuntimeConnectionInfo(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string serviceToken = default(string), string identityCertThumbprint = default(string), string hostServiceUri = default(string), string version = default(string), string publicKey = default(string), bool? isIdentityCertExprired = default(bool?))
         {
+            AdditionalProperties = additionalProperties;
             ServiceToken = serviceToken;
             IdentityCertThumbprint = identityCertThumbprint;
             HostServiceUri = hostServiceUri;
@@ -60,6 +65,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets the token generated in service. Callers use this token to

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeNodeMonitoringData.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeNodeMonitoringData.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -31,6 +33,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the
         /// IntegrationRuntimeNodeMonitoringData class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="nodeName">Name of the integration runtime
         /// node.</param>
         /// <param name="availableMemoryInMB">Available memory (MB) on the
@@ -47,8 +51,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// node.</param>
         /// <param name="receivedBytes">Received bytes on the integration
         /// runtime node.</param>
-        public IntegrationRuntimeNodeMonitoringData(string nodeName = default(string), int? availableMemoryInMB = default(int?), double? cpuUtilization = default(double?), int? concurrentJobsLimit = default(int?), int? concurrentJobsRunning = default(int?), int? maxConcurrentJobs = default(int?), double? sentBytes = default(double?), double? receivedBytes = default(double?))
+        public IntegrationRuntimeNodeMonitoringData(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string nodeName = default(string), int? availableMemoryInMB = default(int?), double? cpuUtilization = default(double?), int? concurrentJobsLimit = default(int?), int? concurrentJobsRunning = default(int?), int? maxConcurrentJobs = default(int?), double? sentBytes = default(double?), double? receivedBytes = default(double?))
         {
+            AdditionalProperties = additionalProperties;
             NodeName = nodeName;
             AvailableMemoryInMB = availableMemoryInMB;
             CpuUtilization = cpuUtilization;
@@ -64,6 +69,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets name of the integration runtime node.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeRemoveNodeRequest.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeRemoveNodeRequest.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -31,9 +33,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the
         /// IntegrationRuntimeRemoveNodeRequest class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="nodeName">The name of the node to be removed.</param>
-        public IntegrationRuntimeRemoveNodeRequest(string nodeName = default(string))
+        public IntegrationRuntimeRemoveNodeRequest(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string nodeName = default(string))
         {
+            AdditionalProperties = additionalProperties;
             NodeName = nodeName;
             CustomInit();
         }
@@ -42,6 +47,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the name of the node to be removed.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeSsisCatalogInfo.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeSsisCatalogInfo.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -31,6 +33,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the IntegrationRuntimeSsisCatalogInfo
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="catalogServerEndpoint">The catalog database server
         /// URL.</param>
         /// <param name="catalogAdminUserName">The administrator user name of
@@ -42,8 +46,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// https://azure.microsoft.com/en-us/pricing/details/sql-database/.
         /// Possible values include: 'Basic', 'Standard', 'Premium',
         /// 'PremiumRS'</param>
-        public IntegrationRuntimeSsisCatalogInfo(string catalogServerEndpoint = default(string), string catalogAdminUserName = default(string), SecureString catalogAdminPassword = default(SecureString), string catalogPricingTier = default(string))
+        public IntegrationRuntimeSsisCatalogInfo(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string catalogServerEndpoint = default(string), string catalogAdminUserName = default(string), SecureString catalogAdminPassword = default(SecureString), string catalogPricingTier = default(string))
         {
+            AdditionalProperties = additionalProperties;
             CatalogServerEndpoint = catalogServerEndpoint;
             CatalogAdminUserName = catalogAdminUserName;
             CatalogAdminPassword = catalogAdminPassword;
@@ -55,6 +60,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the catalog database server URL.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeSsisProperties.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeSsisProperties.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -31,10 +33,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the IntegrationRuntimeSsisProperties
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="catalogInfo">Catalog information for managed dedicated
         /// integration runtime.</param>
-        public IntegrationRuntimeSsisProperties(IntegrationRuntimeSsisCatalogInfo catalogInfo = default(IntegrationRuntimeSsisCatalogInfo))
+        public IntegrationRuntimeSsisProperties(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeSsisCatalogInfo catalogInfo = default(IntegrationRuntimeSsisCatalogInfo))
         {
+            AdditionalProperties = additionalProperties;
             CatalogInfo = catalogInfo;
             CustomInit();
         }
@@ -43,6 +48,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets catalog information for managed dedicated integration

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeStatus.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeStatus.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,12 +31,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the IntegrationRuntimeStatus class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="state">The state of integration runtime. Possible
         /// values include: 'Initial', 'Stopped', 'Started', 'Starting',
         /// 'Stopping', 'NeedRegistration', 'Online', 'Limited',
         /// 'Offline'</param>
-        public IntegrationRuntimeStatus(string state = default(string))
+        public IntegrationRuntimeStatus(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string state = default(string))
         {
+            AdditionalProperties = additionalProperties;
             State = state;
             CustomInit();
         }
@@ -43,6 +48,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets the state of integration runtime. Possible values include:

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeVNetProperties.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/IntegrationRuntimeVNetProperties.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -31,12 +33,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the IntegrationRuntimeVNetProperties
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="vNetId">The ID of the VNet that this integration
         /// runtime will join.</param>
         /// <param name="subnet">The name of the subnet this integration
         /// runtime will join.</param>
-        public IntegrationRuntimeVNetProperties(string vNetId = default(string), string subnet = default(string))
+        public IntegrationRuntimeVNetProperties(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string vNetId = default(string), string subnet = default(string))
         {
+            AdditionalProperties = additionalProperties;
             VNetId = vNetId;
             Subnet = subnet;
             CustomInit();
@@ -46,6 +51,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the ID of the VNet that this integration runtime will

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/JiraLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/JiraLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// (e.g. jira.example.com)</param>
         /// <param name="username">The user name that you use to access Jira
         /// Service.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="port">The TCP port that the Jira server uses to listen
@@ -57,8 +61,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public JiraLinkedService(object host, object username, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), SecretBase password = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public JiraLinkedService(object host, object username, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), SecretBase password = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             Port = port;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/JiraObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/JiraObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the JiraObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public JiraObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public JiraObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/JiraSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/JiraSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the JiraSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public JiraSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public JiraSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/JsonFormat.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/JsonFormat.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the JsonFormat class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="serializer">Serializer. Type: string (or Expression
         /// with resultType string).</param>
         /// <param name="deserializer">Deserializer. Type: string (or
@@ -57,8 +61,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// the array element. Example: {"Column1": "$.Column1Path", "Column2":
         /// "Column2PathInArray"}. Type: object (or Expression with resultType
         /// object).</param>
-        public JsonFormat(object serializer = default(object), object deserializer = default(object), string filePattern = default(string), object nestingSeparator = default(object), object encodingName = default(object), object jsonNodeReference = default(object), object jsonPathDefinition = default(object))
-            : base(serializer, deserializer)
+        public JsonFormat(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object serializer = default(object), object deserializer = default(object), string filePattern = default(string), object nestingSeparator = default(object), object encodingName = default(object), object jsonNodeReference = default(object), object jsonPathDefinition = default(object))
+            : base(additionalProperties, serializer, deserializer)
         {
             FilePattern = filePattern;
             NestingSeparator = nestingSeparator;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/LinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/LinkedService.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -31,10 +33,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the LinkedService class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
-        public LinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string))
+        public LinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string))
         {
+            AdditionalProperties = additionalProperties;
             ConnectVia = connectVia;
             Description = description;
             CustomInit();
@@ -44,6 +49,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the integration runtime reference.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/LookupActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/LookupActivity.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="source">Dataset-specific source properties, same as
         /// copy activity source.</param>
         /// <param name="dataset">Lookup activity dataset reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -47,8 +49,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="firstRowOnly">Whether to return first row or all rows.
         /// Default value is true. Type: boolean (or Expression with resultType
         /// boolean).</param>
-        public LookupActivity(string name, CopySource source, DatasetReference dataset, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), object firstRowOnly = default(object))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public LookupActivity(string name, CopySource source, DatasetReference dataset, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), object firstRowOnly = default(object))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             Source = source;
             Dataset = dataset;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MagentoLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MagentoLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="host">The URL of the Magento instance. (i.e.
         /// 192.168.222.110/magento3)</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="accessToken">The access token from Magento.</param>
@@ -51,8 +55,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public MagentoLinkedService(object host, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase accessToken = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public MagentoLinkedService(object host, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase accessToken = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             AccessToken = accessToken;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MagentoObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MagentoObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the MagentoObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public MagentoObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public MagentoObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MagentoSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MagentoSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the MagentoSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public MagentoSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public MagentoSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ManagedIntegrationRuntime.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ManagedIntegrationRuntime.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -34,6 +36,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ManagedIntegrationRuntime class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Integration runtime description.</param>
         /// <param name="state">Integration runtime state, only valid for
         /// managed dedicated integration runtime. Possible values include:
@@ -43,8 +47,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// integration runtime.</param>
         /// <param name="ssisProperties">SSIS properties for managed
         /// integration runtime.</param>
-        public ManagedIntegrationRuntime(string description = default(string), string state = default(string), IntegrationRuntimeComputeProperties computeProperties = default(IntegrationRuntimeComputeProperties), IntegrationRuntimeSsisProperties ssisProperties = default(IntegrationRuntimeSsisProperties))
-            : base(description)
+        public ManagedIntegrationRuntime(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), string state = default(string), IntegrationRuntimeComputeProperties computeProperties = default(IntegrationRuntimeComputeProperties), IntegrationRuntimeSsisProperties ssisProperties = default(IntegrationRuntimeSsisProperties))
+            : base(additionalProperties, description)
         {
             State = state;
             ComputeProperties = computeProperties;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ManagedIntegrationRuntimeStatus.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ManagedIntegrationRuntimeStatus.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ManagedIntegrationRuntimeStatus
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="state">The state of integration runtime. Possible
         /// values include: 'Initial', 'Stopped', 'Started', 'Starting',
         /// 'Stopping', 'NeedRegistration', 'Online', 'Limited',
@@ -49,8 +51,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// integration runtime.</param>
         /// <param name="lastOperation">The last operation result that occurred
         /// on this integration runtime.</param>
-        public ManagedIntegrationRuntimeStatus(string state = default(string), System.DateTime? createTime = default(System.DateTime?), IList<ManagedIntegrationRuntimeNode> nodes = default(IList<ManagedIntegrationRuntimeNode>), IList<ManagedIntegrationRuntimeError> otherErrors = default(IList<ManagedIntegrationRuntimeError>), ManagedIntegrationRuntimeOperationResult lastOperation = default(ManagedIntegrationRuntimeOperationResult))
-            : base(state)
+        public ManagedIntegrationRuntimeStatus(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string state = default(string), System.DateTime? createTime = default(System.DateTime?), IList<ManagedIntegrationRuntimeNode> nodes = default(IList<ManagedIntegrationRuntimeNode>), IList<ManagedIntegrationRuntimeError> otherErrors = default(IList<ManagedIntegrationRuntimeError>), ManagedIntegrationRuntimeOperationResult lastOperation = default(ManagedIntegrationRuntimeOperationResult))
+            : base(additionalProperties, state)
         {
             CreateTime = createTime;
             Nodes = nodes;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MariaDBLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MariaDBLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,6 +35,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the MariaDBLinkedService class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="connectionString">An ODBC connection string.</param>
@@ -40,8 +44,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public MariaDBLinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public MariaDBLinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase connectionString = default(SecretBase), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MariaDBSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MariaDBSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the MariaDBSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public MariaDBSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public MariaDBSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MariaDBTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MariaDBTableDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the MariaDBTableDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public MariaDBTableDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public MariaDBTableDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MarketoLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MarketoLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// 123-ABC-321.mktorest.com)</param>
         /// <param name="clientId">The client Id of your Marketo
         /// service.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="clientSecret">The client secret of your Marketo
@@ -54,8 +58,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public MarketoLinkedService(object endpoint, object clientId, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase clientSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public MarketoLinkedService(object endpoint, object clientId, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase clientSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Endpoint = endpoint;
             ClientId = clientId;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MarketoObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MarketoObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the MarketoObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public MarketoObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public MarketoObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MarketoSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MarketoSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the MarketoSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public MarketoSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public MarketoSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MongoDbCollectionDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MongoDbCollectionDataset.cs
@@ -40,13 +40,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="collectionName">The table name of the MongoDB
         /// database. Type: string (or Expression with resultType
         /// string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public MongoDbCollectionDataset(LinkedServiceReference linkedServiceName, object collectionName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public MongoDbCollectionDataset(LinkedServiceReference linkedServiceName, object collectionName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CollectionName = collectionName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MongoDbLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MongoDbLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -39,6 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="databaseName">The name of the MongoDB database that
         /// you want to access. Type: string (or Expression with resultType
         /// string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="authenticationType">The authentication type to be used
@@ -58,8 +62,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public MongoDbLinkedService(object server, object databaseName, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string authenticationType = default(string), object username = default(object), SecureString password = default(SecureString), object authSource = default(object), object port = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public MongoDbLinkedService(object server, object databaseName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string authenticationType = default(string), object username = default(object), SecureString password = default(SecureString), object authSource = default(object), object port = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             AuthenticationType = authenticationType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MongoDbSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MongoDbSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the MongoDbSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -37,8 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="query">Database query. Should be a SQL-92 query
         /// expression. Type: string (or Expression with resultType
         /// string).</param>
-        public MongoDbSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public MongoDbSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MultiplePipelineTrigger.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MultiplePipelineTrigger.cs
@@ -32,13 +32,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the MultiplePipelineTrigger class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Trigger description.</param>
         /// <param name="runtimeState">Indicates if trigger is running or not.
         /// Updated when Start/Stop APIs are called on the Trigger. Possible
         /// values include: 'Started', 'Stopped', 'Disabled'</param>
         /// <param name="pipelines">Pipelines that need to be started.</param>
-        public MultiplePipelineTrigger(string description = default(string), string runtimeState = default(string), IList<TriggerPipelineReference> pipelines = default(IList<TriggerPipelineReference>))
-            : base(description, runtimeState)
+        public MultiplePipelineTrigger(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), string runtimeState = default(string), IList<TriggerPipelineReference> pipelines = default(IList<TriggerPipelineReference>))
+            : base(additionalProperties, description, runtimeState)
         {
             Pipelines = pipelines;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MySqlLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/MySqlLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Expression with resultType string).</param>
         /// <param name="database">Database name for connection. Type: string
         /// (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="schema">Schema name for connection. Type: string (or
@@ -48,8 +52,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public MySqlLinkedService(object server, object database, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public MySqlLinkedService(object server, object database, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             Database = database;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ODataLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ODataLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="url">The URL of the OData service endpoint. Type:
         /// string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="authenticationType">Type of authentication used to
@@ -47,8 +51,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public ODataLinkedService(object url, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public ODataLinkedService(object url, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Url = url;
             AuthenticationType = authenticationType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ODataResourceDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ODataResourceDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ODataResourceDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -44,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="parameters">Parameters for dataset.</param>
         /// <param name="path">The OData resource path. Type: string (or
         /// Expression with resultType string).</param>
-        public ODataResourceDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object path = default(object))
-            : base(linkedServiceName, description, structure, parameters)
+        public ODataResourceDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object path = default(object))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             Path = path;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OdbcLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OdbcLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -36,6 +38,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="connectionString">The non-access credential portion of
         /// the connection string as well as an optional encrypted
         /// credential.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="authenticationType">Type of authentication used to
@@ -51,8 +55,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public OdbcLinkedService(SecureString connectionString, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object authenticationType = default(object), SecureString credential = default(SecureString), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public OdbcLinkedService(SecureString connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object authenticationType = default(object), SecureString credential = default(SecureString), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             AuthenticationType = authenticationType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OdbcSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OdbcSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the OdbcSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -41,8 +45,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="preCopyScript">A query to execute before starting the
         /// copy. Type: string (or Expression with resultType string).</param>
-        public OdbcSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object preCopyScript = default(object))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public OdbcSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object preCopyScript = default(object))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             PreCopyScript = preCopyScript;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OracleLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OracleLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -34,14 +36,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the OracleLinkedService class.
         /// </summary>
         /// <param name="connectionString">The connection string.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="encryptedCredential">The encrypted credential used for
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public OracleLinkedService(SecureString connectionString, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public OracleLinkedService(SecureString connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             EncryptedCredential = encryptedCredential;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OracleSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OracleSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the OracleSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -41,8 +45,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="preCopyScript">SQL pre-copy script. Type: string (or
         /// Expression with resultType string).</param>
-        public OracleSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object preCopyScript = default(object))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public OracleSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object preCopyScript = default(object))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             PreCopyScript = preCopyScript;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OracleSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OracleSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the OracleSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -39,8 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="queryTimeout">Query timeout. Type: string (or
         /// Expression with resultType string), pattern:
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
-        public OracleSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object oracleReaderQuery = default(object), object queryTimeout = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public OracleSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object oracleReaderQuery = default(object), object queryTimeout = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             OracleReaderQuery = oracleReaderQuery;
             QueryTimeout = queryTimeout;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OracleTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OracleTableDataset.cs
@@ -40,13 +40,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="tableName">The table name of the on-premises Oracle
         /// database. Type: string (or Expression with resultType
         /// string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public OracleTableDataset(LinkedServiceReference linkedServiceName, object tableName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public OracleTableDataset(LinkedServiceReference linkedServiceName, object tableName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TableName = tableName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OrcFormat.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/OrcFormat.cs
@@ -10,6 +10,8 @@
 
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -28,12 +30,14 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the OrcFormat class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="serializer">Serializer. Type: string (or Expression
         /// with resultType string).</param>
         /// <param name="deserializer">Deserializer. Type: string (or
         /// Expression with resultType string).</param>
-        public OrcFormat(object serializer = default(object), object deserializer = default(object))
-            : base(serializer, deserializer)
+        public OrcFormat(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object serializer = default(object), object deserializer = default(object))
+            : base(additionalProperties, serializer, deserializer)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ParquetFormat.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ParquetFormat.cs
@@ -10,6 +10,8 @@
 
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -28,12 +30,14 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ParquetFormat class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="serializer">Serializer. Type: string (or Expression
         /// with resultType string).</param>
         /// <param name="deserializer">Deserializer. Type: string (or
         /// Expression with resultType string).</param>
-        public ParquetFormat(object serializer = default(object), object deserializer = default(object))
-            : base(serializer, deserializer)
+        public ParquetFormat(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object serializer = default(object), object deserializer = default(object))
+            : base(additionalProperties, serializer, deserializer)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PaypalLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PaypalLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// api.sandbox.paypal.com)</param>
         /// <param name="clientId">The client ID associated with your PayPal
         /// application.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="clientSecret">The client secret associated with your
@@ -54,8 +58,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public PaypalLinkedService(object host, object clientId, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase clientSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public PaypalLinkedService(object host, object clientId, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase clientSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             ClientId = clientId;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PaypalObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PaypalObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the PaypalObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public PaypalObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public PaypalObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PaypalSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PaypalSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the PaypalSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public PaypalSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public PaypalSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PhoenixLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PhoenixLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -39,6 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// to connect to the Phoenix server. Possible values include:
         /// 'Anonymous', 'UsernameAndPassword',
         /// 'WindowsAzureHDInsightService'</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="port">The TCP port that the Phoenix server uses to
@@ -71,8 +75,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public PhoenixLinkedService(object host, string authenticationType, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), object httpPath = default(object), object username = default(object), SecretBase password = default(SecretBase), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public PhoenixLinkedService(object host, string authenticationType, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), object httpPath = default(object), object username = default(object), SecretBase password = default(SecretBase), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             Port = port;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PhoenixObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PhoenixObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the PhoenixObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public PhoenixObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public PhoenixObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PhoenixSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PhoenixSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the PhoenixSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public PhoenixSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public PhoenixSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PipelineResource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PipelineResource.cs
@@ -38,14 +38,17 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="name">The resource name.</param>
         /// <param name="type">The resource type.</param>
         /// <param name="etag">Etag identifies change in the resource.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">The description of the pipeline.</param>
         /// <param name="activities">List of activities in pipeline.</param>
         /// <param name="parameters">List of parameters for pipeline.</param>
         /// <param name="concurrency">The max number of concurrent runs for the
         /// pipeline.</param>
-        public PipelineResource(string id = default(string), string name = default(string), string type = default(string), string etag = default(string), string description = default(string), IList<Activity> activities = default(IList<Activity>), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), int? concurrency = default(int?))
+        public PipelineResource(string id = default(string), string name = default(string), string type = default(string), string etag = default(string), IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<Activity> activities = default(IList<Activity>), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), int? concurrency = default(int?))
             : base(id, name, type, etag)
         {
+            AdditionalProperties = additionalProperties;
             Description = description;
             Activities = activities;
             Parameters = parameters;
@@ -57,6 +60,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the description of the pipeline.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PipelineRun.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PipelineRun.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the PipelineRun class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="runId">Identifier of a run.</param>
         /// <param name="pipelineName">The pipeline name.</param>
         /// <param name="parameters">The full or partial list of parameter
@@ -46,8 +48,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="durationInMs">The duration of a pipeline run.</param>
         /// <param name="status">The status of a pipeline run.</param>
         /// <param name="message">The message from a pipeline run.</param>
-        public PipelineRun(string runId = default(string), string pipelineName = default(string), IDictionary<string, string> parameters = default(IDictionary<string, string>), PipelineRunInvokedBy invokedBy = default(PipelineRunInvokedBy), System.DateTime? lastUpdated = default(System.DateTime?), System.DateTime? runStart = default(System.DateTime?), System.DateTime? runEnd = default(System.DateTime?), int? durationInMs = default(int?), string status = default(string), string message = default(string))
+        public PipelineRun(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string runId = default(string), string pipelineName = default(string), IDictionary<string, string> parameters = default(IDictionary<string, string>), PipelineRunInvokedBy invokedBy = default(PipelineRunInvokedBy), System.DateTime? lastUpdated = default(System.DateTime?), System.DateTime? runStart = default(System.DateTime?), System.DateTime? runEnd = default(System.DateTime?), int? durationInMs = default(int?), string status = default(string), string message = default(string))
         {
+            AdditionalProperties = additionalProperties;
             RunId = runId;
             PipelineName = pipelineName;
             Parameters = parameters;
@@ -65,6 +68,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets identifier of a run.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PolybaseSettings.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PolybaseSettings.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the PolybaseSettings class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="rejectType">Reject type. Possible values include:
         /// 'value', 'percentage'</param>
         /// <param name="rejectValue">Specifies the value or the percentage of
@@ -42,8 +46,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// in delimited text files when PolyBase retrieves data from the text
         /// file. Type: boolean (or Expression with resultType
         /// boolean).</param>
-        public PolybaseSettings(string rejectType = default(string), object rejectValue = default(object), object rejectSampleValue = default(object), object useTypeDefault = default(object))
+        public PolybaseSettings(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string rejectType = default(string), object rejectValue = default(object), object rejectSampleValue = default(object), object useTypeDefault = default(object))
         {
+            AdditionalProperties = additionalProperties;
             RejectType = rejectType;
             RejectValue = rejectValue;
             RejectSampleValue = rejectSampleValue;
@@ -55,6 +60,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets reject type. Possible values include: 'value',

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PostgreSqlLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PostgreSqlLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Expression with resultType string).</param>
         /// <param name="database">Database name for connection. Type: string
         /// (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="schema">Schema name for connection. Type: string (or
@@ -48,8 +52,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public PostgreSqlLinkedService(object server, object database, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public PostgreSqlLinkedService(object server, object database, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             Database = database;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PrestoLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PrestoLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -42,6 +44,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="authenticationType">The authentication mechanism used
         /// to connect to the Presto server. Possible values include:
         /// 'Anonymous', 'LDAP'</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="port">The TCP port that the Presto server uses to
@@ -75,8 +79,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public PrestoLinkedService(object host, object serverVersion, object catalog, string authenticationType, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), object username = default(object), SecretBase password = default(SecretBase), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object timeZoneID = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public PrestoLinkedService(object host, object serverVersion, object catalog, string authenticationType, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), object username = default(object), SecretBase password = default(SecretBase), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object timeZoneID = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             ServerVersion = serverVersion;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PrestoObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PrestoObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the PrestoObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public PrestoObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public PrestoObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PrestoSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/PrestoSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the PrestoSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public PrestoSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public PrestoSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/QuickBooksLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/QuickBooksLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// quickbooks.api.intuit.com)</param>
         /// <param name="companyId">The company ID of the QuickBooks company to
         /// authorize.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="accessToken">The access token for OAuth 1.0
@@ -50,8 +54,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public QuickBooksLinkedService(object endpoint, object companyId, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase accessToken = default(SecretBase), SecretBase accessTokenSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public QuickBooksLinkedService(object endpoint, object companyId, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase accessToken = default(SecretBase), SecretBase accessTokenSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Endpoint = endpoint;
             CompanyId = companyId;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/QuickBooksObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/QuickBooksObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the QuickBooksObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public QuickBooksObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public QuickBooksObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/QuickBooksSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/QuickBooksSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the QuickBooksSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public QuickBooksSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public QuickBooksSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RecurrenceSchedule.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RecurrenceSchedule.cs
@@ -31,13 +31,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the RecurrenceSchedule class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="minutes">The minutes.</param>
         /// <param name="hours">The hours.</param>
         /// <param name="weekDays">The days of the week.</param>
         /// <param name="monthDays">The month days.</param>
         /// <param name="monthlyOccurrences">The monthly occurrences.</param>
-        public RecurrenceSchedule(IList<int?> minutes = default(IList<int?>), IList<int?> hours = default(IList<int?>), IList<DaysOfWeek?> weekDays = default(IList<DaysOfWeek?>), IList<int?> monthDays = default(IList<int?>), IList<RecurrenceScheduleOccurrence> monthlyOccurrences = default(IList<RecurrenceScheduleOccurrence>))
+        public RecurrenceSchedule(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IList<int?> minutes = default(IList<int?>), IList<int?> hours = default(IList<int?>), IList<DaysOfWeek?> weekDays = default(IList<DaysOfWeek?>), IList<int?> monthDays = default(IList<int?>), IList<RecurrenceScheduleOccurrence> monthlyOccurrences = default(IList<RecurrenceScheduleOccurrence>))
         {
+            AdditionalProperties = additionalProperties;
             Minutes = minutes;
             Hours = hours;
             WeekDays = weekDays;
@@ -50,6 +53,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the minutes.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RecurrenceScheduleOccurrence.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RecurrenceScheduleOccurrence.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -31,12 +33,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the RecurrenceScheduleOccurrence
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="day">The day of the week. Possible values include:
         /// 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday',
         /// 'Saturday'</param>
         /// <param name="occurrence">The occurrence.</param>
-        public RecurrenceScheduleOccurrence(DayOfWeek? day = default(DayOfWeek?), int? occurrence = default(int?))
+        public RecurrenceScheduleOccurrence(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), DayOfWeek? day = default(DayOfWeek?), int? occurrence = default(int?))
         {
+            AdditionalProperties = additionalProperties;
             Day = day;
             Occurrence = occurrence;
             CustomInit();
@@ -46,6 +51,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the day of the week. Possible values include:

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RedirectIncompatibleRowSettings.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RedirectIncompatibleRowSettings.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Microsoft.Rest;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,11 +39,14 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// incompatible row. Must be specified if
         /// redirectIncompatibleRowSettings is specified. Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="path">The path for storing the redirect incompatible
         /// row data. Type: string (or Expression with resultType
         /// string).</param>
-        public RedirectIncompatibleRowSettings(object linkedServiceName, object path = default(object))
+        public RedirectIncompatibleRowSettings(object linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object path = default(object))
         {
+            AdditionalProperties = additionalProperties;
             LinkedServiceName = linkedServiceName;
             Path = path;
             CustomInit();
@@ -51,6 +56,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets name of the Azure Storage, Storage SAS, or Azure Data

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RelationalSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RelationalSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the RelationalSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">Database query. Type: string (or Expression
         /// with resultType string).</param>
-        public RelationalSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public RelationalSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RelationalTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/RelationalTableDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the RelationalTableDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -44,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="parameters">Parameters for dataset.</param>
         /// <param name="tableName">The relational table name. Type: string (or
         /// Expression with resultType string).</param>
-        public RelationalTableDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object tableName = default(object))
-            : base(linkedServiceName, description, structure, parameters)
+        public RelationalTableDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object tableName = default(object))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TableName = tableName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SalesforceLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SalesforceLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,6 +35,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SalesforceLinkedService class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="environmentUrl">The URL of Salesforce instance.
@@ -52,8 +56,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public SalesforceLinkedService(IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object environmentUrl = default(object), object username = default(object), SecretBase password = default(SecretBase), SecretBase securityToken = default(SecretBase), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public SalesforceLinkedService(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object environmentUrl = default(object), object username = default(object), SecretBase password = default(SecretBase), SecretBase securityToken = default(SecretBase), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             EnvironmentUrl = environmentUrl;
             Username = username;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SalesforceObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SalesforceObjectDataset.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the SalesforceObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -44,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="parameters">Parameters for dataset.</param>
         /// <param name="objectApiName">The Salesforce object API name. Type:
         /// string (or Expression with resultType string).</param>
-        public SalesforceObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object objectApiName = default(object))
-            : base(linkedServiceName, description, structure, parameters)
+        public SalesforceObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object objectApiName = default(object))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             ObjectApiName = objectApiName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SalesforceSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SalesforceSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SalesforceSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -54,8 +58,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// destination object to NULL when doing upsert/update operation and
         /// insert NULL value when doing insert operation. Type: boolean (or
         /// Expression with resultType boolean).</param>
-        public SalesforceSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string writeBehavior = default(string), object externalIdFieldName = default(object), object ignoreNullValues = default(object))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public SalesforceSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string writeBehavior = default(string), object externalIdFieldName = default(object), object ignoreNullValues = default(object))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             WriteBehavior = writeBehavior;
             ExternalIdFieldName = externalIdFieldName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SalesforceSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SalesforceSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SalesforceSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">Database query. Type: string (or Expression
         /// with resultType string).</param>
-        public SalesforceSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public SalesforceSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapBWLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapBWLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -41,6 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="clientId">Client ID of the client on the BW system.
         /// (Usually a three-digit decimal number represented as a string)
         /// Type: string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="userName">Username to access the SAP BW server. Type:
@@ -51,8 +55,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public SapBWLinkedService(object server, object systemNumber, object clientId, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public SapBWLinkedService(object server, object systemNumber, object clientId, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             SystemNumber = systemNumber;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapCloudForCustomerLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapCloudForCustomerLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -39,6 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// example,
         /// '[https://[tenantname].crm.ondemand.com/sap/c4c/odata/v1]'. Type:
         /// string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="username">The username for Basic authentication. Type:
@@ -50,8 +54,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// runtime credential manager. Either encryptedCredential or
         /// username/password must be provided. Type: string (or Expression
         /// with resultType string).</param>
-        public SapCloudForCustomerLinkedService(object url, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public SapCloudForCustomerLinkedService(object url, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Url = url;
             Username = username;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapCloudForCustomerResourceDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapCloudForCustomerResourceDataset.cs
@@ -42,13 +42,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="path">The path of the SAP Cloud for Customer OData
         /// entity. Type: string (or Expression with resultType
         /// string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public SapCloudForCustomerResourceDataset(LinkedServiceReference linkedServiceName, object path, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public SapCloudForCustomerResourceDataset(LinkedServiceReference linkedServiceName, object path, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             Path = path;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapCloudForCustomerSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapCloudForCustomerSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SapCloudForCustomerSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -42,8 +46,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="writeBehavior">The write behavior for the operation.
         /// Default is 'Insert'. Possible values include: 'Insert',
         /// 'Update'</param>
-        public SapCloudForCustomerSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string writeBehavior = default(string))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public SapCloudForCustomerSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), string writeBehavior = default(string))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             WriteBehavior = writeBehavior;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapCloudForCustomerSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapCloudForCustomerSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SapCloudForCustomerSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -37,8 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="query">SAP Cloud for Customer OData query. For
         /// example, "$top=1". Type: string (or Expression with resultType
         /// string).</param>
-        public SapCloudForCustomerSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public SapCloudForCustomerSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapHanaLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SapHanaLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="server">Host name of the SAP HANA server. Type: string
         /// (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="authenticationType">The authentication type to be used
@@ -48,8 +52,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public SapHanaLinkedService(object server, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public SapHanaLinkedService(object server, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             AuthenticationType = authenticationType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ScheduleTrigger.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ScheduleTrigger.cs
@@ -34,14 +34,16 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ScheduleTrigger class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Trigger description.</param>
         /// <param name="runtimeState">Indicates if trigger is running or not.
         /// Updated when Start/Stop APIs are called on the Trigger. Possible
         /// values include: 'Started', 'Stopped', 'Disabled'</param>
         /// <param name="pipelines">Pipelines that need to be started.</param>
         /// <param name="recurrence">Recurrence schedule configuration.</param>
-        public ScheduleTrigger(string description = default(string), string runtimeState = default(string), IList<TriggerPipelineReference> pipelines = default(IList<TriggerPipelineReference>), ScheduleTriggerRecurrence recurrence = default(ScheduleTriggerRecurrence))
-            : base(description, runtimeState, pipelines)
+        public ScheduleTrigger(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), string runtimeState = default(string), IList<TriggerPipelineReference> pipelines = default(IList<TriggerPipelineReference>), ScheduleTriggerRecurrence recurrence = default(ScheduleTriggerRecurrence))
+            : base(additionalProperties, description, runtimeState, pipelines)
         {
             Recurrence = recurrence;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ScheduleTriggerRecurrence.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ScheduleTriggerRecurrence.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ScheduleTriggerRecurrence class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="frequency">The frequency. Possible values include:
         /// 'NotSpecified', 'Minute', 'Hour', 'Day', 'Week', 'Month',
         /// 'Year'</param>
@@ -37,8 +41,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="endTime">The end time.</param>
         /// <param name="timeZone">The time zone.</param>
         /// <param name="schedule">The recurrence schedule.</param>
-        public ScheduleTriggerRecurrence(string frequency = default(string), int? interval = default(int?), System.DateTime? startTime = default(System.DateTime?), System.DateTime? endTime = default(System.DateTime?), string timeZone = default(string), RecurrenceSchedule schedule = default(RecurrenceSchedule))
+        public ScheduleTriggerRecurrence(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string frequency = default(string), int? interval = default(int?), System.DateTime? startTime = default(System.DateTime?), System.DateTime? endTime = default(System.DateTime?), string timeZone = default(string), RecurrenceSchedule schedule = default(RecurrenceSchedule))
         {
+            AdditionalProperties = additionalProperties;
             Frequency = frequency;
             Interval = interval;
             StartTime = startTime;
@@ -52,6 +57,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets the frequency. Possible values include:

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SelfHostedIntegrationRuntime.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SelfHostedIntegrationRuntime.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -32,9 +34,11 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the SelfHostedIntegrationRuntime
         /// class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Integration runtime description.</param>
-        public SelfHostedIntegrationRuntime(string description = default(string))
-            : base(description)
+        public SelfHostedIntegrationRuntime(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string))
+            : base(additionalProperties, description)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SelfHostedIntegrationRuntimeStatus.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SelfHostedIntegrationRuntimeStatus.cs
@@ -37,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the
         /// SelfHostedIntegrationRuntimeStatus class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="state">The state of integration runtime. Possible
         /// values include: 'Initial', 'Stopped', 'Started', 'Starting',
         /// 'Stopping', 'NeedRegistration', 'Online', 'Limited',
@@ -66,8 +68,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="autoUpdate">Whether Self-hosted integration runtime
         /// auto update has been turned on. Possible values include: 'On',
         /// 'Off'</param>
-        public SelfHostedIntegrationRuntimeStatus(string state = default(string), System.DateTime? createTime = default(System.DateTime?), string taskQueueId = default(string), string internalChannelEncryption = default(string), string version = default(string), IList<SelfHostedIntegrationRuntimeNode> nodes = default(IList<SelfHostedIntegrationRuntimeNode>), System.DateTime? scheduledUpdateDate = default(System.DateTime?), string updateDelayOffset = default(string), string localTimeZoneOffset = default(string), IDictionary<string, string> capabilities = default(IDictionary<string, string>), IList<string> serviceUrls = default(IList<string>), string autoUpdate = default(string))
-            : base(state)
+        public SelfHostedIntegrationRuntimeStatus(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string state = default(string), System.DateTime? createTime = default(System.DateTime?), string taskQueueId = default(string), string internalChannelEncryption = default(string), string version = default(string), IList<SelfHostedIntegrationRuntimeNode> nodes = default(IList<SelfHostedIntegrationRuntimeNode>), System.DateTime? scheduledUpdateDate = default(System.DateTime?), string updateDelayOffset = default(string), string localTimeZoneOffset = default(string), IDictionary<string, string> capabilities = default(IDictionary<string, string>), IList<string> serviceUrls = default(IList<string>), string autoUpdate = default(string))
+            : base(additionalProperties, state)
         {
             CreateTime = createTime;
             TaskQueueId = taskQueueId;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ServiceNowLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ServiceNowLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ServiceNowData.com)</param>
         /// <param name="authenticationType">The authentication type to use.
         /// Possible values include: 'Basic', 'OAuth2'</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="username">The user name used to connect to the
@@ -60,8 +64,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public ServiceNowLinkedService(object endpoint, string authenticationType, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object username = default(object), SecretBase password = default(SecretBase), object clientId = default(object), SecretBase clientSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public ServiceNowLinkedService(object endpoint, string authenticationType, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object username = default(object), SecretBase password = default(SecretBase), object clientId = default(object), SecretBase clientSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Endpoint = endpoint;
             AuthenticationType = authenticationType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ServiceNowObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ServiceNowObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ServiceNowObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public ServiceNowObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public ServiceNowObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ServiceNowSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ServiceNowSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ServiceNowSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public ServiceNowSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public ServiceNowSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SftpServerLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SftpServerLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="host">The SFTP server host name. Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="port">The TCP port number that the SFTP server uses to
@@ -72,8 +76,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// SFTP server. When SkipHostKeyValidation is false,
         /// HostKeyFingerprint should be specified. Type: string (or Expression
         /// with resultType string).</param>
-        public SftpServerLinkedService(object host, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object), object privateKeyPath = default(object), SecureString privateKeyContent = default(SecureString), SecureString passPhrase = default(SecureString), object skipHostKeyValidation = default(object), object hostKeyFingerprint = default(object))
-            : base(connectVia, description)
+        public SftpServerLinkedService(object host, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object port = default(object), string authenticationType = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object), object privateKeyPath = default(object), SecureString privateKeyContent = default(SecureString), SecureString passPhrase = default(SecureString), object skipHostKeyValidation = default(object), object hostKeyFingerprint = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             Port = port;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ShopifyLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ShopifyLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="host">The endpoint of the Shopify server. (i.e.
         /// mystore.myshopify.com)</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="accessToken">The API access token that can be used to
@@ -53,8 +57,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public ShopifyLinkedService(object host, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase accessToken = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public ShopifyLinkedService(object host, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase accessToken = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             AccessToken = accessToken;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ShopifyObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ShopifyObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ShopifyObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public ShopifyObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public ShopifyObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ShopifySource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ShopifySource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ShopifySource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public ShopifySource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public ShopifySource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SparkLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SparkLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -41,6 +43,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// access the Spark server. Possible values include: 'Anonymous',
         /// 'Username', 'UsernameAndPassword',
         /// 'WindowsAzureHDInsightService'</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="serverType">The type of Spark server. Possible values
@@ -75,8 +79,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public SparkLinkedService(object host, object port, string authenticationType, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string serverType = default(string), string thriftTransportProtocol = default(string), object username = default(object), SecretBase password = default(SecretBase), object httpPath = default(object), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public SparkLinkedService(object host, object port, string authenticationType, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), string serverType = default(string), string thriftTransportProtocol = default(string), object username = default(object), SecretBase password = default(SecretBase), object httpPath = default(object), object enableSsl = default(object), object trustedCertPath = default(object), object useSystemTrustStore = default(object), object allowHostNameCNMismatch = default(object), object allowSelfSignedServerCert = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             Port = port;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SparkObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SparkObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the SparkObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public SparkObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public SparkObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SparkSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SparkSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SparkSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public SparkSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public SparkSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlDWSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlDWSink.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SqlDWSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -46,8 +50,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Expression with resultType boolean).</param>
         /// <param name="polyBaseSettings">Specifies PolyBase-related settings
         /// when allowPolyBase is true.</param>
-        public SqlDWSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object preCopyScript = default(object), object allowPolyBase = default(object), PolybaseSettings polyBaseSettings = default(PolybaseSettings))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public SqlDWSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object preCopyScript = default(object), object allowPolyBase = default(object), PolybaseSettings polyBaseSettings = default(PolybaseSettings))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             PreCopyScript = preCopyScript;
             AllowPolyBase = allowPolyBase;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlDWSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlDWSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SqlDWSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -44,8 +48,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// stored procedure parameters. Example: "{Parameter1: {value: "1",
         /// type: "int"}}". Type: object (or Expression with resultType
         /// object), itemType: StoredProcedureParameter.</param>
-        public SqlDWSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), object storedProcedureParameters = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public SqlDWSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), object storedProcedureParameters = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             SqlReaderQuery = sqlReaderQuery;
             SqlReaderStoredProcedureName = sqlReaderStoredProcedureName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlServerLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlServerLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -34,6 +36,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the SqlServerLinkedService class.
         /// </summary>
         /// <param name="connectionString">The connection string.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="userName">The on-premises Windows authentication user
@@ -44,8 +48,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public SqlServerLinkedService(SecureString connectionString, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public SqlServerLinkedService(SecureString connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object userName = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
             UserName = userName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlServerStoredProcedureActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlServerStoredProcedureActivity.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="name">Activity name.</param>
         /// <param name="storedProcedureName">Stored procedure name. Type:
         /// string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -47,8 +49,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="storedProcedureParameters">Value and type setting for
         /// stored procedure parameters. Example: "{Parameter1: {value: "1",
         /// type: "int"}}".</param>
-        public SqlServerStoredProcedureActivity(string name, object storedProcedureName, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public SqlServerStoredProcedureActivity(string name, object storedProcedureName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             StoredProcedureName = storedProcedureName;
             StoredProcedureParameters = storedProcedureParameters;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlServerTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlServerTableDataset.cs
@@ -39,13 +39,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="linkedServiceName">Linked service reference.</param>
         /// <param name="tableName">The table name of the SQL Server dataset.
         /// Type: string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public SqlServerTableDataset(LinkedServiceReference linkedServiceName, object tableName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public SqlServerTableDataset(LinkedServiceReference linkedServiceName, object tableName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             TableName = tableName;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlSink.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlSink.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SqlSink class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="writeBatchSize">Write batch size. Type: integer (or
         /// Expression with resultType integer), minimum: 0.</param>
         /// <param name="writeBatchTimeout">Write batch timeout. Type: string
@@ -50,8 +52,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Expression with resultType string).</param>
         /// <param name="storedProcedureParameters">SQL stored procedure
         /// parameters.</param>
-        public SqlSink(object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object sqlWriterStoredProcedureName = default(object), object sqlWriterTableType = default(object), object preCopyScript = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>))
-            : base(writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
+        public SqlSink(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object writeBatchSize = default(object), object writeBatchTimeout = default(object), object sinkRetryCount = default(object), object sinkRetryWait = default(object), object sqlWriterStoredProcedureName = default(object), object sqlWriterTableType = default(object), object preCopyScript = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>))
+            : base(additionalProperties, writeBatchSize, writeBatchTimeout, sinkRetryCount, sinkRetryWait)
         {
             SqlWriterStoredProcedureName = sqlWriterStoredProcedureName;
             SqlWriterTableType = sqlWriterTableType;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SqlSource.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SqlSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -45,8 +47,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="storedProcedureParameters">Value and type setting for
         /// stored procedure parameters. Example: "{Parameter1: {value: "1",
         /// type: "int"}}".</param>
-        public SqlSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>))
-            : base(sourceRetryCount, sourceRetryWait)
+        public SqlSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object sqlReaderQuery = default(object), object sqlReaderStoredProcedureName = default(object), IDictionary<string, StoredProcedureParameter> storedProcedureParameters = default(IDictionary<string, StoredProcedureParameter>))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             SqlReaderQuery = sqlReaderQuery;
             SqlReaderStoredProcedureName = sqlReaderStoredProcedureName;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SquareLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SquareLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -39,6 +41,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// application.</param>
         /// <param name="redirectUri">The redirect URL assigned in the Square
         /// application dashboard. (i.e. http://localhost:2500)</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="clientSecret">The client secret associated with your
@@ -56,8 +60,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public SquareLinkedService(object host, object clientId, object redirectUri, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase clientSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public SquareLinkedService(object host, object clientId, object redirectUri, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase clientSecret = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             ClientId = clientId;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SquareObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SquareObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the SquareObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public SquareObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public SquareObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SquareSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SquareSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the SquareSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public SquareSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public SquareSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/StagingSettings.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/StagingSettings.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Microsoft.Rest;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -33,14 +35,17 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="linkedServiceName">Staging linked service
         /// reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="path">The path to storage for storing the interim
         /// data. Type: string (or Expression with resultType string).</param>
         /// <param name="enableCompression">Specifies whether to use
         /// compression when copying data via an interim staging. Default value
         /// is false. Type: boolean (or Expression with resultType
         /// boolean).</param>
-        public StagingSettings(LinkedServiceReference linkedServiceName, object path = default(object), object enableCompression = default(object))
+        public StagingSettings(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object path = default(object), object enableCompression = default(object))
         {
+            AdditionalProperties = additionalProperties;
             LinkedServiceName = linkedServiceName;
             Path = path;
             EnableCompression = enableCompression;
@@ -51,6 +56,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets staging linked service reference.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SybaseLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/SybaseLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Expression with resultType string).</param>
         /// <param name="database">Database name for connection. Type: string
         /// (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="schema">Schema name for connection. Type: string (or
@@ -50,8 +54,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public SybaseLinkedService(object server, object database, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), string authenticationType = default(string), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public SybaseLinkedService(object server, object database, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), string authenticationType = default(string), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             Database = database;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TabularTranslator.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TabularTranslator.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,9 +31,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the TabularTranslator class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="columnMappings">Column mappings. Type: string (or
         /// Expression with resultType string).</param>
-        public TabularTranslator(object columnMappings = default(object))
+        public TabularTranslator(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object columnMappings = default(object))
+            : base(additionalProperties)
         {
             ColumnMappings = columnMappings;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TeradataLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TeradataLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="server">Server name for connection. Type: string (or
         /// Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="schema">Schema name for connection. Type: string (or
@@ -48,8 +52,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public TeradataLinkedService(object server, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), string authenticationType = default(string), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public TeradataLinkedService(object server, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object schema = default(object), string authenticationType = default(string), object username = default(object), SecureString password = default(SecureString), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Server = server;
             Schema = schema;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TextFormat.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TextFormat.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the TextFormat class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="serializer">Serializer. Type: string (or Expression
         /// with resultType string).</param>
         /// <param name="deserializer">Deserializer. Type: string (or
@@ -59,8 +63,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// row of data as headers. When used as output,write the headers into
         /// the output as the first row of data. The default value is false.
         /// Type: boolean (or Expression with resultType boolean).</param>
-        public TextFormat(object serializer = default(object), object deserializer = default(object), object columnDelimiter = default(object), object rowDelimiter = default(object), object escapeChar = default(object), object quoteChar = default(object), object nullValue = default(object), object encodingName = default(object), object treatEmptyAsNull = default(object), object skipLineCount = default(object), object firstRowAsHeader = default(object))
-            : base(serializer, deserializer)
+        public TextFormat(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object serializer = default(object), object deserializer = default(object), object columnDelimiter = default(object), object rowDelimiter = default(object), object escapeChar = default(object), object quoteChar = default(object), object nullValue = default(object), object encodingName = default(object), object treatEmptyAsNull = default(object), object skipLineCount = default(object), object firstRowAsHeader = default(object))
+            : base(additionalProperties, serializer, deserializer)
         {
             ColumnDelimiter = columnDelimiter;
             RowDelimiter = rowDelimiter;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Trigger.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/Trigger.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -30,12 +32,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the Trigger class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Trigger description.</param>
         /// <param name="runtimeState">Indicates if trigger is running or not.
         /// Updated when Start/Stop APIs are called on the Trigger. Possible
         /// values include: 'Started', 'Stopped', 'Disabled'</param>
-        public Trigger(string description = default(string), string runtimeState = default(string))
+        public Trigger(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), string runtimeState = default(string))
         {
+            AdditionalProperties = additionalProperties;
             Description = description;
             RuntimeState = runtimeState;
             CustomInit();
@@ -45,6 +50,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets or sets trigger description.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TriggerRun.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TriggerRun.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the TriggerRun class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="triggerRunId">Trigger run id.</param>
         /// <param name="triggerName">Trigger name.</param>
         /// <param name="triggerType">Trigger type.</param>
@@ -42,8 +44,9 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// trigger run. Name, value pair depends on type of trigger.</param>
         /// <param name="triggeredPipelines">List of pipeline name and run Id
         /// triggered by the trigger run.</param>
-        public TriggerRun(string triggerRunId = default(string), string triggerName = default(string), string triggerType = default(string), System.DateTime? triggerRunTimestamp = default(System.DateTime?), string status = default(string), string message = default(string), IDictionary<string, string> properties = default(IDictionary<string, string>), IDictionary<string, string> triggeredPipelines = default(IDictionary<string, string>))
+        public TriggerRun(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string triggerRunId = default(string), string triggerName = default(string), string triggerType = default(string), System.DateTime? triggerRunTimestamp = default(System.DateTime?), string status = default(string), string message = default(string), IDictionary<string, string> properties = default(IDictionary<string, string>), IDictionary<string, string> triggeredPipelines = default(IDictionary<string, string>))
         {
+            AdditionalProperties = additionalProperties;
             TriggerRunId = triggerRunId;
             TriggerName = triggerName;
             TriggerType = triggerType;
@@ -59,6 +62,13 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// An initialization method that performs custom operations like setting defaults
         /// </summary>
         partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
+        /// </summary>
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; set; }
 
         /// <summary>
         /// Gets trigger run id.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TumblingWindowTrigger.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/TumblingWindowTrigger.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -37,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="pipeline">Pipeline for which runs are created when an
         /// event is fired for trigger window that is ready.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Trigger description.</param>
         /// <param name="runtimeState">Indicates if trigger is running or not.
         /// Updated when Start/Stop APIs are called on the Trigger. Possible
@@ -61,8 +65,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// triggered.</param>
         /// <param name="retryPolicy">Retry policy that will be applied for
         /// failed pipeline runs.</param>
-        public TumblingWindowTrigger(TriggerPipelineReference pipeline, string description = default(string), string runtimeState = default(string), string frequency = default(string), int? interval = default(int?), System.DateTime? startTime = default(System.DateTime?), System.DateTime? endTime = default(System.DateTime?), object delay = default(object), int? maxConcurrency = default(int?), RetryPolicy retryPolicy = default(RetryPolicy))
-            : base(description, runtimeState)
+        public TumblingWindowTrigger(TriggerPipelineReference pipeline, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), string runtimeState = default(string), string frequency = default(string), int? interval = default(int?), System.DateTime? startTime = default(System.DateTime?), System.DateTime? endTime = default(System.DateTime?), object delay = default(object), int? maxConcurrency = default(int?), RetryPolicy retryPolicy = default(RetryPolicy))
+            : base(additionalProperties, description, runtimeState)
         {
             Pipeline = pipeline;
             Frequency = frequency;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/UntilActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/UntilActivity.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Boolean. The loop will continue until this expression evaluates to
         /// true</param>
         /// <param name="activities">List of activities to execute.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="timeout">Specifies the timeout for the activity to
@@ -51,8 +53,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])). Type: string
         /// (or Expression with resultType string), pattern:
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
-        public UntilActivity(string name, Expression expression, IList<Activity> activities, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), object timeout = default(object))
-            : base(name, description, dependsOn)
+        public UntilActivity(string name, Expression expression, IList<Activity> activities, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), object timeout = default(object))
+            : base(name, additionalProperties, description, dependsOn)
         {
             Expression = expression;
             Timeout = timeout;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WaitActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WaitActivity.cs
@@ -37,10 +37,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="name">Activity name.</param>
         /// <param name="waitTimeInSeconds">Duration in seconds.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
-        public WaitActivity(string name, int waitTimeInSeconds, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>))
-            : base(name, description, dependsOn)
+        public WaitActivity(string name, int waitTimeInSeconds, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>))
+            : base(name, additionalProperties, description, dependsOn)
         {
             WaitTimeInSeconds = waitTimeInSeconds;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WebActivity.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WebActivity.cs
@@ -39,6 +39,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// values include: 'GET', 'POST', 'PUT'</param>
         /// <param name="url">Web activity target endpoint and path. Type:
         /// string (or Expression with resultType string).</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Activity description.</param>
         /// <param name="dependsOn">Activity depends on condition.</param>
         /// <param name="linkedServiceName">Linked service reference.</param>
@@ -57,8 +59,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// endpoint.</param>
         /// <param name="linkedServices">List of linked services passed to web
         /// endpoint.</param>
-        public WebActivity(string name, string method, object url, string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), object headers = default(object), object body = default(object), WebActivityAuthentication authentication = default(WebActivityAuthentication), IList<DatasetReference> datasets = default(IList<DatasetReference>), IList<LinkedServiceReference> linkedServices = default(IList<LinkedServiceReference>))
-            : base(name, description, dependsOn, linkedServiceName, policy)
+        public WebActivity(string name, string method, object url, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), IList<ActivityDependency> dependsOn = default(IList<ActivityDependency>), LinkedServiceReference linkedServiceName = default(LinkedServiceReference), ActivityPolicy policy = default(ActivityPolicy), object headers = default(object), object body = default(object), WebActivityAuthentication authentication = default(WebActivityAuthentication), IList<DatasetReference> datasets = default(IList<DatasetReference>), IList<LinkedServiceReference> linkedServices = default(IList<LinkedServiceReference>))
+            : base(name, additionalProperties, description, dependsOn, linkedServiceName, policy)
         {
             Method = method;
             Url = url;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WebLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WebLinkedService.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Microsoft.Rest;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -32,10 +34,12 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the WebLinkedService class.
         /// </summary>
         /// <param name="typeProperties">Web linked service properties.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
-        public WebLinkedService(WebLinkedServiceTypeProperties typeProperties, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string))
-            : base(connectVia, description)
+        public WebLinkedService(WebLinkedServiceTypeProperties typeProperties, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string))
+            : base(additionalProperties, connectVia, description)
         {
             TypeProperties = typeProperties;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WebSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WebSource.cs
@@ -10,6 +10,8 @@
 
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -28,13 +30,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the WebSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
         /// Expression with resultType string), pattern:
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
-        public WebSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public WebSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WebTableDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/WebTableDataset.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="index">The zero-based index of the table in the web
         /// page. Type: integer (or Expression with resultType integer),
         /// minimum: 0.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
@@ -48,8 +50,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <param name="path">The relative URL to the web page from the linked
         /// service URL. Type: string (or Expression with resultType
         /// string).</param>
-        public WebTableDataset(LinkedServiceReference linkedServiceName, object index, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object path = default(object))
-            : base(linkedServiceName, description, structure, parameters)
+        public WebTableDataset(LinkedServiceReference linkedServiceName, object index, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>), object path = default(object))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             Index = index;
             Path = path;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/XeroLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/XeroLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="host">The endpoint of the Xero server. (i.e.
         /// api.xero.com)</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="consumerKey">The consumer key associated with the Xero
@@ -56,8 +60,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public XeroLinkedService(object host, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase consumerKey = default(SecretBase), SecretBase privateKey = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public XeroLinkedService(object host, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase consumerKey = default(SecretBase), SecretBase privateKey = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Host = host;
             ConsumerKey = consumerKey;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/XeroObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/XeroObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the XeroObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public XeroObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public XeroObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/XeroSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/XeroSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the XeroSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public XeroSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public XeroSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ZohoLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ZohoLinkedService.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
     using Microsoft.Rest;
     using Microsoft.Rest.Serialization;
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -35,6 +37,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         /// <param name="endpoint">The endpoint of the Zoho server. (i.e.
         /// crm.zoho.com/crm/private)</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
         /// <param name="accessToken">The access token for Zoho
@@ -52,8 +56,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public ZohoLinkedService(object endpoint, IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase accessToken = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
-            : base(connectVia, description)
+        public ZohoLinkedService(object endpoint, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), SecretBase accessToken = default(SecretBase), object useEncryptedEndpoints = default(object), object useHostVerification = default(object), object usePeerVerification = default(object), object encryptedCredential = default(object))
+            : base(additionalProperties, connectVia, description)
         {
             Endpoint = endpoint;
             AccessToken = accessToken;

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ZohoObjectDataset.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ZohoObjectDataset.cs
@@ -34,13 +34,15 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// Initializes a new instance of the ZohoObjectDataset class.
         /// </summary>
         /// <param name="linkedServiceName">Linked service reference.</param>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="description">Dataset description.</param>
         /// <param name="structure">Columns that define the structure of the
         /// dataset. Type: array (or Expression with resultType array),
         /// itemType: DatasetDataElement.</param>
         /// <param name="parameters">Parameters for dataset.</param>
-        public ZohoObjectDataset(LinkedServiceReference linkedServiceName, string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
-            : base(linkedServiceName, description, structure, parameters)
+        public ZohoObjectDataset(LinkedServiceReference linkedServiceName, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), string description = default(string), object structure = default(object), IDictionary<string, ParameterSpecification> parameters = default(IDictionary<string, ParameterSpecification>))
+            : base(linkedServiceName, additionalProperties, description, structure, parameters)
         {
             CustomInit();
         }

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ZohoSource.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/ZohoSource.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.DataFactory.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -29,6 +31,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// <summary>
         /// Initializes a new instance of the ZohoSource class.
         /// </summary>
+        /// <param name="additionalProperties">Unmatched properties from the
+        /// message are deserialized this collection</param>
         /// <param name="sourceRetryCount">Source retry count. Type: integer
         /// (or Expression with resultType integer).</param>
         /// <param name="sourceRetryWait">Source retry wait. Type: string (or
@@ -36,8 +40,8 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// ((\d+)\.)?(\d\d):(60|([0-5][0-9])):(60|([0-5][0-9])).</param>
         /// <param name="query">A query to retrieve data from source. Type:
         /// string (or Expression with resultType string).</param>
-        public ZohoSource(object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
-            : base(sourceRetryCount, sourceRetryWait)
+        public ZohoSource(IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), object sourceRetryCount = default(object), object sourceRetryWait = default(object), object query = default(object))
+            : base(additionalProperties, sourceRetryCount, sourceRetryWait)
         {
             Query = query;
             CustomInit();

--- a/src/SDKs/DataFactory/Management.DataFactory/changelog.md
+++ b/src/SDKs/DataFactory/Management.DataFactory/changelog.md
@@ -9,6 +9,7 @@
   * Support providing a Dynamics password as a SecureString, a secret in Azure Key Vault, or as an encrypted credential.
   * App model for Tumbling Window Trigger
   * Add LinkedService, Dataset, Source for 26 RFI connectors, including: PostgreSQL,Google BigQuery,Impala,ServiceNow,Greenplum/Hawq,HBase,Hive ODBC,Spark ODBC,HBase Phoenix,MariaDB,Presto,Couchbase,Concur,Zoho CRM,Amazon Marketplace Services,PayPal,Square,Shopify,QuickBooks Online,Hubspot,Atlassian Jira,Magento,Xero,Drill,Marketo,Eloqua.
+  * Support round tripping of new properties using additionalProperties for some types
 
 ## Version 0.2.1-preview
 

--- a/src/SDKs/_metadata/datafactory_resource-manager.txt
+++ b/src/SDKs/_metadata/datafactory_resource-manager.txt
@@ -1,10 +1,11 @@
-2017-11-21 03:32:04 UTC
+2017-11-22 21:47:03 UTC
 
 1) azure-rest-api-specs repository information
-GitHub user: Eva-Xiao
+GitHub user: Azure
 Branch:      current
+Commit:      9e9ae3cb5fe1ada01eefe4260d7647ecbb7d40d0
 
 2) AutoRest information
 Requested version: latest
-Bootstrapper version:    C:\Users\fexiao\AppData\Roaming\npm `-- autorest@2.0.4166  
-Latest installed version:    2.0.4168
+Bootstrapper version:    C:\Users\hvermis\AppData\Roaming\npm `-- autorest@2.0.4166  
+Latest installed version:    2.0.4204

--- a/src/SDKs/_metadata/datafactory_resource-manager.txt
+++ b/src/SDKs/_metadata/datafactory_resource-manager.txt
@@ -1,4 +1,4 @@
-2017-11-22 21:47:03 UTC
+2017-11-22 21:57:17 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---
Adding additionalProperties to some of the types to support round-tripping new properties to the service.
Swagger PR Azure/azure-rest-api-specs#2033

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
