### PR TITLE
Update Text Analytics C# SDK auto-generated code.

### DIFF
--- a/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics.Tests/BaseTests.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics.Tests/BaseTests.cs
@@ -7,11 +7,16 @@ namespace Language.Tests
     public abstract class BaseTests
     {
         public static bool IsTestTenant = false;
+        // BaseEndpoint only contains protocol and hostname
+        private static string BaseEndpoint = "https://westus.api.cognitive.microsoft.com";
         private static string SubscriptionKey = "000";
 
         protected ITextAnalyticsClient GetClient(DelegatingHandler handler)
         {
-            return new TextAnalyticsClient(new ApiKeyServiceClientCredentials(SubscriptionKey), handlers: handler);
+            return new TextAnalyticsClient(new ApiKeyServiceClientCredentials(SubscriptionKey), handlers: handler)
+            {
+                Endpoint = BaseEndpoint
+            };
         }
     }
 }

--- a/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Generated/TextAnalytics/ITextAnalyticsClient.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Generated/TextAnalytics/ITextAnalyticsClient.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <summary>
         /// The base URI of the service.
         /// </summary>
-        System.Uri BaseUri { get; set; }
 
         /// <summary>
         /// Gets or sets json serialization settings.
@@ -44,6 +43,12 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// Gets or sets json deserialization settings.
         /// </summary>
         JsonSerializerSettings DeserializationSettings { get; }
+
+        /// <summary>
+        /// Supported Cognitive Services endpoints (protocol and hostname, for
+        /// example: https://westus.api.cognitive.microsoft.com).
+        /// </summary>
+        string Endpoint { get; set; }
 
         /// <summary>
         /// Subscription credentials which uniquely identify client

--- a/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Generated/TextAnalytics/TextAnalyticsClient.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Generated/TextAnalytics/TextAnalyticsClient.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <summary>
         /// The base URI of the service.
         /// </summary>
-        public System.Uri BaseUri { get; set; }
+        internal string BaseUri {get; set;}
 
         /// <summary>
         /// Gets or sets json serialization settings.
@@ -47,6 +47,12 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// Gets or sets json deserialization settings.
         /// </summary>
         public JsonSerializerSettings DeserializationSettings { get; private set; }
+
+        /// <summary>
+        /// Supported Cognitive Services endpoints (protocol and hostname, for example:
+        /// https://westus.api.cognitive.microsoft.com).
+        /// </summary>
+        public string Endpoint { get; set; }
 
         /// <summary>
         /// Subscription credentials which uniquely identify client subscription.
