### PR TITLE
[Azure Search] Fixing management SDK package name

### DIFF
--- a/src/SDKs/Search/Build-SearchPackage.ps1
+++ b/src/SDKs/Search/Build-SearchPackage.ps1
@@ -1,2 +1,2 @@
 $scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-msbuild "$scriptDir\..\..\build.proj" /t:"build;package" /p:scope=Search
+msbuild "$scriptDir\..\..\..\build.proj" /t:"build;package" /p:scope=Search

--- a/src/SDKs/Search/Management/Management.Search/Microsoft.Azure.Management.Search.csproj
+++ b/src/SDKs/Search/Management/Management.Search/Microsoft.Azure.Management.Search.csproj
@@ -4,10 +4,10 @@
 	<!-- Please do not move/edit code below this line -->
 
 	<PropertyGroup>
-		<PackageId>Management.Search</PackageId>
+		<PackageId>Microsoft.Azure.Management.Search</PackageId>
 		<Description>Makes it easy to manage Azure Search services and API keys from a .NET application.</Description>
 		<AssemblyTitle>Microsoft Azure Search Management Library</AssemblyTitle>
-		<AssemblyName>Management.Search</AssemblyName>
+		<AssemblyName>Microsoft.Azure.Management.Search</AssemblyName>
 		<Version>2.0.0</Version>
 		<PackageTags>Microsoft Azure Search;Microsoft Azure Search Management;</PackageTags>
 		<PackageReleaseNotes>This is the Azure Search Management SDK for .NET, based on version 2015-08-19 of the Azure Search Management REST API. It includes support for programmatically provisioning and managing Search services and API keys. It supports all available SKUs, including the new S3 and S3 High-Density SKUs.</PackageReleaseNotes>

--- a/src/SDKs/Search/Management/Search.Management.Tests/Search.Management.Tests.csproj
+++ b/src/SDKs/Search/Management/Search.Management.Tests/Search.Management.Tests.csproj
@@ -13,7 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.5.0-preview" />
-    <ProjectReference Include="..\Management.Search\Management.Search.csproj" />
+    <ProjectReference Include="..\Management.Search\Microsoft.Azure.Management.Search.csproj" />
     <ProjectReference Include="..\..\DataPlane\Microsoft.Azure.Search\Microsoft.Azure.Search.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/src/SDKs/Search/Search.sln
+++ b/src/SDKs/Search/Search.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26228.4
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Management.Search", "Management\Management.Search\Management.Search.csproj", "{A52AF58B-7383-416B-9A7E-601B9C628CDA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Management.Search", "Management\Management.Search\Microsoft.Azure.Management.Search.csproj", "{A52AF58B-7383-416B-9A7E-601B9C628CDA}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Management", "Management", "{248E962E-D501-4153-8B38-459B7DCD6871}"
 EndProject


### PR DESCRIPTION
Somehow the package name in our .csproj file was incorrect. It was `Management.Search` but should be `Microsoft.Azure.Management.Search`.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [X] Please add REST spec PR link to the SDK PR
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [X] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
