### PR TITLE
[ADLA - ADLS] - Non-functional, minor fixes (comments and changelog)

### DIFF
--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/AccountOperationTests.cs
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/AccountOperationTests.cs
@@ -24,7 +24,7 @@ namespace DataLakeAnalytics.Tests
                 commonData = new CommonTestFixture(context, true);
                 var clientToUse = this.GetDataLakeAnalyticsAccountManagementClient(context);
                 
-                // Ensure the account doesn't exist and that the account name is available
+                // Ensure that the account doesn't exist and that the account name is available
                 Assert.False(clientToUse.Account.Exists(commonData.ResourceGroupName, commonData.DataLakeAnalyticsAccountName));
 
                 var checkNameParam = new CheckNameAvailabilityParameters
@@ -58,7 +58,7 @@ namespace DataLakeAnalytics.Tests
                             NewTier = TierType.Commitment100AUHours
                         });
 
-                // Verify the account exists and that the account name is no longer available
+                // Verify that the account exists and that the account name is no longer available
                 Assert.True(clientToUse.Account.Exists(commonData.ResourceGroupName, commonData.DataLakeAnalyticsAccountName));
 
                 responseNameCheck = clientToUse.Account.CheckNameAvailability("EastUS2", checkNameParam);

--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/AccountOperationTests.cs
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/AccountOperationTests.cs
@@ -24,7 +24,7 @@ namespace DataLakeAnalytics.Tests
                 commonData = new CommonTestFixture(context, true);
                 var clientToUse = this.GetDataLakeAnalyticsAccountManagementClient(context);
                 
-                // Ensure the account doesn't exist and that the account name is not available
+                // Ensure the account doesn't exist and that the account name is available
                 Assert.False(clientToUse.Account.Exists(commonData.ResourceGroupName, commonData.DataLakeAnalyticsAccountName));
 
                 var checkNameParam = new CheckNameAvailabilityParameters

--- a/src/SDKs/DataLake.Store/DataLakeStore.Tests/ScenarioTests/AccountOperationTests.cs
+++ b/src/SDKs/DataLake.Store/DataLakeStore.Tests/ScenarioTests/AccountOperationTests.cs
@@ -25,7 +25,7 @@ namespace DataLakeStore.Tests
                 commonData = new CommonTestFixture(context);
                 var clientToUse = this.GetDataLakeStoreAccountManagementClient(context);
 
-                // Ensure that the account name is not available
+                // Ensure that the account name is available
                 var checkNameParam = new CheckNameAvailabilityParameters
                 {
                     Name = commonData.DataLakeStoreAccountName

--- a/src/SDKs/DataLake.Store/changelog.md
+++ b/src/SDKs/DataLake.Store/changelog.md
@@ -4,7 +4,7 @@
 
 **Breaking changes**
 
-- Changed the `ODataQuery` parameter type from `DataLakeAnalyticsAccount` to `DataLakeAnalyticsAccountBasic` for these APIs:
+- Changed the `ODataQuery` parameter type from `DataLakeStoreAccount` to `DataLakeStoreAccountBasic` for these APIs:
     - Account_List
     - Account_ListByResourceGroup
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
