### PR TITLE
Updating KeyVaultCredential to reuse HttpClient from KeyVaultClient

### DIFF
--- a/src/SDKs/KeyVault/Management/Management.KeyVault/Microsoft.Azure.Management.KeyVault.csproj
+++ b/src/SDKs/KeyVault/Management/Management.KeyVault/Microsoft.Azure.Management.KeyVault.csproj
@@ -8,7 +8,7 @@
 		<Description>Provides key vault management capabilities for Microsoft Azure.</Description>
 		<AssemblyTitle>Microsoft Azure Key Vault Management</AssemblyTitle>
 		<AssemblyName>Microsoft.Azure.Management.KeyVault</AssemblyName>
-		<Version>2.4.1-alpha</Version>
+		<Version>2.4.2-preview</Version>
 		<PackageTags>Microsoft Azure key vault management;Key Vault;</PackageTags>
 		<PackageReleaseNotes/>
 	</PropertyGroup>

--- a/src/SDKs/KeyVault/Management/Management.KeyVault/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/Management/Management.KeyVault/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides key vault management capabilities for Microsoft Azure.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.4.1.0")]
+[assembly: AssemblyFileVersion("2.4.2.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault Core Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Core</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Core</AssemblyName>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>3.0.1-preview</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault Core</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault Core Class Library")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Microsoft.Azure.KeyVault.Cryptography.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Microsoft.Azure.KeyVault.Cryptography.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Azure.KeyVault.Cryptography</PackageId>
     <Description>Microsoft Azure Key Vault Cryptography Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Cryptography</AssemblyTitle>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>3.0.1-preview</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault.Cryptography</AssemblyName>
     <PackageTags>Microsoft Azure Key Vault Cryptography</PackageTags>    
     <PackageReleaseNotes>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault Cryptography Class Library.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault Extensions Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Extensions</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Extensions</AssemblyName>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>3.0.1-preview</VersionPrefix>
     <PackageReleaseNotes>
       <![CDATA[
         This is a public preview release of the Azure Key Vault SDK. Included in this preview are updates to support eliptical curve keys.  This package should not be used in production. It is subject to breaking changes, and will not be supported once the preview has ended. 

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault Extensions Class Library")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault WebKey Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault WebKey</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.WebKey</AssemblyName>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>3.0.1-preview</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault WebKey</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault WebKey Class Library.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Customized/KeyVaultClient.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Customized/KeyVaultClient.cs
@@ -59,7 +59,9 @@ namespace Microsoft.Azure.KeyVault
         /// <param name="credential">Credential for key vault operations</param>
         /// <param name="httpClient">Customized HTTP client </param>
         public KeyVaultClient(KeyVaultCredential credential, HttpClient httpClient)
-            : this(credential)
+            // clone the KeyVaultCredential to ensure the instance is only used by this client since it
+            // will use this client's HttpClient for unauthenticated calls to retrieve the auth challange
+            : this(credential.Clone())
         {
             base.HttpClient = httpClient;
         }

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Azure.KeyVault</PackageId>
     <Description>Azure Key Vault enables users to store and use cryptographic keys within the Microsoft Azure environment. Azure Key Vault supports multiple key types and algorithms and enables the use of Hardware Security Modules (HSM) for high value customer keys. In addition, Azure Key Vault allows users to securely store secrets in a Key Vault; secrets are limited size octet objects and Azure Key Vault applies no specific semantics to these objects. A Key Vault may contain a mix of keys and secrets at the same time, and access control for the two types of object is independently controlled. Users, subject to appropriate authorization, may: 1) Manage cryptographic keys using Create, Import, Update, Delete and other operations 2) Manage secrets using Get, Set, Delete and other operations 3) Use cryptographic keys with Sign/Verify, WrapKey/UnwrapKey and Encrypt/Decrypt operations. Operations against Key Vaults are authenticated and authorized using Azure Active Directory. Key Vault now supports certificates, a complex type that makes use of existing key and secret infrastructure for certificate operations. KV certificates also support notification and auto-renewal as well as other management features.</Description>
     <AssemblyTitle>Microsoft Azure Key Vault</AssemblyTitle>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>3.0.1-preview</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault</AssemblyName>
     <PackageTags>Microsoft Azure Key Vault;Key Vault;REST HTTP client;azureofficial;windowsazureofficial</PackageTags>
     <PackageReleaseNotes>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Azure Key Vault enables users to store and use cryptographic keys within the Microsoft Azure environment. Azure Key Vault supports multiple key types and algorithms and enables the use of Hardware Security Modules (HSM) for high value customer keys. In addition, Azure Key Vault allows users to securely store secrets in a Key Vault; secrets are limited size octet objects and Azure Key Vault applies no specific semantics to these objects. A Key Vault may contain a mix of keys and secrets at the same time, and access control for the two types of object is independently controlled. Users, subject to appropriate authorization, may: 1) Manage cryptographic keys using Create, Import, Update, Delete and other operations 2) Manage secrets using Get, Set, Delete and other operations 3) Use cryptographic keys with Sign/Verify, WrapKey/UnwrapKey and Encrypt/Decrypt operations. Operations against Key Vaults are authenticated and authorized using Azure Active Directory.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
