### PR TITLE
 Adding tests for powershell cmdlets 

### DIFF
--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Microsoft.Azure.Sdk.Build.Tasks.sln
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Microsoft.Azure.Sdk.Build.Tasks.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.4
+VisualStudioVersion = 15.0.27130.2003
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Sdk.Build.Tasks", "SdkBuildTasks\Microsoft.Azure.Sdk.Build.Tasks.csproj", "{F7170FBA-EB69-4910-9F52-3259E73FC4ED}"
 EndProject
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "MsbuildTests", "MsbuildTest
 		Tests\MsbuildTests\PackagingTests.proj = Tests\MsbuildTests\PackagingTests.proj
 		Tests\MsbuildTests\PublishNugetPackageTests.proj = Tests\MsbuildTests\PublishNugetPackageTests.proj
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PSCmdLets.Tests", "Tests\PSCmdletTests\PSCmdLets.Tests.csproj", "{FD2F1938-D2C2-4BDF-A23C-FC039D816AC5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,8 +36,15 @@ Global
 		{D36088F5-DE32-4883-BFE1-CE5ACBEB52D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D36088F5-DE32-4883-BFE1-CE5ACBEB52D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D36088F5-DE32-4883-BFE1-CE5ACBEB52D7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD2F1938-D2C2-4BDF-A23C-FC039D816AC5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD2F1938-D2C2-4BDF-A23C-FC039D816AC5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD2F1938-D2C2-4BDF-A23C-FC039D816AC5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD2F1938-D2C2-4BDF-A23C-FC039D816AC5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {A4C59836-DD41-4C62-8055-21076098F0D8}
 	EndGlobalSection
 EndGlobal

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/CodeGenerationCmdletTests.cs
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/CodeGenerationCmdletTests.cs
@@ -1,0 +1,146 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Management.Automation;
+using System.Text;
+using System.Threading;
+using Xunit;
+
+namespace PSCmdLets.Tests
+{
+    public class CodeGenerationCmdletTests
+    {
+        static String scriptsPath = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase), @"TestAssets\SampleRepo\src\SDKs\Compute\Management.Compute");
+        static String genDir = new Uri(Path.Combine(scriptsPath, "Generated")).AbsolutePath;
+        static String azureStackScriptPath = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().GetName().CodeBase), @"TestAssets\SampleRepo\src\AzureStack\AzureAdmin\");
+        static String azureStackGenDir = new Uri(Path.Combine(azureStackScriptPath, "Generated")).AbsolutePath;
+        static String metadataDir = new Uri(Path.Combine(scriptsPath, @"..\..\_metadata")).AbsolutePath;
+
+        [Fact]
+        public void BasicCodeGenerationWithDefaultGenDirectoryScenario()
+        {
+            try
+            {
+                using (PowerShell PowerShellInstance = PowerShell.Create())
+                {
+                    PowerShellInstance.AddScript("powershell.exe -ExecutionPolicy Bypass -File " + new Uri(Path.Combine(scriptsPath, "test1.ps1")).AbsolutePath);
+                    var result = PowerShellInstance.Invoke();
+                    Assert.NotEmpty(result);
+                    Assert.Empty(PowerShellInstance.Streams.Error);
+                    Assert.True(Directory.Exists(genDir));
+                    Assert.NotEmpty(Directory.GetFiles(genDir));
+                    Assert.True(Directory.Exists(metadataDir));
+                }
+            }
+            finally
+            {
+                Cleanup();
+            }
+        }
+
+        [Fact]
+        public void CodeGenerationWithSdkGenDirectoryScenario()
+        {
+            try
+            {
+                using (PowerShell PowerShellInstance = PowerShell.Create())
+                {
+                    PowerShellInstance.AddScript("powershell.exe -ExecutionPolicy Bypass -File " + new Uri(Path.Combine(scriptsPath, "test2.ps1")).AbsolutePath);
+                    var result = PowerShellInstance.Invoke();
+                    Assert.NotEmpty(result);
+                    Assert.Empty(PowerShellInstance.Streams.Error);
+                    Assert.True(Directory.Exists(genDir));
+                    Assert.NotEmpty(Directory.GetFiles(genDir));
+                    Assert.True(Directory.Exists(metadataDir));
+                }
+            }
+            finally
+            {
+                Cleanup();
+            }
+        }
+
+        [Fact]
+        public void CodeGenerationWithSdkRootDirectoryScenario()
+        {
+            try
+            {
+                using (PowerShell PowerShellInstance = PowerShell.Create())
+                {
+                    PowerShellInstance.AddScript("powershell.exe -ExecutionPolicy Bypass -File " + new Uri(Path.Combine(scriptsPath, "test3.ps1")).AbsolutePath);
+                    var result = PowerShellInstance.Invoke();
+                    Assert.NotEmpty(result);
+                    Assert.Empty(PowerShellInstance.Streams.Error);
+                    Assert.True(Directory.Exists(genDir));
+                    Assert.NotEmpty(Directory.GetFiles(genDir));
+                    Assert.True(Directory.Exists(metadataDir));
+                }
+            }
+            finally
+            {
+                Cleanup();
+            }
+        }
+
+        [Fact]
+        public void NonSDKsCodeGenerationScenario()
+        {
+            try
+            {
+                using (PowerShell PowerShellInstance = PowerShell.Create())
+                {
+                    PowerShellInstance.AddScript("powershell.exe -ExecutionPolicy Bypass -File " + new Uri(Path.Combine(azureStackScriptPath, "test5.ps1")).AbsolutePath);
+
+                    var result = PowerShellInstance.Invoke();
+                    Assert.NotEmpty(result);
+                    Assert.Empty(PowerShellInstance.Streams.Error);
+                    Assert.True(Directory.Exists(azureStackGenDir));
+                    Assert.NotEmpty(Directory.GetFiles(azureStackGenDir));
+                    Assert.True(Directory.Exists(metadataDir));
+                }
+            }
+            finally
+            {
+                Cleanup();
+            }
+            
+        }
+
+        [Fact]
+        public void CodeGenerationWithLocalSpecScenario()
+        {
+            try
+            {
+                using (PowerShell PowerShellInstance = PowerShell.Create())
+                {
+                    PowerShellInstance.AddScript("powershell.exe -ExecutionPolicy Bypass -File " + new Uri(Path.Combine(scriptsPath, "test4.ps1")).AbsolutePath);
+                    var result = PowerShellInstance.Invoke();
+                    Assert.NotEmpty(result);
+                    Assert.Empty(PowerShellInstance.Streams.Error);
+                    Assert.True(Directory.Exists(genDir));
+                    Assert.NotEmpty(Directory.GetFiles(genDir));
+                }
+            }
+            finally
+            {
+                Cleanup();
+            }
+        }
+
+        private void Cleanup()
+        {
+            if (Directory.Exists(genDir))
+            {
+                Directory.Delete(genDir, true);
+            }
+            if (Directory.Exists(azureStackGenDir))
+            {
+                Directory.Delete(azureStackGenDir, true);
+            }
+            if (Directory.Exists(metadataDir))
+            {
+                Directory.Delete(metadataDir, true);
+            }
+        }
+    }
+}

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/PSCmdLets.Tests.csproj
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/PSCmdLets.Tests.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <CodeGenCmdletDir>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\..\..\psModules\CodeGenerationModules'))</CodeGenCmdletDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeGenCmdlets Include="$(CodeGenCmdletDir)\**\*.*" />
+    <PackageReference Include="System.Management.Automation.dll" Version="10.0.10586" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <Folder Include="TestAssets\" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Update="TestAssets\**\*.*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
+  <Target Name="CopyTestAssets" AfterTargets="Build">
+    <Copy SourceFiles="@(CodeGenCmdlets)" DestinationFolder="$(OutputPath)\TestAssets" />
+  </Target>
+</Project>

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/AzureStack/AzureAdmin/test5.ps1
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/AzureStack/AzureAdmin/test5.ps1
@@ -1,0 +1,3 @@
+# Basic test for non-SDKs directory
+Import-Module "$PSScriptRoot\..\..\..\..\AutoRestCodeGenerationModule.psm1"
+Start-AutoRestCodeGeneration -ResourceProvider "azsadmin/resource-manager/azurebridge" -AutoRestVersion "latest" -SdkRootDirectory "$PSScriptRoot"

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/SDKs/Compute/Management.Compute/test1.ps1
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/SDKs/Compute/Management.Compute/test1.ps1
@@ -1,0 +1,3 @@
+# Basic test, this is how most generate.ps1s look like
+Import-Module "$PSScriptRoot\..\..\..\..\..\AutoRestCodeGenerationModule.psm1"
+Start-AutoRestCodeGeneration -ResourceProvider "compute/resource-manager" -AutoRestVersion "latest"

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/SDKs/Compute/Management.Compute/test2.ps1
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/SDKs/Compute/Management.Compute/test2.ps1
@@ -1,0 +1,3 @@
+# Basic test, some generate.ps1s explicitly provide the SdkGenerationDirectory
+Import-Module "$PSScriptRoot\..\..\..\..\..\AutoRestCodeGenerationModule.psm1"
+Start-AutoRestCodeGeneration -ResourceProvider "compute/resource-manager" -AutoRestVersion "latest" -SdkGenerationDirectory "$PSScriptRoot\Generated"

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/SDKs/Compute/Management.Compute/test3.ps1
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/SDKs/Compute/Management.Compute/test3.ps1
@@ -1,0 +1,3 @@
+# Basic test, some generate.ps1s explicitly provide the SdkRootDirectory
+Import-Module "$PSScriptRoot\..\..\..\..\..\AutoRestCodeGenerationModule.psm1"
+Start-AutoRestCodeGeneration -ResourceProvider "compute/resource-manager" -AutoRestVersion "latest" -SdkRootDirectory "$PSScriptRoot\..\..\"

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/SDKs/Compute/Management.Compute/test4.ps1
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/SampleRepo/src/SDKs/Compute/Management.Compute/test4.ps1
@@ -1,0 +1,5 @@
+# Advanced test, generate code using a spec on the local disk
+Import-Module "$PSScriptRoot\..\..\..\..\..\AutoRestCodeGenerationModule.psm1"
+$configFilePath = $(Resolve-Path "$PSScriptRoot\..\..\..\..\..\TestRestSpecs\readme.md")
+Write-Host $configFilePath
+Start-AutoRestCodeGenerationWithLocalConfig -ResourceProvider "redis/resource-manager" -AutoRestVersion "latest" -LocalConfigFilePath $configFilePath -SdkGenerationDirectory "$PSScriptRoot\Generated"

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/TestRestSpec/2018-03-01/redis.json
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/TestRestSpec/2018-03-01/redis.json
@@ -1,0 +1,77 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "RedisManagementClient",
+    "description": "REST API for Azure Redis Cache Service.",
+    "version": "2018-03-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Cache/CheckNameAvailability": {
+      "post": {
+        "tags": [
+          "Redis"
+        ],
+        "operationId": "Redis_CheckNameAvailability",
+        "description": "Checks that the redis cache name is valid and is not already in use.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Name is available"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "Gets subscription credentials which uniquely identify the Microsoft Azure subscription. The subscription ID forms part of the URI for every service call."
+    },
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "Client Api Version."
+    }
+  }
+}

--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/TestRestSpec/readme.md
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/Tests/PSCmdletTests/TestAssets/TestRestSpec/readme.md
@@ -1,0 +1,46 @@
+# Redis
+
+> see https://aka.ms/autorest
+
+This is the AutoRest configuration file for Redis.
+
+---
+## Getting Started
+To build the SDK for Redis, simply [Install AutoRest](https://aka.ms/autorest/install) and in this folder, run:
+
+> `autorest`
+
+To see additional help and options, run:
+
+> `autorest --help`
+---
+
+## Configuration
+
+### Basic Information
+These are the global settings for the Redis API.
+
+``` yaml
+openapi-type: arm
+tag: package-2018-03
+```
+
+### Tag: package-2018-03
+
+These settings apply only when `--tag=package-2018-03` is specified on the command line.
+
+``` yaml $(tag) == 'package-2018-03'
+input-file:
+- 2018-03-01/redis.json
+```
+
+## C#
+
+``` yaml $(csharp)
+csharp:
+  # last generated with AutoRest.0.17.3
+  azure-arm: true
+  license-header: MICROSOFT_MIT_NO_VERSION
+  namespace: Microsoft.Azure.Management.Redis
+  clear-output-folder: true
+```


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
