### PR TITLE
reverting generate.cmd to old behavior

### DIFF
--- a/tools/generate.cmd
+++ b/tools/generate.cmd
@@ -44,13 +44,23 @@ if not "%req_help%" == "" (
 
 :: repo information
 set rp="%1"
-if not "%2" == "" (set autoRestVersion="%2")         else (set autoRestVersion="latest")
-if not "%3" == "" (set specsRepoFork="%3")   else (set specsRepoFork="Azure")
+if not "%2" == "" (set version="%2")         else (set version="latest")
+if not "%3" == "" (set specsRepoUser="%3")   else (set specsRepoUser="Azure")
 if not "%4" == "" (set specsRepoBranch="%4") else (set specsRepoBranch="master")
 if not "%5" == "" (set specsRepoName="%5")   else (set specsRepoName="azure-rest-api-specs")
-if not "%6" == "" (set sdkDirectory="%6")      else (set sdkDirectory=%~dp0..\src\SDKS)
+if not "%6" == "" (set sdksFolder="%6")      else (set sdksFolder=%~dp0..\src\SDKS)
+set configFile="https://github.com/%specsRepoUser%/%specsRepoName%/blob/%specsRepoBranch%/specification/%rp%/readme.md"
+
+:: installation
+if "%7" == "" (call npm i -g autorest)
 
 :: code generation
 @echo on
-call powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -File "%~dp0\generateTool.ps1" -ResourceProvider %rp% -SpecsRepoFork %specsRepoFork% -SpecsRepoBranch %specsRepoBranch% -SpecsRepoName %specsRepoName% -SdkDirectory %sdkDirectory% -AutoRestVersion %autoRestVersion%
+call autorest %configFile% --csharp --csharp-sdks-folder=%sdksFolder% --version=%version% --reflect-api-versions
 @echo off
+
+:: metadata
+mkdir %~dp0\..\src\SDKs\_metadata >nul 2>&1
+call powershell %~dp0\generateMetadata.ps1 %specsRepoUser% %specsRepoBranch% %version% %configFile% > %~dp0\..\src\SDKs\_metadata\%rp:/=_%.txt
+
+endlocal


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
