### PR TITLE
Add SDK functionality to make it easier to deserialize/consume EventGrid events

### DIFF
--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Tests/ConsumeEventTests.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Tests/ConsumeEventTests.cs
@@ -1,0 +1,469 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.EventGrid.Models;
+using Microsoft.Rest.Serialization;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace Microsoft.Azure.EventGrid.Tests.ScenarioTests
+{
+    public class ConsumptionTests
+    {
+        readonly EventGridSubscriber eventGridSubscriber;
+
+        public ConsumptionTests()
+        {
+            eventGridSubscriber = new EventGridSubscriber();
+        }
+
+        [Fact]
+        public void ConsumeStorageBlobDeletedEventWithExtraProperty()
+        {
+            string requestContent = "[{   \"topic\": \"/subscriptions/id/resourceGroups/Storage/providers/Microsoft.Storage/storageAccounts/xstoretestaccount\",  \"subject\": \"/blobServices/default/containers/testcontainer/blobs/testfile.txt\",  \"eventType\": \"Microsoft.Storage.BlobDeleted\",  \"eventTime\": \"2017-11-07T20:09:22.5674003Z\",  \"id\": \"4c2359fe-001e-00ba-0e04-58586806d298\",  \"data\": {    \"api\": \"DeleteBlob\",    \"requestId\": \"4c2359fe-001e-00ba-0e04-585868000000\",    \"contentType\": \"text/plain\",    \"blobType\": \"BlockBlob\",    \"url\": \"https://example.blob.core.windows.net/testcontainer/testfile.txt\",    \"sequencer\": \"0000000000000281000000000002F5CA\",   \"brandNewProperty\": \"0000000000000281000000000002F5CA\", \"storageDiagnostics\": {      \"batchId\": \"b68529f3-68cd-4744-baa4-3c0498ec19f0\"    }  },  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is StorageBlobDeletedEventData);
+            StorageBlobDeletedEventData eventData = (StorageBlobDeletedEventData)events[0].Data;
+            Assert.Equal("https://example.blob.core.windows.net/testcontainer/testfile.txt", eventData.Url);
+        }
+
+        [Fact]
+        public void ConsumeCustomEvents()
+        {
+            string requestContent = "[{  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": {    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  },  \"eventType\": \"Contoso.Items.ItemReceived\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}]";
+
+            EventGridSubscriber eventGridSubscriber2 = new EventGridSubscriber();
+
+            // Testing update
+            eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemReceived", typeof(ContosoItemSentEventData));
+            eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemReceived", typeof(ContosoItemReceivedEventData));
+
+            var events = eventGridSubscriber2.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.Single(events);
+            Assert.True(events[0].Data is ContosoItemReceivedEventData);
+            ContosoItemReceivedEventData eventData = (ContosoItemReceivedEventData)events[0].Data;
+            Assert.Equal("512d38b6-c7b8-40c8-89fe-f46f9e9622b6", eventData.ItemSku);
+        }
+
+        [Fact]
+        public void ConsumeCustomEventWithArrayData()
+        {
+            string requestContent = "[{  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": [{    \"itemSku\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"itemUri\": \"https://rp-eastus2.eventgrid.azure.net:553\"  }],  \"eventType\": \"Contoso.Items.ItemReceived\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}]";
+
+            EventGridSubscriber eventGridSubscriber2 = new EventGridSubscriber();
+            eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemReceived", typeof(ContosoItemReceivedEventData[]));
+
+            var events = eventGridSubscriber2.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.Single(events);
+            Assert.True(events[0].Data is ContosoItemReceivedEventData[]);
+            ContosoItemReceivedEventData[] eventData = (ContosoItemReceivedEventData[])events[0].Data;
+            Assert.Equal("512d38b6-c7b8-40c8-89fe-f46f9e9622b6", eventData[0].ItemSku);
+        }
+
+        [Fact]
+        public void ConsumeCustomEventWithBooleanData()
+        {
+            string requestContent = "[{  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": true,  \"eventType\": \"Contoso.Items.ItemReceived\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}]";
+
+            EventGridSubscriber eventGridSubscriber2 = new EventGridSubscriber();
+            eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemReceived", typeof(bool));
+
+            var events = eventGridSubscriber2.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.Single(events);
+            Assert.True(events[0].Data is bool);
+            bool eventData = (bool)events[0].Data;
+            Assert.True(eventData);
+        }
+
+        [Fact]
+        public void ConsumeCustomEventWithStringData()
+        {
+            string requestContent = "[{  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": \"stringdata\",  \"eventType\": \"Contoso.Items.ItemReceived\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}]";
+
+            EventGridSubscriber eventGridSubscriber2 = new EventGridSubscriber();
+            eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemReceived", typeof(string));
+
+            var events = eventGridSubscriber2.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.Single(events);
+            Assert.True(events[0].Data is string);
+            string eventData = (string)events[0].Data;
+            Assert.Equal("stringdata", eventData);
+        }
+
+        [Fact]
+        public void ConsumeCustomEventWithPolymorphicData()
+        {
+            string requestContent = "[{  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": {  \"shippingInfo\":{\"shippingType\":\"Drone\", \"droneId\":\"Drone1\",\"shipmentId\":\"1\"}} ,  \"eventType\": \"Contoso.Items.ItemSent\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}, {  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": {  \"shippingInfo\":{\"shippingType\":\"Rocket\", \"rocketNumber\":1,\"shipmentId\":\"1\"}} ,  \"eventType\": \"Contoso.Items.ItemSent\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}]";
+
+            EventGridSubscriber eventGridSubscriber2 = new EventGridSubscriber();
+            eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemSent", typeof(ContosoItemSentEventData));
+
+            JsonSerializer jsonSerializer = new JsonSerializer();
+            jsonSerializer.Converters.Add(new PolymorphicDeserializeJsonConverter<ShippingInfo>("shippingType"));
+
+            var events = eventGridSubscriber2.DeserializeEventGridEvents(requestContent, jsonSerializer);
+
+            Assert.NotNull(events);
+            Assert.Equal(2, events.Length);
+            Assert.True(events[0].Data is ContosoItemSentEventData);
+            Assert.True(events[1].Data is ContosoItemSentEventData);
+            ContosoItemSentEventData eventData0 = (ContosoItemSentEventData)events[0].Data;
+            Assert.True(eventData0.ShippingInfo is DroneShippingInfo);
+
+            ContosoItemSentEventData eventData1 = (ContosoItemSentEventData)events[1].Data;
+            Assert.True(eventData1.ShippingInfo is RocketShippingInfo);
+        }
+
+        [Fact]
+        public void TestCustomEventMappings()
+        {
+            EventGridSubscriber eventGridSubscriber2 = new EventGridSubscriber();
+            eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemSent", typeof(ContosoItemSentEventData));
+            eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemReceived", typeof(ContosoItemReceivedEventData));
+
+            IReadOnlyList<KeyValuePair<string, Type>> list = eventGridSubscriber2.GetAllCustomEventMappings();
+            Assert.Equal(2, list.Count);
+
+            Assert.True(eventGridSubscriber2.TryGetCustomEventMapping("Contoso.Items.ItemSent", out Type retrievedType));
+            Assert.Equal(typeof(ContosoItemSentEventData), retrievedType);
+
+            Assert.True(eventGridSubscriber2.TryRemoveCustomEventMapping("Contoso.Items.ItemReceived", out retrievedType));
+            Assert.Equal(typeof(ContosoItemReceivedEventData), retrievedType);
+        }
+
+        [Fact]
+        public void ConsumeMultipleEventsInSameBatch()
+        {
+            string requestContent = "[ {  \"topic\": \"/subscriptions/319a9601-1ec0-0000-aebc-8fe82724c81e/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/myaccount\",  \"subject\": \"/blobServices/default/containers/testcontainer/blobs/file1.txt\",  \"eventType\": \"Microsoft.Storage.BlobCreated\",  \"eventTime\": \"2017-08-16T01:57:26.005121Z\",  \"id\": \"602a88ef-0001-00e6-1233-1646070610ea\",  \"data\": {    \"api\": \"PutBlockList\",    \"clientRequestId\": \"799304a4-bbc5-45b6-9849-ec2c66be800a\",    \"requestId\": \"602a88ef-0001-00e6-1233-164607000000\",    \"eTag\": \"0x8D4E44A24ABE7F1\",    \"contentType\": \"text/plain\",    \"contentLength\": 447,    \"blobType\": \"BlockBlob\",    \"url\": \"https://myaccount.blob.core.windows.net/testcontainer/file1.txt\",    \"sequencer\": \"00000000000000EB000000000000C65A\",  },  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}, {   \"topic\": \"/subscriptions/id/resourceGroups/Storage/providers/Microsoft.Storage/storageAccounts/xstoretestaccount\",  \"subject\": \"/blobServices/default/containers/testcontainer/blobs/testfile.txt\",  \"eventType\": \"Microsoft.Storage.BlobDeleted\",  \"eventTime\": \"2017-11-07T20:09:22.5674003Z\",  \"id\": \"4c2359fe-001e-00ba-0e04-58586806d298\",  \"data\": {    \"api\": \"DeleteBlob\",    \"requestId\": \"4c2359fe-001e-00ba-0e04-585868000000\",    \"contentType\": \"text/plain\",    \"blobType\": \"BlockBlob\",    \"url\": \"https://example.blob.core.windows.net/testcontainer/testfile.txt\",    \"sequencer\": \"0000000000000281000000000002F5CA\",    \"storageDiagnostics\": {      \"batchId\": \"b68529f3-68cd-4744-baa4-3c0498ec19f0\"    }  },  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}, {   \"topic\": \"/subscriptions/id/resourceGroups/Storage/providers/Microsoft.Storage/storageAccounts/xstoretestaccount\",  \"subject\": \"/blobServices/default/containers/testcontainer/blobs/testfile.txt\",  \"eventType\": \"Microsoft.Storage.BlobDeleted\",  \"eventTime\": \"2017-11-07T20:09:22.5674003Z\",  \"id\": \"4c2359fe-001e-00ba-0e04-58586806d298\",  \"data\": {    \"api\": \"DeleteBlob\",    \"requestId\": \"4c2359fe-001e-00ba-0e04-585868000000\",    \"contentType\": \"text/plain\",    \"blobType\": \"BlockBlob\",    \"url\": \"https://example.blob.core.windows.net/testcontainer/testfile.txt\",    \"sequencer\": \"0000000000000281000000000002F5CA\",    \"storageDiagnostics\": {      \"batchId\": \"b68529f3-68cd-4744-baa4-3c0498ec19f0\"    }  },  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}, {  \"topic\": \"/subscriptions/id/resourcegroups/rg/providers/Microsoft.ServiceBus/namespaces/testns1\",  \"subject\": \"topics/topic1/subscriptions/sub1\",  \"eventType\": \"Microsoft.ServiceBus.DeadletterMessagesAvailableWithNoListener\",  \"eventTime\": \"2018-02-14T05:12:53.4133526Z\",  \"id\": \"dede87b0-3656-419c-acaf-70c95ddc60f5\",  \"data\": {    \"namespaceName\": \"testns1\",    \"requestUri\": \"https://testns1.servicebus.windows.net/t1/subscriptions/sub1/messages/head\",    \"entityType\": \"subscriber\",    \"queueName\": \"queue1\",    \"topicName\": \"topic1\",    \"subscriptionName\": \"sub1\"  },  \"dataVersion\": \"1\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.Equal(4, events.Length);
+            Assert.True(events[0].Data is StorageBlobCreatedEventData);
+            Assert.True(events[1].Data is StorageBlobDeletedEventData);
+            Assert.True(events[2].Data is StorageBlobDeletedEventData);
+            Assert.True(events[3].Data is ServiceBusDeadletterMessagesAvailableWithNoListenersEventData);
+            StorageBlobDeletedEventData eventData = (StorageBlobDeletedEventData)events[2].Data;
+            Assert.Equal("https://example.blob.core.windows.net/testcontainer/testfile.txt", eventData.Url);
+        }
+
+        // Verify stream support
+        [Fact]
+        public void ConsumeContainerRegistryImagePushedEventFromStream()
+        {
+            string requestContent = "[{  \"id\": \"56afc886-767b-d359-d59e-0da7877166b2\",  \"topic\": \"/SUBSCRIPTIONS/ID/RESOURCEGROUPS/rg/PROVIDERS/MICROSOFT.ContainerRegistry/test1\",  \"subject\": \"test1\",  \"eventType\": \"Microsoft.ContainerRegistry.ImagePushed\",  \"eventTime\": \"2018-01-02T19:17:44.4383997Z\",  \"data\": {\"id\":\"eventID\",\"timestamp\":\"2018-06-20T12:00:33.6125843-07:00\",\"action\":\"testaction\",\"target\":{\"mediaType\":\"test\",\"size\":20,\"digest\":\"digest1\",\"length\":20,\"repository\":\"test\",\"url\":\"url1\",\"tag\":\"test\"},\"request\":{\"id\":\"id\",\"addr\":\"127.0.0.1\",\"host\":\"test\",\"method\":\"method1\",\"useragent\":\"useragent1\"},\"actor\":{\"name\":\"testactor\"},\"source\":{\"addr\":\"127.0.0.1\",\"instanceID\":\"id\"}},  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}]";
+
+            using (var stream = GetStreamFromString(requestContent))
+            {
+                var events = this.eventGridSubscriber.DeserializeEventGridEvents(stream);
+
+                Assert.NotNull(events);
+                Assert.True(events[0].Data is ContainerRegistryImagePushedEventData);
+                ContainerRegistryImagePushedEventData eventData = (ContainerRegistryImagePushedEventData)events[0].Data;
+                Assert.Equal("127.0.0.1", eventData.Request.Addr);
+            }
+        }
+
+        [Fact]
+        public void ConsumeCustomEventWithPolymorphicDataFromStream()
+        {
+            string requestContent = "[{  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": {  \"shippingInfo\":{\"shippingType\":\"Drone\", \"droneId\":\"Drone1\",\"shipmentId\":\"1\"}} ,  \"eventType\": \"Contoso.Items.ItemSent\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}, {  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": {  \"shippingInfo\":{\"shippingType\":\"Rocket\", \"rocketNumber\":1,\"shipmentId\":\"1\"}} ,  \"eventType\": \"Contoso.Items.ItemSent\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}]";
+
+            using (var stream = GetStreamFromString(requestContent))
+            {
+                EventGridSubscriber eventGridSubscriber2 = new EventGridSubscriber();
+                eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemSent", typeof(ContosoItemSentEventData));
+
+                JsonSerializer jsonSerializer = new JsonSerializer();
+                jsonSerializer.Converters.Add(new PolymorphicDeserializeJsonConverter<ShippingInfo>("shippingType"));
+
+                var events = eventGridSubscriber2.DeserializeEventGridEvents(stream, jsonSerializer);
+
+                Assert.NotNull(events);
+                Assert.Equal(2, events.Length);
+                Assert.True(events[0].Data is ContosoItemSentEventData);
+                Assert.True(events[1].Data is ContosoItemSentEventData);
+                ContosoItemSentEventData eventData0 = (ContosoItemSentEventData)events[0].Data;
+                Assert.True(eventData0.ShippingInfo is DroneShippingInfo);
+
+                ContosoItemSentEventData eventData1 = (ContosoItemSentEventData)events[1].Data;
+                Assert.True(eventData1.ShippingInfo is RocketShippingInfo);
+            }
+        }
+
+        // ContainerRegistry events
+        [Fact]
+        public void ConsumeContainerRegistryImagePushedEvent()
+        {
+            string requestContent = "[{  \"id\": \"56afc886-767b-d359-d59e-0da7877166b2\",  \"topic\": \"/SUBSCRIPTIONS/ID/RESOURCEGROUPS/rg/PROVIDERS/MICROSOFT.ContainerRegistry/test1\",  \"subject\": \"test1\",  \"eventType\": \"Microsoft.ContainerRegistry.ImagePushed\",  \"eventTime\": \"2018-01-02T19:17:44.4383997Z\",  \"data\": {\"id\":\"eventID\",\"timestamp\":\"2018-06-20T12:00:33.6125843-07:00\",\"action\":\"testaction\",\"target\":{\"mediaType\":\"test\",\"size\":20,\"digest\":\"digest1\",\"length\":20,\"repository\":\"test\",\"url\":\"url1\",\"tag\":\"test\"},\"request\":{\"id\":\"id\",\"addr\":\"127.0.0.1\",\"host\":\"test\",\"method\":\"method1\",\"useragent\":\"useragent1\"},\"actor\":{\"name\":\"testactor\"},\"source\":{\"addr\":\"127.0.0.1\",\"instanceID\":\"id\"}},  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}]";
+
+
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ContainerRegistryImagePushedEventData);
+            ContainerRegistryImagePushedEventData eventData = (ContainerRegistryImagePushedEventData)events[0].Data;
+            Assert.Equal("127.0.0.1", eventData.Request.Addr);
+        }
+
+        [Fact]
+        public void ConsumeContainerRegistryImageDeletedEvent()
+        {
+            string requestContent = "[{  \"id\": \"56afc886-767b-d359-d59e-0da7877166b2\",  \"topic\": \"/SUBSCRIPTIONS/ID/RESOURCEGROUPS/rg/PROVIDERS/MICROSOFT.ContainerRegistry/test1\",  \"subject\": \"test1\",  \"eventType\": \"Microsoft.ContainerRegistry.ImageDeleted\",  \"eventTime\": \"2018-01-02T19:17:44.4383997Z\",  \"data\": {\"id\":\"eventID\",\"timestamp\":\"2018-06-20T12:00:33.6125843-07:00\",\"action\":\"testaction\",\"target\":{\"mediaType\":\"test\",\"size\":20,\"digest\":\"digest1\",\"length\":20,\"repository\":\"test\",\"url\":\"url1\",\"tag\":\"test\"},\"request\":{\"id\":\"id\",\"addr\":\"127.0.0.1\",\"host\":\"test\",\"method\":\"method1\",\"useragent\":\"useragent1\"},\"actor\":{\"name\":\"testactor\"},\"source\":{\"addr\":\"127.0.0.1\",\"instanceID\":\"id\"}},  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ContainerRegistryImageDeletedEventData);
+            ContainerRegistryImageDeletedEventData eventData = (ContainerRegistryImageDeletedEventData)events[0].Data;
+            Assert.Equal("testactor", eventData.Actor.Name);
+        }
+
+        // IoTHub Device events
+        [Fact]
+        public void ConsumeIoTHubDeviceCreatedEvent()
+        {
+            string requestContent = "[{  \"id\": \"56afc886-767b-d359-d59e-0da7877166b2\",  \"topic\": \"/SUBSCRIPTIONS/ID/RESOURCEGROUPS/rg/PROVIDERS/MICROSOFT.DEVICES/IOTHUBS/hub1\",  \"subject\": \"devices/LogicAppTestDevice\",  \"eventType\": \"Microsoft.Devices.DeviceCreated\",  \"eventTime\": \"2018-01-02T19:17:44.4383997Z\",  \"data\": {    \"twin\": {      \"deviceId\": \"LogicAppTestDevice\",      \"etag\": \"AAAAAAAAAAE=\",      \"status\": \"enabled\",      \"statusUpdateTime\": \"0001-01-01T00:00:00\",      \"connectionState\": \"Disconnected\",      \"lastActivityTime\": \"0001-01-01T00:00:00\",      \"cloudToDeviceMessageCount\": 0,      \"authenticationType\": \"sas\",      \"x509Thumbprint\": {        \"primaryThumbprint\": null,        \"secondaryThumbprint\": null      },      \"version\": 2,      \"properties\": {        \"desired\": {          \"$metadata\": {            \"$lastUpdated\": \"2018-01-02T19:17:44.4383997Z\"          },          \"$version\": 1        },        \"reported\": {          \"$metadata\": {            \"$lastUpdated\": \"2018-01-02T19:17:44.4383997Z\"          },          \"$version\": 1        }      }    },    \"hubName\": \"egtesthub1\",    \"deviceId\": \"LogicAppTestDevice\",    \"operationTimestamp\": \"2018-01-02T19:17:44.4383997Z\",    \"opType\": \"DeviceCreated\"  },  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is IotHubDeviceCreatedEventData);
+            IotHubDeviceCreatedEventData eventData = (IotHubDeviceCreatedEventData)events[0].Data;
+            Assert.Equal("enabled", eventData.Twin.Status);
+        }
+
+        [Fact]
+        public void ConsumeIoTHubDeviceDeletedEvent()
+        {
+            string requestContent = "[{  \"id\": \"56afc886-767b-d359-d59e-0da7877166b2\",  \"topic\": \"/SUBSCRIPTIONS/id/RESOURCEGROUPS/rg/PROVIDERS/MICROSOFT.DEVICES/IOTHUBS/hub1\",  \"subject\": \"devices/LogicAppTestDevice\",  \"eventType\": \"Microsoft.Devices.DeviceDeleted\",  \"eventTime\": \"2018-01-02T19:17:44.4383997Z\",  \"data\": {    \"twin\": {      \"deviceId\": \"LogicAppTestDevice\",      \"etag\": \"AAAAAAAAAAE=\",      \"status\": \"enabled\",      \"statusUpdateTime\": \"0001-01-01T00:00:00\",      \"connectionState\": \"Disconnected\",      \"lastActivityTime\": \"0001-01-01T00:00:00\",      \"cloudToDeviceMessageCount\": 0,      \"authenticationType\": \"sas\",      \"x509Thumbprint\": {        \"primaryThumbprint\": null,        \"secondaryThumbprint\": null      },      \"version\": 2,      \"properties\": {        \"desired\": {          \"$metadata\": {            \"$lastUpdated\": \"2018-01-02T19:17:44.4383997Z\"          },          \"$version\": 1        },        \"reported\": {          \"$metadata\": {            \"$lastUpdated\": \"2018-01-02T19:17:44.4383997Z\"          },          \"$version\": 1        }      }    },    \"hubName\": \"egtesthub1\",    \"deviceId\": \"LogicAppTestDevice\",    \"operationTimestamp\": \"2018-01-02T19:17:44.4383997Z\",    \"opType\": \"DeviceCreated\"  },  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is IotHubDeviceDeletedEventData);
+            IotHubDeviceDeletedEventData eventData = (IotHubDeviceDeletedEventData)events[0].Data;
+            Assert.Equal("AAAAAAAAAAE=", eventData.Twin.Etag);
+        }
+
+        // EventGrid events
+        [Fact]
+        public void ConsumeEventGridSubscriptionValidationEvent()
+        {
+            string requestContent = "[{  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": {    \"validationCode\": \"512d38b6-c7b8-40c8-89fe-f46f9e9622b6\",    \"validationUrl\": \"https://rp-eastus2.eventgrid.azure.net:553/eventsubscriptions/estest/validate?id=B2E34264-7D71-453A-B5FB-B62D0FDC85EE&t=2018-04-26T20:30:54.4538837Z&apiVersion=2018-05-01-preview&token=1BNqCxBBSSE9OnNSfZM4%2b5H9zDegKMY6uJ%2fO2DFRkwQ%3d\"  },  \"eventType\": \"Microsoft.EventGrid.SubscriptionValidationEvent\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is SubscriptionValidationEventData);
+            SubscriptionValidationEventData eventData = (SubscriptionValidationEventData)events[0].Data;
+            Assert.Equal("512d38b6-c7b8-40c8-89fe-f46f9e9622b6", eventData.ValidationCode);
+        }
+
+        [Fact]
+        public void ConsumeEventGridSubscriptionDeletedEvent()
+        {
+            string requestContent = "[{  \"id\": \"2d1781af-3a4c-4d7c-bd0c-e34b19da4e66\",  \"topic\": \"/subscriptions/xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\",  \"subject\": \"\",  \"data\": {    \"eventSubscriptionId\": \"/subscriptions/id/resourceGroups/rg/providers/Microsoft.EventGrid/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/eventsubscription1\"  },  \"eventType\": \"Microsoft.EventGrid.SubscriptionDeletedEvent\",  \"eventTime\": \"2018-01-25T22:12:19.4556811Z\",  \"metadataVersion\": \"1\",  \"dataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is SubscriptionDeletedEventData);
+            SubscriptionDeletedEventData eventData = (SubscriptionDeletedEventData)events[0].Data;
+            Assert.Equal("/subscriptions/id/resourceGroups/rg/providers/Microsoft.EventGrid/topics/topic1/providers/Microsoft.EventGrid/eventSubscriptions/eventsubscription1", eventData.EventSubscriptionId);
+        }
+
+        // Event Hub Events
+        [Fact]
+        public void ConsumeEventHubCaptureFileCreatedEvent()
+        {
+            string requestContent = "[    {        \"topic\": \"/subscriptions/guid/resourcegroups/rgDataMigrationSample/providers/Microsoft.EventHub/namespaces/tfdatamigratens\",        \"subject\": \"eventhubs/hubdatamigration\",        \"eventType\": \"microsoft.EventHUB.CaptureFileCreated\",        \"eventTime\": \"2017-08-31T19:12:46.0498024Z\",        \"id\": \"14e87d03-6fbf-4bb2-9a21-92bd1281f247\",        \"data\": {            \"fileUrl\": \"https://tf0831datamigrate.blob.core.windows.net/windturbinecapture/tfdatamigratens/hubdatamigration/1/2017/08/31/19/11/45.avro\",            \"fileType\": \"AzureBlockBlob\",            \"partitionId\": \"1\",            \"sizeInBytes\": 249168,            \"eventCount\": 1500,            \"firstSequenceNumber\": 2400,            \"lastSequenceNumber\": 3899,            \"firstEnqueueTime\": \"2017-08-31T19:12:14.674Z\",            \"lastEnqueueTime\": \"2017-08-31T19:12:44.309Z\"        },        \"dataVersion\": \"\",        \"metadataVersion\": \"1\"    }]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is EventHubCaptureFileCreatedEventData);
+            EventHubCaptureFileCreatedEventData eventData = (EventHubCaptureFileCreatedEventData)events[0].Data;
+            Assert.Equal("AzureBlockBlob", eventData.FileType);
+        }
+
+        // Media Services events
+        [Fact]
+        public void ConsumeMediaServicesJobStateChangedEvent()
+        {
+            string requestContent = "[   {    \"topic\": \"/subscriptions/{subscription id}/resourceGroups/amsResourceGroup/providers/Microsoft.Media/mediaservices/amsaccount\",    \"subject\": \"transforms/VideoAnalyzerTransform/jobs/{job id}\",    \"eventType\": \"Microsoft.Media.JobStateChange\",    \"eventTime\": \"2018-04-20T21:26:13.8978772\",    \"id\": \"<id>\",    \"data\": {      \"previousState\": \"Processing\",      \"state\": \"Finished\"    },    \"dataVersion\": \"1.0\",    \"metadataVersion\": \"1\"  }]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is MediaJobStateChangeEventData);
+            MediaJobStateChangeEventData eventData = (MediaJobStateChangeEventData)events[0].Data;
+            Assert.Equal("Finished", eventData.State);
+        }
+
+        // Resource Manager (Azure Subscription/Resource Group) events
+        [Fact]
+        public void ConsumeResourceWriteSuccessEvent()
+        {
+            string requestContent = "[   {     \"topic\":\"/subscriptions/{subscription-id}\",     \"subject\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",    \"eventType\":\"Microsoft.Resources.ResourceWriteSuccess\",    \"eventTime\":\"2017-08-16T03:54:38.2696833Z\",    \"id\":\"25b3b0d0-d79b-44d5-9963-440d4e6a9bba\",    \"data\": {        \"authorization\":\"{azure_resource_manager_authorizations}\",        \"claims\":\"{azure_resource_manager_claims}\",        \"correlationId\":\"54ef1e39-6a82-44b3-abc1-bdeb6ce4d3c6\",        \"httpRequest\":\"{request-operation}\",        \"resourceProvider\":\"Microsoft.EventGrid\",        \"resourceUri\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",        \"operationName\":\"Microsoft.EventGrid/eventSubscriptions/write\",        \"status\":\"Succeeded\",        \"subscriptionId\":\"{subscription-id}\",        \"tenantId\":\"72f988bf-86f1-41af-91ab-2d7cd011db47\"        },      \"dataVersion\": \"\",      \"metadataVersion\": \"1\"  }]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ResourceWriteSuccessData);
+            ResourceWriteSuccessData eventData = (ResourceWriteSuccessData)events[0].Data;
+            Assert.Equal("72f988bf-86f1-41af-91ab-2d7cd011db47", eventData.TenantId);
+        }
+
+        [Fact]
+        public void ConsumeResourceWriteFailureEvent()
+        {
+            string requestContent = "[   {     \"topic\":\"/subscriptions/{subscription-id}\",     \"subject\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",    \"eventType\":\"Microsoft.Resources.ResourceWriteFailure\",    \"eventTime\":\"2017-08-16T03:54:38.2696833Z\",    \"id\":\"25b3b0d0-d79b-44d5-9963-440d4e6a9bba\",    \"data\": {        \"authorization\":\"{azure_resource_manager_authorizations}\",        \"claims\":\"{azure_resource_manager_claims}\",        \"correlationId\":\"54ef1e39-6a82-44b3-abc1-bdeb6ce4d3c6\",        \"httpRequest\":\"{request-operation}\",        \"resourceProvider\":\"Microsoft.EventGrid\",        \"resourceUri\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",        \"operationName\":\"Microsoft.EventGrid/eventSubscriptions/write\",        \"status\":\"Succeeded\",        \"subscriptionId\":\"{subscription-id}\",        \"tenantId\":\"72f988bf-86f1-41af-91ab-2d7cd011db47\"        },      \"dataVersion\": \"\",      \"metadataVersion\": \"1\"  }]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ResourceWriteFailureData);
+            ResourceWriteFailureData eventData = (ResourceWriteFailureData)events[0].Data;
+            Assert.Equal("72f988bf-86f1-41af-91ab-2d7cd011db47", eventData.TenantId);
+        }
+
+        [Fact]
+        public void ConsumeResourceWriteCancelEvent()
+        {
+            string requestContent = "[   {     \"topic\":\"/subscriptions/{subscription-id}\",     \"subject\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",    \"eventType\":\"Microsoft.Resources.ResourceWriteCancel\",    \"eventTime\":\"2017-08-16T03:54:38.2696833Z\",    \"id\":\"25b3b0d0-d79b-44d5-9963-440d4e6a9bba\",    \"data\": {        \"authorization\":\"{azure_resource_manager_authorizations}\",        \"claims\":\"{azure_resource_manager_claims}\",        \"correlationId\":\"54ef1e39-6a82-44b3-abc1-bdeb6ce4d3c6\",        \"httpRequest\":\"{request-operation}\",        \"resourceProvider\":\"Microsoft.EventGrid\",        \"resourceUri\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",        \"operationName\":\"Microsoft.EventGrid/eventSubscriptions/write\",        \"status\":\"Succeeded\",        \"subscriptionId\":\"{subscription-id}\",        \"tenantId\":\"72f988bf-86f1-41af-91ab-2d7cd011db47\"        },      \"dataVersion\": \"\",      \"metadataVersion\": \"1\"  }]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ResourceWriteCancelData);
+            ResourceWriteCancelData eventData = (ResourceWriteCancelData)events[0].Data;
+            Assert.Equal("72f988bf-86f1-41af-91ab-2d7cd011db47", eventData.TenantId);
+        }
+
+        [Fact]
+        public void ConsumeResourceDeleteSuccessEvent()
+        {
+            string requestContent = "[   {     \"topic\":\"/subscriptions/{subscription-id}\",     \"subject\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",    \"eventType\":\"Microsoft.Resources.ResourceDeleteSuccess\",    \"eventTime\":\"2017-08-16T03:54:38.2696833Z\",    \"id\":\"25b3b0d0-d79b-44d5-9963-440d4e6a9bba\",    \"data\": {        \"authorization\":\"{azure_resource_manager_authorizations}\",        \"claims\":\"{azure_resource_manager_claims}\",        \"correlationId\":\"54ef1e39-6a82-44b3-abc1-bdeb6ce4d3c6\",        \"httpRequest\":\"{request-operation}\",        \"resourceProvider\":\"Microsoft.EventGrid\",        \"resourceUri\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",        \"operationName\":\"Microsoft.EventGrid/eventSubscriptions/write\",        \"status\":\"Succeeded\",        \"subscriptionId\":\"{subscription-id}\",        \"tenantId\":\"72f988bf-86f1-41af-91ab-2d7cd011db47\"        },      \"dataVersion\": \"\",      \"metadataVersion\": \"1\"  }]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ResourceDeleteSuccessData);
+            ResourceDeleteSuccessData eventData = (ResourceDeleteSuccessData)events[0].Data;
+            Assert.Equal("72f988bf-86f1-41af-91ab-2d7cd011db47", eventData.TenantId);
+        }
+
+        [Fact]
+        public void ConsumeResourceDeleteFailureEvent()
+        {
+            string requestContent = "[   {     \"topic\":\"/subscriptions/{subscription-id}\",     \"subject\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",    \"eventType\":\"Microsoft.Resources.ResourceDeleteFailure\",    \"eventTime\":\"2017-08-16T03:54:38.2696833Z\",    \"id\":\"25b3b0d0-d79b-44d5-9963-440d4e6a9bba\",    \"data\": {        \"authorization\":\"{azure_resource_manager_authorizations}\",        \"claims\":\"{azure_resource_manager_claims}\",        \"correlationId\":\"54ef1e39-6a82-44b3-abc1-bdeb6ce4d3c6\",        \"httpRequest\":\"{request-operation}\",        \"resourceProvider\":\"Microsoft.EventGrid\",        \"resourceUri\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",        \"operationName\":\"Microsoft.EventGrid/eventSubscriptions/write\",        \"status\":\"Succeeded\",        \"subscriptionId\":\"{subscription-id}\",        \"tenantId\":\"72f988bf-86f1-41af-91ab-2d7cd011db47\"        },      \"dataVersion\": \"\",      \"metadataVersion\": \"1\"  }]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ResourceDeleteFailureData);
+            ResourceDeleteFailureData eventData = (ResourceDeleteFailureData)events[0].Data;
+            Assert.Equal("72f988bf-86f1-41af-91ab-2d7cd011db47", eventData.TenantId);
+        }
+
+        [Fact]
+        public void ConsumeResourceDeleteCancelEvent()
+        {
+            string requestContent = "[   {     \"topic\":\"/subscriptions/{subscription-id}\",     \"subject\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",    \"eventType\":\"Microsoft.Resources.ResourceDeleteCancel\",    \"eventTime\":\"2017-08-16T03:54:38.2696833Z\",    \"id\":\"25b3b0d0-d79b-44d5-9963-440d4e6a9bba\",    \"data\": {        \"authorization\":\"{azure_resource_manager_authorizations}\",        \"claims\":\"{azure_resource_manager_claims}\",        \"correlationId\":\"54ef1e39-6a82-44b3-abc1-bdeb6ce4d3c6\",        \"httpRequest\":\"{request-operation}\",        \"resourceProvider\":\"Microsoft.EventGrid\",        \"resourceUri\":\"/subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.EventGrid/eventSubscriptions/LogicAppdd584bdf-8347-49c9-b9a9-d1f980783501\",        \"operationName\":\"Microsoft.EventGrid/eventSubscriptions/write\",        \"status\":\"Succeeded\",        \"subscriptionId\":\"{subscription-id}\",        \"tenantId\":\"72f988bf-86f1-41af-91ab-2d7cd011db47\"        },      \"dataVersion\": \"\",      \"metadataVersion\": \"1\"  }]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ResourceDeleteCancelData);
+            ResourceDeleteCancelData eventData = (ResourceDeleteCancelData)events[0].Data;
+            Assert.Equal("72f988bf-86f1-41af-91ab-2d7cd011db47", eventData.TenantId);
+        }
+
+        // ServiceBus events
+        [Fact]
+        public void ConsumeServiceBusActiveMessagesAvailableWithNoListenersEvent()
+        {
+            string requestContent = "[{  \"topic\": \"/subscriptions/id/resourcegroups/rg/providers/Microsoft.ServiceBus/namespaces/testns1\",  \"subject\": \"topics/topic1/subscriptions/sub1\",  \"eventType\": \"Microsoft.ServiceBus.ActiveMessagesAvailableWithNoListeners\",  \"eventTime\": \"2018-02-14T05:12:53.4133526Z\",  \"id\": \"dede87b0-3656-419c-acaf-70c95ddc60f5\",  \"data\": {    \"namespaceName\": \"testns1\",    \"requestUri\": \"https://testns1.servicebus.windows.net/t1/subscriptions/sub1/messages/head\",    \"entityType\": \"subscriber\",    \"queueName\": \"queue1\",    \"topicName\": \"topic1\",    \"subscriptionName\": \"sub1\"  },  \"dataVersion\": \"1\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ServiceBusActiveMessagesAvailableWithNoListenersEventData);
+            ServiceBusActiveMessagesAvailableWithNoListenersEventData eventData = (ServiceBusActiveMessagesAvailableWithNoListenersEventData)events[0].Data;
+            Assert.Equal("testns1", eventData.NamespaceName);
+        }
+
+        [Fact]
+        public void ConsumeServiceBusDeadletterMessagesAvailableWithNoListenersEvent()
+        {
+            string requestContent = "[{  \"topic\": \"/subscriptions/id/resourcegroups/rg/providers/Microsoft.ServiceBus/namespaces/testns1\",  \"subject\": \"topics/topic1/subscriptions/sub1\",  \"eventType\": \"Microsoft.ServiceBus.DeadletterMessagesAvailableWithNoListener\",  \"eventTime\": \"2018-02-14T05:12:53.4133526Z\",  \"id\": \"dede87b0-3656-419c-acaf-70c95ddc60f5\",  \"data\": {    \"namespaceName\": \"testns1\",    \"requestUri\": \"https://testns1.servicebus.windows.net/t1/subscriptions/sub1/messages/head\",    \"entityType\": \"subscriber\",    \"queueName\": \"queue1\",    \"topicName\": \"topic1\",    \"subscriptionName\": \"sub1\"  },  \"dataVersion\": \"1\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is ServiceBusDeadletterMessagesAvailableWithNoListenersEventData);
+            ServiceBusDeadletterMessagesAvailableWithNoListenersEventData eventData = (ServiceBusDeadletterMessagesAvailableWithNoListenersEventData)events[0].Data;
+            Assert.Equal("testns1", eventData.NamespaceName);
+        }
+
+        // Storage events
+        [Fact]
+        public void ConsumeStorageBlobCreatedEvent()
+        {
+            string requestContent = "[ {  \"topic\": \"/subscriptions/319a9601-1ec0-0000-aebc-8fe82724c81e/resourceGroups/testrg/providers/Microsoft.Storage/storageAccounts/myaccount\",  \"subject\": \"/blobServices/default/containers/testcontainer/blobs/file1.txt\",  \"eventType\": \"Microsoft.Storage.BlobCreated\",  \"eventTime\": \"2017-08-16T01:57:26.005121Z\",  \"id\": \"602a88ef-0001-00e6-1233-1646070610ea\",  \"data\": {    \"api\": \"PutBlockList\",    \"clientRequestId\": \"799304a4-bbc5-45b6-9849-ec2c66be800a\",    \"requestId\": \"602a88ef-0001-00e6-1233-164607000000\",    \"eTag\": \"0x8D4E44A24ABE7F1\",    \"contentType\": \"text/plain\",    \"contentLength\": 447,    \"blobType\": \"BlockBlob\",    \"url\": \"https://myaccount.blob.core.windows.net/testcontainer/file1.txt\",    \"sequencer\": \"00000000000000EB000000000000C65A\",  },  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is StorageBlobCreatedEventData);
+            StorageBlobCreatedEventData eventData = (StorageBlobCreatedEventData)events[0].Data;
+            Assert.Equal("https://myaccount.blob.core.windows.net/testcontainer/file1.txt", eventData.Url);
+        }
+
+        [Fact]
+        public void ConsumeStorageBlobDeletedEvent()
+        {
+            string requestContent = "[{   \"topic\": \"/subscriptions/id/resourceGroups/Storage/providers/Microsoft.Storage/storageAccounts/xstoretestaccount\",  \"subject\": \"/blobServices/default/containers/testcontainer/blobs/testfile.txt\",  \"eventType\": \"Microsoft.Storage.BlobDeleted\",  \"eventTime\": \"2017-11-07T20:09:22.5674003Z\",  \"id\": \"4c2359fe-001e-00ba-0e04-58586806d298\",  \"data\": {    \"api\": \"DeleteBlob\",    \"requestId\": \"4c2359fe-001e-00ba-0e04-585868000000\",    \"contentType\": \"text/plain\",    \"blobType\": \"BlockBlob\",    \"url\": \"https://example.blob.core.windows.net/testcontainer/testfile.txt\",    \"sequencer\": \"0000000000000281000000000002F5CA\",    \"storageDiagnostics\": {      \"batchId\": \"b68529f3-68cd-4744-baa4-3c0498ec19f0\"    }  },  \"dataVersion\": \"\",  \"metadataVersion\": \"1\"}]";
+
+            var events = this.eventGridSubscriber.DeserializeEventGridEvents(requestContent);
+
+            Assert.NotNull(events);
+            Assert.True(events[0].Data is StorageBlobDeletedEventData);
+            StorageBlobDeletedEventData eventData = (StorageBlobDeletedEventData)events[0].Data;
+            Assert.Equal("https://example.blob.core.windows.net/testcontainer/testfile.txt", eventData.Url);
+        }
+
+        // TODO: When new event types are introduced, add one test here for each event type
+
+
+
+        static Stream GetStreamFromString(string eventData)
+        {
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+            writer.Write(eventData);
+            writer.Flush();
+            stream.Position = 0;
+            return stream;
+        }
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Tests/ContosoItemReceivedEventData.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Tests/ContosoItemReceivedEventData.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.EventGrid.Tests
+{
+    class ContosoItemReceivedEventData
+    {
+        [JsonProperty(PropertyName = "itemSku")]
+        public string ItemSku { get; set; }
+
+        [JsonProperty(PropertyName = "itemUri")]
+        public string ItemUri { get; set; }
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Tests/ContosoItemSentEventData.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Tests/ContosoItemSentEventData.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.EventGrid.Tests
+{
+    class ContosoItemSentEventData
+    {
+        [JsonProperty(PropertyName = "shippingInfo")]
+        public ShippingInfo ShippingInfo { get; set; }
+    }
+
+    class ShippingInfo
+    {
+        [JsonProperty(PropertyName = "shippingType")]
+        public string ShippingType { get; set; }
+
+        [JsonProperty(PropertyName = "shipmentId")]
+        public string ShipmentId { get; set; }
+    }
+
+    [JsonObject("Drone")]
+    class DroneShippingInfo : ShippingInfo
+    {
+        [JsonProperty(PropertyName = "droneId")]
+        public string DroneId { get; set; }
+    }
+
+    [JsonObject("Rocket")]
+    class RocketShippingInfo : ShippingInfo
+    {
+        [JsonProperty(PropertyName = "rocketNumber")]
+        public int RocketNumber { get; set; }
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/EventGridSubscriber.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/EventGridSubscriber.cs
@@ -1,0 +1,212 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Microsoft.Azure.EventGrid.Models;
+using Microsoft.Rest.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Azure.EventGrid
+{
+    public class EventGridSubscriber : IEventGridEventDeserializer, ICustomEventTypeMapper
+    {
+        static readonly JsonSerializer defaultJsonSerializer;
+        readonly ConcurrentDictionary<string, Type> customEventTypeMapping;
+
+        static EventGridSubscriber()
+        {
+            defaultJsonSerializer = GetJsonSerializerWithPolymorphicSupport();
+        }
+
+        public EventGridSubscriber()
+        {
+            customEventTypeMapping = new ConcurrentDictionary<string, Type>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Deserializes the provided event data using a default JSON serializer that supports all system event types.
+        /// A webhook/function that is consuming events can call this function to deserialize EventGrid events.
+        /// For system events, the Data property of each event in the returned array will be set to the appropriate
+        /// type (e.g. StorageBlobCreatedEventData). For events on custom topics where the type of the Data property
+        /// can be of any type, the calling function will have to first add a custom event mapping before calling this function.
+        /// </summary>
+        /// <param name="requestContent">The JSON string containing an array of EventGrid events</param>
+        /// <returns>A list of EventGrid Events</returns>
+        public EventGridEvent[] DeserializeEventGridEvents(string requestContent)
+        {
+            return this.DeserializeEventGridEvents(requestContent, defaultJsonSerializer);
+        }
+
+        /// <summary>
+        /// Deserializes the provided event data using a custom JSON serializer.
+        /// A webhook/function that is consuming events can call this function to deserialize EventGrid events.
+        /// For system events, the Data property of each event in the returned array will be set to the appropriate
+        /// type (e.g. StorageBlobCreatedEventData). For events on custom topics where the type of the Data property
+        /// can be of any type, the calling function will have to first add a custom event mapping before calling this function.
+        /// </summary>
+        /// <param name="requestContent">The JSON string containing an array of EventGrid events</param>
+        /// <param name="jsonSerializer">JsonSerializer to use for the deserialization.</param>
+        /// <returns>A list of EventGrid Events</returns>
+        public EventGridEvent[] DeserializeEventGridEvents(string requestContent, JsonSerializer jsonSerializer)
+        {
+            EventGridEvent[] eventGridEvents = JsonConvert.DeserializeObject<EventGridEvent[]>(requestContent);
+            return DeserializeEventGridEventData(eventGridEvents, jsonSerializer);
+        }
+
+        public EventGridEvent[] DeserializeEventGridEvents(Stream requestStream)
+        {
+            return this.DeserializeEventGridEvents(requestStream, defaultJsonSerializer);
+        }
+
+        public EventGridEvent[] DeserializeEventGridEvents(Stream requestStream, JsonSerializer jsonSerializer)
+        {
+            EventGridEvent[] eventGridEvents = null;
+
+            using (var streamReader = new StreamReader(requestStream))
+            {
+                using (var jsonTextReader = new JsonTextReader(streamReader))
+                {
+                    eventGridEvents = (EventGridEvent[])jsonSerializer.Deserialize(jsonTextReader, typeof(EventGridEvent[]));
+                }
+            }
+
+            return DeserializeEventGridEventData(eventGridEvents, jsonSerializer);
+        }
+
+        public void AddOrUpdateCustomEventMapping(string eventType, Type eventDataType)
+        {
+            this.ValidateEventType(eventType);
+
+            if (eventDataType == null)
+            {
+                throw new ArgumentNullException(nameof(eventDataType));
+            }
+
+            this.customEventTypeMapping.AddOrUpdate(
+                eventType,
+                eventDataType,
+                ((key, existingValue) =>
+                {
+                    return eventDataType;
+                }));
+        }
+
+        public bool TryGetCustomEventMapping(string eventType, out Type eventDataType)
+        {
+            this.ValidateEventType(eventType);
+
+            if (this.customEventTypeMapping.TryGetValue(eventType, out eventDataType))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        public IReadOnlyList<KeyValuePair<string, Type>> GetAllCustomEventMappings()
+        {
+            var customEventMappings = new List<KeyValuePair<string, Type>>();
+
+            foreach (KeyValuePair<string, Type> kvp in this.customEventTypeMapping)
+            {
+                customEventMappings.Add(kvp);
+            }
+
+            return customEventMappings.AsReadOnly();
+        }
+
+        public bool TryRemoveCustomEventMapping(string eventType, out Type eventDataType)
+        {
+            this.ValidateEventType(eventType);
+            return this.customEventTypeMapping.TryRemove(eventType, out eventDataType);
+        }
+
+        void ValidateEventType(string eventType)
+        {
+            if (string.IsNullOrEmpty(eventType))
+            {
+                throw new ArgumentNullException(nameof(eventType));
+            }
+        }
+
+        EventGridEvent[] DeserializeEventGridEventData(EventGridEvent[] eventGridEvents, JsonSerializer jsonSerializer)
+        {
+            foreach (EventGridEvent receivedEvent in eventGridEvents)
+            {
+                Type typeOfEventData = null;
+
+                // First, let's attempt to find the mapping for the event type in the system event type mapping.
+                // Note that system event data would always be of type JObject.
+                if (SystemEventTypeMappings.SystemEventMappings.TryGetValue(receivedEvent.EventType, out typeOfEventData))
+                {
+                    JObject dataObject = receivedEvent.Data as JObject;
+                    if (dataObject != null)
+                    {
+                        var eventData = dataObject.ToObject(typeOfEventData, jsonSerializer);
+                        receivedEvent.Data = eventData;
+                    }
+                }
+                // If not a system event, let's attempt to find the mapping for the event type in the custom event mapping.
+                else if (this.TryGetCustomEventMapping(receivedEvent.EventType, out typeOfEventData))
+                {
+                    JToken dataToken = receivedEvent.Data as JToken;
+                    if (dataToken == null)
+                    {
+                        // Nothing to do (e.g. this will happen if Data is a primitive/string type).
+                        continue;
+                    }
+
+                    switch (dataToken.Type)
+                    {
+                        case JTokenType.Object:
+                            var eventData = dataToken.ToObject(typeOfEventData, jsonSerializer);
+                            receivedEvent.Data = eventData;
+                            break;
+                        case JTokenType.Array:
+                            var arrayEventData = JsonConvert.DeserializeObject(
+                                dataToken.ToString(),
+                                typeOfEventData,
+                                jsonSerializer.GetJsonSerializerSettings());
+                            receivedEvent.Data = arrayEventData;
+                            break;
+                        default:
+                            break;
+                    }
+                }
+            }
+
+            return eventGridEvents;
+        }
+
+        static JsonSerializer GetJsonSerializerWithPolymorphicSupport()
+        {
+            JsonSerializerSettings deserializationSettings = new JsonSerializerSettings
+            {
+                DateFormatHandling = DateFormatHandling.IsoDateFormat,
+                DateTimeZoneHandling = DateTimeZoneHandling.Utc,
+                NullValueHandling = NullValueHandling.Ignore,
+                ReferenceLoopHandling = ReferenceLoopHandling.Serialize,
+                Converters = new List<JsonConverter>
+                {
+                    new Iso8601TimeSpanConverter()
+                }
+            };
+
+            JsonSerializer jsonSerializer = JsonSerializer.Create(deserializationSettings);
+
+            // Note: If any of the events have polymorphic data, add converters for them here.
+            // This enables the polymorphic deserialization for the event data.
+            // For example, MediaJobCompletedEventData's JobOutput type is polymorphic 
+            // based on the @odata.type property in the data.
+
+            // Example usage: jsonSerializer.Converters.Add(new PolymorphicDeserializeJsonConverter<JobOutput>("@odata.type"));
+
+            return jsonSerializer;
+        }
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/EventTypes.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/EventTypes.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.EventGrid
+{
+    /// <summary>
+    ///  Represents the names of the various event types for the system events published to
+    ///  Azure Event Grid.
+    /// </summary>
+    public class EventTypes
+    {
+        // Keep this sorted by the name of the service publishing the events.
+
+        // ContainerRegistry events
+        public const string ContainerRegistryImagePushedEvent = "Microsoft.ContainerRegistry.ImagePushed";
+        public const string ContainerRegistryImageDeletedEvent = "Microsoft.ContainerRegistry.ImageDeleted";
+
+        // Device events
+        public const string IoTHubDeviceCreatedEvent = "Microsoft.Devices.DeviceCreated";
+        public const string IoTHubDeviceDeletedEvent = "Microsoft.Devices.DeviceDeleted";
+
+        // EventGrid events
+        public const string EventGridSubscriptionValidationEvent = "Microsoft.EventGrid.SubscriptionValidationEvent";
+        public const string EventGridSubscriptionDeletedEvent = "Microsoft.EventGrid.SubscriptionDeletedEvent";
+
+        // Event Hub Events
+        public const string EventHubCaptureFileCreatedEvent = "Microsoft.EventHub.CaptureFileCreated";
+
+        // Media Services events
+        public const string MediaJobStateChangeEvent = "Microsoft.Media.JobStateChange";
+
+        // Resource Manager (Azure Subscription/Resource Group) events
+        public const string ResourceWriteSuccessEvent = "Microsoft.Resources.ResourceWriteSuccess";
+        public const string ResourceWriteFailureEvent = "Microsoft.Resources.ResourceWriteFailure";
+        public const string ResourceWriteCancelEvent = "Microsoft.Resources.ResourceWriteCancel";
+        public const string ResourceDeleteSuccessEvent = "Microsoft.Resources.ResourceDeleteSuccess";
+        public const string ResourceDeleteFailureEvent = "Microsoft.Resources.ResourceDeleteFailure";
+        public const string ResourceDeleteCancelEvent = "Microsoft.Resources.ResourceDeleteCancel";
+
+        // ServiceBus events
+        public const string ServiceBusActiveMessagesAvailableWithNoListenersEvent = "Microsoft.ServiceBus.ActiveMessagesAvailableWithNoListeners";
+        public const string ServiceBusDeadletterMessagesAvailableWithNoListenerEvent = "Microsoft.ServiceBus.DeadletterMessagesAvailableWithNoListener";
+
+        // Storage events
+        public const string StorageBlobCreatedEvent = "Microsoft.Storage.BlobCreated";
+        public const string StorageBlobDeletedEvent = "Microsoft.Storage.BlobDeleted";
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/ICustomEventTypeMapper.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/ICustomEventTypeMapper.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.EventGrid
+{
+    public interface ICustomEventTypeMapper
+    {
+        void AddOrUpdateCustomEventMapping(string eventType, Type eventDataType);
+
+        bool TryRemoveCustomEventMapping(string eventType, out Type eventDataType);
+
+        bool TryGetCustomEventMapping(string eventType, out Type eventDataType);
+
+        IReadOnlyList<KeyValuePair<string, Type>> GetAllCustomEventMappings();
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/IEventGridEventDeserializer.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/IEventGridEventDeserializer.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Microsoft.Azure.EventGrid.Models;
+using Newtonsoft.Json;
+using System.IO;
+
+namespace Microsoft.Azure.EventGrid
+{
+    public interface IEventGridEventDeserializer
+    {
+        EventGridEvent[] DeserializeEventGridEvents(string requestContent);
+
+        EventGridEvent[] DeserializeEventGridEvents(string requestContent, JsonSerializer jsonSerializer);
+
+        EventGridEvent[] DeserializeEventGridEvents(Stream requestStream);
+
+        EventGridEvent[] DeserializeEventGridEvents(Stream requestStream, JsonSerializer jsonSerializer);
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/JsonSerializerExtensions.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/JsonSerializerExtensions.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Newtonsoft.Json;
+
+namespace Microsoft.Azure.EventGrid
+{
+    static class JsonSerializerExtensions
+    {
+        public static JsonSerializerSettings GetJsonSerializerSettings(this JsonSerializer serializer)
+        {
+            var jsonSerializerSettings = new JsonSerializerSettings
+            {
+                Context = serializer.Context,
+                Culture = serializer.Culture,
+                ContractResolver = serializer.ContractResolver,
+                ConstructorHandling = serializer.ConstructorHandling,
+                CheckAdditionalContent = serializer.CheckAdditionalContent,
+                DateFormatHandling = serializer.DateFormatHandling,
+                DateFormatString = serializer.DateFormatString,
+                DateParseHandling = serializer.DateParseHandling,
+                DateTimeZoneHandling = serializer.DateTimeZoneHandling,
+                DefaultValueHandling = serializer.DefaultValueHandling,
+                FloatFormatHandling = serializer.FloatFormatHandling,
+                Formatting = serializer.Formatting,
+                FloatParseHandling = serializer.FloatParseHandling,
+                MaxDepth = serializer.MaxDepth,
+                MetadataPropertyHandling = serializer.MetadataPropertyHandling,
+                MissingMemberHandling = serializer.MissingMemberHandling,
+                NullValueHandling = serializer.NullValueHandling,
+                ObjectCreationHandling = serializer.ObjectCreationHandling,
+                PreserveReferencesHandling = serializer.PreserveReferencesHandling,
+                ReferenceResolver = serializer.ReferenceResolver,
+                ReferenceLoopHandling = serializer.ReferenceLoopHandling,
+                StringEscapeHandling = serializer.StringEscapeHandling,
+                TraceWriter = serializer.TraceWriter,
+                TypeNameHandling = serializer.TypeNameHandling,
+            };
+
+            foreach (JsonConverter converter in serializer.Converters)
+            {
+                jsonSerializerSettings.Converters.Add(converter);
+            }
+
+            return jsonSerializerSettings;
+        }
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/SystemEventTypeMappings.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/SystemEventTypeMappings.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Microsoft.Azure.EventGrid.Models;
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.EventGrid
+{
+    internal static class SystemEventTypeMappings
+    {
+        public static readonly IReadOnlyDictionary<String, Type> SystemEventMappings = new Dictionary<string, Type>(StringComparer.OrdinalIgnoreCase)
+        {
+            // KEEP THIS SORTED BY THE NAME OF THE PUBLISHING SERVICE
+            // Add handling for additional event types here.
+            // NOTE: If any of the event data fields is polymorphic, remember to add an entry for the discriminator/BaseType
+            // in EventGridSubscriber.GetJsonSerializerWithPolymorphicSupport()
+            // Example: jsonSerializer.Converters.Add(new PolymorphicDeserializeJsonConverter<JobOutput>("@odata.type"));
+
+            // ContainerRegistry events
+            { EventTypes.ContainerRegistryImagePushedEvent, typeof(ContainerRegistryImagePushedEventData) },
+            { EventTypes.ContainerRegistryImageDeletedEvent, typeof(ContainerRegistryImageDeletedEventData) },
+
+            // IoTHub Device events
+            { EventTypes.IoTHubDeviceCreatedEvent, typeof(IotHubDeviceCreatedEventData) },
+            { EventTypes.IoTHubDeviceDeletedEvent, typeof(IotHubDeviceDeletedEventData) },
+
+            // EventGrid events
+            { EventTypes.EventGridSubscriptionValidationEvent, typeof(SubscriptionValidationEventData) },
+            { EventTypes.EventGridSubscriptionDeletedEvent, typeof(SubscriptionDeletedEventData) },
+
+            // Event Hub Events
+            { EventTypes.EventHubCaptureFileCreatedEvent, typeof(EventHubCaptureFileCreatedEventData) },
+
+            // Media Services events
+            { EventTypes.MediaJobStateChangeEvent, typeof(MediaJobStateChangeEventData) },
+
+            // Resource Manager (Azure Subscription/Resource Group) events
+            { EventTypes.ResourceWriteSuccessEvent, typeof(ResourceWriteSuccessData) },
+            { EventTypes.ResourceWriteFailureEvent, typeof(ResourceWriteFailureData) },
+            { EventTypes.ResourceWriteCancelEvent, typeof(ResourceWriteCancelData) },
+            { EventTypes.ResourceDeleteSuccessEvent, typeof(ResourceDeleteSuccessData) },
+            { EventTypes.ResourceDeleteFailureEvent, typeof(ResourceDeleteFailureData) },
+            { EventTypes.ResourceDeleteCancelEvent, typeof(ResourceDeleteCancelData) },
+
+            // ServiceBus events
+            { EventTypes.ServiceBusActiveMessagesAvailableWithNoListenersEvent, typeof(ServiceBusActiveMessagesAvailableWithNoListenersEventData) },
+            { EventTypes.ServiceBusDeadletterMessagesAvailableWithNoListenerEvent, typeof(ServiceBusDeadletterMessagesAvailableWithNoListenersEventData) },
+
+            // Storage events
+            { EventTypes.StorageBlobCreatedEvent, typeof(StorageBlobCreatedEventData) },
+            { EventTypes.StorageBlobDeletedEvent, typeof(StorageBlobDeletedEventData) },
+        };
+    }
+}

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Microsoft.Azure.EventGrid.csproj
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Microsoft.Azure.EventGrid.csproj
@@ -5,11 +5,11 @@
 
 	<PropertyGroup>
 		<PackageId>Microsoft.Azure.EventGrid</PackageId>
-		<Description>This library can be used to publish events to Azure Event Grid. It also defines the event schemas for the events published to EventGrid by various Azure services. </Description>
-		<Version>1.3.0</Version>
+		<Description>This library can be used to publish events to Azure Event Grid and to consume events delivered by EventGrid. It also defines the event schemas for the events published to EventGrid by various Azure services. </Description>
+		<Version>1.4.0</Version>
 		<AssemblyName>Microsoft.Azure.EventGrid</AssemblyName>
 		<PackageTags>Microsoft Azure EventGrid;Event Grid;Event Grid Publishing;</PackageTags>
-		<PackageReleaseNotes>Added support for consuming EventGrid subscription validation events, ServiceBus events and Azure Media events.</PackageReleaseNotes>
+		<PackageReleaseNotes>Added EventGridSubscriber class which provides functionality for consuming EventGrid events.</PackageReleaseNotes>
 	</PropertyGroup>
 	<PropertyGroup>
 		<TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Properties/AssemblyInfo.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyDescription("Provides developers with a library to publish events to Azure EventGrid.")]
 
 [assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.5.0.0")]
+[assembly: AssemblyFileVersion("1.4.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Properties/AssemblyInfo.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Properties/AssemblyInfo.cs
@@ -3,12 +3,13 @@
 
 using System.Reflection;
 using System.Resources;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Microsoft Azure EventGrid Library")]
 [assembly: AssemblyDescription("Provides developers with a library to publish events to Azure EventGrid.")]
 
 [assembly: AssemblyVersion("1.1.0.0")]
-[assembly: AssemblyFileVersion("1.3.0.0")]
+[assembly: AssemblyFileVersion("1.5.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
@@ -17,3 +18,5 @@ using System.Resources;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 [assembly: NeutralResourcesLanguage("en")]
+
+[assembly: InternalsVisibleTo("Microsoft.Azure.EventGrid.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Currently, EventGrid customers handle events in the following way:

EventGridEvent[] eventGridEvents = JsonConvert.DeserializeObject<EventGridEvent[]>(requestContent);

foreach (EventGridEvent eventGridEvent in eventGridEvents)
{
    JObject dataObject = eventGridEvent.Data as JObject;

    // Deserialize the event data into the appropriate type based on event type
    if (string.Equals(eventGridEvent.EventType, SubscriptionValidationEvent, StringComparison.OrdinalIgnoreCase))
    {
        var eventData = dataObject.ToObject<SubscriptionValidationEventData>();
        log.Info($"Got SubscriptionValidation event data, validationCode: {eventData.ValidationCode},  validationUrl: {eventData.ValidationUrl}, topic: {eventGridEvent.Topic}");
        // Handle subscription validation
    }
    else if (string.Equals(eventGridEvent.EventType, StorageBlobCreatedEvent, StringComparison.OrdinalIgnoreCase))
    {
        // Deserialize the data portion of the event into StorageBlobCreatedEventData
        var eventData = dataObject.ToObject<StorageBlobCreatedEventData>();
        log.Info($"Got BlobCreated event data, blob URI {eventData.Url}");
    }
    else if (string.Equals(eventGridEvent.EventType, CustomTopicEvent, StringComparison.OrdinalIgnoreCase))
    {
        // Deserialize the data portion of the event into ContosoItemReceivedEventData
        var eventData = dataObject.ToObject<ContosoItemReceivedEventData>();
        log.Info($"Got ContosoItemReceived event data, item SKU {eventData.ItemSku}");
    }
}

Some of the issues with the above approach are:

1. Discoverability of the event types is a challenge.
2. Mapping of the event types to the corresponding model/data class is also challenging.
3. If an event data has polymorphic properties, deserializing the data portion requires additional handling.

To address the above issues, this PR introduces SDK functionality in C# to enable developers to write code like this:

EventGridSubscriber eventGridSubscriber = new EventGridSubscriber();

// Optionally add one or more custom event type mappings
eventGridSubscriber.AddOrUpdateCustomEventMapping("Contoso.Items.ItemReceived", typeof(ContosoItemReceivedEventData));

var events = eventGridSubscriber.DeserializeEventGridEvents(requestContent);            

foreach (EventGridEvent receivedEvent in events)
{
    if (receivedEvent.Data is SubscriptionValidationEventData)
    {
        SubscriptionValidationEventData eventData = (SubscriptionValidationEventData)receivedEvent.Data;
        log.Info($"Got SubscriptionValidation event data, validationCode: {eventData.ValidationCode},  validationUrl: {eventData.ValidationUrl}, topic: {eventGridEvent.Topic}");
        // Handle subscription validation
    }
    else if (receivedEvent.Data is StorageBlobCreatedEventData)
    {
        StorageBlobCreatedEventData eventData = (StorageBlobCreatedEventData)receivedEvent.Data;
        log.Info($"Got BlobCreated event data, blob URI {eventData.Url}");
        // Handle StorageBlobCreatedEventData
    }
    else if (receivedEvent.Data is ContosoItemReceivedEventData)
    {
        ContosoItemReceivedEventData eventData = (ContosoItemReceivedEventData)receivedEvent.Data;
    }
}

It handles all system event-type mappings, support for custom event mappings (for user topics), automatic polymorphic deserialization of event data.
---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [X] Please add REST spec PR link to the SDK PR
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [X] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
