### PR TITLE
fix customized ElasticPoolUpdate model as well

### DIFF
--- a/src/SDKs/SqlManagement/Management.Sql/Customizations/Models/ElasticPoolUpdate.cs
+++ b/src/SDKs/SqlManagement/Management.Sql/Customizations/Models/ElasticPoolUpdate.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// <summary>
         /// Gets or sets the edition of the elastic pool. Possible values include: 'Basic', 'Standard', 'Premium'
         /// </summary>
+        [JsonIgnore]
         public string Edition
         {
             get
@@ -24,6 +25,7 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// <summary>
         /// Gets the total shared DTU for the database elastic pool.
         /// </summary>
+        [JsonIgnore]
         public int? Dtu
         {
             get
@@ -35,6 +37,7 @@ namespace Microsoft.Azure.Management.Sql.Models
         /// <summary>
         /// Gets storage limit for the database elastic pool in MB.
         /// </summary>
+        [JsonIgnore]
         public int? StorageMB
         {
             get


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->
Fix the Management.Sql customized ElasticPoolUpdate Model as well. (Same issue with previous PR https://github.com/Azure/azure-sdk-for-net/pull/4206. Related Rest spec PR: https://github.com/Azure/azure-rest-api-specs/pull/2734)
---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