@@ -76,51 +82,6 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         protected TextAnalyticsClient(HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : base(rootHandler, handlers)
         {
             Initialize();
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the TextAnalyticsClient class.
-        /// </summary>
-        /// <param name='baseUri'>
-        /// Optional. The base URI of the service.
-        /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        protected TextAnalyticsClient(System.Uri baseUri, params DelegatingHandler[] handlers) : this(handlers)
-        {
-            if (baseUri == null)
-            {
-                throw new System.ArgumentNullException("baseUri");
-            }
-            BaseUri = baseUri;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the TextAnalyticsClient class.
-        /// </summary>
-        /// <param name='baseUri'>
-        /// Optional. The base URI of the service.
-        /// </param>
-        /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
-        /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        protected TextAnalyticsClient(System.Uri baseUri, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
-        {
-            if (baseUri == null)
-            {
-                throw new System.ArgumentNullException("baseUri");
-            }
-            BaseUri = baseUri;
         }
 
         /// <summary>
@@ -177,75 +138,6 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         }
 
         /// <summary>
-        /// Initializes a new instance of the TextAnalyticsClient class.
-        /// </summary>
-        /// <param name='baseUri'>
-        /// Optional. The base URI of the service.
-        /// </param>
-        /// <param name='credentials'>
-        /// Required. Subscription credentials which uniquely identify client subscription.
-        /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        public TextAnalyticsClient(System.Uri baseUri, ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
-        {
-            if (baseUri == null)
-            {
-                throw new System.ArgumentNullException("baseUri");
-            }
-            if (credentials == null)
-            {
-                throw new System.ArgumentNullException("credentials");
-            }
-            BaseUri = baseUri;
-            Credentials = credentials;
-            if (Credentials != null)
-            {
-                Credentials.InitializeServiceClient(this);
-            }
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the TextAnalyticsClient class.
-        /// </summary>
-        /// <param name='baseUri'>
-        /// Optional. The base URI of the service.
-        /// </param>
-        /// <param name='credentials'>
-        /// Required. Subscription credentials which uniquely identify client subscription.
-        /// </param>
-        /// <param name='rootHandler'>
-        /// Optional. The http client handler used to handle http transport.
-        /// </param>
-        /// <param name='handlers'>
-        /// Optional. The delegating handlers to add to the http client pipeline.
-        /// </param>
-        /// <exception cref="System.ArgumentNullException">
-        /// Thrown when a required parameter is null
-        /// </exception>
-        public TextAnalyticsClient(System.Uri baseUri, ServiceClientCredentials credentials, HttpClientHandler rootHandler, params DelegatingHandler[] handlers) : this(rootHandler, handlers)
-        {
-            if (baseUri == null)
-            {
-                throw new System.ArgumentNullException("baseUri");
-            }
-            if (credentials == null)
-            {
-                throw new System.ArgumentNullException("credentials");
-            }
-            BaseUri = baseUri;
-            Credentials = credentials;
-            if (Credentials != null)
-            {
-                Credentials.InitializeServiceClient(this);
-            }
-        }
-
-        /// <summary>
         /// An optional partial-method to perform custom initialization.
         ///</summary>
         partial void CustomInitialize();
@@ -254,7 +146,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// </summary>
         private void Initialize()
         {
-            BaseUri = new System.Uri("https://api.cognitive.microsoft.com/text/analytics/v2.0");
+            BaseUri = "{Endpoint}/text/analytics/v2.0";
             SerializationSettings = new JsonSerializerSettings
             {
                 Formatting = Newtonsoft.Json.Formatting.Indented,
@@ -319,6 +211,10 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// </return>
         public async Task<HttpOperationResponse<KeyPhraseBatchResult>> KeyPhrasesWithHttpMessagesAsync(MultiLanguageBatchInput input, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (Endpoint == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Endpoint");
+            }
             if (input == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "input");
@@ -335,8 +231,9 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
                 ServiceClientTracing.Enter(_invocationId, this, "KeyPhrases", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = BaseUri.AbsoluteUri;
-            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "keyPhrases").ToString();
+            var _baseUrl = BaseUri;
+            var _url = _baseUrl + (_baseUrl.EndsWith("/") ? "" : "/") + "keyPhrases";
+            _url = _url.Replace("{Endpoint}", Endpoint);
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;
@@ -476,6 +373,10 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// </return>
         public async Task<HttpOperationResponse<LanguageBatchResult>> DetectLanguageWithHttpMessagesAsync(BatchInput input, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (Endpoint == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Endpoint");
+            }
             if (input == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "input");
@@ -492,8 +393,9 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
                 ServiceClientTracing.Enter(_invocationId, this, "DetectLanguage", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = BaseUri.AbsoluteUri;
-            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "languages").ToString();
+            var _baseUrl = BaseUri;
+            var _url = _baseUrl + (_baseUrl.EndsWith("/") ? "" : "/") + "languages";
+            _url = _url.Replace("{Endpoint}", Endpoint);
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;
@@ -637,6 +539,10 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// </return>
         public async Task<HttpOperationResponse<SentimentBatchResult>> SentimentWithHttpMessagesAsync(MultiLanguageBatchInput input, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (Endpoint == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Endpoint");
+            }
             if (input == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "input");
@@ -653,8 +559,9 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
                 ServiceClientTracing.Enter(_invocationId, this, "Sentiment", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = BaseUri.AbsoluteUri;
-            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "sentiment").ToString();
+            var _baseUrl = BaseUri;
+            var _url = _baseUrl + (_baseUrl.EndsWith("/") ? "" : "/") + "sentiment";
+            _url = _url.Replace("{Endpoint}", Endpoint);
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;
@@ -798,6 +705,10 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// </return>
         public async Task<HttpOperationResponse<EntitiesBatchResult>> EntitiesWithHttpMessagesAsync(MultiLanguageBatchInput input, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
+            if (Endpoint == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "this.Endpoint");
+            }
             if (input == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "input");
@@ -814,8 +725,9 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
                 ServiceClientTracing.Enter(_invocationId, this, "Entities", tracingParameters);
             }
             // Construct URL
-            var _baseUrl = BaseUri.AbsoluteUri;
-            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "entities").ToString();
+            var _baseUrl = BaseUri;
+            var _url = _baseUrl + (_baseUrl.EndsWith("/") ? "" : "/") + "entities";
+            _url = _url.Replace("{Endpoint}", Endpoint);
             // Create HTTP transport objects
             var _httpRequest = new HttpRequestMessage();
             HttpResponseMessage _httpResponse = null;

--- a/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Microsoft.Azure.CognitiveServices.Language.TextAnalytics.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Microsoft.Azure.CognitiveServices.Language.TextAnalytics.csproj
@@ -16,7 +16,7 @@
     Note: This package is the successor to the Microsoft.Azure.CognitiveServices.Language NuGet package.
 
     Changes in this release:
-    1. Support customizing service endpoints. 
+    1. Support customizing service endpoints by assigning the endpoint string to TextAnalyticsClient.Endpoint. The endpoint string can be found on Azure Portal, it should contain only protocol and hostname, for example: https://westus.api.cognitive.microsoft.com
     ]]></PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Microsoft.Azure.CognitiveServices.Language.TextAnalytics.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Microsoft.Azure.CognitiveServices.Language.TextAnalytics.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.Language.TextAnalytics</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Language APIs.</Description>
-    <Version>2.0.0-preview</Version>
+    <Version>2.1.0-preview</Version>
     <AssemblyName>Microsoft.Azure.CognitiveServices.Language.TextAnalytics</AssemblyName>
     <PackageTags>Microsoft Cognitive Services;Cognitive Services;Cognitive Services SDK;Text Analytics API;Text Analytics;REST HTTP client;netcore451511</PackageTags>
     <PackageReleaseNotes>

--- a/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides API functions for consuming Microsoft Azure Cognitive Services Language APIs.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion("2.1.0.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/_metadata/cognitiveservices_data-plane_TextAnalytics.txt
+++ b/src/SDKs/_metadata/cognitiveservices_data-plane_TextAnalytics.txt
@@ -4,15 +4,15 @@ Commencing code generation
 Generating CSharp code
 Executing AutoRest command
 cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/cognitiveservices/data-plane/TextAnalytics/readme.md --csharp --version=latest --reflect-api-versions --csharp.output-folder=E:\azure-sdk-for-net\src\SDKs\CognitiveServices\dataPlane\Language\TextAnalytics\TextAnalytics\Generated\TextAnalytics
-2018-07-06 00:48:29 UTC
+2018-07-26 19:20:31 UTC
 1) azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      6a9b980b104d37e495f77e82a7aaf32e342e7a1c
+Commit:      c39645d5399639edb6a46d7f87715640e928cd30
 
 2) AutoRest information
 Requested version: latest
-Bootstrapper version:    autorest@2.0.4280
+Bootstrapper version:    autorest@2.0.4282
 
 
 Latest installed version:    


### PR DESCRIPTION
Swagger PR: https://github.com/Azure/azure-rest-api-specs/pull/3491
Doc PR: https://github.com/MicrosoftDocs/azure-docs/pull/12442

Please hold for @assafi's review.

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
