### PR TITLE
Translating legacy SdkDirectory param to SdkRootDirectory

### DIFF
--- a/tools/generateTool.ps1
+++ b/tools/generateTool.ps1
@@ -53,6 +53,8 @@ Param(
     [switch] $PowershellInvoker,
     [Parameter(ParameterSetName="rootdir", Mandatory=$false)]
     [string] $SdkRootDirectory,
+    [Parameter(ParameterSetName="legacyrootdir", Mandatory=$false)]
+    [string] $SdkDirectory,
     [Parameter(ParameterSetName="finaldir", Mandatory=$false)]
     [string] $SdkGenerationDirectory,
     [Parameter(Mandatory = $false)]
@@ -88,6 +90,10 @@ if ($SpecsRepoName.EndsWith("-pr")) {
 if (-not ($modulePath | Test-Path)) {
     NotifyError "Could not find code generation module at: $modulePath. Please run `msbuild build.proj` to install the module."
     Exit -1
+}
+
+if(-not [string]::IsNullOrWhiteSpace($SdkDirectory)) {
+    $SdkRootDirectory = $SdkDirectory
 }
 
 Import-Module "$modulePath"


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
