### PR TITLE
Azure Search: remove indexer limits from service stats API

### DIFF
--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Generated/Models/ServiceLimits.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Generated/Models/ServiceLimits.cs
@@ -31,28 +31,15 @@ namespace Microsoft.Azure.Search.Models
         /// </summary>
         /// <param name="maxFieldsPerIndex">The maximum allowed fields per
         /// index.</param>
-        /// <param name="maxIndexerRunTime">The maximum time an indexer will
-        /// run in a single execution. In the next run, indexing will resume at
-        /// the point where it stopped.</param>
-        /// <param name="maxFileExtractionSize">When using a blob indexer, if
-        /// the size in bytes of a blob's content is larger than this size, it
-        /// results in an error.</param>
-        /// <param name="maxFileContentCharactersToExtract">The maximum number
-        /// of characters extracted from a blob when using a blob indexer. If a
-        /// blob has more content, it is not indexed and a warning is added to
-        /// the indexer execution result.</param>
         /// <param name="maxFieldNestingDepthPerIndex">The maximum depth which
         /// you can nest sub-fields in an index, including the top-level
         /// complex field. For example, a/b/c has a nesting depth of 3.</param>
         /// <param name="maxComplexCollectionFieldsPerIndex">The maximum number
         /// of fields of type Collection(Edm.ComplexType) allowed in an
         /// index.</param>
