### PR TITLE
[Compute] Identity types, identity ids, and IP forwarding.

### DIFF
--- a/src/SDKs/Compute/Management.Compute/Generated/Models/ResourceIdentityType.cs
+++ b/src/SDKs/Compute/Management.Compute/Generated/Models/ResourceIdentityType.cs
@@ -22,7 +22,13 @@ namespace Microsoft.Azure.Management.Compute.Models
     public enum ResourceIdentityType
     {
         [EnumMember(Value = "SystemAssigned")]
-        SystemAssigned
+        SystemAssigned,
+        [EnumMember(Value = "UserAssigned")]
+        UserAssigned,
+        [EnumMember(Value = "SystemAssigned, UserAssigned")]
+        SystemAssignedUserAssigned,
+        [EnumMember(Value = "None")]
+        None
     }
     internal static class ResourceIdentityTypeEnumExtension
     {
@@ -37,6 +43,12 @@ namespace Microsoft.Azure.Management.Compute.Models
             {
                 case ResourceIdentityType.SystemAssigned:
                     return "SystemAssigned";
+                case ResourceIdentityType.UserAssigned:
+                    return "UserAssigned";
+                case ResourceIdentityType.SystemAssignedUserAssigned:
+                    return "SystemAssigned, UserAssigned";
+                case ResourceIdentityType.None:
+                    return "None";
             }
             return null;
         }
@@ -47,6 +59,12 @@ namespace Microsoft.Azure.Management.Compute.Models
             {
                 case "SystemAssigned":
                     return ResourceIdentityType.SystemAssigned;
+                case "UserAssigned":
+                    return ResourceIdentityType.UserAssigned;
+                case "SystemAssigned, UserAssigned":
+                    return ResourceIdentityType.SystemAssignedUserAssigned;
+                case "None":
+                    return ResourceIdentityType.None;
             }
             return null;
         }

--- a/src/SDKs/Compute/Management.Compute/Generated/Models/VirtualMachineIdentity.cs
+++ b/src/SDKs/Compute/Management.Compute/Generated/Models/VirtualMachineIdentity.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.Compute.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -30,18 +32,27 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// Initializes a new instance of the VirtualMachineIdentity class.
         /// </summary>
         /// <param name="principalId">The principal id of virtual machine
+        /// identity. This property will only be provided for a system assigned
         /// identity.</param>
         /// <param name="tenantId">The tenant id associated with the virtual
-        /// machine.</param>
+        /// machine. This property will only be provided for a system assigned
+        /// identity.</param>
         /// <param name="type">The type of identity used for the virtual
-        /// machine. Currently, the only supported type is 'SystemAssigned',
-        /// which implicitly creates an identity. Possible values include:
-        /// 'SystemAssigned'</param>
-        public VirtualMachineIdentity(string principalId = default(string), string tenantId = default(string), ResourceIdentityType? type = default(ResourceIdentityType?))
+        /// machine. The type 'SystemAssigned, UserAssigned' includes both an
+        /// implicitly created identity and a set of user assigned identities.
+        /// The type 'None' will remove any identities from the virtual
+        /// machine. Possible values include: 'SystemAssigned', 'UserAssigned',
+        /// 'SystemAssigned, UserAssigned', 'None'</param>
+        /// <param name="identityIds">The list of user identities associated
+        /// with the Virtual Machine. The user identity references will be ARM
+        /// resource ids in the form:
+        /// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/identities/{identityName}'.</param>
+        public VirtualMachineIdentity(string principalId = default(string), string tenantId = default(string), ResourceIdentityType? type = default(ResourceIdentityType?), IList<string> identityIds = default(IList<string>))
         {
             PrincipalId = principalId;
             TenantId = tenantId;
             Type = type;
+            IdentityIds = identityIds;
             CustomInit();
         }
 
@@ -51,25 +62,38 @@ namespace Microsoft.Azure.Management.Compute.Models
         partial void CustomInit();
 
         /// <summary>
-        /// Gets the principal id of virtual machine identity.
+        /// Gets the principal id of virtual machine identity. This property
+        /// will only be provided for a system assigned identity.
         /// </summary>
         [JsonProperty(PropertyName = "principalId")]
         public string PrincipalId { get; private set; }
 
         /// <summary>
