### PR TITLE
Fixed multiple incorrect steps in build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ src\SDKs\Compute
 =======
 #### If you have recently cloned the repo or did a pull from upstream or did git clean -xdf you need to the following before you do anything else in order to build your projects
 
- 1. Open VS 2017 command prompt
+ 1. Open **elevated** VS 2017 command prompt
  2. Navigate to repository root directory
- 3. execute MsBuild.exe build.proj (this will pull all the build related tools needed to build the repo)
- 4. Skip verification for the following dlls
-    - Sn -Vr Microsoft.Azure.Build.BootstrapTasks.dll
-    - Sn -Vr Microsoft.Azure.Sdk.Build.Tasks.dll
+ 3. Skip verification for the following dlls
+    - Sn -Vr tools\bootstrapTools\taskBinaries\Microsoft.Azure.Build.BootstrapTasks.dll
+    - Sn -Vr tools\SdkBuildTools\tasks\net46\Microsoft.Azure.Sdk.Build.Tasks.dll
+ 4. Execute MsBuild.exe build.proj (this will pull all the build related tools needed to build the repo)
  5. Follow below steps to start building your repo/project
 
 #### If you are building from VS, add a nuget feed source that points to < root >\tools\LocalNugetFeed directory


### PR DESCRIPTION
Fixed multiple incorrect steps in build instructions

* Command prompt should be elevated otherwise `Sn -Vr` would fail
* `Sn -Vr` should be done before msbuild otherwise you'll get `Strong name validation failed` error in msbuild
* You should provide full or relative paths to dlls in `Sn -Vr`. Added relative paths so the user won't have to look for them.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
