### PR TITLE
Fix polling when provisioning state is null

### DIFF
--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LROTests/LROOpertionTestResponses.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LROTests/LROOpertionTestResponses.cs
@@ -275,6 +275,32 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Tests
 
             yield return response3;
         }
+
+        static internal IEnumerable<HttpResponseMessage> MockAsyncOperaionWithNullProvisioningState()
+        {
+            var response1 = new HttpResponseMessage(HttpStatusCode.Accepted)
+            {
+                Content = new StringContent("")
+            };
+            response1.Headers.Add("Location", "http://custom/status");
+
+            yield return response1;
+
+            var response2 = new HttpResponseMessage(HttpStatusCode.Accepted)
+            {
+                Content = new StringContent("null")
+            };
+            response2.Headers.Add("Location", "http://custom/status2");
+
+            yield return response2;
+
+            var response3 = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{ \"properties\": { \"provisioningState\": null }, \"id\": \"100\", \"name\": \"foo\" }")
+            };
+
+            yield return response3;
+        }
         #endregion
 
         #endregion

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LROTests/LongRunningOperationsTest.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure.Tests/LROTests/LongRunningOperationsTest.cs
@@ -148,6 +148,20 @@ namespace Microsoft.Rest.ClientRuntime.Azure.Test
         /// Test
         /// </summary>
         [Fact]
+        public void TestAsyncOperationWithNullProvisioningState()
+        {
+            var tokenCredentials = new TokenCredentials("123", "abc");
+            var handler = new PlaybackTestHandler(LROResponse.MockAsyncOperaionWithNullProvisioningState());
+            var fakeClient = new RedisManagementClient(tokenCredentials, handler);
+            fakeClient.LongRunningOperationInitialTimeout = fakeClient.LongRunningOperationRetryTimeout = 0;
+            var resource = fakeClient.RedisOperations.CreateOrUpdate("rg", "redis", new RedisCreateOrUpdateParameters(), "1234");
+            Assert.Equal("100", resource.Id);
+        }
+
+        /// <summary>
+        /// Test
+        /// </summary>
+        [Fact]
         public void TestAsyncOperationWithNonSuccessStatusAndInvalidResponseContent()
         {
             var tokenCredentials = new TokenCredentials("123", "abc");

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureClientExtensions.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureClientExtensions.cs
@@ -849,7 +849,8 @@ namespace Microsoft.Rest.Azure
                     // the response. In that case the assumption is the status is Succeeded.
                     if (resource != null &&
                         resource["properties"] != null &&
-                        resource["properties"]["provisioningState"] != null)
+                        resource["properties"]["provisioningState"] != null &&
+                        resource["properties"]["provisioningState"].HasValues)
                     {
                         pollingState.Status = (string)resource["properties"]["provisioningState"];
                     }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureClientExtensions.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/AzureClientExtensions.cs
@@ -850,7 +850,7 @@ namespace Microsoft.Rest.Azure
                     if (resource != null &&
                         resource["properties"] != null &&
                         resource["properties"]["provisioningState"] != null &&
-                        resource["properties"]["provisioningState"].HasValues)
+                        (string)resource["properties"]["provisioningState"] != null)
                     {
                         pollingState.Status = (string)resource["properties"]["provisioningState"];
                     }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/LRO/Base/AzureLRO.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/LRO/Base/AzureLRO.cs
@@ -213,7 +213,8 @@ namespace Microsoft.Rest.ClientRuntime.Azure.LRO
                     // the response. In that case the assumption is the status is Succeeded.
                     if (CurrentPollingState.RawBody != null &&
                         CurrentPollingState.RawBody["properties"] != null &&
-                        CurrentPollingState.RawBody["properties"]["provisioningState"] != null)
+                        CurrentPollingState.RawBody["properties"]["provisioningState"] != null &&
+                        CurrentPollingState.RawBody["properties"]["provisioningState"].HasValues)
                     {
                         CurrentPollingState.Status = (string)CurrentPollingState.RawBody["properties"]["provisioningState"];
                     }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/LRO/Base/AzureLRO.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/LRO/Base/AzureLRO.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.LRO
 {
     using Microsoft.Rest.Azure;
     using Microsoft.Rest.ClientRuntime.Azure.Properties;
+    using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -214,7 +215,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.LRO
                     if (CurrentPollingState.RawBody != null &&
                         CurrentPollingState.RawBody["properties"] != null &&
                         CurrentPollingState.RawBody["properties"]["provisioningState"] != null &&
-                        CurrentPollingState.RawBody["properties"]["provisioningState"].HasValues)
+                        (string)CurrentPollingState.RawBody["properties"]["provisioningState"] != null)
                     {
                         CurrentPollingState.Status = (string)CurrentPollingState.RawBody["properties"]["provisioningState"];
                     }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/LRO/LROPollState.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/LRO/LROPollState.cs
