### PR TITLE
[Azure Search] Fixing Build-SearchPackages

### DIFF
--- a/src/SDKs/Search/Build-SearchPackages.ps1
+++ b/src/SDKs/Search/Build-SearchPackages.ps1
@@ -6,5 +6,5 @@ if (!(Test-Path -Path $packagesDir))
     mkdir $packagesDir
 }
 
-msbuild "$scriptDir\..\..\..\build.proj" /t:CreateNugetPackage /p:Scope="SDKs\Search\Management" /p:NugetPackageName="Microsoft.Azure.Management.Search"
-msbuild "$scriptDir\..\..\..\build.proj" /t:CreateNugetPackage /p:Scope="SDKs\Search\DataPlane" /p:NugetPackageName="Microsoft.Azure.Search"
+msbuild "$scriptDir\..\..\..\build.proj" /t:CreateNugetPackage /p:Scope="SDKs\Search\Management"
+msbuild "$scriptDir\..\..\..\build.proj" /t:CreateNugetPackage /p:Scope="SDKs\Search\DataPlane"

--- a/src/SDKs/Search/Build-SearchPackages.ps1
+++ b/src/SDKs/Search/Build-SearchPackages.ps1
@@ -1,3 +1,10 @@
 $scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-msbuild "$scriptDir\..\..\..\build.proj" /t:PublishNuget /p:Scope="SDKs\Search\Management" /p:NugetPackageName="Microsoft.Azure.Management.Search"
-msbuild "$scriptDir\..\..\..\build.proj" /t:PublishNuget /p:Scope="SDKs\Search\DataPlane" /p:NugetPackageName="Microsoft.Azure.Search"
+$packagesDir = "$scriptDir\..\..\..\binaries\packages"
+
+if (!(Test-Path -Path $packagesDir))
+{
+    mkdir $packagesDir
+}
+
+msbuild "$scriptDir\..\..\..\build.proj" /t:CreateNugetPackage /p:Scope="SDKs\Search\Management" /p:NugetPackageName="Microsoft.Azure.Management.Search"
+msbuild "$scriptDir\..\..\..\build.proj" /t:CreateNugetPackage /p:Scope="SDKs\Search\DataPlane" /p:NugetPackageName="Microsoft.Azure.Search"


### PR DESCRIPTION
## Description
Using CreateNugetPackage target instead of PublishNugetPackage.

FYI @updixit @mhko @shahabhijeet 

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
