### PR TITLE
[Azure Search] Hotfix deadlock issue in Documents.CountWithHttpMessag…

### DIFF
--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Microsoft.Azure.Search.Common.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Microsoft.Azure.Search.Common.csproj
@@ -6,7 +6,7 @@
     <Description>Common types needed by the Azure Search .NET libraries. This is not the package you are looking for; It is only meant to be used as a dependency.</Description>
     <AssemblyTitle>Microsoft Azure Search Common Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search.Common</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.1.0")]
 
 [assembly: AssemblyTitle("Microsoft Azure Search Common Library")]
 [assembly: AssemblyDescription("Common types needed by the Azure Search .NET libraries. This is not the assembly you are looking for; It is only meant to be used as a dependency.")]

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Customizations/Documents/DocumentsOperations.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Customizations/Documents/DocumentsOperations.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Search
                 await this.Client.DocumentsProxy.CountWithHttpMessagesAsync(
                     searchRequestOptions, 
                     customHeaders, 
-                    cancellationToken);
+                    cancellationToken).ConfigureAwait(false);
 
             return new AzureOperationResponse<long>()
             {

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Microsoft.Azure.Search.Data.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Microsoft.Azure.Search.Data.csproj
@@ -6,7 +6,7 @@
     <Description>Use this package if you're developing a .NET application using Azure Search, and you only need to query or update documents in your indexes. If you also need to create or update indexes, synonym maps, or other service-level resources, use the Microsoft.Azure.Search package instead.</Description>
     <AssemblyTitle>Microsoft Azure Search Data Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search.Data</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Azure.Search.Common" Version="[5.0.0, 6.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Search.Common" Version="[5.0.1, 6.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.Search.Common\Microsoft.Azure.Search.Common.csproj" />

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.1.0")]
 
 [assembly: AssemblyTitle("Microsoft Azure Search Data Library")]
 [assembly: AssemblyDescription("Use this assembly if you're developing a .NET application using Azure Search, and you only need to query or update documents in your indexes. If you also need to create or update indexes, synonym maps, or other service-level resources, use the Microsoft.Azure.Search assembly instead.")]

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Microsoft.Azure.Search.Service.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Microsoft.Azure.Search.Service.csproj
@@ -6,7 +6,7 @@
     <Description>Use this package if you're developing automation in .NET to manage Azure Search indexes, synonym maps, indexers, data sources, or other service-level resources. If you only need to query or update documents in your indexes, use the Microsoft.Azure.Search.Data package instead. If you need all the functionality of Azure Search, use the Microsoft.Azure.Search package instead.</Description>
     <AssemblyTitle>Microsoft Azure Search Service Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search.Service</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Azure.Search.Common" Version="[5.0.0, 6.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Search.Common" Version="[5.0.1, 6.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.Search.Common\Microsoft.Azure.Search.Common.csproj" />

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.1.0")]
 
 [assembly: AssemblyTitle("Microsoft Azure Search Service Library")]
 [assembly: AssemblyDescription("Use this assembly if you're developing automation in .NET to manage Azure Search indexes, synonym maps, indexers, data sources, or other service-level resources. If you only need to query or update documents in your indexes, use the Microsoft.Azure.Search.Data assembly instead. If you need all the functionality of Azure Search, use the Microsoft.Azure.Search assembly instead.")]

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Microsoft.Azure.Search.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Microsoft.Azure.Search.csproj
@@ -6,7 +6,7 @@
     <Description>Makes it easy to develop a .NET application that uses Azure Search.</Description>
     <AssemblyTitle>Microsoft Azure Search Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search</AssemblyName>
-    <VersionPrefix>5.0.0</VersionPrefix>
+    <VersionPrefix>5.0.1</VersionPrefix>
     <PackageReleaseNotes>This is the newest major version of the Azure Search .NET SDK, based on version 2017-11-11 of the Azure Search REST API. New in this GA version is support for synonyms. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
@@ -14,8 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Search.Data" Version="[5.0.0, 6.0.0)" />
-    <PackageReference Include="Microsoft.Azure.Search.Service" Version="[5.0.0, 6.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Search.Data" Version="[5.0.1, 6.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Search.Service" Version="[5.0.1, 6.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.Search.Data\Microsoft.Azure.Search.Data.csproj" />

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.1.0")]
 
 [assembly: AssemblyTitle("Microsoft Azure Search Library")]
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]


### PR DESCRIPTION
…esAsync

We were missing a call to .ConfigureAwait(false). This change fixes that issue and bumps the GA SDK version to 5.0.1.

FYI @mhko @updixit @Yahnoosh 

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [X] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
