### PR TITLE
Machine Learning Compute: Add optional deleteAll parameter

### DIFF
--- a/src/SDKs/MachineLearningCompute/AzSdk.RP.props
+++ b/src/SDKs/MachineLearningCompute/AzSdk.RP.props
@@ -1,0 +1,7 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!--This file and it's contents are updated at build time moving or editing might result in build failure. Take due deligence while editing this file-->
+  <PropertyGroup>
+    <AzureApiTag>MachineLearningCompute_2017-08-01-preview;</AzureApiTag>
+    <PackageTags>$(PackageTags);$(CommonTags);$(AzureApiTag);</PackageTags>
+  </PropertyGroup>
+</Project>

--- a/src/SDKs/MachineLearningCompute/MachineLearningCompute.Tests/MachineLearningComputeTestBase.cs
+++ b/src/SDKs/MachineLearningCompute/MachineLearningCompute.Tests/MachineLearningComputeTestBase.cs
@@ -21,6 +21,7 @@ namespace MachineLearningCompute.Tests
         public string Location { get; set; }
         public string TestName { get; set; }
         public string ResourceGroupName { get; set; }
+        public string ManagedByResourceGroupName { get; set; }
         public string ClusterName { get; set; }
 
         public MachineLearningComputeTestBase(MockContext context, string testName)
@@ -89,7 +90,11 @@ namespace MachineLearningCompute.Tests
                 }
             };
 
-            return Client.OperationalizationClusters.CreateOrUpdate(ResourceGroupName, ClusterName, newCluster);
+            var createdCluster = Client.OperationalizationClusters.CreateOrUpdate(ResourceGroupName, ClusterName, newCluster);
+
+            ManagedByResourceGroupName = createdCluster.ContainerRegistry.ResourceId.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries)[3];
+
+            return createdCluster;
         }
 
         public OperationalizationCluster CreateClusterWithoutOrchestratorProperties(string description = "Test cluster",
@@ -139,6 +144,5 @@ namespace MachineLearningCompute.Tests
             }
             return servicePrincipalSecret;
         }
-
     }
 }

--- a/src/SDKs/MachineLearningCompute/MachineLearningCompute.Tests/MachineLearningComputeTests.cs
+++ b/src/SDKs/MachineLearningCompute/MachineLearningCompute.Tests/MachineLearningComputeTests.cs
@@ -4,6 +4,8 @@ using Microsoft.Azure.Management.MachineLearningCompute;
 using Xunit.Abstractions;
 using Microsoft.Azure.Management.MachineLearningCompute.Models;
 using System.Linq;
+using Microsoft.Azure.Management.ResourceManager;
+using Microsoft.Azure.Management.ResourceManager.Models;
 using System;
 
 namespace MachineLearningCompute.Tests
@@ -101,7 +103,7 @@ namespace MachineLearningCompute.Tests
 
                 var clusterNames = testBase.Client.OperationalizationClusters.ListByResourceGroup(resourceGroup.Name).Select(cluster => cluster.Name);
 
-                Assert.True(clusterNames.Contains(createdCluster.Name));
+                Assert.Contains(createdCluster.Name, clusterNames);
             }
         }
 
@@ -116,7 +118,7 @@ namespace MachineLearningCompute.Tests
 
                 var clusterNames = testBase.Client.OperationalizationClusters.ListBySubscriptionId().Select(cluster => cluster.Name);
 
-                Assert.True(clusterNames.Contains(createdCluster.Name));
+                Assert.Contains(createdCluster.Name, clusterNames);
             }
         }
 
@@ -166,6 +168,21 @@ namespace MachineLearningCompute.Tests
                 Assert.Equal(OperationStatus.Succeeded, updateResponse.UpdateStatus);
                 Assert.NotNull(updateResponse.UpdateStartedOn);
                 Assert.NotNull(updateResponse.UpdateCompletedOn);
+            }
+        }
+
+        [Fact]
+        public void DeleteAllResources()
+        {
+            using (var context = MockContext.Start(this.GetType().FullName))
+            using (var testBase = new MachineLearningComputeTestBase(context, testNamePrefix + "-deleteall"))
+            {
+                var resourceGroup = testBase.CreateResourceGroup();
+                var createdCluster = testBase.CreateCluster(clusterType: "Local");
+
+                var deleteResponse = testBase.Client.OperationalizationClusters.Delete(resourceGroup.Name, createdCluster.Name, deleteAll: true);
+
+                Assert.False(testBase.ResourcesClient.ResourceGroups.CheckExistence(testBase.ManagedByResourceGroupName));
             }
         }
     }

