### PR TITLE
Regenerated Networking SDK

### DIFF
--- a/src/SDKs/Network/Management.Network/Generated/Models/TopologyParameters.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/TopologyParameters.cs
@@ -10,7 +10,6 @@
 
 namespace Microsoft.Azure.Management.Network.Models
 {
-    using Microsoft.Rest;
     using Newtonsoft.Json;
     using System.Linq;
 
@@ -32,9 +31,15 @@ namespace Microsoft.Azure.Management.Network.Models
         /// </summary>
         /// <param name="targetResourceGroupName">The name of the target
         /// resource group to perform topology on.</param>
-        public TopologyParameters(string targetResourceGroupName)
+        /// <param name="targetVirtualNetwork">The reference of the Virtual
+        /// Network resource.</param>
+        /// <param name="targetSubnet">The reference of the Subnet
+        /// resource.</param>
+        public TopologyParameters(string targetResourceGroupName = default(string), SubResource targetVirtualNetwork = default(SubResource), SubResource targetSubnet = default(SubResource))
         {
             TargetResourceGroupName = targetResourceGroupName;
+            TargetVirtualNetwork = targetVirtualNetwork;
+            TargetSubnet = targetSubnet;
             CustomInit();
         }
 
@@ -51,17 +56,16 @@ namespace Microsoft.Azure.Management.Network.Models
         public string TargetResourceGroupName { get; set; }
 
         /// <summary>
-        /// Validate the object.
+        /// Gets or sets the reference of the Virtual Network resource.
         /// </summary>
-        /// <exception cref="ValidationException">
-        /// Thrown if validation fails
-        /// </exception>
-        public virtual void Validate()
-        {
-            if (TargetResourceGroupName == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "TargetResourceGroupName");
-            }
-        }
+        [JsonProperty(PropertyName = "targetVirtualNetwork")]
+        public SubResource TargetVirtualNetwork { get; set; }
+
+        /// <summary>
+        /// Gets or sets the reference of the Subnet resource.
+        /// </summary>
+        [JsonProperty(PropertyName = "targetSubnet")]
+        public SubResource TargetSubnet { get; set; }
+
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/NetworkWatchersOperations.cs
+++ b/src/SDKs/Network/Management.Network/Generated/NetworkWatchersOperations.cs
@@ -1108,10 +1108,6 @@ namespace Microsoft.Azure.Management.Network
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "parameters");
             }
-            if (parameters != null)
-            {
-                parameters.Validate();
-            }
             if (Client.SubscriptionId == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.SubscriptionId");

--- a/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
+++ b/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
@@ -7,7 +7,7 @@
 		<PackageId>Microsoft.Azure.Management.Network</PackageId>
 		<Description>Provides management capabilities for Network services.</Description>
 		<AssemblyName>Microsoft.Azure.Management.Network</AssemblyName>
-		<Version>16.0.0-preview</Version>
+		<Version>16.1.0-preview</Version>
 		<PackageTags>Microsoft Azure Network management;Network;Network management</PackageTags>    
 		<PackageReleaseNotes/>
 	</PropertyGroup>

--- a/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
+++ b/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
@@ -9,7 +9,7 @@
 		<AssemblyName>Microsoft.Azure.Management.Network</AssemblyName>
 		<Version>16.1.0-preview</Version>
 		<PackageTags>Microsoft Azure Network management;Network;Network management</PackageTags>    
-		<PackageReleaseNotes/>
+		<PackageReleaseNotes>* Updated TopologyParameters with new optional properties: TargetVirtualNetwork, TargetSubnet; TargetResourceGroupName property changed to optional</PackageReleaseNotes>
 	</PropertyGroup>
 	<PropertyGroup>
 		<TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Network Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Network management functions for managing the Microsoft Azure Network service.")]
 
-[assembly: AssemblyVersion("16.1.0.0")]
+[assembly: AssemblyVersion("16.0.0.0")]
 [assembly: AssemblyFileVersion("16.1.0.0")]
 
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Network Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Network management functions for managing the Microsoft Azure Network service.")]
 
-[assembly: AssemblyVersion("16.0.0.0")]
-[assembly: AssemblyFileVersion("16.0.0.0")]
+[assembly: AssemblyVersion("16.1.0.0")]
+[assembly: AssemblyFileVersion("16.1.0.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]

--- a/src/SDKs/_metadata/network_resource-manager.txt
+++ b/src/SDKs/_metadata/network_resource-manager.txt
@@ -1,11 +1,11 @@
-2017-11-09 18:56:39 UTC
+2017-11-29 08:28:24 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure
 Branch:      current
-Commit:      2df71489cc110ca9d3251bf7a4e685ab6616f379
+Commit:      90cd0b9665ac16e4a4b33ec8a7cbe87c26814a03
 
 2) AutoRest information
 Requested version: latest
-Bootstrapper version:    C:\Users\murocha\AppData\Roaming\npm +-- autorest@2.0.4166  `-- oad@0.1.7   `-- autorest@1.2.2  
+Bootstrapper version:    C:\Program Files\nodejs `-- autorest@2.0.4166  
 Latest installed version:    2.0.4168


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

https://github.com/Azure/azure-rest-api-specs/pull/2042
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
