### PR TITLE
Making build assets to build branch

### DIFF
--- a/tools/BuildAssets/metaData/FilesToCopy.txt
+++ b/tools/BuildAssets/metaData/FilesToCopy.txt
@@ -4,6 +4,11 @@ targets/common.NugetPackage.props
 targets/common.targets
 targets/ideCmd.targets
 targets/signing.targets
+targets/core/_AzSdk.props
+targets/core/_build.proj
+targets/core/_Directory.Build.props
+targets/core/_Directory.Build.targets
+targets/core/_test.props
 tasks/common.tasks
 tasks/net46/Microsoft.Build.dll
 tasks/net46/Microsoft.Build.Framework.dll

--- a/tools/BuildAssets/targets/core/_AzSdk.props
+++ b/tools/BuildAssets/targets/core/_AzSdk.props
@@ -1,0 +1,9 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<!--
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>$(LibraryToolsFolder)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  -->
+</Project>

--- a/tools/BuildAssets/targets/core/_Directory.Build.props
+++ b/tools/BuildAssets/targets/core/_Directory.Build.props
@@ -1,0 +1,47 @@
+﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <!-- <LibraryRoot>$(MSBuildThisFileDirectory)</LibraryRoot> -->
+    <LibrarySourceFolder>$(LibraryRoot)src</LibrarySourceFolder>
+    <LibraryToolsFolder>$(LibraryRoot)tools</LibraryToolsFolder>	
+    <LibraryNugetPackageFolder>$(LibraryRoot)restoredPackages</LibraryNugetPackageFolder>
+    <LibraryFriendlyName>Microsoft Azure Management Libraries</LibraryFriendlyName>
+    <AuthenticationSolution>src\Authentication\Authentication.sln</AuthenticationSolution>
+    <ManagementLibrariesSolution>AzureManagementLibraries.sln</ManagementLibrariesSolution>
+    <BinariesFolder>$(LibraryRoot)binaries</BinariesFolder>
+	  <BuildAssetsDir>$(LibraryToolsFolder)\BuildAssets</BuildAssetsDir>
+    <PoliCheckOutputDir>$(LibraryRoot)PolicheckOutput</PoliCheckOutputDir>
+    <BuiltPackageOutputDir>$(BinariesFolder)\packages</BuiltPackageOutputDir>
+    <DelaySign Condition =" '$(DelaySign)' == '' ">false</DelaySign>
+    <CodeSign Condition=" '$(CodeSign)' == '' ">false</CodeSign>
+    <Scope Condition=" '$(Scope)' == '' ">All</Scope>
+    <NuGetCommand>&quot;$(LibraryToolsFolder)\nuget.exe&quot;</NuGetCommand>
+    <NuGetKey Condition=" '$(NuGetKey)' == '' ">1234</NuGetKey>
+    <BuildInParallel>true</BuildInParallel>
+	  <SdkBuildToolsDir>$(LibraryToolsFolder)\SdkBuildTools</SdkBuildToolsDir>
+    <NugetPackageName/>
+    <ImportDirectoryBuildTargets>true</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+  <PropertyGroup>
+    <CIToolsPath>$(OnPremiseBuildTasks)</CIToolsPath>
+    <OnPremiseBuild Condition=" Exists($(OnPremiseBuildTasks)) ">true</OnPremiseBuild>
+    <OnPremiseBuild Condition=" ! Exists($(OnPremiseBuildTasks)) ">false</OnPremiseBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Well Known Properties">
+    <ClientRuntimeRootDir>$(LibraryRoot)src\UpgradeVS17\SdkCommon\ClientRuntime</ClientRuntimeRootDir>
+    <SdkCommonRootDir>$(LibraryRoot)src\UpgradeVS17\SdkCommon\ClientRuntime</SdkCommonRootDir>
+  </PropertyGroup>
+ 
+   <PropertyGroup>
+	<NetSdkBuildTargetsDir Condition=" Exists('$(BuildAssetsDir)') ">$(BuildAssetsDir)\targets</NetSdkBuildTargetsDir>
+	<NetSdkBuildTargetsDir Condition=" Exists('$(SdkBuildToolsDir)') AND '$(NetSdkBuildTargetsDir)' == '' ">$(SdkBuildToolsDir)\targets</NetSdkBuildTargetsDir>
+	<!-- <NetSdkBuildTargetsDir Condition=" '$(NetSdkBuildTargetsDir)' == '' ">$(LibraryToolsFolder)\buildTargets</NetSdkBuildTargetsDir> -->
+	
+	<NetSdkBuildToolsDir Condition="Exists('$(BuildAssetsDir)')">$(BuildAssetsDir)</NetSdkBuildToolsDir>
+	<NetSdkBuildToolsDir Condition="Exists('$(SdkBuildToolsDir)') AND '$(NetSdkBuildToolsDir)' == '' ">$(SdkBuildToolsDir)</NetSdkBuildToolsDir>
+	<!-- <NetSdkBuildToolsDir Condition=" '$(NetSdkBuildToolsDir)' == '' ">$(LibraryToolsFolder)\buildTargets</NetSdkBuildToolsDir> -->
+  </PropertyGroup>
+ 
+	<Import Condition="Exists('$(NetSdkBuildTargetsDir)\common.Build.props')" Project="$(NetSdkBuildTargetsDir)\common.Build.props"/>
+	<Import Condition="Exists('$(NetSdkBuildTargetsDir)\common.NugetPackage.props')" Project="$(NetSdkBuildTargetsDir)\common.NugetPackage.props"/>
+</Project>

