### PR TITLE
Move Bing Search SDKs from Preview to GA

### DIFF
--- a/src/SDKs/CognitiveServices/dataPlane/Language/SpellCheck/BingSpellCheck/Microsoft.Azure.CognitiveServices.SpellCheck.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/SpellCheck/BingSpellCheck/Microsoft.Azure.CognitiveServices.SpellCheck.csproj
@@ -3,10 +3,10 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.SpellCheck</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services SpellCheck API.</Description>
-    <VersionPrefix>0.18.0-preview</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.SpellCheck</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;SpellCheck API;REST HTTPclient;SpellCheckSDK;netcore451511</PackageTags>
-    <PackageReleaseNotes>This is a preview release of the Cognitive Services SpellCheck SDK. Included with this release is support for SpellCheck API.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a public release of the Cognitive Services SpellCheck SDK. Included with this release is support for SpellCheck API.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/CognitiveServices/dataPlane/Language/SpellCheck/BingSpellCheck/Microsoft.Azure.CognitiveServices.SpellCheck.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/SpellCheck/BingSpellCheck/Microsoft.Azure.CognitiveServices.SpellCheck.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.SpellCheck</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services SpellCheck API.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.SpellCheck</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;SpellCheck API;REST HTTPclient;SpellCheckSDK;netcore451511</PackageTags>
     <PackageReleaseNotes>This is a public release of the Cognitive Services SpellCheck SDK. Included with this release is support for SpellCheck API.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Language/SpellCheck/BingSpellCheck/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/SpellCheck/BingSpellCheck/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services SpellCheck Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services SpellCheck API.")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/CognitiveServices/dataPlane/Language/SpellCheck/BingSpellCheck/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/SpellCheck/BingSpellCheck/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services SpellCheck Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services SpellCheck API.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
 [assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingCustomSearch/BingCustomSearch/Microsoft.Azure.CognitiveServices.Search.CustomSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingCustomSearch/BingCustomSearch/Microsoft.Azure.CognitiveServices.Search.CustomSearch.csproj
@@ -6,10 +6,10 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.CustomSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Custom Search API.</Description>
-    <VersionPrefix>1.2.0-preview</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.CustomSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;CustomSearch API;BingCustomSearch API;REST HTTPclient;CustomSearchSDK;BingCustomSearchSDK;netcore451511</PackageTags>
-    <PackageReleaseNotes>This is a preview release of the Cognitive Services Search SDK. Included with this release is support for Custom Search API.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a public release of the Cognitive Services Search SDK. Included with this release is support for Custom Search API.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingCustomSearch/BingCustomSearch/Microsoft.Azure.CognitiveServices.Search.CustomSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingCustomSearch/BingCustomSearch/Microsoft.Azure.CognitiveServices.Search.CustomSearch.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.CustomSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Custom Search API.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.CustomSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;CustomSearch API;BingCustomSearch API;REST HTTPclient;CustomSearchSDK;BingCustomSearchSDK;netcore451511</PackageTags>
     <PackageReleaseNotes>This is a public release of the Cognitive Services Search SDK. Included with this release is support for Custom Search API.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingCustomSearch/BingCustomSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingCustomSearch/BingCustomSearch/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Custom Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Custom Search API.")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingCustomSearch/BingCustomSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingCustomSearch/BingCustomSearch/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Custom Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Custom Search API.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
 [assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch/Microsoft.Azure.CognitiveServices.Search.EntitySearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch/Microsoft.Azure.CognitiveServices.Search.EntitySearch.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.EntitySearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Entity Search API.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.EntitySearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;EntitySearch API;BingEntitySearch API;REST HTTPclient;EntitySearchSDK;BingEntitySearchSDK;netcore451511</PackageTags>
     <PackageReleaseNotes>This is a public release of the Cognitive Services Entity Search SDK. Included with this release is support for Entity Search API.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch/Microsoft.Azure.CognitiveServices.Search.EntitySearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch/Microsoft.Azure.CognitiveServices.Search.EntitySearch.csproj
@@ -6,10 +6,10 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.EntitySearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Entity Search API.</Description>
-    <VersionPrefix>1.1.0-preview</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.EntitySearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;EntitySearch API;BingEntitySearch API;REST HTTPclient;EntitySearchSDK;BingEntitySearchSDK;netcore451511</PackageTags>
-    <PackageReleaseNotes>This is a preview release of the Cognitive Services Entity Search SDK. Included with this release is support for Entity Search API.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a public release of the Cognitive Services Entity Search SDK. Included with this release is support for Entity Search API.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Entity Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Entity Search API.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
 [assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Entity Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Entity Search API.")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingImageSearch/BingImageSearch/Microsoft.Azure.CognitiveServices.Search.ImageSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingImageSearch/BingImageSearch/Microsoft.Azure.CognitiveServices.Search.ImageSearch.csproj
@@ -6,10 +6,10 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.ImageSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Image Search API.</Description>
-    <VersionPrefix>1.1.0-preview</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.ImageSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;ImageSearch API;BingImageSearch API;REST HTTPclient;ImageSearchSDK;BingImageSearchSDK;netcore451511</PackageTags>
-    <PackageReleaseNotes>This is a preview release of the Cognitive Services Search SDK. Included with this release is support for Image Search API.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a public release of the Cognitive Services Search SDK. Included with this release is support for Image Search API.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingImageSearch/BingImageSearch/Microsoft.Azure.CognitiveServices.Search.ImageSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingImageSearch/BingImageSearch/Microsoft.Azure.CognitiveServices.Search.ImageSearch.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.ImageSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Image Search API.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.ImageSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;ImageSearch API;BingImageSearch API;REST HTTPclient;ImageSearchSDK;BingImageSearchSDK;netcore451511</PackageTags>
     <PackageReleaseNotes>This is a public release of the Cognitive Services Search SDK. Included with this release is support for Image Search API.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingImageSearch/BingImageSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingImageSearch/BingImageSearch/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Image Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Image Search API.")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingImageSearch/BingImageSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingImageSearch/BingImageSearch/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Image Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Image Search API.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
 [assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingNewsSearch/BingNewsSearch/Microsoft.Azure.CognitiveServices.Search.NewsSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingNewsSearch/BingNewsSearch/Microsoft.Azure.CognitiveServices.Search.NewsSearch.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.NewsSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services News Search API.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.NewsSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;NewsSearch API;BingNewsSearch API;REST HTTPclient;NewsSearchSDK;BingNewsSearchSDK;netcore451511</PackageTags>
     <PackageReleaseNotes>This is a public release of the Cognitive Services News Search SDK. Included with this release is support for News Search API.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingNewsSearch/BingNewsSearch/Microsoft.Azure.CognitiveServices.Search.NewsSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingNewsSearch/BingNewsSearch/Microsoft.Azure.CognitiveServices.Search.NewsSearch.csproj
@@ -6,10 +6,10 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.NewsSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services News Search API.</Description>
-    <VersionPrefix>1.1.0-preview</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.NewsSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;NewsSearch API;BingNewsSearch API;REST HTTPclient;NewsSearchSDK;BingNewsSearchSDK;netcore451511</PackageTags>
-    <PackageReleaseNotes>This is a preview release of the Cognitive Services News Search SDK. Included with this release is support for News Search API.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a public release of the Cognitive Services News Search SDK. Included with this release is support for News Search API.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingNewsSearch/BingNewsSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingNewsSearch/BingNewsSearch/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services News Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services News Search API.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
 [assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingNewsSearch/BingNewsSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingNewsSearch/BingNewsSearch/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services News Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services News Search API.")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingVideoSearch/BingVideoSearch/Microsoft.Azure.CognitiveServices.Search.VideoSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingVideoSearch/BingVideoSearch/Microsoft.Azure.CognitiveServices.Search.VideoSearch.csproj
@@ -6,10 +6,10 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.VideoSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Video Search API.</Description>
-    <VersionPrefix>1.1.0-preview</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.VideoSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;VideoSearch API;BingVideoSearch API;REST HTTPclient;VideoSearchSDK;BingVideoSearchSDK;netcore451511</PackageTags>
-    <PackageReleaseNotes>This is a preview release of the Cognitive Services Search SDK. Included with this release is support for Video Search API.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a public release of the Cognitive Services Search SDK. Included with this release is support for Video Search API.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingVideoSearch/BingVideoSearch/Microsoft.Azure.CognitiveServices.Search.VideoSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingVideoSearch/BingVideoSearch/Microsoft.Azure.CognitiveServices.Search.VideoSearch.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.VideoSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Video Search API.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.VideoSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;VideoSearch API;BingVideoSearch API;REST HTTPclient;VideoSearchSDK;BingVideoSearchSDK;netcore451511</PackageTags>
     <PackageReleaseNotes>This is a public release of the Cognitive Services Search SDK. Included with this release is support for Video Search API.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingVideoSearch/BingVideoSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingVideoSearch/BingVideoSearch/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Web Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Video Search API.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
 [assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingVideoSearch/BingVideoSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingVideoSearch/BingVideoSearch/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Web Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Video Search API.")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingWebSearch/BingWebSearch/Microsoft.Azure.CognitiveServices.Search.WebSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingWebSearch/BingWebSearch/Microsoft.Azure.CognitiveServices.Search.WebSearch.csproj
@@ -6,10 +6,10 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.WebSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Web Search API.</Description>
-    <VersionPrefix>1.1.0-preview</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.WebSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;WebSearch API;BingWebSearch API;REST HTTPclient;WebSearchSDK;BingWebSearchSDK;netcore451511</PackageTags>
-    <PackageReleaseNotes>This is a preview release of the Cognitive Services Search SDK. Included with this release is support for Web Search API.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is a public release of the Cognitive Services Search SDK. Included with this release is support for Web Search API.</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingWebSearch/BingWebSearch/Microsoft.Azure.CognitiveServices.Search.WebSearch.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingWebSearch/BingWebSearch/Microsoft.Azure.CognitiveServices.Search.WebSearch.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Search.WebSearch</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Web Search API.</Description>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Search.WebSearch</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;WebSearch API;BingWebSearch API;REST HTTPclient;WebSearchSDK;BingWebSearchSDK;netcore451511</PackageTags>
     <PackageReleaseNotes>This is a public release of the Cognitive Services Search SDK. Included with this release is support for Web Search API.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingWebSearch/BingWebSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingWebSearch/BingWebSearch/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Web Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Web Search API.")]
 
-[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.1.0.0")]
 [assembly: AssemblyFileVersion("1.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingWebSearch/BingWebSearch/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingWebSearch/BingWebSearch/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Cognitive Services Web Search Client Library")]
 [assembly: AssemblyDescription("Provides API functions for consuming the Microsoft Azure Cognitive Services Web Search API.")]
 
-[assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.1.0.0")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