--- a/src/SDKs/MachineLearningCompute/MachineLearningCompute.Tests/SessionRecords/MachineLearningCompute.Tests.MachineLearningComputeTests/DeleteAllResources.json
+++ b/src/SDKs/MachineLearningCompute/MachineLearningCompute.Tests/SessionRecords/MachineLearningCompute.Tests.MachineLearningComputeTests/DeleteAllResources.json
@@ -1,0 +1,959 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "edacc6de-d4bc-417e-a976-108faab3ec41"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute\",\r\n  \"namespace\": \"Microsoft.MachineLearningCompute\",\r\n  \"authorization\": {\r\n    \"applicationId\": \"0736f41a-0425-4b46-bdb5-1563eff02385\",\r\n    \"roleDefinitionId\": \"376aa7d7-51a9-463d-bd4d-7e1691345612\",\r\n    \"managedByRoleDefinitionId\": \"91d00862-cf55-46a5-9dce-260bbd92ce25\"\r\n  },\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"operationalizationClusters\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"West Central US\",\r\n        \"Australia East\",\r\n        \"West Europe\",\r\n        \"Southeast Asia\",\r\n        \"East US 2 EUAP\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2017-08-01-preview\",\r\n        \"2017-06-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"East US 2 EUAP\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2017-08-01-preview\",\r\n        \"2017-06-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"East US 2 EUAP\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2017-08-01-preview\",\r\n        \"2017-06-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operations\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"West Central US\",\r\n        \"Australia East\",\r\n        \"West Europe\",\r\n        \"Southeast Asia\",\r\n        \"East US 2 EUAP\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2017-08-01-preview\",\r\n        \"2017-06-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationsStatus\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"West Central US\",\r\n        \"Australia East\",\r\n        \"West Europe\",\r\n        \"Southeast Asia\",\r\n        \"East US 2 EUAP\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2017-08-01-preview\",\r\n        \"2017-06-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:27:13 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14976"
+        ],
+        "x-ms-request-id": [
+          "818d52ad-661a-47fc-8d53-d296c88d1ea1"
+        ],
+        "x-ms-correlation-request-id": [
+          "818d52ad-661a-47fc-8d53-d296c88d1ea1"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232714Z:818d52ad-661a-47fc-8d53-d296c88d1ea1"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Jlc291cmNlZ3JvdXBzL21sY3JwLWRvdG5ldC10ZXN0LWRlbGV0ZWFsbDgyODg/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"East US 2 EUAP\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "36"
+        ],
+        "x-ms-client-request-id": [
+          "b4bc00d9-dc6a-49d8-bfcf-26eccab950a5"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/mlcrp-dotnet-test-deleteall8288\",\r\n  \"name\": \"mlcrp-dotnet-test-deleteall8288\",\r\n  \"location\": \"eastus2euap\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "220"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:27:15 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "x-ms-request-id": [
+          "62bf2e71-64ec-4c8e-93df-365e3a9b1482"
+        ],
+        "x-ms-correlation-request-id": [
+          "62bf2e71-64ec-4c8e-93df-365e3a9b1482"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232716Z:62bf2e71-64ec-4c8e-93df-365e3a9b1482"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/mlcrp-dotnet-test-deleteall8288/providers/Microsoft.MachineLearningCompute/operationalizationClusters/mlcrp-dotnet-test-deleteall9074?api-version=2017-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Jlc291cmNlR3JvdXBzL21sY3JwLWRvdG5ldC10ZXN0LWRlbGV0ZWFsbDgyODgvcHJvdmlkZXJzL01pY3Jvc29mdC5NYWNoaW5lTGVhcm5pbmdDb21wdXRlL29wZXJhdGlvbmFsaXphdGlvbkNsdXN0ZXJzL21sY3JwLWRvdG5ldC10ZXN0LWRlbGV0ZWFsbDkwNzQ/YXBpLXZlcnNpb249MjAxNy0wOC0wMS1wcmV2aWV3",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"properties\": {\r\n    \"description\": \"Test cluster\",\r\n    \"clusterType\": \"Local\",\r\n    \"containerService\": {\r\n      \"orchestratorType\": \"Kubernetes\",\r\n      \"orchestratorProperties\": {\r\n        \"servicePrincipal\": {\r\n          \"clientId\": \"2eca32f5-01fc-4778-ba29-d6b6ecbee43b\",\r\n          \"secret\": \"abcde\"\r\n        }\r\n      }\r\n    }\r\n  },\r\n  \"location\": \"East US 2 EUAP\"\r\n}",
+      "RequestHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "418"
+        ],
+        "x-ms-client-request-id": [
+          "05c43537-58ef-4fbe-865d-f243912c61cf"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288/providers/Microsoft.MachineLearningCompute/operationalizationClusters/mlcrp-dotnet-test-deleteall9074\",\r\n  \"name\": \"mlcrp-dotnet-test-deleteall9074\",\r\n  \"type\": \"Microsoft.MachineLearningCompute/operationalizationClusters\",\r\n  \"location\": \"East US 2 EUAP\",\r\n  \"tags\": null,\r\n  \"properties\": {\r\n    \"createdOn\": \"2017-12-12T23:26:37.036Z\",\r\n    \"description\": \"Test cluster\",\r\n    \"provisioningState\": \"Creating\",\r\n    \"provisioningErrors\": null,\r\n    \"storageAccount\": {\r\n      \"resourceId\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288-azureml-f3d75/providers/Microsoft.Storage/storageAccounts/mlcrpstgda89553055dc\"\r\n    },\r\n    \"containerRegistry\": {\r\n      \"resourceId\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288-azureml-f3d75/providers/Microsoft.ContainerRegistry/registries/mlcrpacrba3342125629\"\r\n    },\r\n    \"clusterType\": \"Local\",\r\n    \"containerService\": {\r\n      \"clusterFqdn\": null,\r\n      \"systemServices\": null,\r\n      \"masterCount\": null,\r\n      \"agentCount\": null,\r\n      \"agentVmSize\": null,\r\n      \"orchestratorType\": \"Kubernetes\",\r\n      \"orchestratorProperties\": {\r\n        \"servicePrincipal\": {\r\n          \"clientId\": \"2eca32f5-01fc-4778-ba29-d6b6ecbee43b\",\r\n          \"secret\": \"<REDACTED>\"\r\n        }\r\n      }\r\n    },\r\n    \"appInsights\": {\r\n      \"resourceId\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288-azureml-f3d75/providers/Microsoft.Insights/components/mlcrpaifda76608eb6b\"\r\n    },\r\n    \"globalServiceConfiguration\": null\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "1461"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:27:23 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1199"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b?api-version=2017-06-01-preview"
+        ],
+        "x-ms-client-request-id": [
+          "05c4353758ef4fbe865df243912c61cf"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "417c846d-263a-4aa7-9f1f-9271f4275c0f"
+        ],
+        "x-ms-correlation-request-id": [
+          "417c846d-263a-4aa7-9f1f-9271f4275c0f"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232723Z:417c846d-263a-4aa7-9f1f-9271f4275c0f"
+        ]
+      },
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b?api-version=2017-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZS9sb2NhdGlvbnMvZWFzdHVzMmV1YXAvb3BlcmF0aW9uc1N0YXR1cy9jYjVhYWY4OC0xNDdkLTQ4YjgtODIwYy0yMjZiMjY4YjVmMGI/YXBpLXZlcnNpb249MjAxNy0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/locations/eastus2euap/operationStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b\",\r\n  \"name\": \"cb5aaf88-147d-48b8-820c-226b268b5f0b\",\r\n  \"status\": \"Creating\",\r\n  \"startTime\": \"2017-12-12T23:26:37.113Z\",\r\n  \"percentComplete\": 0.0\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:27:54 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14961"
+        ],
+        "x-ms-client-request-id": [
+          "70ff96ecd4404ac6bb62d71387181bee"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "965c09a8-892a-409c-997b-77a525e9fdec"
+        ],
+        "x-ms-correlation-request-id": [
+          "965c09a8-892a-409c-997b-77a525e9fdec"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232754Z:965c09a8-892a-409c-997b-77a525e9fdec"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b?api-version=2017-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZS9sb2NhdGlvbnMvZWFzdHVzMmV1YXAvb3BlcmF0aW9uc1N0YXR1cy9jYjVhYWY4OC0xNDdkLTQ4YjgtODIwYy0yMjZiMjY4YjVmMGI/YXBpLXZlcnNpb249MjAxNy0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/locations/eastus2euap/operationStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b\",\r\n  \"name\": \"cb5aaf88-147d-48b8-820c-226b268b5f0b\",\r\n  \"status\": \"Creating\",\r\n  \"startTime\": \"2017-12-12T23:26:37.113Z\",\r\n  \"percentComplete\": 0.0\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:28:24 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14960"
+        ],
+        "x-ms-client-request-id": [
+          "f2ca1c0dc8a74b159c0e522160fe9fb5"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "2a6611cf-c7c5-492a-bbe2-d8322c48b741"
+        ],
+        "x-ms-correlation-request-id": [
+          "2a6611cf-c7c5-492a-bbe2-d8322c48b741"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232824Z:2a6611cf-c7c5-492a-bbe2-d8322c48b741"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b?api-version=2017-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZS9sb2NhdGlvbnMvZWFzdHVzMmV1YXAvb3BlcmF0aW9uc1N0YXR1cy9jYjVhYWY4OC0xNDdkLTQ4YjgtODIwYy0yMjZiMjY4YjVmMGI/YXBpLXZlcnNpb249MjAxNy0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/locations/eastus2euap/operationStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b\",\r\n  \"name\": \"cb5aaf88-147d-48b8-820c-226b268b5f0b\",\r\n  \"status\": \"Creating\",\r\n  \"startTime\": \"2017-12-12T23:26:37.113Z\",\r\n  \"percentComplete\": 0.0\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:28:53 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14959"
+        ],
+        "x-ms-client-request-id": [
+          "c374ea456bcc4d3bae55b452785ae81f"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "46b0adfb-2f5f-4063-8d8c-3cff2df717c4"
+        ],
+        "x-ms-correlation-request-id": [
+          "46b0adfb-2f5f-4063-8d8c-3cff2df717c4"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232854Z:46b0adfb-2f5f-4063-8d8c-3cff2df717c4"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b?api-version=2017-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZS9sb2NhdGlvbnMvZWFzdHVzMmV1YXAvb3BlcmF0aW9uc1N0YXR1cy9jYjVhYWY4OC0xNDdkLTQ4YjgtODIwYy0yMjZiMjY4YjVmMGI/YXBpLXZlcnNpb249MjAxNy0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/locations/eastus2euap/operationStatus/cb5aaf88-147d-48b8-820c-226b268b5f0b\",\r\n  \"name\": \"cb5aaf88-147d-48b8-820c-226b268b5f0b\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2017-12-12T23:26:37.113Z\",\r\n  \"endTime\": \"2017-12-12T23:28:19.054Z\",\r\n  \"percentComplete\": 0.0\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:29:24 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14958"
+        ],
+        "x-ms-client-request-id": [
+          "12b62b2eb4c84f2395c17c1f2467f8bb"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "8f56aa58-2459-450d-866a-e954987785e5"
+        ],
+        "x-ms-correlation-request-id": [
+          "8f56aa58-2459-450d-866a-e954987785e5"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232924Z:8f56aa58-2459-450d-866a-e954987785e5"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/mlcrp-dotnet-test-deleteall8288/providers/Microsoft.MachineLearningCompute/operationalizationClusters/mlcrp-dotnet-test-deleteall9074?api-version=2017-08-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Jlc291cmNlR3JvdXBzL21sY3JwLWRvdG5ldC10ZXN0LWRlbGV0ZWFsbDgyODgvcHJvdmlkZXJzL01pY3Jvc29mdC5NYWNoaW5lTGVhcm5pbmdDb21wdXRlL29wZXJhdGlvbmFsaXphdGlvbkNsdXN0ZXJzL21sY3JwLWRvdG5ldC10ZXN0LWRlbGV0ZWFsbDkwNzQ/YXBpLXZlcnNpb249MjAxNy0wOC0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288/providers/Microsoft.MachineLearningCompute/operationalizationClusters/mlcrp-dotnet-test-deleteall9074\",\r\n  \"name\": \"mlcrp-dotnet-test-deleteall9074\",\r\n  \"type\": \"Microsoft.MachineLearningCompute/operationalizationClusters\",\r\n  \"location\": \"East US 2 EUAP\",\r\n  \"tags\": null,\r\n  \"properties\": {\r\n    \"createdOn\": \"2017-12-12T23:26:37.036Z\",\r\n    \"description\": \"Test cluster\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"provisioningErrors\": null,\r\n    \"storageAccount\": {\r\n      \"resourceId\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288-azureml-f3d75/providers/Microsoft.Storage/storageAccounts/mlcrpstgda89553055dc\"\r\n    },\r\n    \"containerRegistry\": {\r\n      \"resourceId\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288-azureml-f3d75/providers/Microsoft.ContainerRegistry/registries/mlcrpacrba3342125629\"\r\n    },\r\n    \"clusterType\": \"Local\",\r\n    \"containerService\": {\r\n      \"clusterFqdn\": null,\r\n      \"systemServices\": null,\r\n      \"masterCount\": null,\r\n      \"agentCount\": null,\r\n      \"agentVmSize\": null,\r\n      \"orchestratorType\": \"Kubernetes\",\r\n      \"orchestratorProperties\": {\r\n        \"servicePrincipal\": {\r\n          \"clientId\": \"2eca32f5-01fc-4778-ba29-d6b6ecbee43b\",\r\n          \"secret\": \"<REDACTED>\"\r\n        }\r\n      }\r\n    },\r\n    \"appInsights\": {\r\n      \"resourceId\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288-azureml-f3d75/providers/Microsoft.Insights/components/mlcrpaifda76608eb6b\"\r\n    },\r\n    \"globalServiceConfiguration\": null\r\n  }\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:29:24 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14957"
+        ],
+        "x-ms-client-request-id": [
+          "6bc5849e51274363b2994fc7bee5c9bc"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "ba712c24-805d-478f-8ab7-d587383a591f"
+        ],
+        "x-ms-correlation-request-id": [
+          "ba712c24-805d-478f-8ab7-d587383a591f"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232925Z:ba712c24-805d-478f-8ab7-d587383a591f"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/mlcrp-dotnet-test-deleteall8288/providers/Microsoft.MachineLearningCompute/operationalizationClusters/mlcrp-dotnet-test-deleteall9074?api-version=2017-08-01-preview&deleteAll=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Jlc291cmNlR3JvdXBzL21sY3JwLWRvdG5ldC10ZXN0LWRlbGV0ZWFsbDgyODgvcHJvdmlkZXJzL01pY3Jvc29mdC5NYWNoaW5lTGVhcm5pbmdDb21wdXRlL29wZXJhdGlvbmFsaXphdGlvbkNsdXN0ZXJzL21sY3JwLWRvdG5ldC10ZXN0LWRlbGV0ZWFsbDkwNzQ/YXBpLXZlcnNpb249MjAxNy0wOC0wMS1wcmV2aWV3JmRlbGV0ZUFsbD10cnVl",
+      "RequestMethod": "DELETE",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "6a26e674-7d37-40db-b954-e949e047614f"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "0"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:29:25 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Location": [
+          "https://management.azure.com/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/107b2099-cb00-4580-9877-fb66115bdd39?api-version=2017-06-01-preview"
+        ],
+        "Azure-AsyncOperation": [
+          "https://management.azure.com/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/107b2099-cb00-4580-9877-fb66115bdd39?api-version=2017-06-01-preview"
+        ],
+        "x-ms-client-request-id": [
+          "6a26e6747d3740dbb954e949e047614f"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "x-ms-ratelimit-remaining-subscription-writes": [
+          "1198"
+        ],
+        "x-ms-request-id": [
+          "016ed891-c932-4852-a535-740298474a66"
+        ],
+        "x-ms-correlation-request-id": [
+          "016ed891-c932-4852-a535-740298474a66"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232926Z:016ed891-c932-4852-a535-740298474a66"
+        ]
+      },
+      "StatusCode": 202
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/107b2099-cb00-4580-9877-fb66115bdd39?api-version=2017-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZS9sb2NhdGlvbnMvZWFzdHVzMmV1YXAvb3BlcmF0aW9uc1N0YXR1cy8xMDdiMjA5OS1jYjAwLTQ1ODAtOTg3Ny1mYjY2MTE1YmRkMzk/YXBpLXZlcnNpb249MjAxNy0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/locations/eastus2euap/operationStatus/107b2099-cb00-4580-9877-fb66115bdd39\",\r\n  \"name\": \"107b2099-cb00-4580-9877-fb66115bdd39\",\r\n  \"status\": \"Deleting\",\r\n  \"startTime\": \"2017-12-12T23:28:40.261Z\",\r\n  \"percentComplete\": 0.0\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:29:56 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14956"
+        ],
+        "x-ms-client-request-id": [
+          "779862cb5ff54b1493cc2eb75162df6d"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "82922a19-7822-468e-97e2-44459318f0cf"
+        ],
+        "x-ms-correlation-request-id": [
+          "82922a19-7822-468e-97e2-44459318f0cf"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T232956Z:82922a19-7822-468e-97e2-44459318f0cf"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/107b2099-cb00-4580-9877-fb66115bdd39?api-version=2017-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZS9sb2NhdGlvbnMvZWFzdHVzMmV1YXAvb3BlcmF0aW9uc1N0YXR1cy8xMDdiMjA5OS1jYjAwLTQ1ODAtOTg3Ny1mYjY2MTE1YmRkMzk/YXBpLXZlcnNpb249MjAxNy0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/locations/eastus2euap/operationStatus/107b2099-cb00-4580-9877-fb66115bdd39\",\r\n  \"name\": \"107b2099-cb00-4580-9877-fb66115bdd39\",\r\n  \"status\": \"Deleting\",\r\n  \"startTime\": \"2017-12-12T23:28:40.261Z\",\r\n  \"percentComplete\": 0.0\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:30:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14956"
+        ],
+        "x-ms-client-request-id": [
+          "d0a1ababb4ee42be934cf53823f406fb"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "e26407d4-9902-45b0-baf5-62897b1c393e"
+        ],
+        "x-ms-correlation-request-id": [
+          "e26407d4-9902-45b0-baf5-62897b1c393e"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T233026Z:e26407d4-9902-45b0-baf5-62897b1c393e"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/107b2099-cb00-4580-9877-fb66115bdd39?api-version=2017-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZS9sb2NhdGlvbnMvZWFzdHVzMmV1YXAvb3BlcmF0aW9uc1N0YXR1cy8xMDdiMjA5OS1jYjAwLTQ1ODAtOTg3Ny1mYjY2MTE1YmRkMzk/YXBpLXZlcnNpb249MjAxNy0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/locations/eastus2euap/operationStatus/107b2099-cb00-4580-9877-fb66115bdd39\",\r\n  \"name\": \"107b2099-cb00-4580-9877-fb66115bdd39\",\r\n  \"status\": \"Deleting\",\r\n  \"startTime\": \"2017-12-12T23:28:40.261Z\",\r\n  \"percentComplete\": 0.0\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:30:56 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14954"
+        ],
+        "x-ms-client-request-id": [
+          "88392a80126740629a454c8610ff272d"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "4e02520e-e1c2-4a4d-b497-985ee4db362e"
+        ],
+        "x-ms-correlation-request-id": [
+          "4e02520e-e1c2-4a4d-b497-985ee4db362e"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T233057Z:4e02520e-e1c2-4a4d-b497-985ee4db362e"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/providers/Microsoft.MachineLearningCompute/locations/eastus2euap/operationsStatus/107b2099-cb00-4580-9877-fb66115bdd39?api-version=2017-06-01-preview",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Byb3ZpZGVycy9NaWNyb3NvZnQuTWFjaGluZUxlYXJuaW5nQ29tcHV0ZS9sb2NhdGlvbnMvZWFzdHVzMmV1YXAvb3BlcmF0aW9uc1N0YXR1cy8xMDdiMjA5OS1jYjAwLTQ1ODAtOTg3Ny1mYjY2MTE1YmRkMzk/YXBpLXZlcnNpb249MjAxNy0wNi0wMS1wcmV2aWV3",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.MachineLearningCompute.MachineLearningComputeManagementClient/0.2.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/locations/eastus2euap/operationStatus/107b2099-cb00-4580-9877-fb66115bdd39\",\r\n  \"name\": \"107b2099-cb00-4580-9877-fb66115bdd39\",\r\n  \"status\": \"Succeeded\",\r\n  \"startTime\": \"2017-12-12T23:28:40.261Z\",\r\n  \"endTime\": \"2017-12-12T23:30:41.34Z\",\r\n  \"percentComplete\": 0.0,\r\n  \"error\": {}\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:31:27 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14952"
+        ],
+        "x-ms-client-request-id": [
+          "9fe9bfcc4436451eb7043396938505b8"
+        ],
+        "x-ms-client-session-id": [
+          ""
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "X-Frame-Options": [
+          "SAMEORIGIN"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-request-id": [
+          "59f0d948-0a64-468f-90a4-79d57e0e123f"
+        ],
+        "x-ms-correlation-request-id": [
+          "59f0d948-0a64-468f-90a4-79d57e0e123f"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T233127Z:59f0d948-0a64-468f-90a4-79d57e0e123f"
+        ]
+      },
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups/mlcrp-dotnet-test-deleteall8288-azureml-f3d75?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Jlc291cmNlZ3JvdXBzL21sY3JwLWRvdG5ldC10ZXN0LWRlbGV0ZWFsbDgyODgtYXp1cmVtbC1mM2Q3NT9hcGktdmVyc2lvbj0yMDE3LTA1LTEw",
+      "RequestMethod": "HEAD",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "14371f0f-6e18-4172-8359-feef60468999"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "",
+      "ResponseHeaders": {
+        "Content-Length": [
+          "137"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:32:26 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-failure-cause": [
+          "gateway"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14964"
+        ],
+        "x-ms-request-id": [
+          "0ad7e818-ebcc-4b09-953d-d9e4ab1f824d"
+        ],
+        "x-ms-correlation-request-id": [
+          "0ad7e818-ebcc-4b09-953d-d9e4ab1f824d"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T233226Z:0ad7e818-ebcc-4b09-953d-d9e4ab1f824d"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 404
+    },
+    {
+      "RequestUri": "/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourcegroups?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvNzRlY2NlZjAtNGI4ZC00ZjgzLWI1ZjktZmExMDBkMTU1YjIyL3Jlc291cmNlZ3JvdXBzP2FwaS12ZXJzaW9uPTIwMTctMDUtMTA=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "96b6b0df-102f-4e19-ad22-eb3cf752ad06"
+        ],
+        "accept-language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.25815.04",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/amitarrg\",\r\n      \"name\": \"amitarrg\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/amitarrg-azureml-69c23\",\r\n      \"name\": \"amitarrg-azureml-69c23\",\r\n      \"location\": \"eastus2\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/amlbigdata\",\r\n      \"name\": \"amlbigdata\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/amlhdinsight2\",\r\n      \"name\": \"amlhdinsight2\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/asupekar-dev-acs1\",\r\n      \"name\": \"asupekar-dev-acs1\",\r\n      \"location\": \"eastus2\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/asupekar-wcus-acs\",\r\n      \"name\": \"asupekar-wcus-acs\",\r\n      \"location\": \"westcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/asupekar-wcus-acs_testcluster101_westcentralus\",\r\n      \"name\": \"asupekar-wcus-acs_testcluster101_westcentralus\",\r\n      \"location\": \"westcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/asupekar-wcus-local\",\r\n      \"name\": \"asupekar-wcus-local\",\r\n      \"location\": \"westcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/cleanupservice\",\r\n      \"name\": \"cleanupservice\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/cloud-shell-storage-westus\",\r\n      \"name\": \"cloud-shell-storage-westus\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/cloudtest\",\r\n      \"name\": \"cloudtest\",\r\n      \"location\": \"southcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/cloudtestafx\",\r\n      \"name\": \"cloudtestafx\",\r\n      \"location\": \"westus2\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-Networking\",\r\n      \"name\": \"Default-Networking\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-ServiceBus-NorthCentralUS\",\r\n      \"name\": \"Default-ServiceBus-NorthCentralUS\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-ServiceBus-SouthCentralUS\",\r\n      \"name\": \"Default-ServiceBus-SouthCentralUS\",\r\n      \"location\": \"southcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-ServiceBus-WestUS\",\r\n      \"name\": \"Default-ServiceBus-WestUS\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-SQL-NorthCentralUS\",\r\n      \"name\": \"Default-SQL-NorthCentralUS\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-Storage-NorthCentralUS\",\r\n      \"name\": \"Default-Storage-NorthCentralUS\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-Storage-SouthCentralUS\",\r\n      \"name\": \"Default-Storage-SouthCentralUS\",\r\n      \"location\": \"southcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-Storage-WestUS\",\r\n      \"name\": \"Default-Storage-WestUS\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/Default-Web-WestUS\",\r\n      \"name\": \"Default-Web-WestUS\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/DefaultResourceGroup-ASE\",\r\n      \"name\": \"DefaultResourceGroup-ASE\",\r\n      \"location\": \"australiasoutheast\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/DefaultResourceGroup-EUS\",\r\n      \"name\": \"DefaultResourceGroup-EUS\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/DefaultResourceGroup-SUK\",\r\n      \"name\": \"DefaultResourceGroup-SUK\",\r\n      \"location\": \"uksouth\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/DefaultResourceGroup-WCUS\",\r\n      \"name\": \"DefaultResourceGroup-WCUS\",\r\n      \"location\": \"westcentralus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/DefaultResourceGroup-WEU\",\r\n      \"name\": \"DefaultResourceGroup-WEU\",\r\n      \"location\": \"westeurope\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/ExperimentationServicesRg\",\r\n      \"name\": \"ExperimentationServicesRg\",\r\n      \"location\": \"eastus2euap\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/hdinsightUDM24AY2PST5NOKY4N4GIVMNHMFTDE7IG3YCAAFWY3LOEXOCEBLQ-North-Central-US\",\r\n      \"name\": \"hdinsightUDM24AY2PST5NOKY4N4GIVMNHMFTDE7IG3YCAAFWY3LOEXOCEBLQ-North-Central-US\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/ibiza-integration\",\r\n      \"name\": \"ibiza-integration\",\r\n      \"location\": \"eastus2\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/IbizaIntegration\",\r\n      \"name\": \"IbizaIntegration\",\r\n      \"location\": \"eastus2\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics001\",\r\n      \"name\": \"metaanalytics001\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics001jes\",\r\n      \"name\": \"metaanalytics001jes\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics001ux\",\r\n      \"name\": \"metaanalytics001ux\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics002\",\r\n      \"name\": \"metaanalytics002\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics002jes\",\r\n      \"name\": \"metaanalytics002jes\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics003\",\r\n      \"name\": \"metaanalytics003\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics003jes\",\r\n      \"name\": \"metaanalytics003jes\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics003jestest\",\r\n      \"name\": \"metaanalytics003jestest\",\r\n      \"location\": \"southcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics003ux\",\r\n      \"name\": \"metaanalytics003ux\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics004\",\r\n      \"name\": \"metaanalytics004\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics004jes\",\r\n      \"name\": \"metaanalytics004jes\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics004ux\",\r\n      \"name\": \"metaanalytics004ux\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics005\",\r\n      \"name\": \"metaanalytics005\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics005jes\",\r\n      \"name\": \"metaanalytics005jes\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics005ux\",\r\n      \"name\": \"metaanalytics005ux\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics006\",\r\n      \"name\": \"metaanalytics006\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics006jes\",\r\n      \"name\": \"metaanalytics006jes\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics006jms\",\r\n      \"name\": \"metaanalytics006jms\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics006jms-stage\",\r\n      \"name\": \"metaanalytics006jms-stage\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics006lfs\",\r\n      \"name\": \"metaanalytics006lfs\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics006pm\",\r\n      \"name\": \"metaanalytics006pm\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics006pm-stage\",\r\n      \"name\": \"metaanalytics006pm-stage\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics006ux\",\r\n      \"name\": \"metaanalytics006ux\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics007\",\r\n      \"name\": \"metaanalytics007\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics007jes\",\r\n      \"name\": \"metaanalytics007jes\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics008\",\r\n      \"name\": \"metaanalytics008\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/metaanalytics008jes\",\r\n      \"name\": \"metaanalytics008jes\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/mlcrp-dotnet-test-deleteall8288\",\r\n      \"name\": \"mlcrp-dotnet-test-deleteall8288\",\r\n      \"location\": \"eastus2euap\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/MLStudioDri\",\r\n      \"name\": \"MLStudioDri\",\r\n      \"location\": \"southcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/ragargeastus2\",\r\n      \"name\": \"ragargeastus2\",\r\n      \"location\": \"eastus2\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/requestresponse001\",\r\n      \"name\": \"requestresponse001\",\r\n      \"location\": \"southcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/requestresponse0011\",\r\n      \"name\": \"requestresponse0011\",\r\n      \"location\": \"southcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/requestresponse005_1\",\r\n      \"name\": \"requestresponse005_1\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/ResourceGroup\",\r\n      \"name\": \"ResourceGroup\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/RH-StressTest-Daily-Group\",\r\n      \"name\": \"RH-StressTest-Daily-Group\",\r\n      \"location\": \"eastus2euap\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/RH-StressTest-Weekly-Group\",\r\n      \"name\": \"RH-StressTest-Weekly-Group\",\r\n      \"location\": \"eastus2euap\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/securitydata\",\r\n      \"name\": \"securitydata\",\r\n      \"location\": \"eastus\",\r\n      \"tags\": {},\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/singlenode001\",\r\n      \"name\": \"singlenode001\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/singlenode002\",\r\n      \"name\": \"singlenode002\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/singlenode003\",\r\n      \"name\": \"singlenode003\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/singlenode004\",\r\n      \"name\": \"singlenode004\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/singlenode005\",\r\n      \"name\": \"singlenode005\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/singlenode006\",\r\n      \"name\": \"singlenode006\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/singlenode007\",\r\n      \"name\": \"singlenode007\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/singlenode008\",\r\n      \"name\": \"singlenode008\",\r\n      \"location\": \"northcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/stcobrg\",\r\n      \"name\": \"stcobrg\",\r\n      \"location\": \"eastus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/testbuild-psi-pxmegwzr\",\r\n      \"name\": \"testbuild-psi-pxmegwzr\",\r\n      \"location\": \"eastus2euap\",\r\n      \"tags\": {\r\n        \"creationTime\": \"1505830409.888664\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/testbuild-psi-uecqixyi\",\r\n      \"name\": \"testbuild-psi-uecqixyi\",\r\n      \"location\": \"eastus2euap\",\r\n      \"tags\": {\r\n        \"creationTime\": \"1505830192.1902156\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/testbuild-sample-dlwf\",\r\n      \"name\": \"testbuild-sample-dlwf\",\r\n      \"location\": \"eastus2euap\",\r\n      \"tags\": {\r\n        \"creationTime\": \"1505860075.8903906\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/testbuild-sample-peys\",\r\n      \"name\": \"testbuild-sample-peys\",\r\n      \"location\": \"eastus2euap\",\r\n      \"tags\": {\r\n        \"creationTime\": \"1505840002.5961745\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/testbuild-sample-uidx\",\r\n      \"name\": \"testbuild-sample-uidx\",\r\n      \"location\": \"eastus2euap\",\r\n      \"tags\": {\r\n        \"creationTime\": \"1505839961.8238065\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/testbuild-sample-yxry\",\r\n      \"name\": \"testbuild-sample-yxry\",\r\n      \"location\": \"eastus2euap\",\r\n      \"tags\": {\r\n        \"creationTime\": \"1505851134.9409468\"\r\n      },\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/testeuap\",\r\n      \"name\": \"testeuap\",\r\n      \"location\": \"eastus2euap\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/trangevisptestrg\",\r\n      \"name\": \"trangevisptestrg\",\r\n      \"location\": \"eastus2euap\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/trangeviuswcmlcrg\",\r\n      \"name\": \"trangeviuswcmlcrg\",\r\n      \"location\": \"westcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/trangeviuswcmlcrg_trangeviuswcmlc_westcentralus\",\r\n      \"name\": \"trangeviuswcmlcrg_trangeviuswcmlc_westcentralus\",\r\n      \"location\": \"westcentralus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    },\r\n    {\r\n      \"id\": \"/subscriptions/74eccef0-4b8d-4f83-b5f9-fa100d155b22/resourceGroups/tudormlcrptestrg\",\r\n      \"name\": \"tudormlcrptestrg\",\r\n      \"location\": \"westus\",\r\n      \"properties\": {\r\n        \"provisioningState\": \"Succeeded\"\r\n      }\r\n    }\r\n  ]\r\n}",
+      "ResponseHeaders": {
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Date": [
+          "Tue, 12 Dec 2017 23:32:39 GMT"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "Vary": [
+          "Accept-Encoding"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "14963"
+        ],
+        "x-ms-request-id": [
+          "fa36de69-6fc5-41f9-a04e-6face0554594"
+        ],
+        "x-ms-correlation-request-id": [
+          "fa36de69-6fc5-41f9-a04e-6face0554594"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20171212T233239Z:fa36de69-6fc5-41f9-a04e-6face0554594"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ]
+      },
+      "StatusCode": 200
+    }
+  ],
+  "Names": {
+    ".ctor": [
+      "mlcrp-dotnet-test-deleteall8288",
+      "mlcrp-dotnet-test-deleteall9074"
+    ]
+  },
+  "Variables": {
+    "SubscriptionId": "74eccef0-4b8d-4f83-b5f9-fa100d155b22",
+    "ServicePrincipal": "2eca32f5-01fc-4778-ba29-d6b6ecbee43b"
+  }
+}

