### PR TITLE
[Storage] Make SignedResource not required in listSericeSAS

### DIFF
--- a/src/SDKs/Storage/Management.Storage/Generated/IStorageManagementClient.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/IStorageManagementClient.cs
@@ -51,19 +51,20 @@ namespace Microsoft.Azure.Management.Storage
         string ApiVersion { get; }
 
         /// <summary>
-        /// Gets or sets the preferred language for the response.
+        /// The preferred language for the response.
         /// </summary>
         string AcceptLanguage { get; set; }
 
         /// <summary>
-        /// Gets or sets the retry timeout in seconds for Long Running
-        /// Operations. Default value is 30.
+        /// The retry timeout in seconds for Long Running Operations. Default
+        /// value is 30.
         /// </summary>
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is generated
-        /// and included in each request. Default is true.
+        /// Whether a unique x-ms-client-request-id should be generated. When
+        /// set to true a unique x-ms-client-request-id value is generated and
+        /// included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/SDKs/Storage/Management.Storage/Generated/Models/OperationDisplay.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/Models/OperationDisplay.cs
@@ -34,11 +34,13 @@ namespace Microsoft.Azure.Management.Storage.Models
         /// etc.</param>
         /// <param name="operation">Type of operation: get, read, delete,
         /// etc.</param>
-        public OperationDisplay(string provider = default(string), string resource = default(string), string operation = default(string))
+        /// <param name="description">Description of the operation.</param>
+        public OperationDisplay(string provider = default(string), string resource = default(string), string operation = default(string), string description = default(string))
         {
             Provider = provider;
             Resource = resource;
             Operation = operation;
+            Description = description;
             CustomInit();
         }
 
@@ -64,6 +66,12 @@ namespace Microsoft.Azure.Management.Storage.Models
         /// </summary>
         [JsonProperty(PropertyName = "operation")]
         public string Operation { get; set; }
+
+        /// <summary>
+        /// Gets or sets description of the operation.
+        /// </summary>
+        [JsonProperty(PropertyName = "description")]
+        public string Description { get; set; }
 
     }
 }

--- a/src/SDKs/Storage/Management.Storage/Generated/Models/Restriction.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/Models/Restriction.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Azure.Management.Storage.Models
         /// type is set to location. This would be different locations where
         /// the SKU is restricted.</param>
         /// <param name="reasonCode">The reason for the restriction. As of now
-        /// this can be “QuotaId” or “NotAvailableForSubscription”. Quota Id is
+        /// this can be "QuotaId" or "NotAvailableForSubscription". Quota Id is
         /// set when the SKU has requiredQuotas parameter as the subscription
-        /// does not belong to that quota. The “NotAvailableForSubscription” is
+        /// does not belong to that quota. The "NotAvailableForSubscription" is
         /// related to capacity at DC. Possible values include: 'QuotaId',
         /// 'NotAvailableForSubscription'</param>
         public Restriction(string type = default(string), IList<string> values = default(IList<string>), string reasonCode = default(string))
@@ -72,9 +72,9 @@ namespace Microsoft.Azure.Management.Storage.Models
 
         /// <summary>
         /// Gets or sets the reason for the restriction. As of now this can be
-        /// “QuotaId” or “NotAvailableForSubscription”. Quota Id is set when
+        /// "QuotaId" or "NotAvailableForSubscription". Quota Id is set when
         /// the SKU has requiredQuotas parameter as the subscription does not
-        /// belong to that quota. The “NotAvailableForSubscription” is related
+        /// belong to that quota. The "NotAvailableForSubscription" is related
         /// to capacity at DC. Possible values include: 'QuotaId',
         /// 'NotAvailableForSubscription'
         /// </summary>

--- a/src/SDKs/Storage/Management.Storage/Generated/Models/ServiceSasParameters.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/Models/ServiceSasParameters.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Management.Storage.Models
         /// content language.</param>
         /// <param name="contentType">The response header override for content
         /// type.</param>
