### PR TITLE
Azure data factory: Add AAD support for sql dw and azure sql

### DIFF
--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDWLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDWLinkedService.cs
@@ -40,14 +40,25 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
+        /// <param name="servicePrincipalId">The ID of the service principal
+        /// used to authenticate against Azure SQL Data Warehouse. Type: string
+        /// (or Expression with resultType string).</param>
+        /// <param name="servicePrincipalKey">The key of the service principal
+        /// used to authenticate against Azure SQL Data Warehouse.</param>
+        /// <param name="tenant">The name or ID of the tenant to which the
+        /// service principal belongs. Type: string (or Expression with
+        /// resultType string).</param>
         /// <param name="encryptedCredential">The encrypted credential used for
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureSqlDWLinkedService(SecretBase connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
+        public AzureSqlDWLinkedService(SecretBase connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object servicePrincipalId = default(object), SecretBase servicePrincipalKey = default(SecretBase), object tenant = default(object), object encryptedCredential = default(object))
             : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
+            ServicePrincipalId = servicePrincipalId;
+            ServicePrincipalKey = servicePrincipalKey;
+            Tenant = tenant;
             EncryptedCredential = encryptedCredential;
             CustomInit();
         }
@@ -62,6 +73,29 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         [JsonProperty(PropertyName = "typeProperties.connectionString")]
         public SecretBase ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the service principal used to authenticate
+        /// against Azure SQL Data Warehouse. Type: string (or Expression with
+        /// resultType string).
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.servicePrincipalId")]
+        public object ServicePrincipalId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the key of the service principal used to authenticate
+        /// against Azure SQL Data Warehouse.
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.servicePrincipalKey")]
+        public SecretBase ServicePrincipalKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name or ID of the tenant to which the service
+        /// principal belongs. Type: string (or Expression with resultType
+        /// string).
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.tenant")]
+        public object Tenant { get; set; }
 
         /// <summary>
         /// Gets or sets the encrypted credential used for authentication.

--- a/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDatabaseLinkedService.cs
+++ b/src/SDKs/DataFactory/Management.DataFactory/Generated/Models/AzureSqlDatabaseLinkedService.cs
@@ -42,14 +42,25 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// message are deserialized this collection</param>
         /// <param name="connectVia">The integration runtime reference.</param>
         /// <param name="description">Linked service description.</param>
+        /// <param name="servicePrincipalId">The ID of the service principal
+        /// used to authenticate against Azure SQL Database. Type: string (or
+        /// Expression with resultType string).</param>
+        /// <param name="servicePrincipalKey">The key of the service principal
+        /// used to authenticate against Azure SQL Database.</param>
+        /// <param name="tenant">The name or ID of the tenant to which the
+        /// service principal belongs. Type: string (or Expression with
+        /// resultType string).</param>
         /// <param name="encryptedCredential">The encrypted credential used for
         /// authentication. Credentials are encrypted using the integration
         /// runtime credential manager. Type: string (or Expression with
         /// resultType string).</param>
-        public AzureSqlDatabaseLinkedService(SecretBase connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object encryptedCredential = default(object))
+        public AzureSqlDatabaseLinkedService(SecretBase connectionString, IDictionary<string, object> additionalProperties = default(IDictionary<string, object>), IntegrationRuntimeReference connectVia = default(IntegrationRuntimeReference), string description = default(string), object servicePrincipalId = default(object), SecretBase servicePrincipalKey = default(SecretBase), object tenant = default(object), object encryptedCredential = default(object))
             : base(additionalProperties, connectVia, description)
         {
             ConnectionString = connectionString;
+            ServicePrincipalId = servicePrincipalId;
+            ServicePrincipalKey = servicePrincipalKey;
+            Tenant = tenant;
             EncryptedCredential = encryptedCredential;
             CustomInit();
         }
@@ -64,6 +75,29 @@ namespace Microsoft.Azure.Management.DataFactory.Models
         /// </summary>
         [JsonProperty(PropertyName = "typeProperties.connectionString")]
         public SecretBase ConnectionString { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ID of the service principal used to authenticate
+        /// against Azure SQL Database. Type: string (or Expression with
+        /// resultType string).
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.servicePrincipalId")]
+        public object ServicePrincipalId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the key of the service principal used to authenticate
+        /// against Azure SQL Database.
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.servicePrincipalKey")]
+        public SecretBase ServicePrincipalKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name or ID of the tenant to which the service
+        /// principal belongs. Type: string (or Expression with resultType
+        /// string).
+        /// </summary>
+        [JsonProperty(PropertyName = "typeProperties.tenant")]
+        public object Tenant { get; set; }
 
         /// <summary>
         /// Gets or sets the encrypted credential used for authentication.

--- a/src/SDKs/DataFactory/Management.DataFactory/changelog.md
+++ b/src/SDKs/DataFactory/Management.DataFactory/changelog.md
@@ -1,5 +1,10 @@
 # Changelog for the Azure Data Factory V2 .NET SDK
 
+## Version 0.5.0-preview
+
+### Feature Additions
+  * Enable AAD auth via service principal and management service identity for Azure SQL DB/DW linked service types
+
 ## Version 0.4.0-preview
 
 ### Feature Additions

--- a/src/SDKs/_metadata/datafactory_resource-manager.txt
+++ b/src/SDKs/_metadata/datafactory_resource-manager.txt
@@ -1,11 +1,11 @@
-2018-01-29 06:12:53 UTC
+2018-02-02 07:13:12 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure
 Branch:      master
-Commit:      6af881374aa0fa4af3c037b2fef15a2f15d0f42c
+Commit:      f9ec24015ab77a2d7a1dfd33ddd208824459a7ca
 
 2) AutoRest information
 Requested version: latest
-Bootstrapper version:    C:\Users\dashe\AppData\Roaming\npm `-- autorest@2.0.4245  
+Bootstrapper version:    C:\Program Files\nodejs `-- autorest@2.0.4245  
 Latest installed version:    


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
