### PR TITLE
Updating code generation scripts documentation

### DIFF
--- a/Documentation/code-generation-instructions.md
+++ b/Documentation/code-generation-instructions.md
@@ -1,6 +1,6 @@
 # How to generate Code
 
-To generate code, simply run the `generate.ps1` powershell script. If a powershell script does not exist under the RP directory, create one using an example [here](https://github.com/Azure/azure-sdk-for-net/blob/psSdkJson6/src/SDKs/Compute/Management.Compute/generate.ps1).
+To generate code, simply run the `generate.ps1` powershell script. 
 
 If code generation fails for any reason, here are a few common steps to resolve the issues.
 
@@ -14,6 +14,25 @@ msbuild build.proj
 ```
 - Run the `generate.ps1` command again
 
+## Powershell code generation script
+
+When the build tools are installed, AutoRest code generation commandlets are also installed on the user machine under the current user profile.
+
+If a powershell script does not exist under the RP directory, create one using the script generation utility script [here](https://github.com/Azure/azure-sdk-for-net/blob/psSdkJson6/tools/HelperUtilities/psScripts/Create-AutoRestCodeGenerationScript.ps1)
+An example usage is as below
+```
+tools\HelperUtilities\psScripts\Create-AutoRestCodeGenerationScript.ps1 -ResourceProvider compute/resource-manager -ScriptPath "src\SDKs\Compute\Management.Compute\"
+```
+The generation script can also be manually created using an example [here](https://github.com/Azure/azure-sdk-for-net/blob/psSdkJson6/src/SDKs/Compute/Management.Compute/generate.ps1).
+
+Please make sure that the `--output-folder` setting is set in the configuration file for the RP. This path should be relative to `src\SDKs`. For example, the `--output-folder` in configuration file for Compute is to 
+```
+$(csharp-sdks-folder)/Compute/Management.Compute/Generated
+```
+The code generation script defaults `csharp-sdks-folder` to `src\SDKs`. If for some reason this is incorrectly set, one can explicitly set the final location where code is generated using `SdkGenerationDirectory` parameter. This is discouraged though. When using the `SdkGenerationDirectory` parameter the `generate.ps1` code would look like
+```
+Start-AutoRestCodeGeneration -ResourceProvider "compute/resource-manager" -AutoRestVersion "latest" SdkGenerationDirectory "$PSScriptRoot"
+```
 
 # When opening a PR
 
@@ -36,7 +55,7 @@ RP is the resource provider's directory under SDKs, eg.: Compute
 To generate the `SdkInfo*.cs` file, please run the `generate.ps1` script
 
 ## Code generation artifacts
-If code is generated using `generate.ps1`, information related to the generation gets logged in a `.txt` file under `src\SDKs\_metadata` eg.: [here](https://github.com/Azure/azure-sdk-for-net/blob/psSdkJson6/src/SDKs/_metadata/compute_resource-manager.txt)
+If code is generated using `generate.ps1`, information related to the code generation gets logged in a `.txt` file under `src\SDKs\_metadata` eg.: [here](https://github.com/Azure/azure-sdk-for-net/blob/psSdkJson6/src/SDKs/_metadata/compute_resource-manager.txt)
 
 Please check the branch and fork of the REST spec for which the code was generated, this must always be `Azure` and `master` respectively for a PR to be valid. Code generated using specifications not checked in the Azure master branch will not be merged.
 
@@ -47,9 +66,23 @@ For detailed information about publishing and the overall workflow towards devel
 For testing purposes, code can be generated from any fork and branch.
 To do so, modify the `generate.ps1` as below
 ```
-powershell.exe -ExecutionPolicy Bypass -NoLogo -NonInteractive -NoProfile -File "<relativepath>\..\tools\generateTool.ps1" -ResourceProvider "<resourceprovider>" -PowershellInvoker -AutoRestVersion "latest" -SpecsRepoFork "<forkname>" -SpecsRepoBranch "<branchname>"
+Start-AutoRestCodeGeneration -ResourceProvider "<resourceprovider>" -AutoRestVersion "latest" -SpecsRepoFork "<forkname>" -SpecsRepoBranch "<branchname>"
 ```
-If the spec is a completely different repo, add the following argument to the command above
+If the spec is in a completely different repo, add the following argument to the command above
 ```
 -SpecsRepoName "<specsrepo>"
 ```
+We can also generate an sdk from a spec on a local path. 
+
+```
+Start-AutoRestCodeGenerationWithLocalConfig -ResourceProvider "<resourceprovider>" -AutoRestVersion "latest" -LocalConfigFilePath "<path_to_config_file>"
+```
+Please note that the code generated from a spec on the local disk will not be accepted in the PRs against azure-sdk-for-net repo, this is for testing purposes only.
+
+The `StartAutoRestCodeGeneration` and `Start-AutoRestCodeGenerationWithLocalConfig` also expose a number of other useful parameters that can be checked by running
+```
+Get-Help StartAutoRestCodeGeneration
+Get-Help Start-AutoRestCodeGenerationWithLocalConfig
+```
+
+


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->
Addresses https://github.com/Azure/azure-sdk-for-net/issues/4357
## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
