### PR TITLE
Fixed customization for ADLS gen 2 storage types

### DIFF
--- a/src/SDKs/HDInsight/Management.HDInsight.Tests/UnitTests/CreateConverterTests.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight.Tests/UnitTests/CreateConverterTests.cs
@@ -109,6 +109,14 @@ namespace Management.HDInsight.Tests.UnitTests
             ClusterCreateParametersExtended extendedParams = CreateParametersConverter.GetExtendedClusterCreateParameters("testCluster", createParams);
         }
 
+        [Fact]
+        public void CanConvertAdlsGen2Cluster()
+        {
+            ClusterCreateParameters createParams = GetClusterCreateParamsWithMinRequiredValues();
+            createParams.DefaultStorageInfo = new AzureDataLakeStoreGen2Info("adlsGen2StorageAccount", "key", "fileSystem");
+            ExtendedParameterValidators.ValidateSpecConversion(createParams);
+        }
+
         private static ClusterCreateParameters GetClusterCreateParamsWithMinRequiredValues()
         {
             return new ClusterCreateParameters

--- a/src/SDKs/HDInsight/Management.HDInsight.Tests/Utilities/ExtendedParameterValidators.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight.Tests/Utilities/ExtendedParameterValidators.cs
@@ -31,6 +31,7 @@ namespace Management.HDInsight.Tests.UnitTests
             Assert.Equal(createParams.Version, extendedParams.Properties.ClusterVersion);
             Assert.Equal(OSType.Linux, extendedParams.Properties.OsType);
             Assert.Equal(createParams.SecurityProfile, extendedParams.Properties.SecurityProfile);
+            ValidateStorageProfile(createParams.DefaultStorageInfo, extendedParams.Properties.StorageProfile);
 
             //Validate configurations.
             Dictionary<string, Dictionary<string, string>> configurations = extendedParams.Properties.ClusterDefinition.Configurations as Dictionary<string, Dictionary<string, string>>;
@@ -43,6 +44,22 @@ namespace Management.HDInsight.Tests.UnitTests
 
             //Validate roles.
             ValidateRoles(extendedParams.Properties.ComputeProfile.Roles, createParams);
+        }
+
+        public static void ValidateStorageProfile(StorageInfo inputStorageInfo, StorageProfile convertedStorageProfile)
+        {
+            // Note: WASB and ADLS Gen 1 details are validated in configuration validation
+            AzureDataLakeStoreGen2Info adlsGen2Info = inputStorageInfo as AzureDataLakeStoreGen2Info;
+            if (adlsGen2Info != null)
+            {
+                Assert.NotNull(convertedStorageProfile);
+                Assert.NotNull(convertedStorageProfile.Storageaccounts);
+                Assert.NotEmpty(convertedStorageProfile.Storageaccounts);
+                StorageAccount defaultStorageAccount = convertedStorageProfile.Storageaccounts.Single(storageAccount => storageAccount.IsDefault.Value);
+                Assert.Equal(adlsGen2Info.StorageAccountName, defaultStorageAccount.Name);
+                Assert.Equal(adlsGen2Info.StorageAccountKey, defaultStorageAccount.Key);
+                Assert.Equal(adlsGen2Info.StorageFileSystem, defaultStorageAccount.FileSystem);
+            }
         }
 
         public static void ValidateRoles(IList<Role> roleCollection, ClusterCreateParameters createParams)
@@ -258,26 +275,32 @@ namespace Management.HDInsight.Tests.UnitTests
         public static void ValidateStorageConfigurations(IReadOnlyDictionary<string, Dictionary<string, string>> configurations, StorageInfo defaultStorageInfo,
             Dictionary<string, string> additionalStorageAccounts)
         {
-            Assert.True(configurations.ContainsKey(ConfigurationKey.CoreSite));
-            Dictionary<string, string> coreConfig = configurations[ConfigurationKey.CoreSite];
-            Assert.True(coreConfig.ContainsKey(Constants.StorageConfigurations.DefaultFsKey));
             AzureStorageInfo azureStorage = defaultStorageInfo as AzureStorageInfo;
             AzureDataLakeStoreInfo adlStorage = defaultStorageInfo as AzureDataLakeStoreInfo;
-            if (azureStorage != null)
-            {
-                Assert.True(coreConfig.ContainsKey(string.Format(Constants.StorageConfigurations.WasbStorageAccountKeyFormat, azureStorage.StorageAccountName)));
-            }
-            else if (adlStorage != null)
-            {
-                Assert.True(coreConfig.ContainsKey(Constants.StorageConfigurations.AdlHostNameKey));
-                Assert.True(coreConfig.ContainsKey(Constants.StorageConfigurations.AdlMountPointKey));
-            }
 
-            if (additionalStorageAccounts != null && additionalStorageAccounts.Any())
+            bool shouldValidateCoreConfig = azureStorage != null || adlStorage != null || additionalStorageAccounts.Any();
+            if (shouldValidateCoreConfig)
             {
-                foreach (KeyValuePair<string, string> additionalStorageAccount in additionalStorageAccounts)
+                Assert.True(configurations.ContainsKey(ConfigurationKey.CoreSite));
+                Dictionary<string, string> coreConfig = configurations[ConfigurationKey.CoreSite];
+                Assert.True(coreConfig.ContainsKey(Constants.StorageConfigurations.DefaultFsKey));
+                
+                if (azureStorage != null)
                 {
-                    Assert.True(coreConfig.ContainsKey(string.Format(Constants.StorageConfigurations.WasbStorageAccountKeyFormat, additionalStorageAccount.Key)));
+                    Assert.True(coreConfig.ContainsKey(string.Format(Constants.StorageConfigurations.WasbStorageAccountKeyFormat, azureStorage.StorageAccountName)));
+                }
+                else if (adlStorage != null)
+                {
+                    Assert.True(coreConfig.ContainsKey(Constants.StorageConfigurations.AdlHostNameKey));
+                    Assert.True(coreConfig.ContainsKey(Constants.StorageConfigurations.AdlMountPointKey));
+                }
+
+                if (additionalStorageAccounts != null && additionalStorageAccounts.Any())
+                {
+                    foreach (KeyValuePair<string, string> additionalStorageAccount in additionalStorageAccounts)
+                    {
+                        Assert.True(coreConfig.ContainsKey(string.Format(Constants.StorageConfigurations.WasbStorageAccountKeyFormat, additionalStorageAccount.Key)));
+                    }
                 }
             }
         }

