### PR TITLE
EventGrid DataPlane consumption SDK: Added summary documentation for public facing methods + minor fixes

### DIFF
--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Tests/ConsumeEventTests.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Tests/ConsumeEventTests.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.EventGrid.Tests.ScenarioTests
             eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemSent", typeof(ContosoItemSentEventData));
             eventGridSubscriber2.AddOrUpdateCustomEventMapping("Contoso.Items.ItemReceived", typeof(ContosoItemReceivedEventData));
 
-            IReadOnlyList<KeyValuePair<string, Type>> list = eventGridSubscriber2.GetAllCustomEventMappings();
+            IReadOnlyList<KeyValuePair<string, Type>> list = eventGridSubscriber2.ListAllCustomEventMappings().ToList();
             Assert.Equal(2, list.Count);
 
             Assert.True(eventGridSubscriber2.TryGetCustomEventMapping("Contoso.Items.ItemSent", out Type retrievedType));

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/ICustomEventTypeMapper.cs
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid/Customization/ICustomEventTypeMapper.cs
@@ -15,6 +15,6 @@ namespace Microsoft.Azure.EventGrid
 
         bool TryGetCustomEventMapping(string eventType, out Type eventDataType);
 
-        IReadOnlyList<KeyValuePair<string, Type>> GetAllCustomEventMappings();
+        IEnumerable<KeyValuePair<string, Type>> ListAllCustomEventMappings();
     }
 }


### PR DESCRIPTION
1) Added summary/documentation for public facing methods
2) Made the List API return an IEnumerable instead of IReadOnlyList.
3) Make sure the provided custom JsonSerializer is used for deserializing properties in the outer envelope.

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [X] Please add REST spec PR link to the SDK PR
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [X] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [X] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [X] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