-        public ServiceSasParameters(string canonicalizedResource, string resource, string permissions = default(string), string iPAddressOrRange = default(string), HttpProtocol? protocols = default(HttpProtocol?), System.DateTime? sharedAccessStartTime = default(System.DateTime?), System.DateTime? sharedAccessExpiryTime = default(System.DateTime?), string identifier = default(string), string partitionKeyStart = default(string), string partitionKeyEnd = default(string), string rowKeyStart = default(string), string rowKeyEnd = default(string), string keyToSign = default(string), string cacheControl = default(string), string contentDisposition = default(string), string contentEncoding = default(string), string contentLanguage = default(string), string contentType = default(string))
+        public ServiceSasParameters(string canonicalizedResource, string resource = default(string), string permissions = default(string), string iPAddressOrRange = default(string), HttpProtocol? protocols = default(HttpProtocol?), System.DateTime? sharedAccessStartTime = default(System.DateTime?), System.DateTime? sharedAccessExpiryTime = default(System.DateTime?), string identifier = default(string), string partitionKeyStart = default(string), string partitionKeyEnd = default(string), string rowKeyStart = default(string), string rowKeyEnd = default(string), string keyToSign = default(string), string cacheControl = default(string), string contentDisposition = default(string), string contentEncoding = default(string), string contentLanguage = default(string), string contentType = default(string))
         {
             CanonicalizedResource = canonicalizedResource;
             Resource = resource;
@@ -224,10 +224,6 @@ namespace Microsoft.Azure.Management.Storage.Models
             if (CanonicalizedResource == null)
             {
                 throw new ValidationException(ValidationRules.CannotBeNull, "CanonicalizedResource");
-            }
-            if (Resource == null)
-            {
-                throw new ValidationException(ValidationRules.CannotBeNull, "Resource");
             }
             if (Identifier != null)
             {

--- a/src/SDKs/Storage/Management.Storage/Generated/StorageManagementClient.cs
+++ b/src/SDKs/Storage/Management.Storage/Generated/StorageManagementClient.cs
@@ -57,19 +57,20 @@ namespace Microsoft.Azure.Management.Storage
         public string ApiVersion { get; private set; }
 
         /// <summary>
-        /// Gets or sets the preferred language for the response.
+        /// The preferred language for the response.
         /// </summary>
         public string AcceptLanguage { get; set; }
 
         /// <summary>
-        /// Gets or sets the retry timeout in seconds for Long Running Operations.
-        /// Default value is 30.
+        /// The retry timeout in seconds for Long Running Operations. Default value is
+        /// 30.
         /// </summary>
         public int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is generated and
-        /// included in each request. Default is true.
+        /// Whether a unique x-ms-client-request-id should be generated. When set to
+        /// true a unique x-ms-client-request-id value is generated and included in
+        /// each request. Default is true.
         /// </summary>
         public bool? GenerateClientRequestId { get; set; }
 

--- a/src/SDKs/_metadata/storage_resource-manager.txt
+++ b/src/SDKs/_metadata/storage_resource-manager.txt
@@ -1,11 +1,11 @@
-2018-06-25 03:10:42 UTC
+2018-08-03 12:02:19 UTC
 
 1) azure-rest-api-specs repository information
 GitHub user: azure
 Branch:      master
-Commit:      37ca9e71d6c89b46ab990eb064ddb70308fd5824
+Commit:      d3a52a102020f22da05f40da9c54fc5fb2d93734
 
 2) AutoRest information
 Requested version: latest
-Bootstrapper version:    C:\Users\weiwei\AppData\Roaming\npm `-- autorest@2.0.4280  
+Bootstrapper version:    C:\Users\weiwei\AppData\Roaming\npm `-- autorest@2.0.4283  
 Latest installed version:    


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->
SignedResource not required in listSericeSAS from server, so set is as not required in swagger/SDK.
Also add description to operation to fix swagger validate failure. (this failure not happen before, might cause by autorest upgrade)

Swagger pass review and merged in https://github.com/Azure/azure-rest-api-specs/pull/3463 
---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
