### PR TITLE
Updated OI Data Plane to use a standard client constructors

### DIFF
--- a/src/SDKs/OperationalInsights/DataPlane/OperationalInsights.Tests/ScenarioTests/QueryTests.cs
+++ b/src/SDKs/OperationalInsights/DataPlane/OperationalInsights.Tests/ScenarioTests/QueryTests.cs
@@ -100,7 +100,7 @@ namespace OperationalInsights.Data.Test.ScenarioTests
         private OperationalInsightsDataClient GetClient(MockContext ctx, string workspaceId = DefaultWorkspaceId, string apiKey = DefaultApiKey)
         {
             var credentials = new ApiKeyClientCredentials(apiKey);
-            var client = OperationalInsightsDataClient.CreateClient(credentials, HttpMockServer.CreateInstance());
+            var client = new OperationalInsightsDataClient(credentials, HttpMockServer.CreateInstance());
             client.WorkspaceId = workspaceId;
 
             return client;

--- a/src/SDKs/OperationalInsights/DataPlane/OperationalInsights/Generated/OperationalInsightsDataClient.cs
+++ b/src/SDKs/OperationalInsights/DataPlane/OperationalInsights/Generated/OperationalInsightsDataClient.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.OperationalInsights
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        internal OperationalInsightsDataClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        public OperationalInsightsDataClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (credentials == null)
             {
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.OperationalInsights
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        internal OperationalInsightsDataClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public OperationalInsightsDataClient(ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (credentials == null)
             {
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.OperationalInsights
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        internal OperationalInsightsDataClient(System.Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        public OperationalInsightsDataClient(System.Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
         {
             if (baseUri == null)
             {
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.OperationalInsights
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        internal OperationalInsightsDataClient(System.Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
+        public OperationalInsightsDataClient(System.Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
         {
             if (baseUri == null)
             {


### PR DESCRIPTION
Updated OI Data Plane to use a standard client constructors instead of static factory methods

I originally thought this was necessary for the C# client in order to always add a custom DelegatingHandler to the HttpClient but found a way around that using CustomInitialize() that isn't too scary.

I am waiting on a PR in the API specs repo to remove the 'use-internal-constructors: true' setting: https://github.com/Azure/azure-rest-api-specs/pull/2058. The spec itself is here: https://github.com/csuich2/azure-rest-api-specs/blob/current/specification/operationalinsights/data-plane/readme.md.

This change *does* remove some static constructors, however this data plane SDK was just merged a few days ago and hasn't be released publicly yet. Because of this, is it OK to not bump the version, or do I need to bump it to 1.0.1-preview?

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [see comment] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
