### PR TITLE
Create PS module for code generation methods

### DIFF
--- a/tools/BuildAssets/metaData/FilesToCopy.txt
+++ b/tools/BuildAssets/metaData/FilesToCopy.txt
@@ -11,3 +11,4 @@ tasks/net46/Microsoft.Build.Tasks.Core.dll
 tasks/net46/Microsoft.Build.Utilities.Core.dll
 tasks/net46/Microsoft.Azure.Sdk.Build.Tasks.dll
 tasks/net46/System.Threading.Thread.dll
+psModules/CodeGenerationModules/generateDotNetSdkCode.psm1

--- a/tools/BuildAssets/psModules/CodeGenerationModules/generateDotNetSdkCode.psm1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/generateDotNetSdkCode.psm1
@@ -1,3 +1,44 @@
+$errorStream = New-Object -TypeName "System.Text.StringBuilder";
+$outputStream = New-Object -TypeName "System.Text.StringBuilder";
+
+
+function Clear-OutputStreams {
+    $errorStream.Clear() | Out-Null
+    $outputStream.Clear() | Out-Null
+}
+
+function Write-InfoLog {
+    param(
+        [string] $msg,
+        [switch] $logToConsole,
+        [switch] $logToFile
+    )
+    if(![string]::IsNullOrEmpty($msg) -and $logToFile)
+    {
+        $outputStream.Append("$msg`n") | Out-Null
+    }
+    if($logToConsole)
+    {
+        Write-Host $msg
+    }
+}
+
+function Write-ErrorLog {
+    param(
+        [string] $msg,
+        [switch] $logToConsole,
+        [switch] $logToFile
+    )
+    if(![string]::IsNullOrEmpty($msg) -and $logToFile)
+    {
+        $errorStream.Append("$msg`n") | Out-Null
+    }
+    if($logToConsole)
+    {
+        Write-Error $msg
+    }
+}
+
 function launchProcess {
     param(
         [Parameter(Mandatory = $true)]
@@ -20,98 +61,147 @@ function launchProcess {
     $p.WaitForExit()
     $stdout = $p.StandardOutput.ReadToEnd()
     $stderr = $p.StandardError.ReadToEnd()
-    Write-Host $stdout
-    Write-Host $stderr
-    return $p.ExitCode
+    Write-InfoLog $stdout -logToConsole
+    Write-ErrorLog $stderr
+    if($p.ExitCode -ne 0)
+    {
+        throw [System.Exception] "Command $cmd $args returned $p.ExitCode"
+    }
 }
 
 function Get-AutoRestHelp {
-    Write-Host("Fetching AutoRest help");
+    Write-InfoLog "Fetching AutoRest help" -logToConsole
     launchProcess "cmd.exe" "/c autorest.cmd --help"
 }
 
 function Install-AutoRest {
     param(
         [Parameter(Mandatory = $true)]
-        $Version
+        $AutoRestVersion
     )
-    Write-Host "Installing AutoRest version: $Version";
-    $exitCode = launchProcess "cmd.exe" "/c npm.cmd install -g autorest@$Version"
-    if ($exitCode -ne 0) {
-        Write-Error "AutoRest installation failed; please try again"
+    
+    Write-InfoLog "Installing AutoRest version: $AutoRestVersion" -logToConsole
+    
+    Try {
+        launchProcess "cmd.exe" "/c npm.cmd install -g autorest@$AutoRestVersion"
     }
-    else {
-        Write-Host "AutoRest installed successfully."
+    Catch [System.Exception] {
+        Write-ErrorLog $_.Exception.ToString()
+        throw [System.Exception] "AutoRest Installation failed"
     }
+    Write-InfoLog "AutoRest installed successfully." -logToConsole
 }
 
 function Start-CodeGeneration {
 param(
-    [Parameter(Mandatory = $true, HelpMessage ="Please provide a spec to generate the code")]
-    [string] $ConfigFile,
+    [Parameter(Mandatory = $true)]
+    [string] $SpecsRepoFork,
+    [Parameter(Mandatory = $true)]
+    [string] $SpecsRepoBranch,
+    [Parameter(Mandatory = $true)]
+    [string] $SpecsRepoName,
     [Parameter(Mandatory = $true, HelpMessage ="Please provide an output directory for the generated code")]
     [string] $SdkDirectory,
     [Parameter(Mandatory = $true, HelpMessage ="Please provide a version for the AutoRest release")]
-    [string] $Version
+    [string] $AutoRestVersion
     )
-
-    Write-Host("Generating CSharp code");
+    
+    $configFile="https://github.com/$SpecsRepoFork/$SpecsRepoName/blob/$SpecsRepoBranch/specification/$ResourceProvider/readme.md" 
+    Write-InfoLog "Generating CSharp code" -logToConsole
     $cmd = "cmd.exe"
-    $args = "/c autorest.cmd $ConfigFile --csharp --csharp-sdks-folder=$SdkDirectory --version=$Version --reflect-api-versions"
-    Write-Output "Executing AutoRest command"
-    Write-Output "$cmd $args"
-    launchProcess $cmd $args
+    $args = "/c autorest.cmd $configFile --csharp --csharp-sdks-folder=$SdkDirectory --version=$AutoRestVersion --reflect-api-versions"
+    
+    Write-InfoLog "Executing AutoRest command" -logToFile
+    Write-InfoLog "$cmd $args" -logToFile
+
+    Try {
+        launchProcess $cmd $args
+    }
+    Catch [System.Exception] {
+        Write-ErrorLog $_.Exception.ToString()
+        throw [System.Exception] "AutoRest code generation for $configFile failed. Please try again"
+    }
+    
+    Try {
+        Start-MetadataGeneration -AutoRestVersion $AutoRestVersion -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch
+    }
+    Catch [System.Exception] {
+        Write-ErrorLog $_.Exception.ToString()
+        throw [System.Exception] "Metadata generation for $configFile failed. Please try again"
+    }
 }
 
 function Start-MetadataGeneration {
     param(
+
+        [Parameter(Mandatory = $true)]
+        [string] $AutoRestVersion,
         [Parameter(Mandatory = $true)]
         [string] $SpecsRepoFork,
         [Parameter(Mandatory = $true)]
-        [string] $SpecsRepoBranch,
-        [Parameter(Mandatory = $true)]
-        [string] $Version
+        [string] $SpecsRepoBranch
     )
+    
+    Write-InfoLog $([DateTime]::UtcNow.ToString('u').Replace('Z',' UTC')) -logToFile
 
-    Write-Output $([DateTime]::UtcNow.ToString('u').Replace('Z',' UTC'))
-
-    Write-Output ""
-    Write-Output "1) azure-rest-api-specs repository information"
-    Write-Output "GitHub fork: $SpecsRepoFork"
-    Write-Output "Branch:      $SpecsRepoBranch"
+    Write-InfoLog "" -logToFile
+    Write-InfoLog "1) azure-rest-api-specs repository information" -logToFile
+    Write-InfoLog "GitHub fork: $SpecsRepoFork" -logToFile
+    Write-InfoLog "Branch:      $SpecsRepoBranch" -logToFile
     
     Try
     {
         [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-        Write-Output "Commit:     " (Invoke-RestMethod "https://api.github.com/repos/$($SpecsRepoFork)/azure-rest-api-specs/branches/$($SpecsRepoBranch)").commit.sha
+        $op = (Invoke-RestMethod "https://api.github.com/repos/$($SpecsRepoFork)/azure-rest-api-specs/branches/$($SpecsRepoBranch)").commit.sha | Out-String
+        Write-InfoLog "Commit:      $op" -logToFile
     }
     Catch [System.Exception]
     {
-        Write-Output $_.Exception.ToString()
+        Write-ErrorLog $_.Exception.ToString()
+        throw $_
     }
 
-    Write-Output ""
-    Write-Output "2) AutoRest information"
-    Write-Output "Requested version:" $Version
+    Write-InfoLog "" -logToFile
+    Write-InfoLog "2) AutoRest information" -logToFile
+    Write-InfoLog "Requested version: $AutoRestVersion" -logToFile
+    
     Try
     {
-        Write-Output "Bootstrapper version:   " (npm list -g autorest)
+        $op = $((npm list -g autorest) | Out-String).Replace("`n", " ").Replace("`r"," ").Trim()
+        Write-InfoLog "Bootstrapper version:    $op" -logToFile
+        Write-InfoLog "`n" -logToFile
     }
     Catch{}
     Try
     {
-        Write-Output "Latest installed version:   " (autorest --list-installed | Where {$_ -like "*Latest Core Installed*"}).Split()[-1]
+        $op = (autorest --list-installed | Where {$_ -like "*Latest Core Installed*"}).Split()[-1] | Out-String
+        $op = $op.Replace("`n", " ").Replace("`r"," ").Trim()
+        Write-InfoLog "Latest installed version:    $op" -logToFile
     }
     Catch{}
     Try
     {
-        Write-Output "Latest installed version:   " (autorest --list-installed | Where {$_ -like "*@microsoft.azure/autorest-core*"} | Select -Last 1).Split('|')[3]
+        $op = (autorest --list-installed | Where {$_ -like "*@microsoft.azure/autorest-core*"} | Select -Last 1).Split('|')[3] | Out-String
+        $op = $op.Replace("`n", " ").Replace("`r"," ").Trim()
+        Write-InfoLog "Latest installed version:    $op" -logToFile
     }
     Catch{}
+}
+
+function Get-ErrorStream {
+    $errorStream.ToString()
+}
+
+function Get-OutputStream {
+    $outputStream.ToString()
 }
 
 
 export-modulemember -function Get-AutoRestHelp
 export-modulemember -function Install-AutoRest
 export-modulemember -function Start-CodeGeneration
-export-modulemember -function Start-MetadataGeneration
+export-modulemember -function Get-ErrorStream
+export-modulemember -function Get-OutputStream
+export-modulemember -function Write-InfoLog
+export-modulemember -function Write-ErrorLog
+export-modulemember -function Clear-OutputStreams

--- a/tools/BuildAssets/psModules/CodeGenerationModules/generateDotNetSdkCode.psm1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/generateDotNetSdkCode.psm1
@@ -1,0 +1,117 @@
+function launchProcess {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $command, 
+        [string] $args)
+    $pinfo = New-Object System.Diagnostics.ProcessStartInfo
+    $pinfo.FileName = $command
+    $pinfo.RedirectStandardError = $true
+    $pinfo.RedirectStandardOutput = $true
+    $pinfo.UseShellExecute = $false
+    
+    if(![string]::IsNullOrEmpty($args))
+    {
+        $pinfo.Arguments = $args
+    }
+    
+    $p = New-Object System.Diagnostics.Process
+    $p.StartInfo = $pinfo
+    $p.Start() | Out-Null
+    $p.WaitForExit()
+    $stdout = $p.StandardOutput.ReadToEnd()
+    $stderr = $p.StandardError.ReadToEnd()
+    Write-Host $stdout
+    Write-Host $stderr
+    return $p.ExitCode
+}
+
+function Get-AutoRestHelp {
+    Write-Host("Fetching AutoRest help");
+    launchProcess "cmd.exe" "/c autorest.cmd --help"
+}
+
+function Install-AutoRest {
+    param(
+        [Parameter(Mandatory = $true)]
+        $Version
+    )
+    Write-Host "Installing AutoRest version: $Version";
+    $exitCode = launchProcess "cmd.exe" "/c npm.cmd install -g autorest@$Version"
+    if ($exitCode -ne 0) {
+        Write-Error "AutoRest installation failed; please try again"
+    }
+    else {
+        Write-Host "AutoRest installed successfully."
+    }
+}
+
+function Start-CodeGeneration {
+param(
+    [Parameter(Mandatory = $true, HelpMessage ="Please provide a spec to generate the code")]
+    [string] $ConfigFile,
+    [Parameter(Mandatory = $true, HelpMessage ="Please provide an output directory for the generated code")]
+    [string] $SdkDirectory,
+    [Parameter(Mandatory = $true, HelpMessage ="Please provide a version for the AutoRest release")]
+    [string] $Version
+    )
+
+    Write-Host("Generating CSharp code");
+    $cmd = "cmd.exe"
+    $args = "/c autorest.cmd $ConfigFile --csharp --csharp-sdks-folder=$SdkDirectory --version=$Version --reflect-api-versions"
+    Write-Output "Executing AutoRest command"
+    Write-Output "$cmd $args"
+    launchProcess $cmd $args
+}
+
+function Start-MetadataGeneration {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string] $SpecsRepoFork,
+        [Parameter(Mandatory = $true)]
+        [string] $SpecsRepoBranch,
+        [Parameter(Mandatory = $true)]
+        [string] $Version
+    )
+
+    Write-Output $([DateTime]::UtcNow.ToString('u').Replace('Z',' UTC'))
+
+    Write-Output ""
+    Write-Output "1) azure-rest-api-specs repository information"
+    Write-Output "GitHub fork: $SpecsRepoFork"
+    Write-Output "Branch:      $SpecsRepoBranch"
+    
+    Try
+    {
+        [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+        Write-Output "Commit:     " (Invoke-RestMethod "https://api.github.com/repos/$($SpecsRepoFork)/azure-rest-api-specs/branches/$($SpecsRepoBranch)").commit.sha
+    }
+    Catch [System.Exception]
+    {
+        Write-Output $_.Exception.ToString()
+    }
+
+    Write-Output ""
+    Write-Output "2) AutoRest information"
+    Write-Output "Requested version:" $Version
+    Try
+    {
+        Write-Output "Bootstrapper version:   " (npm list -g autorest)
+    }
+    Catch{}
+    Try
+    {
+        Write-Output "Latest installed version:   " (autorest --list-installed | Where {$_ -like "*Latest Core Installed*"}).Split()[-1]
+    }
+    Catch{}
+    Try
+    {
+        Write-Output "Latest installed version:   " (autorest --list-installed | Where {$_ -like "*@microsoft.azure/autorest-core*"} | Select -Last 1).Split('|')[3]
+    }
+    Catch{}
+}
+
+
+export-modulemember -function Get-AutoRestHelp
+export-modulemember -function Install-AutoRest
+export-modulemember -function Start-CodeGeneration
+export-modulemember -function Start-MetadataGeneration

--- a/tools/BuildAssets/psModules/CodeGenerationModules/generateTemplate.ps1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/generateTemplate.ps1
@@ -1,0 +1,4 @@
+<#
+    This is a template to describe how to call the generateTool.ps1 script to generate the code using AutoRest
+#>
+powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -File "$(split-path $SCRIPT:MyInvocation.MyCommand.Path -parent)\..\..\..\..\tools\generateTool.ps1" -ResourceProvider "<ResourceProviderName>" -SdkDirectory "$(split-path $SCRIPT:MyInvocation.MyCommand.Path -parent)" -PowershellInvoker


### PR DESCRIPTION
Adding a new powershell module that the `generateTool.ps1` script will use to generate code
- Contains utilities to install AutoRest
- Logging methods to capture outputs of processes launched
- Validation and metadata generation

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
