### PR TITLE
Azure Location Based Services:  Changed assembly and package name to official name.

### DIFF
--- a/src/SDKs/LocationBasedServices/Management.LocationBasedServices/Microsoft.Azure.Management.LocationBasedServices.csproj
+++ b/src/SDKs/LocationBasedServices/Management.LocationBasedServices/Microsoft.Azure.Management.LocationBasedServices.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.reference.props'))" />
   <PropertyGroup>
-    <PackageId>Microsoft.Azure.Management.LocationServices</PackageId>
+    <PackageId>Microsoft.Azure.Management.LocationBasedServices</PackageId>
     <Description>Microsoft Azure Management Location Based Services Library</Description>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <AssemblyName>Microsoft.Azure.Management.LocationServices</AssemblyName>
+    <AssemblyName>Microsoft.Azure.Management.LocationBasedServices</AssemblyName>
     <PackageTags>Microsoft Azure Location Based Services management;Location Services;Location Services management;REST HTTP client;windowsazureofficial;netcore451511</PackageTags>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
The assembly and package name didn't reflect the most recent official name.  This SDK has never been pushed to nuget; it was just added for the first time in December.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