-        /// Gets the tenant id associated with the virtual machine.
+        /// Gets the tenant id associated with the virtual machine. This
+        /// property will only be provided for a system assigned identity.
         /// </summary>
         [JsonProperty(PropertyName = "tenantId")]
         public string TenantId { get; private set; }
 
         /// <summary>
-        /// Gets or sets the type of identity used for the virtual machine.
-        /// Currently, the only supported type is 'SystemAssigned', which
-        /// implicitly creates an identity. Possible values include:
-        /// 'SystemAssigned'
+        /// Gets or sets the type of identity used for the virtual machine. The
+        /// type 'SystemAssigned, UserAssigned' includes both an implicitly
+        /// created identity and a set of user assigned identities. The type
+        /// 'None' will remove any identities from the virtual machine.
+        /// Possible values include: 'SystemAssigned', 'UserAssigned',
+        /// 'SystemAssigned, UserAssigned', 'None'
         /// </summary>
         [JsonProperty(PropertyName = "type")]
         public ResourceIdentityType? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of user identities associated with the
+        /// Virtual Machine. The user identity references will be ARM resource
+        /// ids in the form:
+        /// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/identities/{identityName}'.
+        /// </summary>
+        [JsonProperty(PropertyName = "identityIds")]
+        public IList<string> IdentityIds { get; set; }
 
     }
 }

--- a/src/SDKs/Compute/Management.Compute/Generated/Models/VirtualMachineScaleSetIdentity.cs
+++ b/src/SDKs/Compute/Management.Compute/Generated/Models/VirtualMachineScaleSetIdentity.cs
@@ -11,6 +11,8 @@
 namespace Microsoft.Azure.Management.Compute.Models
 {
     using Newtonsoft.Json;
+    using System.Collections;
+    using System.Collections.Generic;
     using System.Linq;
 
     /// <summary>
@@ -32,18 +34,28 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// class.
         /// </summary>
         /// <param name="principalId">The principal id of virtual machine scale
-        /// set identity.</param>
+        /// set identity. This property will only be provided for a system
+        /// assigned identity.</param>
         /// <param name="tenantId">The tenant id associated with the virtual
-        /// machine scale set.</param>
+        /// machine scale set. This property will only be provided for a system
+        /// assigned identity.</param>
         /// <param name="type">The type of identity used for the virtual
-        /// machine scale set. Currently, the only supported type is
-        /// 'SystemAssigned', which implicitly creates an identity. Possible
-        /// values include: 'SystemAssigned'</param>
-        public VirtualMachineScaleSetIdentity(string principalId = default(string), string tenantId = default(string), ResourceIdentityType? type = default(ResourceIdentityType?))
+        /// machine scale set. The type 'SystemAssigned, UserAssigned' includes
+        /// both an implicitly created identity and a set of user assigned
+        /// identities. The type 'None' will remove any identities from the
+        /// virtual machine scale set. Possible values include:
+        /// 'SystemAssigned', 'UserAssigned', 'SystemAssigned, UserAssigned',
+        /// 'None'</param>
+        /// <param name="identityIds">The list of user identities associated
+        /// with the virtual machine scale set. The user identity references
+        /// will be ARM resource ids in the form:
+        /// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/identities/{identityName}'.</param>
+        public VirtualMachineScaleSetIdentity(string principalId = default(string), string tenantId = default(string), ResourceIdentityType? type = default(ResourceIdentityType?), IList<string> identityIds = default(IList<string>))
         {
             PrincipalId = principalId;
             TenantId = tenantId;
             Type = type;
+            IdentityIds = identityIds;
             CustomInit();
         }
 
@@ -53,25 +65,38 @@ namespace Microsoft.Azure.Management.Compute.Models
         partial void CustomInit();
 
         /// <summary>
-        /// Gets the principal id of virtual machine scale set identity.
+        /// Gets the principal id of virtual machine scale set identity. This
+        /// property will only be provided for a system assigned identity.
         /// </summary>
         [JsonProperty(PropertyName = "principalId")]
         public string PrincipalId { get; private set; }
 
         /// <summary>
         /// Gets the tenant id associated with the virtual machine scale set.
+        /// This property will only be provided for a system assigned identity.
         /// </summary>
         [JsonProperty(PropertyName = "tenantId")]
         public string TenantId { get; private set; }
 
         /// <summary>
         /// Gets or sets the type of identity used for the virtual machine
-        /// scale set. Currently, the only supported type is 'SystemAssigned',
-        /// which implicitly creates an identity. Possible values include:
-        /// 'SystemAssigned'
+        /// scale set. The type 'SystemAssigned, UserAssigned' includes both an
+        /// implicitly created identity and a set of user assigned identities.
+        /// The type 'None' will remove any identities from the virtual machine
+        /// scale set. Possible values include: 'SystemAssigned',
+        /// 'UserAssigned', 'SystemAssigned, UserAssigned', 'None'
         /// </summary>
         [JsonProperty(PropertyName = "type")]
         public ResourceIdentityType? Type { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of user identities associated with the
+        /// virtual machine scale set. The user identity references will be ARM
+        /// resource ids in the form:
+        /// '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/identities/{identityName}'.
+        /// </summary>
+        [JsonProperty(PropertyName = "identityIds")]
+        public IList<string> IdentityIds { get; set; }
 
     }
 }