@@ -138,7 +138,8 @@ namespace Microsoft.Rest.ClientRuntime.Azure.LRO
             string provisionState = string.Empty;
             if (this.RawBody != null &&
                    this.RawBody["properties"] != null &&
-                   this.RawBody["properties"]["provisioningState"] != null)
+                   this.RawBody["properties"]["provisioningState"] != null &&
+                   this.RawBody["properties"]["provisioningState"].HasValues)
             {
                 provisionState = (string)this.RawBody["properties"]["provisioningState"];
             }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/LRO/LROPollState.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/LRO/LROPollState.cs
@@ -139,7 +139,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.LRO
             if (this.RawBody != null &&
                    this.RawBody["properties"] != null &&
                    this.RawBody["properties"]["provisioningState"] != null &&
-                   this.RawBody["properties"]["provisioningState"].HasValues)
+                   (string)this.RawBody["properties"]["provisioningState"] != null)
             {
                 provisionState = (string)this.RawBody["properties"]["provisioningState"];
             }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Microsoft.Rest.ClientRuntime.Azure.csproj
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Microsoft.Rest.ClientRuntime.Azure.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Rest.ClientRuntime.Azure</PackageId>
     <Description>Provides common error handling, tracing, and HTTP/REST-based pipeline manipulation.</Description>
     <AssemblyTitle>Client Runtime for Microsoft Azure Libraries</AssemblyTitle>
-    <Version>3.3.12</Version>
+    <Version>3.3.13</Version>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure</AssemblyName>
     <PackageTags>Microsoft Azure AutoRest ClientRuntime REST  $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
     <PackageReleaseNotes>

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/PollingState.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/PollingState.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Rest.Azure
                 case HttpStatusCode.OK:
                     if (resource != null && resource["properties"] != null &&
                         resource["properties"]["provisioningState"] != null &&
-                        resource["properties"]["provisioningState"].HasValues)
+                        (string)resource["properties"]["provisioningState"] != null)
                     {
                         Status = (string)resource["properties"]["provisioningState"];
                     }
@@ -87,7 +87,7 @@ namespace Microsoft.Rest.Azure
                 case HttpStatusCode.Created:
                     if (resource != null && resource["properties"] != null &&
                         resource["properties"]["provisioningState"] != null &&
-                        resource["properties"]["provisioningState"].HasValues)
+                        (string)resource["properties"]["provisioningState"] != null)
                     {
                         Status = (string) resource["properties"]["provisioningState"];
                     }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/PollingState.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/PollingState.cs
@@ -74,7 +74,8 @@ namespace Microsoft.Rest.Azure
                     break;
                 case HttpStatusCode.OK:
                     if (resource != null && resource["properties"] != null &&
-                        resource["properties"]["provisioningState"] != null)
+                        resource["properties"]["provisioningState"] != null &&
+                        resource["properties"]["provisioningState"].HasValues)
                     {
                         Status = (string)resource["properties"]["provisioningState"];
                     }
@@ -85,7 +86,8 @@ namespace Microsoft.Rest.Azure
                     break;
                 case HttpStatusCode.Created:
                     if (resource != null && resource["properties"] != null &&
-                        resource["properties"]["provisioningState"] != null)
+                        resource["properties"]["provisioningState"] != null &&
+                        resource["properties"]["provisioningState"].HasValues)
                     {
                         Status = (string) resource["properties"]["provisioningState"];
                     }

--- a/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/ClientRuntime.Azure/ClientRuntime.Azure/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Rest Azure Client Runtime")]
 [assembly: AssemblyDescription("Client infrastructure for Azure client libraries.")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.3.12.0")]
+[assembly: AssemblyFileVersion("3.3.13.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
