### PR TITLE
Minor updates and fixes for AppAuthentication library

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For a full list of packages available for download in this repository, please se
 ### Prerequisites:
   Install VS 2017 (Professional or higher) + VS2017 Update 1
   (https://www.visualstudio.com/).
-  To know more about VS 2017 and it's project system (https://docs.microsoft.com/en-us/visualstudio/#pivot=workloads&panel=windows)
+  To know more about VS 2017 and its project system (https://docs.microsoft.com/en-us/visualstudio/#pivot=workloads&panel=windows)
 
 ### Directory Restructure
 Directory structure has been simplified and consolidated in fewer directories

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         // List of potential token providers. 
         private readonly List<NonInteractiveAzureServiceTokenProviderBase> _potentialAccessTokenProviders;
 
-        // Ensures only one threads gets the token from the actual source. It is then cached, so other threads can get it from the cache. 
+        // Ensures only one thread gets the token from the actual source. It is then cached, so other threads can get it from the cache. 
         private static readonly SemaphoreSlim Semaphore = new SemaphoreSlim(1, 1);
 
         /// <summary>
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             }
             finally
             {
-                // Whichever way the try block exists, the semaphone must be released. 
+                // Whichever way the try block exits, the semaphore must be released. 
                 Semaphore.Release();
             }
             

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderException.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderException.cs
@@ -8,6 +8,9 @@ namespace Microsoft.Azure.Services.AppAuthentication
     /// <summary>
     /// Instance of this exception is thrown if access token cannot be acquired. 
     /// </summary>
+#if FullNetFx
+    [Serializable]
+#endif
     public class AzureServiceTokenProviderException : Exception
     {
         internal const string MsiEndpointNotListening = "Unable to connect to the Managed Service Identity (MSI) endpoint. Please check that you are running on an Azure resource that has MSI setup.";
@@ -37,7 +40,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <param name="authority">Authority for which token was expected.</param>
         /// <param name="message">Reason why token could not be acquired.</param>
         internal AzureServiceTokenProviderException(string connectionString, string resource, string authority, string message) : 
-            base($"Parameters: Connectionstring: {connectionString ?? "[No connection string specified]"}, " +
+            base($"Parameters: Connection String: {connectionString ?? "[No connection string specified]"}, " +
                  $"Resource: {resource}, Authority: {authority ?? "[No authority specified]"}. Exception Message: {message}")
         {
         }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderFactory.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderFactory.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
             string runAs = connectionSettings[RunAs];
 
-            // If RunAs=Developer
             if (string.Equals(runAs, Developer, StringComparison.OrdinalIgnoreCase))
             {
+                // If RunAs=Developer
                 ValidateAttribute(connectionSettings, DeveloperTool, connectionString);
 
                 // And Dev Tool equals AzureCLI or VisualStudio
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             }
             else if (string.Equals(runAs, App, StringComparison.OrdinalIgnoreCase))
             {
-                // If AuthenticateAs=App
+                // If RunAs=App
                 // If AppId key is present, use certificate or Client Secret based token provider
                 if (connectionSettings.ContainsKey(AppId))
                 {

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <PackageId>Microsoft.Azure.Services.AppAuthentication</PackageId>
         <Description>Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.</Description>
-        <Version>1.0.2</Version>
+        <Version>1.0.3</Version>
         <AssemblyName>Microsoft.Azure.Services.AppAuthentication</AssemblyName>
         <PackageTags>Azure Authentication AppAuthentication</PackageTags>
 	<PackageReleaseNotes>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <PackageId>Microsoft.Azure.Services.AppAuthentication</PackageId>
         <Description>Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.</Description>
-        <Version>1.0.1</Version>
+        <Version>1.0.2</Version>
         <AssemblyName>Microsoft.Azure.Services.AppAuthentication</AssemblyName>
         <PackageTags>Azure Authentication AppAuthentication</PackageTags>
 	<PackageReleaseNotes>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -9,7 +9,8 @@
 		<![CDATA[
 			Documentation can be found at https://go.microsoft.com/fwlink/p/?linkid=862452.
 			
-			Bug fix: Microsoft.Azure.Services.AppAuthentication.targets was missing.
+			MsiAccessTokenProvider updated to use IDMS endpoint for authentication
+			Bug fix: Serializable tag was missing on AzureServicesTokenProviderException
 		]]>
 	</PackageReleaseNotes>
     </PropertyGroup>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft.Azure.Services.AppAuthentication")]
 [assembly: AssemblyDescription("Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.")]
 
-[assembly: AssemblyVersion("1.0.2.0")]
-[assembly: AssemblyFileVersion("1.0.2.0")]
+[assembly: AssemblyVersion("1.0.3.0")]
+[assembly: AssemblyFileVersion("1.0.3.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft.Azure.Services.AppAuthentication")]
 [assembly: AssemblyDescription("Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.")]
 
-[assembly: AssemblyVersion("1.0.1.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyVersion("1.0.2.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