--- a/src/SDKs/Compute/Management.Compute/Generated/Models/VirtualMachineScaleSetNetworkConfiguration.cs
+++ b/src/SDKs/Compute/Management.Compute/Generated/Models/VirtualMachineScaleSetNetworkConfiguration.cs
@@ -49,7 +49,9 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// group.</param>
         /// <param name="dnsSettings">The dns settings to be applied on the
         /// network interfaces.</param>
-        public VirtualMachineScaleSetNetworkConfiguration(string name, IList<VirtualMachineScaleSetIPConfiguration> ipConfigurations, string id = default(string), bool? primary = default(bool?), bool? enableAcceleratedNetworking = default(bool?), SubResource networkSecurityGroup = default(SubResource), VirtualMachineScaleSetNetworkConfigurationDnsSettings dnsSettings = default(VirtualMachineScaleSetNetworkConfigurationDnsSettings))
+        /// <param name="enableIPForwarding">Whether IP forwarding enabled on
+        /// this NIC.</param>
+        public VirtualMachineScaleSetNetworkConfiguration(string name, IList<VirtualMachineScaleSetIPConfiguration> ipConfigurations, string id = default(string), bool? primary = default(bool?), bool? enableAcceleratedNetworking = default(bool?), SubResource networkSecurityGroup = default(SubResource), VirtualMachineScaleSetNetworkConfigurationDnsSettings dnsSettings = default(VirtualMachineScaleSetNetworkConfigurationDnsSettings), bool? enableIPForwarding = default(bool?))
             : base(id)
         {
             Name = name;
@@ -58,6 +60,7 @@ namespace Microsoft.Azure.Management.Compute.Models
             NetworkSecurityGroup = networkSecurityGroup;
             DnsSettings = dnsSettings;
             IpConfigurations = ipConfigurations;
+            EnableIPForwarding = enableIPForwarding;
             CustomInit();
         }
 