--- a/src/SDKs/HDInsight/Management.HDInsight/Customizations/Models/AzureDataLakeStoreGen2Info.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight/Customizations/Models/AzureDataLakeStoreGen2Info.cs
@@ -1,0 +1,53 @@
+﻿namespace Microsoft.Azure.Management.HDInsight.Models
+{
+    using System;
+
+    /// <summary>
+    /// Gets or sets the StorageAccountName, StorageAccountKey and StorageFileSystem for the Azure Data Lake Storage Gen 2 account.
+    /// </summary>
+    public class AzureDataLakeStoreGen2Info : StorageInfo
+    {
+        private readonly string _storageFileSystem;
+        private readonly string _storageAccountKey;
+        private static string _defaultAzureStorageSuffix = ".dfs.core.windows.net";
+
+        /// <summary>
+        /// Gets the Azure Data Lake Storage Gen 2 file system.
+        /// </summary>
+        public string StorageFileSystem
+        {
+            get { return _storageFileSystem; }
+        }
+
+        /// <summary>
+        /// Gets the Azure Data Lake Storage Gen 2 account key.
+        /// </summary>
+        public string StorageAccountKey
+        {
+            get { return _storageAccountKey; }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the AzureStorageInfo class.
+        /// </summary>
+        /// <param name="storageAccountName">Fully Qualified StorageAccountName for the Azure Data Lake Storage Gen 2 Account.</param>
+        /// <param name="storageAccountKey">StorageKey for the Azure Data Lake Storage Gen 2 Account.</param>
+        /// <param name="storageFileSystem">File system for the Azure Data Lake Storage Gen 2 account. The cluster will leverage to store some cluster-level files.</param>
+        public AzureDataLakeStoreGen2Info(string storageAccountName, string storageAccountKey, string storageFileSystem)
+            : base(storageAccountName)
+        {
+            if (string.IsNullOrWhiteSpace(storageAccountKey))
+            {
+                throw new ArgumentException(Constants.Errors.ERROR_INPUT_CANNOT_BE_EMPTY, "storageAccountKey");
+            }
+
+            if (!storageAccountName.Contains("."))
+            {
+                this.StorageAccountName = storageAccountName + _defaultAzureStorageSuffix;
+            }
+
+            this._storageAccountKey = storageAccountKey;
+            this._storageFileSystem = storageFileSystem;
+        }
+    }
+}

--- a/src/SDKs/HDInsight/Management.HDInsight/Customizations/Models/AzureStorageInfo.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight/Customizations/Models/AzureStorageInfo.cs
@@ -57,13 +57,5 @@ namespace Microsoft.Azure.Management.HDInsight.Models
             this._storageAccountKey = storageAccountKey;
             this._storageContainer = storageContainer;
         }
-
-        public string StorageAccountUri 
-        {
-            get
-            {
-                return string.Format("wasb://{0}@{1}", StorageContainer, StorageAccountName);
-            }
-        }
     }
 }

--- a/src/SDKs/HDInsight/Management.HDInsight/Management.HDInsight.csproj
+++ b/src/SDKs/HDInsight/Management.HDInsight/Management.HDInsight.csproj
@@ -7,11 +7,11 @@
 		<PackageId>Microsoft.Azure.Management.HDInsight</PackageId>
 		<Description>Azure HDInsight Management SDK Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.HDInsight</AssemblyName>
-		<Version>3.0.3-preview</Version>
+		<Version>3.1.0-preview</Version>
 		<PackageTags>Microsoft Azure HDInsight Management;HDInsight;HDInsight Management</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[
-        This is a public preview release of the Azure HDInsight SDK. Added support for ADLS Gen 2.
+        This is a public preview release of the Azure HDInsight SDK. Fixed customization support for ADLS Gen 2.
       ]]>
 		</PackageReleaseNotes>
     

--- a/src/SDKs/HDInsight/Management.HDInsight/Properties/AssemblyInfo.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft Azure HDInsight Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure HDInsight.")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.3.0")]
+[assembly: AssemblyFileVersion("3.1.0.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.Management.HDInsight.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 


### PR DESCRIPTION
This PR contains a fix to customization to support a storage account type that was added earlier. No Swagger spec changes had been made.

---

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
