### PR TITLE
Content Moderator- Set language as a non-required field for Screen Text API 

### DIFF
--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Helpers/Constants.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Helpers/Constants.cs
@@ -895,7 +895,7 @@ namespace ContentModeratorTests
 		/// <param name="contentType"></param>
 		/// <param name="textContent"></param>
 		/// <returns></returns>
-		public static Responses GetTextResponse(ContentModeratorClient client, ContentModeratorAPI api, string listid, Stream textContent, string contentType = "text/plain", string language = "eng",bool? isAutoCorrect = false, bool? isPii = false, bool? isClassify = false)
+		public static Responses GetTextResponse(ContentModeratorClient client, ContentModeratorAPI api, string listid, Stream textContent, string contentType = "text/plain", string language = default(string),bool? isAutoCorrect = false, bool? isPii = false, bool? isClassify = false)
 		{
             Responses r = new Responses();
             Utilities u = new Utilities();
@@ -909,7 +909,7 @@ namespace ContentModeratorTests
 				switch (api)
 				{
 					case ContentModeratorAPI.SCREEN_TEXT:
-						var tempST = client.TextModeration.ScreenTextWithHttpMessagesAsync(language,contentType, textContent,isAutoCorrect,isPii,listid,isClassify);
+						var tempST = client.TextModeration.ScreenTextWithHttpMessagesAsync(contentType,textContent,language,isAutoCorrect,isPii,listid,isClassify);
                         u.WaitUntilCompleted(tempST);
                         if (tempST.Exception != null)
                         {

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.11.0.0")]
-[assembly: AssemblyFileVersion("0.11.0.0")]
+[assembly: AssemblyVersion("0.12.0.0")]
+[assembly: AssemblyFileVersion("0.12.0.0")]

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.12.0.0")]
-[assembly: AssemblyFileVersion("0.12.0.0")]
+[assembly: AssemblyVersion("0.11.0.0")]
+[assembly: AssemblyFileVersion("0.11.0.0")]

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/SessionRecords/TextModerator/ScreenText.json
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/SessionRecords/TextModerator/ScreenText.json
@@ -1,10 +1,10 @@
 {
   "Entries": [
     {
-      "RequestUri": "/contentmoderator/moderate/v1.0/ProcessText/Screen/?language=eng&autocorrect=false&PII=false&listId=&classify=false",
-      "EncodedRequestUri": "L2NvbnRlbnRtb2RlcmF0b3IvbW9kZXJhdGUvdjEuMC9Qcm9jZXNzVGV4dC9TY3JlZW4vP2xhbmd1YWdlPWVuZyZhdXRvY29ycmVjdD1mYWxzZSZQSUk9ZmFsc2UmbGlzdElkPSZjbGFzc2lmeT1mYWxzZQ==",
+      "RequestUri": "/contentmoderator/moderate/v1.0/ProcessText/Screen/?autocorrect=false&PII=false&listId=&classify=false",
+      "EncodedRequestUri": "L2NvbnRlbnRtb2RlcmF0b3IvbW9kZXJhdGUvdjEuMC9Qcm9jZXNzVGV4dC9TY3JlZW4vP2F1dG9jb3JyZWN0PWZhbHNlJlBJST1mYWxzZSZsaXN0SWQ9JmNsYXNzaWZ5PWZhbHNl",
       "RequestMethod": "POST",
-      "RequestBody": "crap 764-87-9887",
+      "RequestBody": "crap 764-879-887",
       "RequestHeaders": {
         "Content-Type": [
           "text/plain"
@@ -22,7 +22,7 @@
           "Microsoft.CognitiveServices.ContentModerator.ContentModeratorClient/0.0.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"OriginalText\": \"crap 764-87-9887\",\r\n  \"NormalizedText\": \"crap 764- 87- 9887\",\r\n  \"Misrepresentation\": null,\r\n  \"Language\": \"eng\",\r\n  \"Terms\": [\r\n    {\r\n      \"Index\": 0,\r\n      \"OriginalIndex\": 0,\r\n      \"ListId\": 0,\r\n      \"Term\": \"crap\"\r\n    }\r\n  ],\r\n  \"Status\": {\r\n    \"Code\": 3000,\r\n    \"Description\": \"OK\",\r\n    \"Exception\": null\r\n  },\r\n  \"TrackingId\": \"fdf029a7-fba5-434e-a9b7-0d1d4a8841ca\"\r\n}",
+      "ResponseBody": "{\r\n  \"OriginalText\": \"crap 764-879-887\",\r\n  \"NormalizedText\": \"crap 764- 879- 887\",\r\n  \"Misrepresentation\": null,\r\n  \"Language\": \"eng\",\r\n  \"Terms\": [\r\n    {\r\n      \"Index\": 0,\r\n      \"OriginalIndex\": 0,\r\n      \"ListId\": 0,\r\n      \"Term\": \"crap\"\r\n    }\r\n  ],\r\n  \"Status\": {\r\n    \"Code\": 3000,\r\n    \"Description\": \"OK\",\r\n    \"Exception\": null\r\n  },\r\n  \"TrackingId\": \"4b411c02-c882-443b-be08-7a736535d0be\"\r\n}",
       "ResponseHeaders": {
         "Content-Length": [
           "291"
@@ -37,7 +37,7 @@
           "no-cache"
         ],
         "apim-request-id": [
-          "8e04a65e-c7ec-4818-82e9-263a40275886"
+          "16a5bce3-1817-440b-a503-5b4b90ac601d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains; preload"
@@ -49,7 +49,7 @@
           "no-cache"
         ],
         "Date": [
-          "Fri, 06 Apr 2018 18:33:51 GMT"
+          "Mon, 16 Apr 2018 20:15:26 GMT"
         ],
         "X-AspNet-Version": [
           "4.0.30319"

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/TextModerator.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/TextModerator.cs
@@ -95,12 +95,11 @@ namespace ContentModeratorTests
                 using (MockContext context = MockContext.Start("TextModerator"))
                 {
                     HttpMockServer.Initialize("TextModerator", "ScreenText");
-                    TermListId = "";
                     byte[] byteArray = Encoding.UTF8.GetBytes("crap 764-87-9887");
                     MemoryStream stream = new MemoryStream(byteArray);
                     api = ContentModeratorAPI.SCREEN_TEXT;
                     client = Constants.GenerateClient(api, HttpMockServer.CreateInstance());
-                    results = Constants.GetTextResponse(client, api, TermListId, stream);
+                    results = Constants.GetTextResponse(client, api, "", stream);
                     var screenText = results.ScreenText;
                     Assert.NotNull(screenText);
                     Assert.Equal(HttpStatusCode.OK, screenText.Response.StatusCode);

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Generated/ITextModeration.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Generated/ITextModeration.cs
@@ -26,15 +26,15 @@ namespace Microsoft.CognitiveServices.ContentModerator
         /// Detects profanity in more than 100 languages and match against
         /// custom and shared blacklists.
         /// </remarks>
-        /// <param name='language'>
-        /// Language of the terms.
-        /// </param>
         /// <param name='textContentType'>
         /// The content type. Possible values include: 'text/plain',
         /// 'text/html', 'text/xml', 'text/markdown'
         /// </param>
         /// <param name='textContent'>
         /// Content to screen.
+        /// </param>
+        /// <param name='language'>
+        /// Language of the text.
         /// </param>
         /// <param name='autocorrect'>
         /// Autocorrect text.
@@ -63,7 +63,7 @@ namespace Microsoft.CognitiveServices.ContentModerator
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse<Screen>> ScreenTextWithHttpMessagesAsync(string language, string textContentType, Stream textContent, bool? autocorrect = false, bool? pII = false, string listId = default(string), bool? classify = false, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse<Screen>> ScreenTextWithHttpMessagesAsync(string textContentType, Stream textContent, string language = default(string), bool? autocorrect = false, bool? pII = false, string listId = default(string), bool? classify = false, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
         /// <summary>
         /// This operation will detect the language of given input content.
         /// Returns the &lt;a

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Generated/TextModeration.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Generated/TextModeration.cs
@@ -53,15 +53,15 @@ namespace Microsoft.CognitiveServices.ContentModerator
         /// Detects profanity in more than 100 languages and match against custom and
         /// shared blacklists.
         /// </remarks>
-        /// <param name='language'>
-        /// Language of the terms.
-        /// </param>
         /// <param name='textContentType'>
         /// The content type. Possible values include: 'text/plain', 'text/html',
         /// 'text/xml', 'text/markdown'
         /// </param>
         /// <param name='textContent'>
         /// Content to screen.
+        /// </param>
+        /// <param name='language'>
+        /// Language of the text.
         /// </param>
         /// <param name='autocorrect'>
         /// Autocorrect text.
@@ -96,15 +96,11 @@ namespace Microsoft.CognitiveServices.ContentModerator
         /// <return>
         /// A response object containing the response body and response headers.
         /// </return>
-        public async Task<HttpOperationResponse<Screen>> ScreenTextWithHttpMessagesAsync(string language, string textContentType, Stream textContent, bool? autocorrect = false, bool? pII = false, string listId = default(string), bool? classify = false, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async Task<HttpOperationResponse<Screen>> ScreenTextWithHttpMessagesAsync(string textContentType, Stream textContent, string language = default(string), bool? autocorrect = false, bool? pII = false, string listId = default(string), bool? classify = false, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             if (Client.BaseUrl == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "this.Client.BaseUrl");
-            }
-            if (language == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "language");
             }
             if (textContentType == null)
             {

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Generated/TextModerationExtensions.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Generated/TextModerationExtensions.cs
@@ -26,15 +26,15 @@ namespace Microsoft.CognitiveServices.ContentModerator
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
-            /// <param name='language'>
-            /// Language of the terms.
-            /// </param>
             /// <param name='textContentType'>
             /// The content type. Possible values include: 'text/plain', 'text/html',
             /// 'text/xml', 'text/markdown'
             /// </param>
             /// <param name='textContent'>
             /// Content to screen.
+            /// </param>
+            /// <param name='language'>
+            /// Language of the text.
             /// </param>
             /// <param name='autocorrect'>
             /// Autocorrect text.
@@ -48,9 +48,9 @@ namespace Microsoft.CognitiveServices.ContentModerator
             /// <param name='classify'>
             /// Classify input.
             /// </param>
-            public static Screen ScreenText(this ITextModeration operations, string language, string textContentType, Stream textContent, bool? autocorrect = false, bool? pII = false, string listId = default(string), bool? classify = false)
+            public static Screen ScreenText(this ITextModeration operations, string textContentType, Stream textContent, string language = default(string), bool? autocorrect = false, bool? pII = false, string listId = default(string), bool? classify = false)
             {
-                return operations.ScreenTextAsync(language, textContentType, textContent, autocorrect, pII, listId, classify).GetAwaiter().GetResult();
+                return operations.ScreenTextAsync(textContentType, textContent, language, autocorrect, pII, listId, classify).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -63,15 +63,15 @@ namespace Microsoft.CognitiveServices.ContentModerator
             /// <param name='operations'>
             /// The operations group for this extension method.
             /// </param>
-            /// <param name='language'>
-            /// Language of the terms.
-            /// </param>
             /// <param name='textContentType'>
             /// The content type. Possible values include: 'text/plain', 'text/html',
             /// 'text/xml', 'text/markdown'
             /// </param>
             /// <param name='textContent'>
             /// Content to screen.
+            /// </param>
+            /// <param name='language'>
+            /// Language of the text.
             /// </param>
             /// <param name='autocorrect'>
             /// Autocorrect text.
@@ -88,9 +88,9 @@ namespace Microsoft.CognitiveServices.ContentModerator
             /// <param name='cancellationToken'>
             /// The cancellation token.
             /// </param>
-            public static async Task<Screen> ScreenTextAsync(this ITextModeration operations, string language, string textContentType, Stream textContent, bool? autocorrect = false, bool? pII = false, string listId = default(string), bool? classify = false, CancellationToken cancellationToken = default(CancellationToken))
+            public static async Task<Screen> ScreenTextAsync(this ITextModeration operations, string textContentType, Stream textContent, string language = default(string), bool? autocorrect = false, bool? pII = false, string listId = default(string), bool? classify = false, CancellationToken cancellationToken = default(CancellationToken))
             {
-                using (var _result = await operations.ScreenTextWithHttpMessagesAsync(language, textContentType, textContent, autocorrect, pII, listId, classify, null, cancellationToken).ConfigureAwait(false))
+                using (var _result = await operations.ScreenTextWithHttpMessagesAsync(textContentType, textContent, language, autocorrect, pII, listId, classify, null, cancellationToken).ConfigureAwait(false))
                 {
                     return _result.Body;
                 }

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Microsoft.Azure.CognitiveServices.ContentModerator.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Microsoft.Azure.CognitiveServices.ContentModerator.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.ContentModerator</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Content Moderator APIs.</Description>
-    <Version>0.11.0-preview</Version>
+    <Version>0.12.0-preview</Version>
     <AssemblyName>Microsoft.Azure.CognitiveServices.ContentModerator</AssemblyName>
     <PackageTags>ContentModerator;Content Moderator;</PackageTags>
     <PackageReleaseNotes>This is a preview release of the Cognitive Services Content Moderator SDK.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Microsoft.Azure.CognitiveServices.ContentModerator.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Microsoft.Azure.CognitiveServices.ContentModerator.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.ContentModerator</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Content Moderator APIs.</Description>
-    <Version>0.12.0-preview</Version>
+    <Version>0.11.0-preview</Version>
     <AssemblyName>Microsoft.Azure.CognitiveServices.ContentModerator</AssemblyName>
     <PackageTags>ContentModerator;Content Moderator;</PackageTags>
     <PackageReleaseNotes>This is a preview release of the Cognitive Services Content Moderator SDK.</PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/generate.ps1
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/generate.ps1
@@ -1,0 +1,4 @@
+<#
+    This is a template to describe how to call the generateTool.ps1 script to generate the code using AutoRest
+#>
+powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -File "$(split-path $SCRIPT:MyInvocation.MyCommand.Path -parent)\..\..\..\..\..\..\..\tools\generateTool.ps1" -ResourceProvider "cognitiveservices/data-plane/ContentModerator" -PowershellInvoker

--- a/src/SDKs/_metadata/cognitiveservices_data-plane_ContentModerator.txt
+++ b/src/SDKs/_metadata/cognitiveservices_data-plane_ContentModerator.txt
@@ -1,9 +1,9 @@
-2018-04-06 18:09:46 UTC
+2018-04-17 20:05:22 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure
 Branch:      master
-Commit:      55711dc50d55d1a04cf8af2a61da7ab50c7e9f1c
+Commit:      b6cb0b6eefd6f0dbb099b8a4babc95d69550c576
 
 2) AutoRest information
 Requested version: latest

--- a/src/SDKs/_metadata/cognitiveservices_data-plane_ContentModerator.txt
+++ b/src/SDKs/_metadata/cognitiveservices_data-plane_ContentModerator.txt
@@ -1,11 +1,17 @@
-2018-04-17 20:05:22 UTC
-
+﻿Executing AutoRest command
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/cognitiveservices/data-plane/ContentModerator/readme.md --csharp --csharp-sdks-folder=C:\LatestSdk\tools\..\src\SDKs\ --version=latest --reflect-api-versions
+2018-04-17 23:04:14 UTC
 1) azure-rest-api-specs repository information
-GitHub user: Azure
+GitHub fork: Azure
 Branch:      master
-Commit:      b6cb0b6eefd6f0dbb099b8a4babc95d69550c576
+Commit:      9666a766d478b21b587210260fb7de342ae9980e
 
 2) AutoRest information
 Requested version: latest
-Bootstrapper version:    C:\Users\v-sodsou\AppData\Roaming\npm `-- autorest@2.0.4262  
+Bootstrapper version:    C:\Users\v-sodsou\AppData\Roaming\npm  `-- autorest@2.0.4262
+
+
 Latest installed version:    
+.\tools\generate.ps1 was invoked by generate.ps1
+
+


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->
https://github.com/Azure/azure-rest-api-specs/pull/2884
---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
