### PR TITLE
Updated crypto to include Rs384 and rs512

### DIFF
--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography.Tests/Tests/Cryptography/Algorithms/RsaKeyTests.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography.Tests/Tests/Cryptography/Algorithms/RsaKeyTests.cs
@@ -130,6 +130,48 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Tests
             Assert.True( verify );
         }
 
+        [Fact]
+        public async Task KeyVault_RsaKeyRS384()
+        {
+            var key = GetTestRsaKey();
+            var hash = SHA384.Create();
+
+            var digest = hash.ComputeHash(CEK, 0, CEK.Length);
+
+            Assert.NotNull(digest);
+
+            var signature = await key.SignAsync(digest, "RS384").ConfigureAwait(false);
+
+            Assert.True(signature.Item2.Equals("RS384"));
+            Assert.NotNull(signature.Item1);
+
+            var verify = await key.VerifyAsync(digest, signature.Item1, signature.Item2).ConfigureAwait(false);
+
+            Assert.True(verify);
+
+        }
+
+        [Fact]
+        public async Task KeyVault_RsaKeyRS512()
+        {
+            var key = GetTestRsaKey();
+            var hash = SHA512.Create();
+
+            var digest = hash.ComputeHash(CEK, 0, CEK.Length);
+
+            Assert.NotNull(digest);
+
+            var signature = await key.SignAsync(digest, "RS512").ConfigureAwait(false);
+
+            Assert.True(signature.Item2.Equals("RS512"));
+            Assert.NotNull(signature.Item1);
+
+            var verify = await key.VerifyAsync(digest, signature.Item1, signature.Item2).ConfigureAwait(false);
+
+            Assert.True(verify);
+
+        }
+
         public RsaKey GetTestRsaKey()
         {
             var jwkString = "{\"kty\":\"RSA\",\"n\":\"rZ8pnmXkhfmmgNWVVdtNcYy2q0OAcCGIpeFzsN9URqJsiBEiWQfxlUxFTbM4kVWPqjauKt6byvApBGEeMA7Qs8kxwRVP-BD4orXRe9VPgliM92rH0UxQWHmCHUe7G7uUAFPwbiDVhWuFzELxNa6Kljg6Z9DuUKoddmQvlYWj8uSunofCtDi_zzlZKGYTOYJma5IYScHNww1yjLp8-b-Be2UdHbrPkCv6Nuwi6MVIKjPpEeRQgfefRmxDBJQKY3OfydMXZmEwukYXVkUcdIP8XwG2OxnfdRK0oAo0NDebNNVuT89k_3AyZLTr1KbDmx1nnjwa8uB8k-uLtcOC9igbTw\",\"e\":\"AQAB\",\"d\":\"H-z7hy_vVJ9yeZBMtIvt8qpQUK_J51STPwV085otcgud72tPKJXoW2658664ASl9kGwbnLBwb2G3-SEunuGqiNS_PGUB3niob6sFSUMRKsPDsB9HfPoOcCZvwZiWFGRqs6C7vlR1TuJVqRjKJ_ffbf4K51oo6FZPspx7j4AShLAwLUSQ60Ld5QPuxYMYZIMpdVbMVIVHJ26pR4Y18e_0GYmEGnbF5N0HkwqQmfmTiIK5aoGnD3GGgqHeHmWBwh6_WAq90ITLcX_zBeqQUgBSj-Z5v61SroO9Eang36T9mMoYrcPpYwemtAOb4HhQYDj8dCCfbeOcVmvZ9UJKWCX2oQ\",\"dp\":\"HW87UpwPoj3lPI9B9K1hJFeuGgarpakvtHuk1HpZ5hXWFGAJiXoWRV-jvYyjoM2k7RpSxPyuuFFmYHcIxiGFp2ES4HnP0BIhKVa2DyugUxIEcMK53C43Ub4mboJPZTSC3sapKgAmA2ue624sapWmshTPpx9qnUP2Oj3cSMkgMGE\",\"dq\":\"RhwEwb5FYio0GS2tmul8FAYsNH7JDehwI1yUApnTiakhSenFetml4PYyVkKR4csgLZEi3RY6J3R8Tg-36zrZuF7hxhVJn80L5_KETSpfEI3jcrXMVg4SRaMsWLY9Ahxflt2FJgUnHOmWRLmP6_hmaTcxxSACjbyUd_HhwNavD5E\",\"qi\":\"wYPZ4lKIslA1w3FaAzQifnNLABYXXUZ_KAA3a8T8fuxkdE4OP3xIFX7WHhnmBd6uOFiEcGoeq2jNQqDg91rV5661-5muQKcvp4uUsNId5rQw9EZw-kdDcwMtVFTEBfvVuyp83X974xYAHn1Jd8wWohSwrpi1QuH5cQMR5Fm6I1A\",\"p\":\"74Ot7MgxRu4euB31UWnGtrqYPjJmvbjYESS43jfDfo-s62ggV5a39P_YPg6oosgtGHNw0QDxunUOXNu9iriaYPf_imptRk69bKN8Nrl727Y-AaBYdLf1UZuwz8X07FqHAH5ghYpk79djld8QvkUUJLpx6rzcW8BJLTOi46DtzZE\",\"q\":\"uZJu-qenARIt28oj_Jlsk-p_KLnqdczczZfbRDd7XNp6csGLa8R0EyYqUB4xLWELQZsX4tAu9SaAO62tuuEy5wbOAmOVrq2ntoia1mGQSJdoeVq6OqtN300xVnaBc3us0rm8C6-824fEQ1PWXoulXLKcSqBhFT-hQahsYi-kat8\"}";

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/AlgorithmResolver.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/AlgorithmResolver.cs
@@ -32,6 +32,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography
             Default.AddAlgorithm( RsaOaep.AlgorithmName, new RsaOaep() );
 
             Default.AddAlgorithm( Rs256.AlgorithmName, new Rs256() );
+            Default.AddAlgorithm( Rs384.AlgorithmName, new Rs384() );
+            Default.AddAlgorithm( Rs512.AlgorithmName, new Rs512());
 
 #if NET45
             Default.AddAlgorithm( RsNull.AlgorithmName, new RsNull() );

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs256.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs256.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         internal const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
         internal const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
 
+        internal const int SHA256_LENGTH = 32;
         public Rs256()
             : base( AlgorithmName )
         {
@@ -50,8 +51,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != 32 )
-                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 32 bytes for SHA-256" );
+                if ( digest.Length != SHA256_LENGTH )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format( "The digest must be {0} bytes for SHA-256", SHA256_LENGTH ));
 
 #if NET45
                 if ( _key is RSACryptoServiceProvider )
