### PR TITLE
Bump up consumption version

### DIFF
--- a/src/SDKs/Consumption/Management.Consumption/Microsoft.Azure.Management.Consumption.csproj
+++ b/src/SDKs/Consumption/Management.Consumption/Microsoft.Azure.Management.Consumption.csproj
@@ -6,7 +6,7 @@
     <PropertyGroup>
         <PackageId>Microsoft.Azure.Management.Consumption</PackageId>
         <Description>Microsoft Azure Consumption Management Library</Description>
-        <VersionPrefix>3.0.0</VersionPrefix>    
+        <VersionPrefix>3.0.1</VersionPrefix>    
         <AssemblyName>Microsoft.Azure.Management.Consumption</AssemblyName>    
         <PackageTags>Consumptionmanagement;Consumption;</PackageTags>
       <PackageReleaseNotes>

--- a/src/SDKs/Consumption/Management.Consumption/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Consumption/Management.Consumption/Properties/AssemblyInfo.cs
@@ -8,8 +8,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Azure Consumption Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure Consumption.")]
 
-[assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyVersion("3.0.1.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

Bumping up consumption version to 3.0.1

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X ] Title of the pull request is clear and informative.
- [X ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [X ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
