### PR TITLE
Expose new SKUs for VirtualNetworkGateway ER and VPN VMSS

### DIFF
--- a/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkGatewaySku.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkGatewaySku.cs
@@ -31,10 +31,12 @@ namespace Microsoft.Azure.Management.Network.Models
         /// </summary>
         /// <param name="name">Gateway SKU name. Possible values include:
         /// 'Basic', 'HighPerformance', 'Standard', 'UltraPerformance',
-        /// 'VpnGw1', 'VpnGw2', 'VpnGw3'</param>
+        /// 'VpnGw1', 'VpnGw2', 'VpnGw3', 'VpnGw1AZ', 'VpnGw2AZ', 'VpnGw3AZ',
+        /// 'ErGw1AZ', 'ErGw2AZ', 'ErGw3AZ'</param>
         /// <param name="tier">Gateway SKU tier. Possible values include:
         /// 'Basic', 'HighPerformance', 'Standard', 'UltraPerformance',
-        /// 'VpnGw1', 'VpnGw2', 'VpnGw3'</param>
+        /// 'VpnGw1', 'VpnGw2', 'VpnGw3', 'VpnGw1AZ', 'VpnGw2AZ', 'VpnGw3AZ',
+        /// 'ErGw1AZ', 'ErGw2AZ', 'ErGw3AZ'</param>
         /// <param name="capacity">The capacity.</param>
         public VirtualNetworkGatewaySku(string name = default(string), string tier = default(string), int? capacity = default(int?))
         {
@@ -52,7 +54,8 @@ namespace Microsoft.Azure.Management.Network.Models
         /// <summary>
         /// Gets or sets gateway SKU name. Possible values include: 'Basic',
         /// 'HighPerformance', 'Standard', 'UltraPerformance', 'VpnGw1',
-        /// 'VpnGw2', 'VpnGw3'
+        /// 'VpnGw2', 'VpnGw3', 'VpnGw1AZ', 'VpnGw2AZ', 'VpnGw3AZ', 'ErGw1AZ',
+        /// 'ErGw2AZ', 'ErGw3AZ'
         /// </summary>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
@@ -60,7 +63,8 @@ namespace Microsoft.Azure.Management.Network.Models
         /// <summary>
         /// Gets or sets gateway SKU tier. Possible values include: 'Basic',
         /// 'HighPerformance', 'Standard', 'UltraPerformance', 'VpnGw1',
-        /// 'VpnGw2', 'VpnGw3'
+        /// 'VpnGw2', 'VpnGw3', 'VpnGw1AZ', 'VpnGw2AZ', 'VpnGw3AZ', 'ErGw1AZ',
+        /// 'ErGw2AZ', 'ErGw3AZ'
         /// </summary>
         [JsonProperty(PropertyName = "tier")]
         public string Tier { get; set; }

--- a/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkGatewaySkuName.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkGatewaySkuName.cs
@@ -23,5 +23,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public const string VpnGw1 = "VpnGw1";
         public const string VpnGw2 = "VpnGw2";
         public const string VpnGw3 = "VpnGw3";
+        public const string VpnGw1AZ = "VpnGw1AZ";
+        public const string VpnGw2AZ = "VpnGw2AZ";
+        public const string VpnGw3AZ = "VpnGw3AZ";
+        public const string ErGw1AZ = "ErGw1AZ";
+        public const string ErGw2AZ = "ErGw2AZ";
+        public const string ErGw3AZ = "ErGw3AZ";
     }
 }

--- a/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkGatewaySkuTier.cs
+++ b/src/SDKs/Network/Management.Network/Generated/Models/VirtualNetworkGatewaySkuTier.cs
@@ -23,5 +23,11 @@ namespace Microsoft.Azure.Management.Network.Models
         public const string VpnGw1 = "VpnGw1";
         public const string VpnGw2 = "VpnGw2";
         public const string VpnGw3 = "VpnGw3";
+        public const string VpnGw1AZ = "VpnGw1AZ";
+        public const string VpnGw2AZ = "VpnGw2AZ";
+        public const string VpnGw3AZ = "VpnGw3AZ";
+        public const string ErGw1AZ = "ErGw1AZ";
+        public const string ErGw2AZ = "ErGw2AZ";
+        public const string ErGw3AZ = "ErGw3AZ";
     }
 }

--- a/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
+++ b/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
@@ -7,11 +7,12 @@
 		<PackageId>Microsoft.Azure.Management.Network</PackageId>
 		<Description>Provides management capabilities for Network services.</Description>
 		<AssemblyName>Microsoft.Azure.Management.Network</AssemblyName>
-		<Version>20.0.0-preview</Version>
+		<Version>19.0.1-preview</Version>
 		<PackageTags>Microsoft Azure Network management;Network;Network management;</PackageTags>    
 		<PackageReleaseNotes>
 		<![CDATA[
 			- Made id read-only by bringing properties from shared resource in DDos Protection plan functionality
+			- Introduce new SKUs for cross zone VPN and ExpressRoute gateways.
 		]]></PackageReleaseNotes>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
+++ b/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
@@ -7,7 +7,7 @@
 		<PackageId>Microsoft.Azure.Management.Network</PackageId>
 		<Description>Provides management capabilities for Network services.</Description>
 		<AssemblyName>Microsoft.Azure.Management.Network</AssemblyName>
-		<Version>19.0.0-preview</Version>
+		<Version>20.0.0-preview</Version>
 		<PackageTags>Microsoft Azure Network management;Network;Network management;</PackageTags>    
 		<PackageReleaseNotes>
 		<![CDATA[

--- a/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Network Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Network management functions for managing the Microsoft Azure Network service.")]
 
-[assembly: AssemblyVersion("19.0.0.0")]
-[assembly: AssemblyFileVersion("19.0.0.0")]
+[assembly: AssemblyVersion("20.0.0.0")]
+[assembly: AssemblyFileVersion("20.0.0.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]

--- a/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure Network Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Network management functions for managing the Microsoft Azure Network service.")]
 
-[assembly: AssemblyVersion("20.0.0.0")]
-[assembly: AssemblyFileVersion("20.0.0.0")]
+[assembly: AssemblyVersion("19.0.0.0")]
+[assembly: AssemblyFileVersion("19.0.1.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]

--- a/src/SDKs/_metadata/network_resource-manager.txt
+++ b/src/SDKs/_metadata/network_resource-manager.txt
@@ -1,11 +1,11 @@
-2018-04-26 20:59:33 UTC
+2018-05-15 23:11:28 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: Azure
-Branch:      master
-Commit:      b9721ae4c9f04914cc89260b8339dc33372f835b
+Branch:      Network-2018-05-01
+Commit:      c8aea945a903ec70e8acf18530cc9924fa822cfb
 
 2) AutoRest information
 Requested version: latest
-Bootstrapper version:    C:\Users\mitryakh\AppData\Roaming\npm `-- autorest@2.0.4262  
+Bootstrapper version:    C:\Users\ritwikb\AppData\Roaming\npm `-- autorest@2.0.4262  
 Latest installed version:    


### PR DESCRIPTION
Expose new SKUs for VirtualNetworkGateway ER and VPN VMSS

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
