### PR TITLE
Determining sdkdirectory for powershell invokers

### DIFF
--- a/src/SDKs/CognitiveServices/dataPlane/Language/Language/Language/generate.ps1
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/Language/Language/generate.ps1
@@ -1,0 +1,4 @@
+<#
+    This is a template to describe how to call the generateTool.ps1 script to generate the code using AutoRest
+#>
+powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -File "$(split-path $SCRIPT:MyInvocation.MyCommand.Path -parent)\..\..\..\..\..\..\..\tools\generateTool.ps1" -ResourceProvider "cognitiveservices/data-plane/TextAnalytics" -PowershellInvoker

--- a/tools/generateTool.ps1
+++ b/tools/generateTool.ps1
@@ -51,8 +51,7 @@ Param(
     [string] $SpecsRepoFork = "Azure",
     [string] $SpecsRepoName = "azure-rest-api-specs",
     [string] $SpecsRepoBranch = "master",
-    [Parameter(Mandatory = $true)]
-    [string] $SdkDirectory= "$([System.IO.Path]::GetTempPath())\Compute",
+    [string] $SdkDirectory,
     [string] $AutoRestVersion = "latest",
     [switch] $PowershellInvoker
 )
@@ -62,6 +61,10 @@ Write-Host "autorest version received is : $AutoRestVersion"
 $errorStream = New-Object -TypeName "System.Text.StringBuilder";
 $outputStream = New-Object -TypeName "System.Text.StringBuilder";
 $currPath = split-path $SCRIPT:MyInvocation.MyCommand.Path -parent
+if([string]::IsNullOrEmpty($SdkDirectory))
+{
+    $SdkDirectory = "$currPath\..\src\SDKs\"
+}
 $modulePath = "$currPath\SdkBuildTools\psModules\CodeGenerationModules\generateDotNetSdkCode.psm1"
 $logFile = "$currPath\..\src\SDKs\_metadata\$($ResourceProvider.Replace("/","_")).txt"
 $errorFile = "$currPath\SdkBuildTools\errorlog.txt"


### PR DESCRIPTION
We need this so that the `generateTool.ps1` picks up the `src\SDKs` directly instead of the invoking script itself and the code generated goes into the directory defined in the `csharp-sdks-folder` in the config file
For the `generate.cmd` we're already using this path
Adding an example for cognitive services, tested

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