@@ -72,8 +73,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != 32 )
-                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 32 bytes for SHA-256" );
+                if ( digest.Length != SHA256_LENGTH )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format( "The digest must be {0} bytes for SHA-256", SHA256_LENGTH ));
 
                 if ( signature == null || signature.Length == 0 )
                     throw new ArgumentNullException( "signature" );

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs256.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs256.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         internal const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
         internal const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
 
-        internal const int SHA256_LENGTH = 32;
+        internal const int SHA256_DIGEST_LENGTH = 32;
         public Rs256()
             : base( AlgorithmName )
         {
@@ -51,8 +51,10 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != SHA256_LENGTH )
-                    throw new ArgumentOutOfRangeException( "digest", String.Format( "The digest must be {0} bytes for SHA-256", SHA256_LENGTH ));
+                if ( digest.Length != SHA256_DIGEST_LENGTH
+     )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format( "The digest must be {0} bytes for SHA-256", SHA256_DIGEST_LENGTH
+         ));
 
 #if NET45
                 if ( _key is RSACryptoServiceProvider )
@@ -73,8 +75,10 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != SHA256_LENGTH )
-                    throw new ArgumentOutOfRangeException( "digest", String.Format( "The digest must be {0} bytes for SHA-256", SHA256_LENGTH ));
+                if ( digest.Length != SHA256_DIGEST_LENGTH
+     )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format( "The digest must be {0} bytes for SHA-256", SHA256_DIGEST_LENGTH
+         ));
 
                 if ( signature == null || signature.Length == 0 )
                     throw new ArgumentNullException( "signature" );

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs384.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs384.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         internal const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
         internal const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
 
+        internal const int SHA384_LENGTH = 48;
         public Rs384()
             : base( AlgorithmName )
         {
@@ -50,8 +51,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != 48 )
-                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 48 bytes for SHA-384" );
+                if ( digest.Length != SHA384_LENGTH )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-384", SHA384_LENGTH ));
 
 #if NET45
                 if ( _key is RSACryptoServiceProvider )
