### PR TITLE
add retry-after

### DIFF
--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Fakes/FakeHttpHandler.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/Fakes/FakeHttpHandler.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Fakes
             NumberOfTimesToFail = int.MaxValue;
         }
 
+        public System.Action<HttpResponseMessage> TweakResponse { get; set; }
+
         public int NumberOfTimesToFail { get; set; }
 
         public int NumberOfTimesFailedSoFar { get; private set; }
@@ -29,6 +31,10 @@ namespace Microsoft.Rest.ClientRuntime.Tests.Fakes
             if (NumberOfTimesToFail > NumberOfTimesFailedSoFar)
             {
                 response = new HttpResponseMessage(StatusCodeToReturn);
+                if (TweakResponse != null)
+                {
+                    TweakResponse(response);
+                }
                 NumberOfTimesFailedSoFar++;
             }
 

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ServiceClientTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ServiceClientTests.cs
@@ -111,6 +111,22 @@ namespace Microsoft.Rest.ClientRuntime.Tests
         }
 
         [Fact]
+        public void RetryAfterHandleTest()
+        {
+            var http = new FakeHttpHandler();
+            http.NumberOfTimesToFail = 2;
+            http.StatusCodeToReturn = (HttpStatusCode) 429;
+            http.TweakResponse = (response) => { response.Headers.Add("Retry-After", "10"); };
+
+            var fakeClient = new FakeServiceClient(http, new RetryAfterDelegatingHandler());
+            
+            var result = fakeClient.DoStuffSync();
+
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal(2, http.NumberOfTimesFailedSoFar);
+        }
+
+        [Fact]
         public void FakeSvcClientWithHttpClient()
         {
             HttpClient hc = new HttpClient(new ContosoMessageHandler());

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/RetryAfterDelegatingHandler.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/RetryAfterDelegatingHandler.cs
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Rest
+{
+    /// <summary>
+    /// Http retry handler.
+    /// </summary>
+    public class RetryAfterDelegatingHandler : DelegatingHandler 
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryAfterDelegatingHandler"/> class. 
+        /// Sets default retry policy base on Exponential Backoff.
+        /// </summary>
+        public RetryAfterDelegatingHandler()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RetryAfterDelegatingHandler"/> class.
+        /// </summary>
+        /// <param name="innerHandler">Inner http handler.</param>
+        public RetryAfterDelegatingHandler(DelegatingHandler innerHandler)
+            : base(innerHandler) 
+        {
+        }
+
+        /// <summary>
+        /// Sends an HTTP request to the inner handler to send to the server as an asynchronous
+        /// operation. Retries request if a 429 is returned and there is a retry-after header.
+        /// </summary>
+        /// <param name="request">The HTTP request message to send to the server.</param>
+        /// <param name="cancellationToken">A cancellation token to cancel operation.</param>
+        /// <returns>Returns System.Threading.Tasks.Task&lt;TResult&gt;. The 
+        /// task object representing the asynchronous operation.</returns>
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            do {
+                var response = await base.SendAsync(request, cancellationToken);
+                
+                // if they send back a 429
+                if( response.StatusCode == ((HttpStatusCode)429) ) {
+
+                    // and there is a retry-after header
+                    if (response.Headers.Contains("Retry-After"))
+                    {
+                        try {
+                            // and we get a number of seconds from the header
+                            string retryValue = response.Headers.GetValues("Retry-After").FirstOrDefault();
+                            var retryAfter = int.Parse(retryValue, CultureInfo.InvariantCulture);
+                            
+                            // wait for that duration
+                            await Task.Delay(retryAfter,cancellationToken);
+
+                            // and try again
+                            continue;
+                        } catch {
+                            // if something throws while trying to get the retry-after
+                            // we're just going to suppress it. let the response go
+                            // back to the consumer.
+                        }
+                    }
+                }
+                // if we haven't hit continue, then return the response up the stream
+                return response;
+            } while( true );
+        }
+    }
+}

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/ServiceClient.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/ServiceClient.cs
@@ -433,8 +433,10 @@ namespace Microsoft.Rest
                 }
 
                 HttpClientHandler = httpClientHandler;
-                DelegatingHandler currentHandler = new RetryDelegatingHandler();
-                currentHandler.InnerHandler = HttpClientHandler;
+                // Now, the RetryAfterDelegatingHandler should be the absoulte outermost handler 
+                // because it's extremely lightweight and non-interfering
+                DelegatingHandler currentHandler =
+                    new RetryDelegatingHandler(new RetryAfterDelegatingHandler {InnerHandler = httpClientHandler});
 
                 if (handlers != null)
                 {

--- a/src/SdkCommon/ClientRuntime/ClientRuntime/TransientFaultHandling/HttpStatusCodeErrorDetectionStrategy.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/TransientFaultHandling/HttpStatusCodeErrorDetectionStrategy.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Rest.TransientFaultHandling
         /// <summary>
         /// Returns true if status code in HttpRequestExceptionWithStatus exception is greater 
         /// than or equal to 500 and not NotImplemented (501) or HttpVersionNotSupported (505).
+        /// Or it's 429 (TOO MANY REQUESTS)
         /// </summary>
         /// <param name="ex">Exception to check against.</param>
         /// <returns>True if exception is transient otherwise false.</returns>
@@ -25,6 +26,7 @@ namespace Microsoft.Rest.TransientFaultHandling
                 if ((httpException = ex as HttpRequestWithStatusException) != null)
                 {
                     if (httpException.StatusCode == HttpStatusCode.RequestTimeout ||
+                        httpException.StatusCode == (HttpStatusCode)429 ||
                         (httpException.StatusCode >= HttpStatusCode.InternalServerError &&
                          httpException.StatusCode != HttpStatusCode.NotImplemented &&
                          httpException.StatusCode != HttpStatusCode.HttpVersionNotSupported))


### PR DESCRIPTION
Adds a 429 RetryAfterDelegatingHandler  (and includes a test!)

The handler can be added to a client, upon which, 429's with a Retry-After header will attempt to retry the same request. 

