### PR TITLE
[Azure Search] Fixing some long-lived bugs in the data plane SDK

### DIFF
--- a/src/SDKs/Search/Build-SearchPackage.ps1
+++ b/src/SDKs/Search/Build-SearchPackage.ps1
@@ -1,2 +1,0 @@
-$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-msbuild "$scriptDir\..\..\..\build.proj" /t:"build;package" /p:scope=Search

--- a/src/SDKs/Search/Build-SearchPackages.ps1
+++ b/src/SDKs/Search/Build-SearchPackages.ps1
@@ -1,0 +1,3 @@
+$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+msbuild "$scriptDir\..\..\..\build.proj" /t:PublishNuget /p:Scope="SDKs\Search\Management" /p:NugetPackageName="Microsoft.Azure.Management.Search"
+msbuild "$scriptDir\..\..\..\build.proj" /t:PublishNuget /p:Scope="SDKs\Search\DataPlane" /p:NugetPackageName="Microsoft.Azure.Search"

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Customizations/Indexes/FieldBuilder.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Customizations/Indexes/FieldBuilder.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Search
     using Microsoft.Azure.Search.Models;
     using Microsoft.Spatial;
     using Newtonsoft.Json.Serialization;
+    using Newtonsoft.Json;
 
     /// <summary>
     /// Builds field definitions for an Azure Search index by reflecting over a user-defined model type.