-        public ServiceLimits(int? maxFieldsPerIndex = default(int?), System.TimeSpan? maxIndexerRunTime = default(System.TimeSpan?), long? maxFileExtractionSize = default(long?), int? maxFileContentCharactersToExtract = default(int?), int? maxFieldNestingDepthPerIndex = default(int?), int? maxComplexCollectionFieldsPerIndex = default(int?))
+        public ServiceLimits(int? maxFieldsPerIndex = default(int?), int? maxFieldNestingDepthPerIndex = default(int?), int? maxComplexCollectionFieldsPerIndex = default(int?))
         {
             MaxFieldsPerIndex = maxFieldsPerIndex;
-            MaxIndexerRunTime = maxIndexerRunTime;
-            MaxFileExtractionSize = maxFileExtractionSize;
-            MaxFileContentCharactersToExtract = maxFileContentCharactersToExtract;
             MaxFieldNestingDepthPerIndex = maxFieldNestingDepthPerIndex;
             MaxComplexCollectionFieldsPerIndex = maxComplexCollectionFieldsPerIndex;
             CustomInit();
@@ -68,29 +55,6 @@ namespace Microsoft.Azure.Search.Models
         /// </summary>
         [JsonProperty(PropertyName = "maxFieldsPerIndex")]
         public int? MaxFieldsPerIndex { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum time an indexer will run in a single
-        /// execution. In the next run, indexing will resume at the point where
-        /// it stopped.
-        /// </summary>
-        [JsonProperty(PropertyName = "maxIndexerRunTime")]
-        public System.TimeSpan? MaxIndexerRunTime { get; set; }
-
-        /// <summary>
-        /// Gets or sets when using a blob indexer, if the size in bytes of a
-        /// blob's content is larger than this size, it results in an error.
-        /// </summary>
-        [JsonProperty(PropertyName = "maxFileExtractionSize")]
-        public long? MaxFileExtractionSize { get; set; }
-
-        /// <summary>
-        /// Gets or sets the maximum number of characters extracted from a blob
-        /// when using a blob indexer. If a blob has more content, it is not
-        /// indexed and a warning is added to the indexer execution result.
-        /// </summary>
-        [JsonProperty(PropertyName = "maxFileContentCharactersToExtract")]
-        public int? MaxFileContentCharactersToExtract { get; set; }
 
         /// <summary>
         /// Gets or sets the maximum depth which you can nest sub-fields in an

--- a/src/SDKs/Search/DataPlane/Search.Tests/SessionRecords/Microsoft.Azure.Search.Tests.ServiceStatsTests/GetServiceStatsReturnsCorrectDefinition.json
+++ b/src/SDKs/Search/DataPlane/Search.Tests/SessionRecords/Microsoft.Azure.Search.Tests.ServiceStatsTests/GetServiceStatsReturnsCorrectDefinition.json
@@ -7,7 +7,7 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "678ce00a-0105-4dc5-a31f-e53d34157c08"
+          "28a2c199-4b31-4317-8517-926e4fca679b"
         ],
         "accept-language": [
           "en-US"
@@ -29,7 +29,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 05 Apr 2018 17:52:21 GMT"
+          "Fri, 06 Apr 2018 17:14:44 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -44,13 +44,13 @@
           "1199"
         ],
         "x-ms-request-id": [
-          "2df39f27-2586-4fa2-a597-cf68f6c026b3"
+          "fe132cb9-5918-4fcf-aa24-0cf26b9292b6"
         ],
         "x-ms-correlation-request-id": [
-          "2df39f27-2586-4fa2-a597-cf68f6c026b3"
+          "fe132cb9-5918-4fcf-aa24-0cf26b9292b6"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20180405T175221Z:2df39f27-2586-4fa2-a597-cf68f6c026b3"
+          "NORTHEUROPE:20180406T171445Z:fe132cb9-5918-4fcf-aa24-0cf26b9292b6"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -62,8 +62,8 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourcegroups/azsmnet5350?api-version=2016-09-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlZ3JvdXBzL2F6c21uZXQ1MzUwP2FwaS12ZXJzaW9uPTIwMTYtMDktMDE=",
+      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourcegroups/azsmnet119?api-version=2016-09-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlZ3JvdXBzL2F6c21uZXQxMTk/YXBpLXZlcnNpb249MjAxNi0wOS0wMQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"location\": \"West US\"\r\n}",
       "RequestHeaders": {
@@ -74,7 +74,7 @@
           "29"
         ],
         "x-ms-client-request-id": [
-          "559f2ed0-62fb-433e-a065-9d86119f15a5"
+          "46ba551c-3455-4a90-aa24-01813d9b60b6"
         ],
         "accept-language": [
           "en-US"
@@ -84,10 +84,10 @@
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.5.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet5350\",\r\n  \"name\": \"azsmnet5350\",\r\n  \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet119\",\r\n  \"name\": \"azsmnet119\",\r\n  \"location\": \"westus\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "175"
+          "173"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -99,7 +99,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 05 Apr 2018 17:52:23 GMT"
+          "Fri, 06 Apr 2018 17:14:46 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -108,13 +108,13 @@
           "1198"
         ],
         "x-ms-request-id": [
-          "966bad4e-92a4-429f-880a-d567b0d03cec"
+          "82826144-d80f-45ca-809e-0b1bcb8c72ba"
         ],
         "x-ms-correlation-request-id": [
-          "966bad4e-92a4-429f-880a-d567b0d03cec"
+          "82826144-d80f-45ca-809e-0b1bcb8c72ba"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20180405T175223Z:966bad4e-92a4-429f-880a-d567b0d03cec"
+          "NORTHEUROPE:20180406T171446Z:82826144-d80f-45ca-809e-0b1bcb8c72ba"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -126,8 +126,8 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet5350/providers/Microsoft.Search/searchServices/azs-5189?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ1MzUwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy01MTg5P2FwaS12ZXJzaW9uPTIwMTUtMDgtMTk=",
+      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet119/providers/Microsoft.Search/searchServices/azs-5320?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlR3JvdXBzL2F6c21uZXQxMTkvcHJvdmlkZXJzL01pY3Jvc29mdC5TZWFyY2gvc2VhcmNoU2VydmljZXMvYXpzLTUzMjA/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
       "RequestMethod": "PUT",
       "RequestBody": "{\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  },\r\n  \"location\": \"West US\"\r\n}",
       "RequestHeaders": {
@@ -138,7 +138,7 @@
           "67"
         ],
         "x-ms-client-request-id": [
-          "fa45a534-3953-4ff5-9c77-d473fa85ff9e"
+          "ca0249fc-2d35-45f0-bab8-fd3efb5b3c4d"
         ],
         "accept-language": [
           "en-US"
@@ -148,10 +148,10 @@
           "Microsoft.Azure.Management.Search.SearchManagementClient/2.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet5350/providers/Microsoft.Search/searchServices/azs-5189\",\r\n  \"name\": \"azs-5189\",\r\n  \"type\": \"Microsoft.Search/searchServices\",\r\n  \"location\": \"West US\",\r\n  \"properties\": {\r\n    \"replicaCount\": 1,\r\n    \"partitionCount\": 1,\r\n    \"status\": \"running\",\r\n    \"statusDetails\": \"\",\r\n    \"provisioningState\": \"succeeded\",\r\n    \"hostingMode\": \"Default\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet119/providers/Microsoft.Search/searchServices/azs-5320\",\r\n  \"name\": \"azs-5320\",\r\n  \"type\": \"Microsoft.Search/searchServices\",\r\n  \"location\": \"West US\",\r\n  \"properties\": {\r\n    \"replicaCount\": 1,\r\n    \"partitionCount\": 1,\r\n    \"status\": \"running\",\r\n    \"statusDetails\": \"\",\r\n    \"provisioningState\": \"succeeded\",\r\n    \"hostingMode\": \"Default\"\r\n  },\r\n  \"sku\": {\r\n    \"name\": \"free\"\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
-          "385"
+          "384"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -163,34 +163,34 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 05 Apr 2018 17:52:31 GMT"
+          "Fri, 06 Apr 2018 17:14:54 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "ETag": [
-          "W/\"datetime'2018-04-05T17%3A52%3A31.2072295Z'\""
+          "W/\"datetime'2018-04-06T17%3A14%3A54.3501216Z'\""
         ],
         "x-ms-request-id": [
-          "fa45a534-3953-4ff5-9c77-d473fa85ff9e"
+          "ca0249fc-2d35-45f0-bab8-fd3efb5b3c4d"
         ],
         "request-id": [
-          "fa45a534-3953-4ff5-9c77-d473fa85ff9e"
+          "ca0249fc-2d35-45f0-bab8-fd3efb5b3c4d"
         ],
         "elapsed-time": [
-          "3390"
+          "4148"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1196"
+          "1197"
         ],
         "x-ms-correlation-request-id": [
-          "4686ec4c-e67f-408b-a514-c86f5a2dbc0e"
+          "09c7d9da-4996-42da-b82e-433a024970e6"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20180405T175231Z:4686ec4c-e67f-408b-a514-c86f5a2dbc0e"
+          "NORTHEUROPE:20180406T171454Z:09c7d9da-4996-42da-b82e-433a024970e6"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -199,13 +199,13 @@
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet5350/providers/Microsoft.Search/searchServices/azs-5189/listAdminKeys?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ1MzUwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy01MTg5L2xpc3RBZG1pbktleXM/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
+      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet119/providers/Microsoft.Search/searchServices/azs-5320/listAdminKeys?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlR3JvdXBzL2F6c21uZXQxMTkvcHJvdmlkZXJzL01pY3Jvc29mdC5TZWFyY2gvc2VhcmNoU2VydmljZXMvYXpzLTUzMjAvbGlzdEFkbWluS2V5cz9hcGktdmVyc2lvbj0yMDE1LTA4LTE5",
       "RequestMethod": "POST",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "71bbde7b-2131-4f4f-8d53-e745699c7780"
+          "b2640791-7387-42b9-96b2-0a98ff70ce42"
         ],
         "accept-language": [
           "en-US"
@@ -215,7 +215,7 @@
           "Microsoft.Azure.Management.Search.SearchManagementClient/2.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"primaryKey\": \"150BE983903B78AE7D725B2329FC36EF\",\r\n  \"secondaryKey\": \"FBCA81C0D292D7CB7325F648A7341AFE\"\r\n}",
+      "ResponseBody": "{\r\n  \"primaryKey\": \"F7E18F909ABD2E3A018A1D6F77E4A9A5\",\r\n  \"secondaryKey\": \"A18D1626D845AB65BA247CF1F34EE54B\"\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -227,7 +227,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 05 Apr 2018 17:52:33 GMT"
+          "Fri, 06 Apr 2018 17:14:56 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -240,25 +240,25 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "71bbde7b-2131-4f4f-8d53-e745699c7780"
+          "b2640791-7387-42b9-96b2-0a98ff70ce42"
         ],
         "request-id": [
-          "71bbde7b-2131-4f4f-8d53-e745699c7780"
+          "b2640791-7387-42b9-96b2-0a98ff70ce42"
         ],
         "elapsed-time": [
-          "147"
+          "178"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1195"
+          "1196"
         ],
         "x-ms-correlation-request-id": [
-          "feb30dc1-6401-4621-993b-1b7aaaf7df14"
+          "8e69a163-69fe-4d41-8c7a-7f0045df741e"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20180405T175233Z:feb30dc1-6401-4621-993b-1b7aaaf7df14"
+          "NORTHEUROPE:20180406T171457Z:8e69a163-69fe-4d41-8c7a-7f0045df741e"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -267,13 +267,13 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet5350/providers/Microsoft.Search/searchServices/azs-5189/listQueryKeys?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ1MzUwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy01MTg5L2xpc3RRdWVyeUtleXM/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
+      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet119/providers/Microsoft.Search/searchServices/azs-5320/listQueryKeys?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlR3JvdXBzL2F6c21uZXQxMTkvcHJvdmlkZXJzL01pY3Jvc29mdC5TZWFyY2gvc2VhcmNoU2VydmljZXMvYXpzLTUzMjAvbGlzdFF1ZXJ5S2V5cz9hcGktdmVyc2lvbj0yMDE1LTA4LTE5",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "610dd2cb-7af0-471a-b6b3-ad8e90759ec6"
+          "0cc4dd7f-55a4-4419-a582-b18223fe802e"
         ],
         "accept-language": [
           "en-US"
@@ -283,7 +283,7 @@
           "Microsoft.Azure.Management.Search.SearchManagementClient/2.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": null,\r\n      \"key\": \"0FA62BECA61B6729B8C6CB81B8F02734\"\r\n    }\r\n  ],\r\n  \"nextLink\": null\r\n}",
+      "ResponseBody": "{\r\n  \"value\": [\r\n    {\r\n      \"name\": null,\r\n      \"key\": \"88AE21069E52A4880418D1BE59D0372A\"\r\n    }\r\n  ],\r\n  \"nextLink\": null\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -295,7 +295,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 05 Apr 2018 17:52:33 GMT"
+          "Fri, 06 Apr 2018 17:14:56 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -308,13 +308,13 @@
           "Accept-Encoding"
         ],
         "x-ms-request-id": [
-          "610dd2cb-7af0-471a-b6b3-ad8e90759ec6"
+          "0cc4dd7f-55a4-4419-a582-b18223fe802e"
         ],
         "request-id": [
-          "610dd2cb-7af0-471a-b6b3-ad8e90759ec6"
+          "0cc4dd7f-55a4-4419-a582-b18223fe802e"
         ],
         "elapsed-time": [
-          "125"
+          "159"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
@@ -323,10 +323,10 @@
           "14999"
         ],
         "x-ms-correlation-request-id": [
-          "9e954dbb-d973-4ad3-98e2-60d871c23ef2"
+          "a822f4ef-c3e7-4f4a-8b6b-e85c183440ae"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20180405T175234Z:9e954dbb-d973-4ad3-98e2-60d871c23ef2"
+          "NORTHEUROPE:20180406T171457Z:a822f4ef-c3e7-4f4a-8b6b-e85c183440ae"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -341,20 +341,20 @@
       "RequestBody": "",
       "RequestHeaders": {
         "client-request-id": [
-          "d484f603-f7bc-4b97-ad84-db22576a9fe6"
+          "84ba30c5-9edb-4760-98cb-e9d71f542388"
         ],
         "accept-language": [
           "en-US"
         ],
         "api-key": [
-          "150BE983903B78AE7D725B2329FC36EF"
+          "F7E18F909ABD2E3A018A1D6F77E4A9A5"
         ],
         "User-Agent": [
           "FxVersion/4.6.25211.01",
           "Microsoft.Azure.Search.SearchServiceClient/5.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://azs-5189.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01_Preview.ServiceStatistics\",\r\n  \"counters\": {\r\n    \"documentCount\": {\r\n      \"usage\": 0,\r\n      \"quota\": null\r\n    },\r\n    \"indexesCount\": {\r\n      \"usage\": 0,\r\n      \"quota\": 3\r\n    },\r\n    \"indexersCount\": {\r\n      \"usage\": 0,\r\n      \"quota\": 3\r\n    },\r\n    \"dataSourcesCount\": {\r\n      \"usage\": 0,\r\n      \"quota\": 3\r\n    },\r\n    \"storageSize\": {\r\n      \"usage\": 0,\r\n      \"quota\": 52428800\r\n    },\r\n    \"synonymMaps\": {\r\n      \"usage\": 0,\r\n      \"quota\": 3\r\n    }\r\n  },\r\n  \"limits\": {\r\n    \"maxFieldsPerIndex\": 1000,\r\n    \"maxIndexerRunTime\": \"PT1M\",\r\n    \"maxFileExtractionSize\": 16777216,\r\n    \"maxFileContentCharactersToExtract\": 32768,\r\n    \"maxFieldNestingDepthPerIndex\": 10,\r\n    \"maxComplexCollectionFieldsPerIndex\": 100\r\n  }\r\n}",
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://azs-5320.search-dogfood.windows-int.net/$metadata#Microsoft.Azure.Search.V2016_09_01_Preview.ServiceStatistics\",\r\n  \"counters\": {\r\n    \"documentCount\": {\r\n      \"usage\": 0,\r\n      \"quota\": null\r\n    },\r\n    \"indexesCount\": {\r\n      \"usage\": 0,\r\n      \"quota\": 3\r\n    },\r\n    \"indexersCount\": {\r\n      \"usage\": 0,\r\n      \"quota\": 3\r\n    },\r\n    \"dataSourcesCount\": {\r\n      \"usage\": 0,\r\n      \"quota\": 3\r\n    },\r\n    \"storageSize\": {\r\n      \"usage\": 0,\r\n      \"quota\": 52428800\r\n    },\r\n    \"synonymMaps\": {\r\n      \"usage\": 0,\r\n      \"quota\": 3\r\n    }\r\n  },\r\n  \"limits\": {\r\n    \"maxFieldsPerIndex\": 1000,\r\n    \"maxIndexerRunTime\": \"PT1M\",\r\n    \"maxFileExtractionSize\": 16777216,\r\n    \"maxFileContentCharactersToExtract\": 32768,\r\n    \"maxFieldNestingDepthPerIndex\": 10,\r\n    \"maxComplexCollectionFieldsPerIndex\": 100\r\n  }\r\n}",
       "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
@@ -366,7 +366,7 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 05 Apr 2018 17:52:35 GMT"
+          "Fri, 06 Apr 2018 17:14:58 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -375,10 +375,10 @@
           "Accept-Encoding"
         ],
         "request-id": [
-          "d484f603-f7bc-4b97-ad84-db22576a9fe6"
+          "84ba30c5-9edb-4760-98cb-e9d71f542388"
         ],
         "elapsed-time": [
-          "159"
+          "108"
         ],
         "OData-Version": [
           "4.0"
@@ -393,13 +393,13 @@
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet5350/providers/Microsoft.Search/searchServices/azs-5189?api-version=2015-08-19",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlR3JvdXBzL2F6c21uZXQ1MzUwL3Byb3ZpZGVycy9NaWNyb3NvZnQuU2VhcmNoL3NlYXJjaFNlcnZpY2VzL2F6cy01MTg5P2FwaS12ZXJzaW9uPTIwMTUtMDgtMTk=",
+      "RequestUri": "/subscriptions/3c729b2a-4f86-4bb2-abe8-4b8647af156c/resourceGroups/azsmnet119/providers/Microsoft.Search/searchServices/azs-5320?api-version=2015-08-19",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvM2M3MjliMmEtNGY4Ni00YmIyLWFiZTgtNGI4NjQ3YWYxNTZjL3Jlc291cmNlR3JvdXBzL2F6c21uZXQxMTkvcHJvdmlkZXJzL01pY3Jvc29mdC5TZWFyY2gvc2VhcmNoU2VydmljZXMvYXpzLTUzMjA/YXBpLXZlcnNpb249MjAxNS0wOC0xOQ==",
       "RequestMethod": "DELETE",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "5247ac71-26c8-41df-bebc-31cfc167e07e"
+          "e0e343dc-d499-4f4d-9c76-807e8a233215"
         ],
         "accept-language": [
           "en-US"
@@ -421,31 +421,31 @@
           "no-cache"
         ],
         "Date": [
-          "Thu, 05 Apr 2018 17:52:40 GMT"
+          "Fri, 06 Apr 2018 17:15:04 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-request-id": [
-          "5247ac71-26c8-41df-bebc-31cfc167e07e"
+          "e0e343dc-d499-4f4d-9c76-807e8a233215"
         ],
         "request-id": [
-          "5247ac71-26c8-41df-bebc-31cfc167e07e"
+          "e0e343dc-d499-4f4d-9c76-807e8a233215"
         ],
         "elapsed-time": [
-          "808"
+          "1852"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1196"
+          "1199"
         ],
         "x-ms-correlation-request-id": [
-          "97ffe652-5d25-42b7-a288-b11046e978e5"
+          "ddc70504-3529-4455-a723-7f7817fe421f"
         ],
         "x-ms-routing-request-id": [
-          "NORTHEUROPE:20180405T175240Z:97ffe652-5d25-42b7-a288-b11046e978e5"
+          "NORTHEUROPE:20180406T171505Z:ddc70504-3529-4455-a723-7f7817fe421f"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -456,10 +456,10 @@
   ],
   "Names": {
     "GenerateName": [
-      "azsmnet5350"
+      "azsmnet119"
     ],
     "GenerateServiceName": [
-      "azs-5189"
+      "azs-5320"
     ]
   },
   "Variables": {

--- a/src/SDKs/Search/DataPlane/Search.Tests/Tests/ServiceStatsTests.cs
+++ b/src/SDKs/Search/DataPlane/Search.Tests/Tests/ServiceStatsTests.cs
@@ -31,9 +31,6 @@ namespace Microsoft.Azure.Search.Tests
                     Limits = new ServiceLimits
                     {
                         MaxFieldsPerIndex = 1000,
-                        MaxIndexerRunTime = TimeSpan.FromMinutes(1),
-                        MaxFileExtractionSize = 16777216,
-                        MaxFileContentCharactersToExtract = 32768,
                         MaxFieldNestingDepthPerIndex = 10,
                         MaxComplexCollectionFieldsPerIndex = 100
                     }

--- a/src/SDKs/_metadata/search_data-plane_Microsoft.Azure.Search.Service.txt
+++ b/src/SDKs/_metadata/search_data-plane_Microsoft.Azure.Search.Service.txt
@@ -1,9 +1,9 @@
-2018-04-05 17:48:08 UTC
+2018-04-06 17:10:40 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure
 Branch:      master
-Commit:      94df8612289968e9537dbd4a4023d692da9cefe1
+Commit:      bcb73c4629b948c5a6010e3c0e8cbd3196e8ae09
 
 2) AutoRest information
 Requested version: latest


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Removing indexer related limits from 'Get Service Statistics' API - note that we are not changing the version of the SDK as this only affect a preview version that has not been released yet.
REST spec PR link: https://github.com/Azure/azure-rest-api-specs/pull/2824

> Please Note - This PR targets a preview branch that the Azure Search team controls

<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
