### PR TITLE
[Cognitive Services] FAKE PR.

### DIFF
--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Microsoft.Azure.CognitiveServices.ContentModerator.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Microsoft.Azure.CognitiveServices.ContentModerator.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
- <!-- Please do not move/edit code below this line -->
+  <!-- Please do not move/edit code below this line -->
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.reference.props'))" />
   <!-- Please do not move/edit code above this line -->
+  
   <PropertyGroup>
     <PackageId>Microsoft.Azure.CognitiveServices.ContentModerator</PackageId>
     <Description>This client library provides access to the Microsoft Cognitive Services Content Moderator APIs.</Description>
-    <Version>0.12.1-preview</Version>
+    <Version>0.13.0-preview</Version>
     <AssemblyName>Microsoft.Azure.CognitiveServices.ContentModerator</AssemblyName>
     <PackageTags>ContentModerator;Content Moderator;</PackageTags>
     <PackageReleaseNotes>
@@ -13,7 +14,7 @@
     This is a preview release of the Cognitive Services Content Moderator SDK.
     
     Changes in this release:
-    1. Additional AzureRegions: Canada Central, Japan East, Central India and UK South
+    1. Supported customizing service endpoints by assigning the endpoint string to ContentModeratorClient.Endpoint. The endpoint string can be found on Azure Portal, it should contain only protocol and hostname, for example: https://westus.api.cognitive.microsoft.com.
     ]]>
 	</PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Properties/AssemblyInfo.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Reflection;
+using System.Resources;
+
+[assembly: AssemblyTitle("Microsoft Cognitive Services Content Moderator SDK")]
+[assembly: AssemblyDescription("Provides access to the Microsoft Cognitive Services Content Moderator APIs.")]
+
+[assembly: AssemblyVersion("0.9.0.0")]
+[assembly: AssemblyFileVersion("0.13.0.0")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("Microsoft")]
+[assembly: AssemblyProduct("Microsoft Azure .NET SDK")]
+[assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+[assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
For nailing down the error in https://github.com/Azure/azure-sdk-for-net/pull/4653

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
