### PR TITLE
Additional params for code generation

### DIFF
--- a/tools/BuildAssets/psModules/CodeGenerationModules/generateDotNetSdkCode.psm1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/generateDotNetSdkCode.psm1
@@ -107,8 +107,14 @@ param(
     [string] $SpecsRepoBranch,
     [Parameter(Mandatory = $true)]
     [string] $SpecsRepoName,
-    [Parameter(Mandatory = $true, HelpMessage ="Please provide an output directory for the generated code")]
-    [string] $SdkDirectory,
+    [Parameter(Mandatory = $false, ParameterSetName="rootdir", HelpMessage ="Please provide an output directory for the generated code")]
+    [string] $SdkRootDirectory,
+    [Parameter(Mandatory=$false, ParameterSetName="finaldir", HelpMessage ="Please provide an output directory for the generated code")]
+    [string] $SdkGenerationDirectory,
+    [Parameter(Mandatory = $false)]
+    [string] $Namespace,
+    [Parameter(Mandatory = $false)]
+    [string] $ConfigFileTag,
     [Parameter(Mandatory = $true, HelpMessage ="Please provide a version for the AutoRest release")]
     [string] $AutoRestVersion
     )
@@ -116,7 +122,26 @@ param(
     $configFile="https://github.com/$SpecsRepoFork/$SpecsRepoName/blob/$SpecsRepoBranch/specification/$ResourceProvider/readme.md" 
     Write-InfoLog "Generating CSharp code" -logToConsole
     $cmd = "cmd.exe"
-    $args = "/c autorest.cmd $configFile --csharp --csharp-sdks-folder=$SdkDirectory --version=$AutoRestVersion --reflect-api-versions"
+    $args = "/c autorest.cmd $configFile --csharp --version=$AutoRestVersion --reflect-api-versions"
+    
+    if(-not [string]::IsNullOrWhiteSpace($Namespace))
+    {
+        $args = $args + " --csharp.namespace=$Namespace"
+    }
+
+    if(-not [string]::IsNullOrWhiteSpace($ConfigFileTag))
+    {
+        $args = $args + " --tag=$ConfigFileTag"
+    }
+
+    if(-not [string]::IsNullOrWhiteSpace($SdkGenerationDirectory))
+    {
+        $args = $args + " --csharp.output-folder=$SdkGenerationDirectory"
+    }
+    elseif(-not [string]::IsNullOrWhiteSpace($SdkRootDirectory))
+    {
+        $args = $args + " --csharp-sdks-folder=$SdkRootDirectory"
+    }
     
     Write-InfoLog "Executing AutoRest command" -logToFile
     Write-InfoLog "$cmd $args" -logToFile


### PR DESCRIPTION

Addressing https://github.com/Azure/azure-sdk-for-net/issues/4222
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