--- a/tools/BuildAssets/targets/core/_Directory.Build.targets
+++ b/tools/BuildAssets/targets/core/_Directory.Build.targets
@@ -1,0 +1,5 @@
+﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<Import Condition="Exists('$(NetSdkBuildTargetsDir)\common.targets')" Project="$(NetSdkBuildTargetsDir)\common.targets" />
+	<Import Condition="Exists('$(NetSdkBuildTargetsDir)\ideCmd.targets')" Project="$(NetSdkBuildTargetsDir)\ideCmd.targets" />
+	<!-- <Import Project="tools\bootstrapTools\bootstrap.targets" /> -->
+</Project>

--- a/tools/BuildAssets/targets/core/_build.proj
+++ b/tools/BuildAssets/targets/core/_build.proj
@@ -1,0 +1,18 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<!-- 
+	DefaultTargets="Init"
+	<Import Project="_Directory.Build.props" />	
+	<Import Project="_test.props" />
+	<Import Project="_AzSdk.props" />
+	<Import Project="_Directory.Build.targets" /> -->
+  
+	<Target Name="Clean" DependsOnTargets="$(CleanTraversedProjectsDependsOn)" />
+	<Target Name="Restore" DependsOnTargets="$(RestoreTraversedProjectsDependsOn)" /> 
+	<Target Name="Build" DependsOnTargets="$(BuildTraversedProjectsDependsOn)" />
+	<Target Name="Rebuild" DependsOnTargets="Clean;Build" />
+	<Target Name="PublishNuget" DependsOnTargets="$(PublishNugetDependsOn)" />
+	<Target Name="CreateNugetPackage" DependsOnTargets="$(PackageNugetDependsOn)" />
+	<Target Name="RunTests" DependsOnTargets="$(RunTestProjectsDependsOn)" />
+	<Target Name="SignNuget" DependsOnTargets="$(SignNugetDependsOn)" />
+	<Target Name="Help" DependsOnTargets="$(HelpDependsOn)" />   
+</Project>

--- a/tools/BuildAssets/targets/core/_test.props
+++ b/tools/BuildAssets/targets/core/_test.props
@@ -1,0 +1,22 @@
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+	<PropertyGroup>
+		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+		<RestorePackagesPath>$(LibraryNugetPackageFolder)</RestorePackagesPath>
+		<NugetCommonProfileTags/>
+		<PackageOutputPath>$(BuiltPackageOutputDir)</PackageOutputPath>
+		<AddProjectReferenceForDebuggingPurpose>false</AddProjectReferenceForDebuggingPurpose>
+		<AddNugetReferenceForCIandCmdlineBuild>true</AddNugetReferenceForCIandCmdlineBuild>
+		<SkipBuildingTestProject>false</SkipBuildingTestProject>
+		<SignAssembly>true</SignAssembly>
+		<DelaySign>true</DelaySign>
+		<AssemblyOriginatorKeyFile>$(LibraryToolsFolder)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
+	<ItemGroup>  
+		<PackageReference Include="xunit" Version="2.3.1" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+	</ItemGroup>
+	<ItemGroup> 
+	   <Compile Include="$(LibraryToolsFolder)\DisableTestRunParallel.cs" Link="DisableTestRunParallel.cs" Exclude="bin\**;obj\**;**\*.xproj;packages\**" /> 
+	</ItemGroup>
+</Project>


### PR DESCRIPTION
- Moving remaining set of build files out of main branch.
- This will leave bootstrap related files only linked to branch.
- This makes all branch independent of build assets