@@ -105,6 +108,12 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// </summary>
         [JsonProperty(PropertyName = "properties.ipConfigurations")]
         public IList<VirtualMachineScaleSetIPConfiguration> IpConfigurations { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether IP forwarding enabled on this NIC.
+        /// </summary>
+        [JsonProperty(PropertyName = "properties.enableIPForwarding")]
+        public bool? EnableIPForwarding { get; set; }
 
         /// <summary>
         /// Validate the object.

--- a/src/SDKs/Compute/Management.Compute/Generated/Models/VirtualMachineScaleSetUpdateNetworkConfiguration.cs
+++ b/src/SDKs/Compute/Management.Compute/Generated/Models/VirtualMachineScaleSetUpdateNetworkConfiguration.cs
@@ -49,7 +49,9 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// network interfaces.</param>
         /// <param name="ipConfigurations">The virtual machine scale set IP
         /// Configuration.</param>
-        public VirtualMachineScaleSetUpdateNetworkConfiguration(string id = default(string), string name = default(string), bool? primary = default(bool?), bool? enableAcceleratedNetworking = default(bool?), SubResource networkSecurityGroup = default(SubResource), VirtualMachineScaleSetNetworkConfigurationDnsSettings dnsSettings = default(VirtualMachineScaleSetNetworkConfigurationDnsSettings), IList<VirtualMachineScaleSetUpdateIPConfiguration> ipConfigurations = default(IList<VirtualMachineScaleSetUpdateIPConfiguration>))
+        /// <param name="enableIPForwarding">Whether IP forwarding enabled on
+        /// this NIC.</param>
+        public VirtualMachineScaleSetUpdateNetworkConfiguration(string id = default(string), string name = default(string), bool? primary = default(bool?), bool? enableAcceleratedNetworking = default(bool?), SubResource networkSecurityGroup = default(SubResource), VirtualMachineScaleSetNetworkConfigurationDnsSettings dnsSettings = default(VirtualMachineScaleSetNetworkConfigurationDnsSettings), IList<VirtualMachineScaleSetUpdateIPConfiguration> ipConfigurations = default(IList<VirtualMachineScaleSetUpdateIPConfiguration>), bool? enableIPForwarding = default(bool?))
             : base(id)
         {
             Name = name;
@@ -58,6 +60,7 @@ namespace Microsoft.Azure.Management.Compute.Models
             NetworkSecurityGroup = networkSecurityGroup;
             DnsSettings = dnsSettings;
             IpConfigurations = ipConfigurations;
+            EnableIPForwarding = enableIPForwarding;
             CustomInit();
         }
 
@@ -103,6 +106,12 @@ namespace Microsoft.Azure.Management.Compute.Models
         /// </summary>
         [JsonProperty(PropertyName = "properties.ipConfigurations")]
         public IList<VirtualMachineScaleSetUpdateIPConfiguration> IpConfigurations { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether IP forwarding enabled on this NIC.
+        /// </summary>
+        [JsonProperty(PropertyName = "properties.enableIPForwarding")]
+        public bool? EnableIPForwarding { get; set; }
 
     }
 }

--- a/src/SDKs/Compute/Management.Compute/Microsoft.Azure.Management.Compute.csproj
+++ b/src/SDKs/Compute/Management.Compute/Microsoft.Azure.Management.Compute.csproj
@@ -6,12 +6,12 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.Compute</PackageId>
     <Description>Provides developers with libraries for the updated compute platform under Azure Resource manager to deploy virtual machine, virtual machine extensions and availability set management capabilities. Launch, restart, scale, capture and manage VMs, VM Extensions and more. Note: This client library is for Virtual Machines under Azure Resource Manager.</Description>
-    <Version>17.1.0</Version>
+    <Version>17.2.0</Version>
     <AssemblyName>Microsoft.Azure.Management.Compute</AssemblyName>
     <PackageTags>management;virtual machine;compute;</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
-        This is a public release of the Azure Compute SDK. Included with this release is adding restriction info to SKU restriction.
+        This is a public release of the Azure Compute SDK. Included with this release is adding identity ID property and more types for virtual machine identity, and enabling ip forwarding for vm scale set.
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SDKs/Compute/Management.Compute/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Compute/Management.Compute/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure Compute Resources.")]
 
 [assembly: AssemblyVersion("17.0.0.0")]
-[assembly: AssemblyFileVersion("17.1.0.0")]
+[assembly: AssemblyFileVersion("17.2.0.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]

--- a/src/SDKs/_metadata/compute_resource-manager.txt
+++ b/src/SDKs/_metadata/compute_resource-manager.txt
@@ -1,9 +1,9 @@
-2017-12-13 22:53:10 UTC
+2017-12-15 23:49:01 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure
 Branch:      current
-Commit:      13291dd9244584a66de3c53cc1a85998efd288b3
+Commit:      ca7dadf950700baa6a9fde9e78bd80d4498213f4
 
 2) AutoRest information
 Requested version: latest


### PR DESCRIPTION
Adding UserAssigned and None to identity types,
Adding identity id property.
Enabling IP forwarding for vm scale set.

https://github.com/Azure/azure-rest-api-specs/pull/2099/files

https://github.com/Azure/azure-rest-api-specs/pull/2151/files

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