--- a/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/IOperationalizationClustersOperations.cs
+++ b/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/IOperationalizationClustersOperations.cs
@@ -117,6 +117,9 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
         /// <param name='clusterName'>
         /// The name of the cluster.
         /// </param>
+        /// <param name='deleteAll'>
+        /// If true, deletes all resources associated with this cluster.
+        /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
         /// </param>
@@ -129,7 +132,7 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders>> DeleteWithHttpMessagesAsync(string resourceGroupName, string clusterName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders>> DeleteWithHttpMessagesAsync(string resourceGroupName, string clusterName, bool? deleteAll = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Gets the credentials for the specified cluster such as Storage, ACR
         /// and ACS credentials. This is a long running operation because it
@@ -292,6 +295,9 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
         /// <param name='clusterName'>
         /// The name of the cluster.
         /// </param>
+        /// <param name='deleteAll'>
+        /// If true, deletes all resources associated with this cluster.
+        /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
         /// </param>
@@ -304,7 +310,7 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders>> BeginDeleteWithHttpMessagesAsync(string resourceGroupName, string clusterName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders>> BeginDeleteWithHttpMessagesAsync(string resourceGroupName, string clusterName, bool? deleteAll = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// Updates system services in a cluster.
         /// </summary>

--- a/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/Models/SslConfiguration.cs
+++ b/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/Models/SslConfiguration.cs
@@ -32,11 +32,10 @@ namespace Microsoft.Azure.Management.MachineLearningCompute.Models
         /// </summary>
         /// <param name="status">SSL status. Allowed values are Enabled and
         /// Disabled. Possible values include: 'Enabled', 'Disabled'</param>
-        /// <param name="cert">The SSL cert data in PEM format encoded as
-        /// base64 string</param>
-        /// <param name="key">The SSL key data in PEM format encoded as base64
-        /// string. This is not returned in response of GET/PUT on the
-        /// resource. To see this please call listKeys API.</param>
+        /// <param name="cert">The SSL cert data in PEM format.</param>
+        /// <param name="key">The SSL key data in PEM format. This is not
+        /// returned in response of GET/PUT on the resource. To see this please
+        /// call listKeys API.</param>
         /// <param name="cname">The CName of the certificate.</param>
         public SslConfiguration(string status = default(string), string cert = default(string), string key = default(string), string cname = default(string))
         {
@@ -60,16 +59,15 @@ namespace Microsoft.Azure.Management.MachineLearningCompute.Models
         public string Status { get; set; }
 
         /// <summary>
-        /// Gets or sets the SSL cert data in PEM format encoded as base64
-        /// string
+        /// Gets or sets the SSL cert data in PEM format.
         /// </summary>
         [JsonProperty(PropertyName = "cert")]
         public string Cert { get; set; }
 
         /// <summary>
-        /// Gets or sets the SSL key data in PEM format encoded as base64
-        /// string. This is not returned in response of GET/PUT on the
-        /// resource. To see this please call listKeys API.
+        /// Gets or sets the SSL key data in PEM format. This is not returned
+        /// in response of GET/PUT on the resource. To see this please call
+        /// listKeys API.
         /// </summary>
         [JsonProperty(PropertyName = "key")]
         public string Key { get; set; }

--- a/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/OperationalizationClustersOperations.cs
+++ b/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/OperationalizationClustersOperations.cs
@@ -542,16 +542,19 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
         /// <param name='clusterName'>
         /// The name of the cluster.
         /// </param>
+        /// <param name='deleteAll'>
+        /// If true, deletes all resources associated with this cluster.
+        /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public async Task<AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders>> DeleteWithHttpMessagesAsync(string resourceGroupName, string clusterName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders>> DeleteWithHttpMessagesAsync(string resourceGroupName, string clusterName, bool? deleteAll = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Send request
-            AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders> _response = await BeginDeleteWithHttpMessagesAsync(resourceGroupName, clusterName, customHeaders, cancellationToken).ConfigureAwait(false);
+            AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders> _response = await BeginDeleteWithHttpMessagesAsync(resourceGroupName, clusterName, deleteAll, customHeaders, cancellationToken).ConfigureAwait(false);
             return await Client.GetPostOrDeleteOperationResultAsync(_response, customHeaders, cancellationToken).ConfigureAwait(false);
         }
 
@@ -1693,6 +1696,9 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
         /// <param name='clusterName'>
         /// The name of the cluster.
         /// </param>
+        /// <param name='deleteAll'>
+        /// If true, deletes all resources associated with this cluster.
+        /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
         /// </param>
@@ -1711,7 +1717,7 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders>> BeginDeleteWithHttpMessagesAsync(string resourceGroupName, string clusterName, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<AzureOperationHeaderResponse<OperationalizationClustersDeleteHeaders>> BeginDeleteWithHttpMessagesAsync(string resourceGroupName, string clusterName, bool? deleteAll = default(bool?), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (Client.ApiVersion == null)
             {
@@ -1768,6 +1774,7 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
                 Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
                 tracingParameters.Add("resourceGroupName", resourceGroupName);
                 tracingParameters.Add("clusterName", clusterName);
+                tracingParameters.Add("deleteAll", deleteAll);
                 tracingParameters.Add("cancellationToken", cancellationToken);
                 ServiceClientTracing.Enter(_invocationId, this, "BeginDelete", tracingParameters);
             }
@@ -1781,6 +1788,10 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
             if (Client.ApiVersion != null)
             {
                 _queryParameters.Add(string.Format("api-version={0}", System.Uri.EscapeDataString(Client.ApiVersion)));
+            }
+            if (deleteAll != null)
+            {
+                _queryParameters.Add(string.Format("deleteAll={0}", System.Uri.EscapeDataString(Rest.Serialization.SafeJsonConvert.SerializeObject(deleteAll, Client.SerializationSettings).Trim('"'))));
             }
             if (_queryParameters.Count > 0)
             {

--- a/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/OperationalizationClustersOperationsExtensions.cs
+++ b/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/OperationalizationClustersOperationsExtensions.cs
@@ -169,9 +169,12 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
             /// <param name='clusterName'>
             /// The name of the cluster.
             /// </param>
-            public static OperationalizationClustersDeleteHeaders Delete(this IOperationalizationClustersOperations operations, string resourceGroupName, string clusterName)
+            /// <param name='deleteAll'>
+            /// If true, deletes all resources associated with this cluster.
+            /// </param>
+            public static OperationalizationClustersDeleteHeaders Delete(this IOperationalizationClustersOperations operations, string resourceGroupName, string clusterName, bool? deleteAll = default(bool?))
             {
-                return operations.DeleteAsync(resourceGroupName, clusterName).GetAwaiter().GetResult();
+                return operations.DeleteAsync(resourceGroupName, clusterName, deleteAll).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -186,12 +189,15 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
             /// <param name='clusterName'>
             /// The name of the cluster.
             /// </param>
+            /// <param name='deleteAll'>
+            /// If true, deletes all resources associated with this cluster.
+            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<OperationalizationClustersDeleteHeaders> DeleteAsync(this IOperationalizationClustersOperations operations, string resourceGroupName, string clusterName, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<OperationalizationClustersDeleteHeaders> DeleteAsync(this IOperationalizationClustersOperations operations, string resourceGroupName, string clusterName, bool? deleteAll = default(bool?), CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.DeleteWithHttpMessagesAsync(resourceGroupName, clusterName, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.DeleteWithHttpMessagesAsync(resourceGroupName, clusterName, deleteAll, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Headers;
                 }
@@ -453,9 +459,12 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
             /// <param name='clusterName'>
             /// The name of the cluster.
             /// </param>
-            public static OperationalizationClustersDeleteHeaders BeginDelete(this IOperationalizationClustersOperations operations, string resourceGroupName, string clusterName)
+            /// <param name='deleteAll'>
+            /// If true, deletes all resources associated with this cluster.
+            /// </param>
+            public static OperationalizationClustersDeleteHeaders BeginDelete(this IOperationalizationClustersOperations operations, string resourceGroupName, string clusterName, bool? deleteAll = default(bool?))
             {
-                return operations.BeginDeleteAsync(resourceGroupName, clusterName).GetAwaiter().GetResult();
+                return operations.BeginDeleteAsync(resourceGroupName, clusterName, deleteAll).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -470,12 +479,15 @@ namespace Microsoft.Azure.Management.MachineLearningCompute
             /// <param name='clusterName'>
             /// The name of the cluster.
             /// </param>
+            /// <param name='deleteAll'>
+            /// If true, deletes all resources associated with this cluster.
+            /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<OperationalizationClustersDeleteHeaders> BeginDeleteAsync(this IOperationalizationClustersOperations operations, string resourceGroupName, string clusterName, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<OperationalizationClustersDeleteHeaders> BeginDeleteAsync(this IOperationalizationClustersOperations operations, string resourceGroupName, string clusterName, bool? deleteAll = default(bool?), CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, clusterName, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.BeginDeleteWithHttpMessagesAsync(resourceGroupName, clusterName, deleteAll, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Headers;
                 }

--- a/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/SdkInfo_MachineLearningComputeManagementClient.cs
+++ b/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Generated/SdkInfo_MachineLearningComputeManagementClient.cs
@@ -1,0 +1,19 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+internal static partial class SdkInfo
+{
+    public static IEnumerable<Tuple<string, string, string>> ApiInfo_MachineLearningComputeManagementClient
+    {
+        get
+        {
+            return new Tuple<string, string, string>[]
+            {
+                new Tuple<string, string, string>("MachineLearningCompute", "MachineLearningCompute", "2017-08-01-preview"),
+                new Tuple<string, string, string>("MachineLearningCompute", "OperationalizationClusters", "2017-08-01-preview"),
+            }.AsEnumerable();
+        }
+    }
+}

--- a/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Microsoft.Azure.Management.MachineLearningCompute.csproj
+++ b/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Microsoft.Azure.Management.MachineLearningCompute.csproj
@@ -7,9 +7,9 @@
         <PackageId>Microsoft.Azure.Management.MachineLearningCompute</PackageId>
         <Description>Provides developers with a library to create and manage machine learning compute resources.</Description>
         <AssemblyName>Microsoft.Azure.Management.MachineLearningCompute</AssemblyName>
-        <Version>0.2.0</Version>
-        <PackageTags>Microsoft Azure Machine Learning Compute management;</PackageTags>
-        <PackageReleaseNotes>Orchestrator properties and orchestrator service principal are optional since the resource provider will create one if not provided.</PackageReleaseNotes>
+        <Version>0.3.0</Version>
+        <PackageTags>Microsoft Azure Machine Learning Compute management;REST HTTP client;azureofficial;windowsazureofficial;netcore451511</PackageTags>
+        <PackageReleaseNotes>Added optional 'deleteAll' parameter to delete all resources associated with the cluster.</PackageReleaseNotes>
     </PropertyGroup>
     <PropertyGroup>
         <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Microsoft.Azure.Management.MachineLearningCompute.csproj
+++ b/src/SDKs/MachineLearningCompute/Management.MachineLearningCompute/Microsoft.Azure.Management.MachineLearningCompute.csproj
@@ -8,7 +8,7 @@
         <Description>Provides developers with a library to create and manage machine learning compute resources.</Description>
         <AssemblyName>Microsoft.Azure.Management.MachineLearningCompute</AssemblyName>
         <Version>0.3.0</Version>
-        <PackageTags>Microsoft Azure Machine Learning Compute management;REST HTTP client;azureofficial;windowsazureofficial;netcore451511</PackageTags>
+        <PackageTags>Microsoft Azure Machine Learning Compute management;</PackageTags>
         <PackageReleaseNotes>Added optional 'deleteAll' parameter to delete all resources associated with the cluster.</PackageReleaseNotes>
     </PropertyGroup>
     <PropertyGroup>

--- a/src/SDKs/_metadata/machinelearningcompute_resource-manager.txt
+++ b/src/SDKs/_metadata/machinelearningcompute_resource-manager.txt
@@ -1,11 +1,11 @@
-2017-10-31 21:56:22 UTC
+2017-12-18 18:20:26 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure
 Branch:      current
-Commit:      5ceb9c24160362fca070a168708e24b8ce3dc5b0
+Commit:      ca7dadf950700baa6a9fde9e78bd80d4498213f4
 
 2) AutoRest information
 Requested version: latest
-Bootstrapper version:    C:\Users\sthutchi\AppData\Roaming\npm `-- autorest@2.0.4166  
-Latest installed version:    2.0.4168
+Bootstrapper version:    C:\Users\sthutchi\AppData\Roaming\npm `-- autorest@2.0.4215  
+Latest installed version:    


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
When deleting an operationalization cluster we leave behind the ACR, Application Insights, and Storage Accounts so the user has them for history. However some users do not want to delete these manually if they are not needed. The optional 'deleteAll' parameter adds the ability to delete all resources associated with the cluster as well.

[REST spec PR](https://github.com/Azure/azure-rest-api-specs/pull/2078)

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
