### PR TITLE
[Azure Search] Regenerate data plane SDK from the committed swagger specs

### DIFF
--- a/src/SDKs/_metadata/search_data-plane_Microsoft.Azure.Search.Data.txt
+++ b/src/SDKs/_metadata/search_data-plane_Microsoft.Azure.Search.Data.txt
@@ -1,10 +1,10 @@
 ﻿Executing AutoRest command
-cmd.exe /c autorest.cmd https://github.com/mhko/azure-rest-api-specs/blob/auto/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=E:\ac-sdk\azure-sdk-for-net\tools\..\src\SDKs\
-2018-05-18 21:59:26 UTC
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/search/data-plane/Microsoft.Azure.Search.Data/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=E:\ac-sdk\push\azure-sdk-for-net\tools\..\src\SDKs\
+2018-05-22 17:14:57 UTC
 1) azure-rest-api-specs repository information
-GitHub fork: mhko
-Branch:      auto
-Commit:      5dafab8941c1ac4932a4789b44a6b08b13edc5c0
+GitHub fork: Azure
+Branch:      master
+Commit:      e76b99571744235eb7d16ff55581d6ad21ffd254
 
 2) AutoRest information
 Requested version: latest


### PR DESCRIPTION
Regenerate data plane SDK from the committed swagger specs. 

The PR for the merged swagger spec can be found here. https://github.com/Azure/azure-rest-api-specs/pull/3106 

@brjohnstmsft, @Yahnoosh 

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
