### PR TITLE
[Azure Search] Remove inheritdoc and improve SearchCredentials documentation

### DIFF
--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Customizations/Search/Models/ExtensibleEnum.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Customizations/Search/Models/ExtensibleEnum.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Search.Models
         /// Compares the ExtensibleEnum for equality with another ExtensibleEnum.
         /// </summary>
         /// <param name="other">The ExtensibleEnum with which to compare.</param>
-        /// <returns><b>true</b> if the ExtensibleEnum objects are equal; <b>false</b> otherwise.</returns>
+        /// <returns><c>true</c> if the ExtensibleEnum objects are equal; otherwise, <c>false</c>.</returns>
         public bool Equals(T other)
         {
             if (object.ReferenceEquals(other, null))
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Search.Models
         /// Determines whether the specified object is equal to the current object.
         /// </summary>
         /// <param name="obj">The object to compare with the current object.</param>
-        /// <returns><b>true</b> if the specified object is equal to the current object; otherwise, <b>false</b>.</returns>
+        /// <returns><c>true</c> if the specified object is equal to the current object; otherwise, <c>false</c>.</returns>
         public override bool Equals(object obj)
         {
             return this.Equals(obj as T);

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Customizations/Search/Models/ExtensibleEnum.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Customizations/Search/Models/ExtensibleEnum.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Search.Models
         /// Compares the ExtensibleEnum for equality with another ExtensibleEnum.
         /// </summary>
         /// <param name="other">The ExtensibleEnum with which to compare.</param>
-        /// <returns>true if the ExtensibleEnum objects are equal; false otherwise.</returns>
+        /// <returns><b>true</b> if the ExtensibleEnum objects are equal; <b>false</b> otherwise.</returns>
         public bool Equals(T other)
         {
             if (object.ReferenceEquals(other, null))
@@ -81,13 +81,20 @@ namespace Microsoft.Azure.Search.Models
             return this._name == other._name;
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Determines whether the specified object is equal to the current object.
+        /// </summary>
+        /// <param name="obj">The object to compare with the current object.</param>
+        /// <returns><b>true</b> if the specified object is equal to the current object; otherwise, <b>false</b>.</returns>
         public override bool Equals(object obj)
         {
             return this.Equals(obj as T);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Serves as the default hash function.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
         public override int GetHashCode()
         {
             return _name.GetHashCode();

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Customizations/Search/SearchCredentials.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Customizations/Search/SearchCredentials.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Azure.Search
     /// Credentials used to authenticate to an Azure Search service.
     /// <see href="https://docs.microsoft.com/rest/api/searchservice/"/>
     /// </summary>
+    /// <remarks>
+    /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Search.
+    /// </remarks>
     public class SearchCredentials : ServiceClientCredentials
     {
         /// <summary>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Customizations/ISearchIndexClient.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Customizations/ISearchIndexClient.Customization.cs
@@ -9,8 +9,11 @@ namespace Microsoft.Azure.Search
     public partial interface ISearchIndexClient
     {
         /// <summary>
-        /// Gets the credentials used to authenticate to an Azure Search service.
+        /// Gets the credentials used to authenticate to an Azure Search service. This can be either a query API key or an admin API key.
         /// </summary>
+        /// <remarks>
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Search.
+        /// </remarks>
         SearchCredentials SearchCredentials { get; }
 
         /// <summary>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Customizations/SearchIndexClient.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Customizations/SearchIndexClient.Customization.cs
@@ -51,13 +51,25 @@ namespace Microsoft.Azure.Search
             Initialize(searchServiceName, indexName, credentials);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets the credentials used to authenticate to an Azure Search service. This can be either a query API key or an admin API key.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Search.
+        /// </remarks>
         public SearchCredentials SearchCredentials => (SearchCredentials)Credentials;
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Indicates whether the index client should use HTTP GET for making Search and Suggest requests to the
+        /// Azure Search REST API. The default is <c>false</c>, which indicates that HTTP POST will be used.
+        /// </summary>
         public bool UseHttpGetForQueries { get; set; }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Changes the BaseUri of this client to target a different index in the same Azure Search service. This method is NOT thread-safe; You
+        /// must guarantee that no other threads are using the client before calling it.
+        /// </summary>
+        /// <param name="newIndexName">The name of the index to which all subsequent requests should be sent.</param>
         [Obsolete("This method is deprecated. Please set the IndexName property instead.")]
         public void TargetDifferentIndex(string newIndexName)
         {

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourceOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourceOperations.Customization.cs
@@ -13,24 +13,40 @@ namespace Microsoft.Azure.Search
     internal partial class DataSourcesOperations
     {
         /// <summary>
-        /// Creates a new Azure Search datasource or updates a datasource if
-        /// it already exists.
+        /// Creates a new Azure Search datasource or updates a datasource if it already
+        /// exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Data-Source" />
         /// </summary>
         /// <param name='dataSource'>
         /// The definition of the datasource to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
-        /// The headers that will be added to request.
+        /// Headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
         public Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(dataSource?.Name, dataSource, searchRequestOptions, accessCondition, customHeaders, cancellationToken);
@@ -51,6 +67,18 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
         /// <returns>
         /// A response with the value <c>true</c> if the data source exists; <c>false</c> otherwise.
         /// </returns>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourceOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourceOperations.Customization.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Search
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null.
         /// </exception>
-        /// <return>
+        /// <returns>
         /// A response object containing the response body and response headers.
-        /// </return>
+        /// </returns>
         public Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(dataSource?.Name, dataSource, searchRequestOptions, accessCondition, customHeaders, cancellationToken);

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourceOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourceOperations.Customization.cs
@@ -12,13 +12,48 @@ namespace Microsoft.Azure.Search
 
     internal partial class DataSourcesOperations
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Creates a new Azure Search datasource or updates a datasource if
+        /// it already exists.
+        /// </summary>
+        /// <param name='dataSource'>
+        /// The definition of the datasource to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='accessCondition'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
         public Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(dataSource?.Name, dataSource, searchRequestOptions, accessCondition, customHeaders, cancellationToken);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Determines whether or not the given data source exists in the Azure Search service.
+        /// </summary>
+        /// <param name="dataSourceName">
+        /// The name of the data source.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>
+        /// A response with the value <c>true</c> if the data source exists; <c>false</c> otherwise.
+        /// </returns>
         public Task<AzureOperationResponse<bool>> ExistsWithHttpMessagesAsync(
             string dataSourceName,
             SearchRequestOptions searchRequestOptions = default(SearchRequestOptions),

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourcesOperationsExtensions.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourcesOperationsExtensions.Customization.cs
@@ -16,8 +16,9 @@ namespace Microsoft.Azure.Search
     public static partial class DataSourcesOperationsExtensions
     {
         /// <summary>
-        /// Creates a new Azure Search datasource or updates a datasource if it
-        /// already exists.
+        /// Creates a new Azure Search datasource or updates a datasource if it already
+        /// exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Data-Source" />
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -26,19 +27,23 @@ namespace Microsoft.Azure.Search
         /// The definition of the datasource to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
+        /// <return>
+        /// The datasource that was created or updated.
+        /// </return>
         public static DataSource CreateOrUpdate(this IDataSourcesOperations operations, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition))
         {
             return operations.CreateOrUpdateAsync(dataSource, searchRequestOptions, accessCondition).GetAwaiter().GetResult();
         }
 
         /// <summary>
-        /// Creates a new Azure Search datasource or updates a datasource if it
-        /// already exists.
+        /// Creates a new Azure Search datasource or updates a datasource if it already
+        /// exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Data-Source" />
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -55,6 +60,9 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <return>
+        /// The datasource that was created or updated.
+        /// </return>
         public static async Task<DataSource> CreateOrUpdateAsync(this IDataSourcesOperations operations, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(dataSource, searchRequestOptions, accessCondition, null, cancellationToken).ConfigureAwait(false))
@@ -73,7 +81,7 @@ namespace Microsoft.Azure.Search
         /// The name of the data source.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <returns>
         /// <c>true</c> if the data source exists; <c>false</c> otherwise.
@@ -96,7 +104,7 @@ namespace Microsoft.Azure.Search
         /// The name of the data source.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourcesOperationsExtensions.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/DataSourcesOperationsExtensions.Customization.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Azure.Search
         /// <param name='accessCondition'>
         /// Additional parameters for the operation.
         /// </param>
-        /// <return>
+        /// <returns>
         /// The datasource that was created or updated.
-        /// </return>
+        /// </returns>
         public static DataSource CreateOrUpdate(this IDataSourcesOperations operations, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition))
         {
             return operations.CreateOrUpdateAsync(dataSource, searchRequestOptions, accessCondition).GetAwaiter().GetResult();
@@ -60,9 +60,9 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        /// <return>
+        /// <returns>
         /// The datasource that was created or updated.
-        /// </return>
+        /// </returns>
         public static async Task<DataSource> CreateOrUpdateAsync(this IDataSourcesOperations operations, DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(dataSource, searchRequestOptions, accessCondition, null, cancellationToken).ConfigureAwait(false))

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/IDataSourcesOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/IDataSourcesOperations.Customization.cs
@@ -13,24 +13,40 @@ namespace Microsoft.Azure.Search
     public partial interface IDataSourcesOperations
     {
         /// <summary>
-        /// Creates a new Azure Search datasource or updates a datasource if
-        /// it already exists.
+        /// Creates a new Azure Search datasource or updates a datasource if it already
+        /// exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Data-Source" />
         /// </summary>
         /// <param name='dataSource'>
         /// The definition of the datasource to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
-        /// The headers that will be added to request.
+        /// Headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
         Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -40,7 +56,7 @@ namespace Microsoft.Azure.Search
         /// The name of the data source.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -48,6 +64,18 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
         /// <returns>
         /// A response with the value <c>true</c> if the data source exists; <c>false</c> otherwise.
         /// </returns>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/IDataSourcesOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/DataSources/IDataSourcesOperations.Customization.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Search
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null.
         /// </exception>
-        /// <return>
+        /// <returns>
         /// A response object containing the response body and response headers.
-        /// </return>
+        /// </returns>
         Task<AzureOperationResponse<DataSource>> CreateOrUpdateWithHttpMessagesAsync(DataSource dataSource, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/ISearchServiceClient.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/ISearchServiceClient.Customization.cs
@@ -9,8 +9,11 @@ namespace Microsoft.Azure.Search
     public partial interface ISearchServiceClient
     {
         /// <summary>
-        /// Gets the credentials used to authenticate to an Azure Search service.
+        /// Gets the credentials used to authenticate to an Azure Search service. This can be either a query API key or an admin API key.
         /// </summary>
+        /// <remarks>
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Search.
+        /// </remarks>
         SearchCredentials SearchCredentials { get; }
     }
 }

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IIndexersOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IIndexersOperations.Customization.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Search
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null.
         /// </exception>
-        /// <return>
+        /// <returns>
         /// A response object containing the response body and response headers.
-        /// </return>
+        /// </returns>
         Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IIndexersOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IIndexersOperations.Customization.cs
@@ -13,8 +13,9 @@ namespace Microsoft.Azure.Search
     public partial interface IIndexersOperations
     {
         /// <summary>
-        /// Creates a new Azure Search indexer or updates an indexer if it
-        /// already exists.
+        /// Creates a new Azure Search indexer or updates an indexer if it already
+        /// exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Create-Indexer" />
         /// </summary>
         /// <param name='indexer'>
         /// The definition of the indexer to create or update.
@@ -26,11 +27,26 @@ namespace Microsoft.Azure.Search
         /// Additional parameters for the operation
         /// </param>
         /// <param name='customHeaders'>
-        /// The headers that will be added to request.
+        /// Headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
         Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -40,7 +56,7 @@ namespace Microsoft.Azure.Search
         /// The name of the indexer.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -48,6 +64,18 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
         /// <returns>
         /// A response with the value <c>true</c> if the indexer exists; <c>false</c> otherwise.
         /// </returns>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperations.Customization.cs
@@ -13,24 +13,40 @@ namespace Microsoft.Azure.Search
     internal partial class IndexersOperations
     {
         /// <summary>
-        /// Creates a new Azure Search indexer or updates an indexer if it
-        /// already exists.
+        /// Creates a new Azure Search indexer or updates an indexer if it already
+        /// exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Create-Indexer" />
         /// </summary>
         /// <param name='indexer'>
         /// The definition of the indexer to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
-        /// The headers that will be added to request.
+        /// Headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
         public Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(indexer?.Name, indexer, searchRequestOptions, accessCondition, customHeaders, cancellationToken);
@@ -43,7 +59,7 @@ namespace Microsoft.Azure.Search
         /// The name of the indexer.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -51,6 +67,18 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
         /// <returns>
         /// A response with the value <c>true</c> if the indexer exists; <c>false</c> otherwise.
         /// </returns>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperations.Customization.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Search
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null.
         /// </exception>
-        /// <return>
+        /// <returns>
         /// A response object containing the response body and response headers.
-        /// </return>
+        /// </returns>
         public Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(indexer?.Name, indexer, searchRequestOptions, accessCondition, customHeaders, cancellationToken);

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperations.Customization.cs
@@ -12,13 +12,48 @@ namespace Microsoft.Azure.Search
 
     internal partial class IndexersOperations
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Creates a new Azure Search indexer or updates an indexer if it
+        /// already exists.
+        /// </summary>
+        /// <param name='indexer'>
+        /// The definition of the indexer to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='accessCondition'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
         public Task<AzureOperationResponse<Indexer>> CreateOrUpdateWithHttpMessagesAsync(Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(indexer?.Name, indexer, searchRequestOptions, accessCondition, customHeaders, cancellationToken);
         }
-        
-        /// <inheritdoc />
+
+        /// <summary>
+        /// Determines whether or not the given indexer exists in the Azure Search service.
+        /// </summary>
+        /// <param name="indexerName">
+        /// The name of the indexer.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>
+        /// A response with the value <c>true</c> if the indexer exists; <c>false</c> otherwise.
+        /// </returns>
         public Task<AzureOperationResponse<bool>> ExistsWithHttpMessagesAsync(
             string indexerName,
             SearchRequestOptions searchRequestOptions = default(SearchRequestOptions),

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperationsExtensions.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperationsExtensions.Customization.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Azure.Search
         /// <param name='accessCondition'>
         /// Additional parameters for the operation.
         /// </param>
-        /// <return>
+        /// <returns>
         /// The indexer that was created or updated.
-        /// </return>
+        /// </returns>
         public static Indexer CreateOrUpdate(this IIndexersOperations operations, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition))
         {
             return operations.CreateOrUpdateAsync(indexer, searchRequestOptions, accessCondition).GetAwaiter().GetResult();
@@ -60,9 +60,9 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        /// <return>
+        /// <returns>
         /// The indexer that was created or updated.
-        /// </return>
+        /// </returns>
         public static async Task<Indexer> CreateOrUpdateAsync(this IIndexersOperations operations, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(indexer, searchRequestOptions, accessCondition, null, cancellationToken).ConfigureAwait(false))

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperationsExtensions.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/IndexersOperationsExtensions.Customization.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Creates a new Azure Search indexer or updates an indexer if it already
         /// exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Create-Indexer" />
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -26,11 +27,14 @@ namespace Microsoft.Azure.Search
         /// The definition of the indexer to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
+        /// <return>
+        /// The indexer that was created or updated.
+        /// </return>
         public static Indexer CreateOrUpdate(this IIndexersOperations operations, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition))
         {
             return operations.CreateOrUpdateAsync(indexer, searchRequestOptions, accessCondition).GetAwaiter().GetResult();
@@ -39,6 +43,7 @@ namespace Microsoft.Azure.Search
         /// <summary>
         /// Creates a new Azure Search indexer or updates an indexer if it already
         /// exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Create-Indexer" />
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -47,14 +52,17 @@ namespace Microsoft.Azure.Search
         /// The definition of the indexer to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <return>
+        /// The indexer that was created or updated.
+        /// </return>
         public static async Task<Indexer> CreateOrUpdateAsync(this IIndexersOperations operations, Indexer indexer, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(indexer, searchRequestOptions, accessCondition, null, cancellationToken).ConfigureAwait(false))
@@ -73,7 +81,7 @@ namespace Microsoft.Azure.Search
         /// The name of the indexer.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <returns>
         /// <c>true</c> if the indexer exists; <c>false</c> otherwise.
@@ -96,7 +104,7 @@ namespace Microsoft.Azure.Search
         /// The name of the indexer.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IIndexesOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IIndexesOperations.Customization.cs
@@ -55,9 +55,9 @@ namespace Microsoft.Azure.Search
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        /// <return>
+        /// <returns>
         /// A response object containing the response body and response headers.
-        /// </return>
+        /// </returns>
         Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IIndexesOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IIndexesOperations.Customization.cs
@@ -18,32 +18,46 @@ namespace Microsoft.Azure.Search
         SearchServiceClient Client { get; }
 
         /// <summary>
-        /// Creates a new Azure Search index or updates an index if it already
-        /// exists.
+        /// Creates a new Azure Search index or updates an index if it already exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Index" />
         /// </summary>
         /// <param name='index'>
         /// The definition of the index to create or update.
         /// </param>
         /// <param name='allowIndexDowntime'>
-        /// Allows new analyzers, tokenizers, token filters, or char filters
-        /// to be added to an index by taking the index offline for at least
-        /// a few seconds. This temporarily causes indexing and query
-        /// requests to fail. Performance and write availability of the index
-        /// can be impaired for several minutes after the index is updated,
-        /// or longer for very large indexes.
+        /// Allows new analyzers, tokenizers, token filters, or char filters to be
+        /// added to an index by taking the index offline for at least a few seconds.
+        /// This temporarily causes indexing and query requests to fail. Performance
+        /// and write availability of the index can be impaired for several minutes
+        /// after the index is updated, or longer for very large indexes.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
-        /// The headers that will be added to request.
+        /// Headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
         Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -53,7 +67,7 @@ namespace Microsoft.Azure.Search
         /// The name of the index.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -61,6 +75,18 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
         /// <returns>
         /// A response with the value <c>true</c> if the index exists; <c>false</c> otherwise.
         /// </returns>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperations.Customization.cs
@@ -13,32 +13,46 @@ namespace Microsoft.Azure.Search
     internal partial class IndexesOperations
     {
         /// <summary>
-        /// Creates a new Azure Search index or updates an index if it already
-        /// exists.
+        /// Creates a new Azure Search index or updates an index if it already exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Index" />
         /// </summary>
         /// <param name='index'>
         /// The definition of the index to create or update.
         /// </param>
         /// <param name='allowIndexDowntime'>
-        /// Allows new analyzers, tokenizers, token filters, or char filters
-        /// to be added to an index by taking the index offline for at least
-        /// a few seconds. This temporarily causes indexing and query
-        /// requests to fail. Performance and write availability of the index
-        /// can be impaired for several minutes after the index is updated,
-        /// or longer for very large indexes.
+        /// Allows new analyzers, tokenizers, token filters, or char filters to be
+        /// added to an index by taking the index offline for at least a few seconds.
+        /// This temporarily causes indexing and query requests to fail. Performance
+        /// and write availability of the index can be impaired for several minutes
+        /// after the index is updated, or longer for very large indexes.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
-        /// The headers that will be added to request.
+        /// Headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
         public Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(index != null ? index.Name : null, index, allowIndexDowntime, searchRequestOptions, accessCondition, customHeaders, cancellationToken);
@@ -51,7 +65,7 @@ namespace Microsoft.Azure.Search
         /// The name of the index.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -59,6 +73,18 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
         /// <returns>
         /// A response with the value <c>true</c> if the index exists; <c>false</c> otherwise.
         /// </returns>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperations.Customization.cs
@@ -50,9 +50,9 @@ namespace Microsoft.Azure.Search
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null
         /// </exception>
-        /// <return>
+        /// <returns>
         /// A response object containing the response body and response headers.
-        /// </return>
+        /// </returns>
         public Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(index != null ? index.Name : null, index, allowIndexDowntime, searchRequestOptions, accessCondition, customHeaders, cancellationToken);

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperations.Customization.cs
@@ -12,13 +12,56 @@ namespace Microsoft.Azure.Search
 
     internal partial class IndexesOperations
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Creates a new Azure Search index or updates an index if it already
+        /// exists.
+        /// </summary>
+        /// <param name='index'>
+        /// The definition of the index to create or update.
+        /// </param>
+        /// <param name='allowIndexDowntime'>
+        /// Allows new analyzers, tokenizers, token filters, or char filters
+        /// to be added to an index by taking the index offline for at least
+        /// a few seconds. This temporarily causes indexing and query
+        /// requests to fail. Performance and write availability of the index
+        /// can be impaired for several minutes after the index is updated,
+        /// or longer for very large indexes.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='accessCondition'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
         public Task<AzureOperationResponse<Index>> CreateOrUpdateWithHttpMessagesAsync(Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(index != null ? index.Name : null, index, allowIndexDowntime, searchRequestOptions, accessCondition, customHeaders, cancellationToken);
         }
-        
-        /// <inheritdoc />
+
+        /// <summary>
+        /// Determines whether or not the given index exists in the Azure Search service.
+        /// </summary>
+        /// <param name="indexName">
+        /// The name of the index.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>
+        /// A response with the value <c>true</c> if the index exists; <c>false</c> otherwise.
+        /// </returns>
         public Task<AzureOperationResponse<bool>> ExistsWithHttpMessagesAsync(
             string indexName,
             SearchRequestOptions searchRequestOptions = default(SearchRequestOptions),

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperationsExtensions.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperationsExtensions.Customization.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.Search
         /// <param name='accessCondition'>
         /// Additional parameters for the operation.
         /// </param>
-        /// <return>
+        /// <returns>
         /// The index that was created or updated.
-        /// </return>
+        /// </returns>
         public static Index CreateOrUpdate(this IIndexesOperations operations, Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition))
         {
             return operations.CreateOrUpdateAsync(index, allowIndexDowntime, searchRequestOptions, accessCondition).GetAwaiter().GetResult();
@@ -76,9 +76,9 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        /// <return>
+        /// <returns>
         /// The index that was created or updated.
-        /// </return>
+        /// </returns>
         public static async Task<Index> CreateOrUpdateAsync(this IIndexesOperations operations, Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(index, allowIndexDowntime, searchRequestOptions, accessCondition, null, cancellationToken).ConfigureAwait(false))

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperationsExtensions.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/IndexesOperationsExtensions.Customization.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Search
     {
         /// <summary>
         /// Creates a new Azure Search index or updates an index if it already exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Index" />
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -35,11 +36,14 @@ namespace Microsoft.Azure.Search
         /// or longer for very large indexes.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
+        /// <return>
+        /// The index that was created or updated.
+        /// </return>
         public static Index CreateOrUpdate(this IIndexesOperations operations, Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition))
         {
             return operations.CreateOrUpdateAsync(index, allowIndexDowntime, searchRequestOptions, accessCondition).GetAwaiter().GetResult();
@@ -47,6 +51,7 @@ namespace Microsoft.Azure.Search
 
         /// <summary>
         /// Creates a new Azure Search index or updates an index if it already exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Index" />
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -63,14 +68,17 @@ namespace Microsoft.Azure.Search
         /// or longer for very large indexes.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <return>
+        /// The index that was created or updated.
+        /// </return>
         public static async Task<Index> CreateOrUpdateAsync(this IIndexesOperations operations, Index index, bool? allowIndexDowntime = default(bool?), SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(index, allowIndexDowntime, searchRequestOptions, accessCondition, null, cancellationToken).ConfigureAwait(false))
@@ -89,7 +97,7 @@ namespace Microsoft.Azure.Search
         /// The name of the index.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <returns>
         /// <c>true</c> if the index exists; <c>false</c> otherwise.
@@ -112,7 +120,7 @@ namespace Microsoft.Azure.Search
         /// The name of the index.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
@@ -141,7 +149,7 @@ namespace Microsoft.Azure.Search
         /// The operations group for this extension method.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <returns>
         /// The list of all index names for the search service.
@@ -164,7 +172,7 @@ namespace Microsoft.Azure.Search
         /// The operations group for this extension method.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SearchServiceClient.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SearchServiceClient.Customization.cs
@@ -47,7 +47,12 @@ namespace Microsoft.Azure.Search
             Initialize(searchServiceName, credentials);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Gets the credentials used to authenticate to an Azure Search service. This can be either a query API key or an admin API key.
+        /// </summary>
+        /// <remarks>
+        /// See <see href="https://docs.microsoft.com/azure/search/search-security-api-keys"/> for more information about API keys in Azure Search.
+        /// </remarks>
         public SearchCredentials SearchCredentials => (SearchCredentials)Credentials;
 
         private void Initialize(string searchServiceName, SearchCredentials credentials)

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/ISynonymMapsOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/ISynonymMapsOperations.Customization.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Search
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null.
         /// </exception>
-        /// <return>
+        /// <returns>
         /// A response object containing the response body and response headers.
-        /// </return>
+        /// </returns>
         Task<AzureOperationResponse<SynonymMap>> CreateOrUpdateWithHttpMessagesAsync(SynonymMap synonymMap, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/ISynonymMapsOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/ISynonymMapsOperations.Customization.cs
@@ -13,24 +13,40 @@ namespace Microsoft.Azure.Search
     public partial interface ISynonymMapsOperations
     {
         /// <summary>
-        /// Creates a new Azure Search synonymmap or updates a synonymmap if
-        /// it already exists.
+        /// Creates a new Azure Search synonym map or updates a synonym map if it
+        /// already exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Synonym-Map" />
         /// </summary>
         /// <param name='synonymMap'>
-        /// The definition of the synonymmap to create or update.
+        /// The definition of the synonym map to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
-        /// The headers that will be added to request.
+        /// Headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
         Task<AzureOperationResponse<SynonymMap>> CreateOrUpdateWithHttpMessagesAsync(SynonymMap synonymMap, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
@@ -40,7 +56,7 @@ namespace Microsoft.Azure.Search
         /// The name of the synonym map.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -48,6 +64,18 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
         /// <returns>
         /// A response with the value <c>true</c> if the synonym map exists; <c>false</c> otherwise.
         /// </returns>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/SynonymMapsOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/SynonymMapsOperations.Customization.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Search
         /// <exception cref="System.ArgumentNullException">
         /// Thrown when a required parameter is null.
         /// </exception>
-        /// <return>
+        /// <returns>
         /// A response object containing the response body and response headers.
-        /// </return>
+        /// </returns>
         public Task<AzureOperationResponse<SynonymMap>> CreateOrUpdateWithHttpMessagesAsync(SynonymMap synonymMap, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(synonymMap?.Name, synonymMap, searchRequestOptions, accessCondition, customHeaders, cancellationToken);

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/SynonymMapsOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/SynonymMapsOperations.Customization.cs
@@ -13,24 +13,40 @@ namespace Microsoft.Azure.Search
     internal partial class SynonymMapsOperations
     {
         /// <summary>
-        /// Creates a new Azure Search synonymmap or updates a synonymmap if
-        /// it already exists.
+        /// Creates a new Azure Search synonym map or updates a synonym map if it
+        /// already exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Synonym-Map" />
         /// </summary>
         /// <param name='synonymMap'>
-        /// The definition of the synonymmap to create or update.
+        /// The definition of the synonym map to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='customHeaders'>
-        /// The headers that will be added to request.
+        /// Headers that will be added to request.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
         public Task<AzureOperationResponse<SynonymMap>> CreateOrUpdateWithHttpMessagesAsync(SynonymMap synonymMap, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(synonymMap?.Name, synonymMap, searchRequestOptions, accessCondition, customHeaders, cancellationToken);
@@ -51,6 +67,18 @@ namespace Microsoft.Azure.Search
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <exception cref="CloudException">
+        /// Thrown when the operation returned an invalid status code.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.SerializationException">
+        /// Thrown when unable to deserialize the response.
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null.
+        /// </exception>
         /// <returns>
         /// A response with the value <c>true</c> if the synonym map exists; <c>false</c> otherwise.
         /// </returns>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/SynonymMapsOperations.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/SynonymMapsOperations.Customization.cs
@@ -12,13 +12,48 @@ namespace Microsoft.Azure.Search
 
     internal partial class SynonymMapsOperations
     {
-        /// <inheritdoc />
+        /// <summary>
+        /// Creates a new Azure Search synonymmap or updates a synonymmap if
+        /// it already exists.
+        /// </summary>
+        /// <param name='synonymMap'>
+        /// The definition of the synonymmap to create or update.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='accessCondition'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
         public Task<AzureOperationResponse<SynonymMap>> CreateOrUpdateWithHttpMessagesAsync(SynonymMap synonymMap, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             return CreateOrUpdateWithHttpMessagesAsync(synonymMap?.Name, synonymMap, searchRequestOptions, accessCondition, customHeaders, cancellationToken);
         }
 
-        /// <inheritdoc />
+        /// <summary>
+        /// Determines whether or not the given synonym map exists in the Azure Search service.
+        /// </summary>
+        /// <param name="synonymMapName">
+        /// The name of the synonym map.
+        /// </param>
+        /// <param name='searchRequestOptions'>
+        /// Additional parameters for the operation
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <returns>
+        /// A response with the value <c>true</c> if the synonym map exists; <c>false</c> otherwise.
+        /// </returns>
         public Task<AzureOperationResponse<bool>> ExistsWithHttpMessagesAsync(
             string synonymMapName,
             SearchRequestOptions searchRequestOptions = default(SearchRequestOptions),

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/SynonymMapsOperationsExtensions.Customization.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/SynonymMaps/SynonymMapsOperationsExtensions.Customization.cs
@@ -15,8 +15,9 @@ namespace Microsoft.Azure.Search
     public static partial class SynonymMapsOperationsExtensions
     {
         /// <summary>
-        /// Creates a new Azure Search synonymmap or updates a synonymmap if it
+        /// Creates a new Azure Search synonym map or updates a synonym map if it
         /// already exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Synonym-Map" />
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -25,19 +26,21 @@ namespace Microsoft.Azure.Search
         /// The definition of the synonymmap to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
+        /// <returns>The synonym map that was created or updated.</returns>
         public static SynonymMap CreateOrUpdate(this ISynonymMapsOperations operations, SynonymMap synonymMap, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition))
         {
             return operations.CreateOrUpdateAsync(synonymMap, searchRequestOptions, accessCondition).GetAwaiter().GetResult();
         }
 
         /// <summary>
-        /// Creates a new Azure Search synonymmap or updates a synonymmap if it
+        /// Creates a new Azure Search synonym map or updates a synonym map if it
         /// already exists.
+        /// <see href="https://docs.microsoft.com/rest/api/searchservice/Update-Synonym-Map" />
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
@@ -46,14 +49,15 @@ namespace Microsoft.Azure.Search
         /// The definition of the synonymmap to create or update.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='accessCondition'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
+        /// <returns>The synonym map that was created or updated.</returns>
         public static async Task<SynonymMap> CreateOrUpdateAsync(this ISynonymMapsOperations operations, SynonymMap synonymMap, SearchRequestOptions searchRequestOptions = default(SearchRequestOptions), AccessCondition accessCondition = default(AccessCondition), CancellationToken cancellationToken = default(CancellationToken))
         {
             using (var _result = await operations.CreateOrUpdateWithHttpMessagesAsync(synonymMap, searchRequestOptions, accessCondition, null, cancellationToken).ConfigureAwait(false))
@@ -72,7 +76,7 @@ namespace Microsoft.Azure.Search
         /// The name of the synonym map.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <returns>
         /// <c>true</c> if the synonym map exists; <c>false</c> otherwise.
@@ -95,7 +99,7 @@ namespace Microsoft.Azure.Search
         /// The name of the synonym map.
         /// </param>
         /// <param name='searchRequestOptions'>
-        /// Additional parameters for the operation
+        /// Additional parameters for the operation.
         /// </param>
         /// <param name='cancellationToken'>
         /// The cancellation token.


### PR DESCRIPTION
`<inheritdoc />` is not supported by the .NET API browser. As a workaround, I'm copying documentation instead. Also adding more detail to `SearchCredentials` per feedback from Heidi.

Once this is in the preview SDK, I'll merge it back to the GA SDK.

FYI @HeidiSteen @Yahnoosh @mhko @jeji1101

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