@@ -53,17 +54,22 @@ namespace Microsoft.Azure.Search
             var fields = new List<Field>();
             foreach (JsonProperty prop in contract.Properties)
             {
+                IList<Attribute> attributes = prop.AttributeProvider.GetAttributes(true);
+                if (attributes.Any(attr => attr is JsonIgnoreAttribute))
+                {
+                    continue;
+                }
+
                 DataType dataType = GetDataType(prop.PropertyType, prop.PropertyName);
 
                 var field = new Field(prop.PropertyName, dataType);
-
-                IList<Attribute> attributes = prop.AttributeProvider.GetAttributes(true);
+                                
                 foreach (Attribute attribute in attributes)
                 {
                     IsRetrievableAttribute isRetrievableAttribute;
                     AnalyzerAttribute analyzerAttribute;
                     SearchAnalyzerAttribute searchAnalyzerAttribute;
-                    IndexAnalyzerAttribute indexAnalyzerAttribute;
+                    IndexAnalyzerAttribute indexAnalyzerAttribute;                    
                     if (attribute is IsSearchableAttribute)
                     {
                         field.IsSearchable = true;

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Customizations/Indexes/IndexesOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Customizations/Indexes/IndexesOperations.Customization.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Azure.Search
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Search.Models;
@@ -36,8 +38,13 @@ namespace Microsoft.Azure.Search
             // Argument checking is done by the SearchIndexClient constructor. Note that HttpClient can't be shared in
             // case it has already been used (SearchIndexClient will attempt to set the Timeout property on it).
             Uri indexBaseUri = new Uri(Client.BaseUri, String.Format("indexes('{0}')", indexName));
-            var indexClient = new SearchIndexClient(indexBaseUri, Client.Credentials);
-            indexClient.HttpClient.Timeout = this.Client.HttpClient.Timeout;
+            var indexClient =
+                new SearchIndexClient(
+                    indexBaseUri, 
+                    Client.Credentials, 
+                    Client.HttpMessageHandlers.OfType<HttpClientHandler>().SingleOrDefault());
+
+            indexClient.HttpClient.Timeout = Client.HttpClient.Timeout;
             return indexClient;
         }
     }

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Microsoft.Azure.Search.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Microsoft.Azure.Search.csproj
@@ -5,7 +5,7 @@
     <Description>Makes it easy to develop a .NET application that uses Azure Search.</Description>
     <AssemblyTitle>Microsoft Azure Search Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search</AssemblyName>
-    <VersionPrefix>3.0.4</VersionPrefix>
+    <VersionPrefix>3.0.5</VersionPrefix>
     <PackageTags>Microsoft Azure Search;Search</PackageTags>
     <PackageReleaseNotes>This is the newest major version of the Azure Search .NET SDK, based on version 2016-09-01 of the Azure Search REST API. New in this version is support for indexing Azure Blob storage (including parsing of JSON blobs), indexing Azure Table storage, indexer field mappings, custom analyzers, and ETags. Also included is support for reflection-based field definitions via the FieldBuilder class, thanks to a contribution from Ian Griffiths (https://github.com/idg10). See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade.</PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.4.0")]
+[assembly: AssemblyFileVersion("3.0.5.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/Search/DataPlane/Search.Tests/Tests/Models/ReflectableModel.cs
+++ b/src/SDKs/Search/DataPlane/Search.Tests/Tests/Models/ReflectableModel.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Search.Tests
     using Microsoft.Azure.Search;
     using Microsoft.Azure.Search.Models;
     using Microsoft.Spatial;
+    using Newtonsoft.Json;
 
     public class ReflectableModel
     {
@@ -69,5 +70,15 @@ namespace Microsoft.Azure.Search.Tests
         public int? NullableInt { get; set; }
 
         public GeographyPoint GeographyPoint { get; set; }
+
+        [JsonIgnore]
+        [IsRetrievable(false)]
+        public RecordEnum recordEnum { get; set; }
+    }
+
+    public enum RecordEnum
+    {
+        Test1,
+        Test2
     }
 }

--- a/src/SDKs/Search/DataPlane/Search.Tests/Tests/SearchServiceClientTests.cs
+++ b/src/SDKs/Search/DataPlane/Search.Tests/Tests/SearchServiceClientTests.cs
@@ -5,10 +5,12 @@
 namespace Microsoft.Azure.Search.Tests
 {
     using System;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
     using Microsoft.Azure.Search.Models;
     using Microsoft.Azure.Search.Tests.Utilities;
+    using Microsoft.Rest;
     using Microsoft.Rest.Azure;
     using Xunit;
 
@@ -57,6 +59,29 @@ namespace Microsoft.Azure.Search.Tests
 
                 Assert.Equal(serviceClient.HttpClient.Timeout, indexClient.HttpClient.Timeout);
             });
+        }
+
+        [Fact]
+        public void IndexClientHasSameHandlerPipelineAsSearchClient()
+        {
+            var testClientHandler = new HttpClientHandler();
+
+            var serviceClient =
+                new SearchServiceClient(
+                    "azs-test-service", 
+                    new SearchCredentials("abc"),
+                    testClientHandler,
+                    new FakeDelegatingHandler());
+
+            SearchIndexClient indexClient = (SearchIndexClient)serviceClient.Indexes.GetClient("test");
+
+            // Delegating handlers don't propagate to the index client because they can't be cloned, and
+            // therefore they can't be safely shared since the client constructors mutate each handler to
+            // set its inner handler.
+            Assert.Collection(
+                indexClient.HttpMessageHandlers,
+                h => Assert.IsType<RetryDelegatingHandler>(h),
+                h => Assert.Same(testClientHandler, h));
         }
 
         [Fact]
@@ -119,6 +144,11 @@ namespace Microsoft.Azure.Search.Tests
             Assert.Throws<ArgumentNullException>(
                 "credentials",
                 () => new SearchServiceClient(uri, credentials: null, rootHandler: handler));
+        }
+
+        private class FakeDelegatingHandler : DelegatingHandler
+        {
+            // Do nothing.
         }
     }
 }


### PR DESCRIPTION
## Description

This PR fixes a few long-standing bugs in the Azure Search data plane SDK. You won't see it in the commits, but one of the bugs fixed is the [incompatibility with JSON.NET 10.0.1](https://github.com/Azure/azure-sdk-for-net/issues/3441). This is fixed just by virtue of rebuilding the SDK with the latest `ClientRuntime` on the correct branch (`psSdk6Json` instead of `vs17Dev`).

The other fixes are for these issues:
  - [Custom HttpClientHandler not called on Search requests](https://github.com/Azure/azure-sdk-for-net/issues/3451)
  - [FieldBuilder tries to read a property marked with JsonIgnore](https://github.com/Azure/azure-sdk-for-net/issues/3309)

There are no Swagger changes and no breaking changes in this PR. This PR bumps the SDK version number from 3.0.4 to 3.0.5.

See individual commits for more details.

FYI @Yahnoosh @mhko @updixit @shahabhijeet 

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
