### PR TITLE
Adding flexible AutoRestCodegeneration flags

### DIFF
--- a/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
@@ -347,7 +347,7 @@ function Start-AutoRestCodeGeneration {
 
         [Parameter(Mandatory = $false)]
         [ValidateSet("singleapi", "multiapi")]
-        [string] $SdkGenerationType = "singleapi"
+        [string] $SdkGenerationType = "singleapi",
 
         [Parameter(Mandatory = $false)]
         [string] $AutoRestCodeGenerationFlags
@@ -438,7 +438,7 @@ function Start-AutoRestCodeGenerationWithLocalConfig {
 
         [Parameter(Mandatory = $false)]
         [ValidateSet("singleapi", "multiapi")]
-        [string] $SdkGenerationType = "singleapi"
+        [string] $SdkGenerationType = "singleapi",
 
         [Parameter(Mandatory = $false)]
         [string] $AutoRestCodeGenerationFlags

--- a/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
@@ -137,7 +137,9 @@ param(
     [Parameter(Mandatory = $true, HelpMessage ="Please provide a version for the AutoRest release")]
     [string] $AutoRestVersion,
     [Parameter(Mandatory = $false)]
-    [string] $SdkGenerationType
+    [string] $SdkGenerationType,
+    [Parameter(Mandatory = $false)]
+    [string] $AutoRestCodeGenerationFlags
     )
     
     Write-InfoLog "Generating CSharp code" 
@@ -147,6 +149,11 @@ param(
     if(-not [string]::IsNullOrWhiteSpace($Namespace))
     {
         $args = $args + " --csharp.namespace=$Namespace"
+    }
+
+    if(-not [string]::IsNullOrWhiteSpace($AutoRestCodeGenerationFlags))
+    {
+        $args = $args + " $AutoRestCodeGenerationFlags"
     }
 
     if(-not [string]::IsNullOrWhiteSpace($ConfigFileTag))
@@ -297,6 +304,12 @@ function Get-OutputStream {
 
 .PARAMETER ConfigFileTag
     The tag in config file for which to generate the sdk. Code generation fails if incorrect tags are provided
+
+.PARAMETER SdkGenerationType
+    The SdkGenerationType denotes whether this is a single-api or a multi-api SDK, by default this is single-api
+
+.PARAMETER AutoRestCodeGenerationFlags
+    Any additional flags that autorest needs to generate the code. Should be provided as " --flag1 --flag2 "
     
 #>
 function Start-AutoRestCodeGeneration {
@@ -335,16 +348,19 @@ function Start-AutoRestCodeGeneration {
         [Parameter(Mandatory = $false)]
         [ValidateSet("singleapi", "multiapi")]
         [string] $SdkGenerationType = "singleapi"
+
+        [Parameter(Mandatory = $false)]
+        [string] $AutoRestCodeGenerationFlags
     )
 
     if(-not [string]::IsNullOrWhiteSpace($SdkDirectory)) {
-        Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkDirectory $SdkDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType
+        Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkDirectory $SdkDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags
     }
     elseif (-not [string]::IsNullOrWhiteSpace($SdkRootDirectory)) {
-        Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkRootDirectory $SdkRootDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType
+        Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkRootDirectory $SdkRootDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags
     }
     elseif (-not [string]::IsNullOrWhiteSpace($SdkGenerationDirectory)){
-        Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkGenerationDirectory $SdkGenerationDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType
+        Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkGenerationDirectory $SdkGenerationDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags
     }
     else {
         # default path which is the root directory of the RP in sdk repo
@@ -353,7 +369,7 @@ function Start-AutoRestCodeGeneration {
         {
             Write-Error "Could not find default output directory since script is not run from a sdk repo, please provide one!"
         }
-        Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkDirectory $SdkDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType
+        Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkDirectory $SdkDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags
     }
 }
 
@@ -389,6 +405,12 @@ function Start-AutoRestCodeGeneration {
 .PARAMETER ConfigFileTag
     The tag in config file for which to generate the sdk. Code generation fails if incorrect tags are provided
 
+.PARAMETER SdkGenerationType
+    The SdkGenerationType denotes whether this is a single-api or a multi-api SDK, by default this is single-api
+
+.PARAMETER AutoRestCodeGenerationFlags
+    Any additional flags that autorest needs to generate the code. Should be provided as " --flag1 --flag2 "
+
 #>
 function Start-AutoRestCodeGenerationWithLocalConfig {
     [CmdletBinding(DefaultParameterSetName="sdkRootDir")]
@@ -417,16 +439,19 @@ function Start-AutoRestCodeGenerationWithLocalConfig {
         [Parameter(Mandatory = $false)]
         [ValidateSet("singleapi", "multiapi")]
         [string] $SdkGenerationType = "singleapi"
+
+        [Parameter(Mandatory = $false)]
+        [string] $AutoRestCodeGenerationFlags
     )
 
     if (-not [string]::IsNullOrWhiteSpace($SdkDirectory)) {
         $SdkRootDirectory = $SdkDirectory
     }
     if(-not [string]::IsNullOrWhiteSpace($SdkRootDirectory)) {
-        Start-CodeGeneration -ResourceProvider $ResourceProvider -LocalConfigFilePath $LocalConfigFilePath -SdkRootDirectory $SdkRootDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag 
+        Start-CodeGeneration -ResourceProvider $ResourceProvider -LocalConfigFilePath $LocalConfigFilePath -SdkRootDirectory $SdkRootDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags
     }
     elseif(-not [string]::IsNullOrWhiteSpace($SdkGenerationDirectory)) {
-        Start-CodeGeneration -ResourceProvider $ResourceProvider -LocalConfigFilePath $LocalConfigFilePath -SdkGenerationDirectory $SdkGenerationDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag
+        Start-CodeGeneration -ResourceProvider $ResourceProvider -LocalConfigFilePath $LocalConfigFilePath -SdkGenerationDirectory $SdkGenerationDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags
     }
     else
     {
@@ -447,7 +472,8 @@ function Start-CodeGeneration {
         [string] $Namespace,
         [string] $ConfigFileTag,
         [string] $LocalConfigFilePath,
-        [string] $SdkGenerationType
+        [string] $SdkGenerationType,
+        [string] $AutoRestCodeGenerationFlags
     )
     $localSdkRepoDirectory = Get-SdkRepoRootDirectory($(Get-InvokingScriptPath))
     
@@ -503,10 +529,10 @@ function Start-CodeGeneration {
         Write-InfoLog "Commencing code generation"  
         
         if(-not [string]::IsNullOrWhiteSpace($SdkRootDirectory)) {
-            Invoke-AutoRestCodeGenerationCommand -ConfigFile $configFile -SdkRootDirectory $SdkRootDirectory -AutoRestVersion $AutoRestVersion -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SdkGenerationType $SdkGenerationType
+            Invoke-AutoRestCodeGenerationCommand -ConfigFile $configFile -SdkRootDirectory $SdkRootDirectory -AutoRestVersion $AutoRestVersion -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SdkGenerationType $SdkGenerationType -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags
         }
         elseif(-not [string]::IsNullOrWhiteSpace($SdkGenerationDirectory)) {
-            Invoke-AutoRestCodeGenerationCommand -ConfigFile $configFile -SdkGenerationDirectory $SdkGenerationDirectory -AutoRestVersion $AutoRestVersion -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SdkGenerationType $SdkGenerationType
+            Invoke-AutoRestCodeGenerationCommand -ConfigFile $configFile -SdkGenerationDirectory $SdkGenerationDirectory -AutoRestVersion $AutoRestVersion -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SdkGenerationType $SdkGenerationType -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags
         }
         else {
             Write-ErrorLog "Could not find an output directory to generate code, aborting."


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