@@ -72,8 +73,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != 48 )
-                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 48 bytes for SHA-384" );
+                if ( digest.Length != SHA384_LENGTH)
+                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-384", SHA384_LENGTH ));
 
                 if ( signature == null || signature.Length == 0 )
                     throw new ArgumentNullException( "signature" );

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs384.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs384.cs
@@ -1,0 +1,97 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+//
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    /// <summary>
+    /// RSA SHA-256 Signature algorithim.
+    /// </summary>
+    public class Rs384 : RsaSignature
+    {
+        public const string AlgorithmName = "RS384";
+
+        internal const string OID_OIWSEC_SHA256 = "2.16.840.1.101.3.4.2.1";
+        internal const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
+        internal const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
+
+        public Rs384()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override ISignatureTransform CreateSignatureTransform( AsymmetricAlgorithm key )
+        {
+            return new Rs384SignatureTransform( key );
+        }
+
+        class Rs384SignatureTransform : ISignatureTransform
+        {
+            private RSA _key;
+
+            public Rs384SignatureTransform( AsymmetricAlgorithm key )
+            {
+                if ( key == null )
+                    throw new ArgumentNullException( "key" );
+
+                if ( !( key is RSA ) )
+                    throw new ArgumentException( string.Format( "key must be of type {0}", typeof( RSA ).AssemblyQualifiedName ), "key" );
+
+                _key = key as RSA;
+            }
+
+            public byte[] Sign( byte[] digest )
+            {
+                if ( digest == null || digest.Length == 0 )
+                    throw new ArgumentNullException( "digest" );
+
+                if ( digest.Length != 48 )
+                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 48 bytes for SHA-384" );
+
+#if NET45
+                if ( _key is RSACryptoServiceProvider )
+                {
+                    return ((RSACryptoServiceProvider)_key).SignHash( digest, OID_OIWSEC_SHA384 );
+                }
+
+                throw new CryptographicException( string.Format( "{0} is not supported", _key.GetType().FullName ) );
+#elif NETSTANDARD
+                return _key.SignHash( digest, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1 );
+#else
+                #error Unknown Framework
+#endif
+            }
+
+            public bool Verify( byte[] digest, byte[] signature )
+            {
+                if ( digest == null || digest.Length == 0 )
+                    throw new ArgumentNullException( "digest" );
+
+                if ( digest.Length != 48 )
+                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 48 bytes for SHA-384" );
+
+                if ( signature == null || signature.Length == 0 )
+                    throw new ArgumentNullException( "signature" );
+
+
+#if NET45
+                if ( _key is RSACryptoServiceProvider )
+                {
+                    return ((RSACryptoServiceProvider)_key).VerifyHash( digest, OID_OIWSEC_SHA384, signature );
+                }
+
+                throw new CryptographicException( string.Format( "{0} is not supported", _key.GetType().FullName ) );
+#elif NETSTANDARD
+                return _key.VerifyHash( digest, signature, HashAlgorithmName.SHA384, RSASignaturePadding.Pkcs1 );
+#else
+                #error Unknown Framework
+#endif
+            }
+        }
+    }
+}

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs384.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs384.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         internal const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
         internal const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
 
-        internal const int SHA384_LENGTH = 48;
+        internal const int SHA384_DIGEST_LENGTH = 48;
         public Rs384()
             : base( AlgorithmName )
         {
@@ -51,8 +51,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != SHA384_LENGTH )
-                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-384", SHA384_LENGTH ));
+                if ( digest.Length != SHA384_DIGEST_LENGTH )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-384", SHA384_DIGEST_LENGTH ));
 
 #if NET45
                 if ( _key is RSACryptoServiceProvider )
@@ -73,8 +73,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != SHA384_LENGTH)
-                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-384", SHA384_LENGTH ));
+                if ( digest.Length != SHA384_DIGEST_LENGTH)
+                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-384", SHA384_DIGEST_LENGTH ));
 
                 if ( signature == null || signature.Length == 0 )
                     throw new ArgumentNullException( "signature" );

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs512.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs512.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         internal const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
         internal const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
 
-        internal const int SHA512_LENGTH = 64;
+        internal const int SHA512_DIGEST_LENGTH = 64;
 
         public Rs512()
             : base( AlgorithmName )
@@ -52,8 +52,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != SHA512_LENGTH )
-                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-512", SHA512_LENGTH));
+                if ( digest.Length != SHA512_DIGEST_LENGTH )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-512", SHA512_DIGEST_LENGTH));
 
 #if NET45
                 if ( _key is RSACryptoServiceProvider )
