### PR TITLE
[Azure Search] Remove JsonConvert.DefaultSettings check from unit tests

### DIFF
--- a/src/SDKs/Search/Management/Search.Management.Tests/Utilities/SearchTestBase.cs
+++ b/src/SDKs/Search/Management/Search.Management.Tests/Utilities/SearchTestBase.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Azure.Search.Tests.Utilities
     using System.Runtime.CompilerServices;
     using Microsoft.Azure.Management.Search;
     using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Serialization;
 
     public abstract class SearchTestBase<TTestFixture> : TestBase where TTestFixture : IResourceFixture, new()
     {
@@ -40,16 +38,6 @@ namespace Microsoft.Azure.Search.Tests.Utilities
                 Data = new TTestFixture();
                 Data.Initialize(mockContext);
 
-                Func<JsonSerializerSettings> oldDefault = JsonConvert.DefaultSettings;
-
-                // This should ensure that the SDK doesn't depend on global JSON.NET settings.
-                JsonConvert.DefaultSettings = () =>
-                    new JsonSerializerSettings() 
-                    {
-                        Converters = new[] { new InvalidJsonConverter() },
-                        ContractResolver = new InvalidContractResolver()
-                    };
-
                 try
                 {
                     testBody();
@@ -57,34 +45,7 @@ namespace Microsoft.Azure.Search.Tests.Utilities
                 finally
                 {
                     Data.Cleanup();
-                    JsonConvert.DefaultSettings = oldDefault;
                 }
-            }
-        }
-
-        private class InvalidContractResolver : IContractResolver
-        {
-            public JsonContract ResolveContract(Type type)
-            {
-                throw new InvalidOperationException(JsonErrorMessage);
-            }
-        }
-
-        private class InvalidJsonConverter : JsonConverter
-        {
-            public override bool CanConvert(Type objectType)
-            {
-                throw new InvalidOperationException(JsonErrorMessage);
-            }
-
-            public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-            {
-                throw new InvalidOperationException(JsonErrorMessage);
-            }
-
-            public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-            {
-                throw new InvalidOperationException(JsonErrorMessage);
             }
         }
     }


### PR DESCRIPTION
Some time ago, we added a check to every Azure Search unit test that uses the Run() method. This check is intended to ensure that none of our SDK code uses the global JsonConvert.DefaultSettings, since these can be altered by other code in the same AppDomain. This was causing issues for customers, and is the reason we added SafeJsonConvert to ClientRuntime and AutoRest.

The check in the Run() method installs a custom JsonConverter and ContractResolver that throw exceptions whenever they're called. It does this using a try/finally block so that the change should only be visible while running the unit test.

Unfortunately, since JsonConvert.DefaultSettings is global state, this approach is fragile. For example, running tests in parallel can break this because some infrastructure such as the VS test runner framework itself uses JSON.NET in ways that rely on DefaultSettings.

Given the fragility of this approach, we've decided to remove these checks altogether since they were causing spurious test failures.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