@@ -74,8 +74,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != SHA512_LENGTH )
-                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-512", SHA512_LENGTH) );
+                if ( digest.Length != SHA512_DIGEST_LENGTH )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-512", SHA512_DIGEST_LENGTH) );
 
                 if ( signature == null || signature.Length == 0 )
                     throw new ArgumentNullException( "signature" );

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs512.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs512.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
         internal const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
         internal const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
 
+        internal const int SHA512_LENGTH = 64;
+
         public Rs512()
             : base( AlgorithmName )
         {
@@ -50,8 +52,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != 64 )
-                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 64 bytes for SHA-512" );
+                if ( digest.Length != SHA512_LENGTH )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-512", SHA512_LENGTH));
 
 #if NET45
                 if ( _key is RSACryptoServiceProvider )
@@ -72,8 +74,8 @@ namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
                 if ( digest == null || digest.Length == 0 )
                     throw new ArgumentNullException( "digest" );
 
-                if ( digest.Length != 64 )
-                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 64 bytes for SHA-512" );
+                if ( digest.Length != SHA512_LENGTH )
+                    throw new ArgumentOutOfRangeException( "digest", String.Format("The digest must be {0} bytes for SHA-512", SHA512_LENGTH) );
 
                 if ( signature == null || signature.Length == 0 )
                     throw new ArgumentNullException( "signature" );

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs512.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Algorithms/Rs512.cs
@@ -1,0 +1,97 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+//
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.Azure.KeyVault.Cryptography.Algorithms
+{
+    /// <summary>
+    /// RSA SHA-512 Signature algorithim.
+    /// </summary>
+    public class Rs512 : RsaSignature
+    {
+        public const string AlgorithmName = "RS512";
+
+        internal const string OID_OIWSEC_SHA256 = "2.16.840.1.101.3.4.2.1";
+        internal const string OID_OIWSEC_SHA384 = "2.16.840.1.101.3.4.2.2";
+        internal const string OID_OIWSEC_SHA512 = "2.16.840.1.101.3.4.2.3";
+
+        public Rs512()
+            : base( AlgorithmName )
+        {
+        }
+
+        public override ISignatureTransform CreateSignatureTransform( AsymmetricAlgorithm key )
+        {
+            return new Rs512SignatureTransform( key );
+        }
+
+        class Rs512SignatureTransform : ISignatureTransform
+        {
+            private RSA _key;
+
+            public Rs512SignatureTransform( AsymmetricAlgorithm key )
+            {
+                if ( key == null )
+                    throw new ArgumentNullException( "key" );
+
+                if ( !( key is RSA ) )
+                    throw new ArgumentException( string.Format( "key must be of type {0}", typeof( RSA ).AssemblyQualifiedName ), "key" );
+
+                _key = key as RSA;
+            }
+
+            public byte[] Sign( byte[] digest )
+            {
+                if ( digest == null || digest.Length == 0 )
+                    throw new ArgumentNullException( "digest" );
+
+                if ( digest.Length != 64 )
+                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 64 bytes for SHA-512" );
+
+#if NET45
+                if ( _key is RSACryptoServiceProvider )
+                {
+                    return ((RSACryptoServiceProvider)_key).SignHash( digest, OID_OIWSEC_SHA512 );
+                }
+
+                throw new CryptographicException( string.Format( "{0} is not supported", _key.GetType().FullName ) );
+#elif NETSTANDARD
+                return _key.SignHash( digest, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1 );
+#else
+                #error Unknown Framework
+#endif
+            }
+
+            public bool Verify( byte[] digest, byte[] signature )
+            {
+                if ( digest == null || digest.Length == 0 )
+                    throw new ArgumentNullException( "digest" );
+
+                if ( digest.Length != 64 )
+                    throw new ArgumentOutOfRangeException( "digest", "The digest must be 64 bytes for SHA-512" );
+
+                if ( signature == null || signature.Length == 0 )
+                    throw new ArgumentNullException( "signature" );
+
+
+#if NET45
+                if ( _key is RSACryptoServiceProvider )
+                {
+                    return ((RSACryptoServiceProvider)_key).VerifyHash( digest, OID_OIWSEC_SHA512, signature );
+                }
+
+                throw new CryptographicException( string.Format( "{0} is not supported", _key.GetType().FullName ) );
+#elif NETSTANDARD
+                return _key.VerifyHash( digest, signature, HashAlgorithmName.SHA512, RSASignaturePadding.Pkcs1 );
+#else
+                #error Unknown Framework
+#endif
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
