### PR TITLE
Enabling warnings as errors for SDK test projects

### DIFF
--- a/src/AzSdk.test.reference.props
+++ b/src/AzSdk.test.reference.props
@@ -11,6 +11,5 @@
   </ItemGroup>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
   </PropertyGroup>
 </Project>

--- a/src/AzSdk.test.reference.props
+++ b/src/AzSdk.test.reference.props
@@ -9,4 +9,8 @@
     <!-- This is needed for discovering tests in test explorer -->
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />	
   </ItemGroup>
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
 </Project>

--- a/src/SDKs/ApiManagement/ApiManagement.Tests/ApiManagement.Tests.csproj
+++ b/src/SDKs/ApiManagement/ApiManagement.Tests/ApiManagement.Tests.csproj
@@ -7,6 +7,9 @@
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>ApiManagementManagement.Tests</AssemblyName>    
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <NoWarn>1591,1998</NoWarn>
+  </PropertyGroup>
 
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>

--- a/src/SDKs/ApiManagement/ApiManagement.Tests/ApiManagement.Tests.csproj
+++ b/src/SDKs/ApiManagement/ApiManagement.Tests/ApiManagement.Tests.csproj
@@ -7,14 +7,7 @@
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>ApiManagementManagement.Tests</AssemblyName>    
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <NoWarn>1591,1998</NoWarn>
-  </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
-
+  
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="2.1.0-ForTest" />-->
     <ProjectReference Include="..\Management.ApiManagement\Microsoft.Azure.Management.ApiManagement.csproj" />

--- a/src/SDKs/ApiManagement/ApiManagement.Tests/ManagementApiTests/ApiExportImportTests.cs
+++ b/src/SDKs/ApiManagement/ApiManagement.Tests/ManagementApiTests/ApiExportImportTests.cs
@@ -16,7 +16,7 @@ namespace ApiManagement.Tests.ManagementApiTests
     public class ApiExportImportTests : TestBase
     {
         [Fact]
-        public async Task SwaggerTest()
+        public void SwaggerTest()
         {
             Environment.SetEnvironmentVariable("AZURE_TEST_MODE", "Playback");
             using (MockContext context = MockContext.Start(this.GetType().FullName))
@@ -76,7 +76,7 @@ namespace ApiManagement.Tests.ManagementApiTests
         }
 
         [Fact]
-        public async Task WadlTest()
+        public void WadlTest()
         {
             Environment.SetEnvironmentVariable("AZURE_TEST_MODE", "Playback");
             using (MockContext context = MockContext.Start(this.GetType().FullName))
@@ -138,7 +138,7 @@ namespace ApiManagement.Tests.ManagementApiTests
         }
 
         [Fact]
-        public async Task WsdlTest()
+        public void WsdlTest()
         {
             Environment.SetEnvironmentVariable("AZURE_TEST_MODE", "Playback");
             using (MockContext context = MockContext.Start(this.GetType().FullName))

--- a/src/SDKs/ApiManagement/ApiManagement.Tests/ManagementApiTests/ReportTests.cs
+++ b/src/SDKs/ApiManagement/ApiManagement.Tests/ManagementApiTests/ReportTests.cs
@@ -16,7 +16,7 @@ namespace ApiManagement.Tests.ManagementApiTests
     public class ReportTests : TestBase
     {
         [Fact]
-        public async Task Query()
+        public void Query()
         {
             Environment.SetEnvironmentVariable("AZURE_TEST_MODE", "Playback");
             using (MockContext context = MockContext.Start(this.GetType().FullName))

--- a/src/SDKs/ApplicationInsights/DataPlane/Data.ApplicationInsights.Tests/Data.ApplicationInsights.Tests.csproj
+++ b/src/SDKs/ApplicationInsights/DataPlane/Data.ApplicationInsights.Tests/Data.ApplicationInsights.Tests.csproj
@@ -7,9 +7,6 @@
     <VersionPrefix>1.0.0-preview</VersionPrefix>
     <!--<TargetFrameworks>netcoreapp1.1</TargetFrameworks>-->
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <NoWarn>xUnit1026,1591</NoWarn>
-  </PropertyGroup>
   
   <ItemGroup>
     <None Update="SessionRecords\**\*.json">

--- a/src/SDKs/ApplicationInsights/DataPlane/Data.ApplicationInsights.Tests/Data.ApplicationInsights.Tests.csproj
+++ b/src/SDKs/ApplicationInsights/DataPlane/Data.ApplicationInsights.Tests/Data.ApplicationInsights.Tests.csproj
@@ -7,6 +7,9 @@
     <VersionPrefix>1.0.0-preview</VersionPrefix>
     <!--<TargetFrameworks>netcoreapp1.1</TargetFrameworks>-->
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <NoWarn>xUnit1026,1591</NoWarn>
+  </PropertyGroup>
   
   <ItemGroup>
     <None Update="SessionRecords\**\*.json">

--- a/src/SDKs/ApplicationInsights/DataPlane/Data.ApplicationInsights.Tests/ScenarioTests/Events/EventsExtensionTests.cs
+++ b/src/SDKs/ApplicationInsights/DataPlane/Data.ApplicationInsights.Tests/ScenarioTests/Events/EventsExtensionTests.cs
@@ -23,8 +23,8 @@ namespace Data.ApplicationInsights.Tests.ScenarioTests.Events
         [MemberData(nameof(AvailabilityResultsData))]
         [MemberData(nameof(PerformanceCountersData))]
         [MemberData(nameof(CustomMetricsData))]
-        public async Task GetEventsAsync<T>(EventType eventType, MultiQueryAsync<T> multiQueryAsync, SingleQueryAsync<T> singleQueryAsync,
-            object unused1, object unused2) where T : EventsResultData
+        public async Task GetEventsAsync<T>(EventType eventType, MultiQueryAsync<T> multiQueryAsync, SingleQueryAsync<T> singleQueryAsync
+            /* object unused1, object unused2*/ ) where T : EventsResultData
         {
             using (var ctx = MockContext.Start(GetType().FullName, $"GetEvents.{eventType}"))
             {
@@ -68,7 +68,7 @@ namespace Data.ApplicationInsights.Tests.ScenarioTests.Events
         [MemberData(nameof(AvailabilityResultsData))]
         [MemberData(nameof(PerformanceCountersData))]
         [MemberData(nameof(CustomMetricsData))]
-        public void GetEvents<T>(EventType eventType, object unused1, object unused2,
+        public void GetEvents<T>(EventType eventType, /* object unused1, object unused2, */
             MultiQuery<T> multiQuery, SingleQuery<T> singleQuery) where T : EventsResultData
         {
             using (var ctx = MockContext.Start(GetType().FullName, $"GetEvents.{eventType}"))

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/APIKeysTests.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/APIKeysTests.cs
@@ -56,7 +56,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                 .GetAwaiter()
                                                 .GetResult();
 
-                Assert.Equal(1, getAllAPIKeys.Body.Count());
+                Assert.Single(getAllAPIKeys.Body);
                 AreEqual(apiKeyProperties, getAllAPIKeys.Body.ElementAt(0));
 
                 string fullkeyId = getAllAPIKeys.Body.ElementAt(0).Id;
@@ -85,7 +85,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                         .GetResult();
 
                 //get API again, should get an NOT found exception
-                Assert.Throws(typeof(CloudException), () =>
+                Assert.Throws<CloudException>(() =>
                 {
                     getAPIKey = insightsClient
                                             .APIKeys
@@ -109,12 +109,13 @@ namespace ApplicationInsights.Tests.Scenarios
             Assert.True(response.LinkedWriteProperties.Count >= request.LinkedWriteProperties.Count);
             foreach (var readaccess in request.LinkedReadProperties)
             {
-                Assert.True(response.LinkedReadProperties.Any(r => r == readaccess));
+                Assert.Contains(response.LinkedReadProperties, r => r == readaccess);
+
             }
 
             foreach (var writeaccess in request.LinkedWriteProperties)
             {
-                Assert.True(response.LinkedWriteProperties.Any(w => w == writeaccess));
+                Assert.Contains(response.LinkedWriteProperties, w => w == writeaccess);
             }
         }
 

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/ComponentsTests.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/ComponentsTests.cs
@@ -111,7 +111,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                     .GetResult();
 
                 //get component again, should get an exception
-                Assert.Throws(typeof(CloudException), () =>
+                Assert.Throws<CloudException>(() =>
                 {
                     getComponentResponse = insightsClient
                                                         .Components

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/ContinuousExportsTests.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/ContinuousExportsTests.cs
@@ -45,7 +45,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                             createContinuousExportProperties)
                                                         .GetAwaiter()
                                                         .GetResult();
-                Assert.Equal(1, createContinuousExportResponse.Body.Count());
+                Assert.Single(createContinuousExportResponse.Body);
                 AreEqual(createContinuousExportProperties, createContinuousExportResponse.Body.FirstOrDefault());
 
                 //get all continuous exports
@@ -57,7 +57,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                 .GetAwaiter()
                                                 .GetResult();
 
-                Assert.Equal(1, getAllContinuousExports.Body.Count());
+                Assert.Single(getAllContinuousExports.Body);
                 AreEqual(createContinuousExportProperties, getAllContinuousExports.Body.FirstOrDefault());
 
                 string exportId = getAllContinuousExports.Body.FirstOrDefault().ExportId;

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/TestBase.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/TestBase.cs
@@ -86,7 +86,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                 .GetResult();
 
             //get component again, should get an exception
-            Assert.Throws(typeof(CloudException), () =>
+            Assert.Throws<CloudException>(() =>
             {
                 var getComponentResponse = insightsClient
                                                     .Components

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/WebtestsTests.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/WebtestsTests.cs
@@ -103,7 +103,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                 .GetResult();
 
                 //get webtest again, should get an exception
-                Assert.Throws(typeof(CloudException), () =>
+                Assert.Throws<CloudException>(() =>
                 {
                     getWebTestResponse = insightsClient
                                                 .WebTests

--- a/src/SDKs/Authorization/Authorization.Tests/Tests/BasicTests.cs
+++ b/src/SDKs/Authorization/Authorization.Tests/Tests/BasicTests.cs
@@ -56,8 +56,8 @@ namespace Authorization.Tests
                 {
                     Assert.NotNull(classicAdmin);
                     Assert.NotNull(classicAdmin.Id);
-                    Assert.True(classicAdmin.Id.Contains("/providers/Microsoft.Authorization/classicAdministrators/"));
-                    Assert.True(classicAdmin.Id.Contains("/subscriptions/" + client.SubscriptionId));
+                    Assert.Contains("/providers/Microsoft.Authorization/classicAdministrators/", classicAdmin.Id);
+                    Assert.Contains("/subscriptions/" + client.SubscriptionId, classicAdmin.Id);
                     Assert.NotNull(classicAdmin.Name);
                     Assert.NotNull(classicAdmin.Type);
                     Assert.Equal("Microsoft.Authorization/classicAdministrators", classicAdmin.Type);
@@ -436,7 +436,7 @@ namespace Authorization.Tests
                     var nextPage = client.RoleAssignments.ListNext(firstPage.NextPageLink);
 
                     Assert.NotNull(nextPage);
-                    Assert.NotEqual(0, nextPage.Count());
+                    Assert.NotEmpty(nextPage);
 
                     foreach (var roleAssignment in nextPage)
                     {

--- a/src/SDKs/Automation/Management.Automation/Customization/SoftwareUpdateConfigurationMachineRunsOperationsExtensions.cs
+++ b/src/SDKs/Automation/Management.Automation/Customization/SoftwareUpdateConfigurationMachineRunsOperationsExtensions.cs
@@ -142,9 +142,6 @@
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
-        /// <param name='osType'>
-        /// The computer osType targeted by this machine run
-        /// </param>
         /// <param name='skip'>
         /// number of entries you skip before returning results
         /// </param>
@@ -199,9 +196,6 @@
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
-        /// </param>
-        /// <param name='osType'>
-        /// The computer osType targeted by this machine run
         /// </param>
         /// <param name='skip'>
         /// number of entries you skip before returning results

--- a/src/SDKs/Billing/Billing.Tests/ScenarioTests/BillingPeriodsTests.cs
+++ b/src/SDKs/Billing/Billing.Tests/ScenarioTests/BillingPeriodsTests.cs
@@ -43,7 +43,7 @@ namespace Billing.Tests.ScenarioTests
                 var billingMgmtClient = BillingTestUtilities.GetBillingManagementClient(context, new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK });
                 var billingPeriods = billingMgmtClient.BillingPeriods.List(RangeFilter, null, 1);
                 Assert.NotNull(billingPeriods);
-                Assert.Equal(1, billingPeriods.Count());
+                Assert.Single(billingPeriods);
                 var billingPeriod = billingPeriods.First();
                 Assert.True(billingPeriod.BillingPeriodStartDate.Value <= billingPeriod.BillingPeriodEndDate.Value);
                 Assert.NotNull(billingPeriod.Name);

--- a/src/SDKs/Billing/Billing.Tests/ScenarioTests/InvoicesTests.cs
+++ b/src/SDKs/Billing/Billing.Tests/ScenarioTests/InvoicesTests.cs
@@ -32,7 +32,7 @@ namespace Billing.Tests.ScenarioTests
                 var invoices = billingMgmtClient.Invoices.List();
                 Assert.NotNull(invoices);
                 Assert.True(invoices.Any());
-                Assert.False(invoices.Any(x => x.DownloadUrl != null));
+                Assert.DoesNotContain(invoices, x => x.DownloadUrl != null);
             }
         }
 
@@ -45,7 +45,7 @@ namespace Billing.Tests.ScenarioTests
                 var billingMgmtClient = BillingTestUtilities.GetBillingManagementClient(context, new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK });
                 var invoices = billingMgmtClient.Invoices.List(DownloadUrlExpand, RangeFilter, null, 1);
                 Assert.NotNull(invoices);
-                Assert.Equal(1, invoices.Count());
+                Assert.Single(invoices);
                 Assert.NotNull(invoices.First().DownloadUrl);
                 var invoice = invoices.First();
                 Assert.False(string.IsNullOrWhiteSpace(invoice.DownloadUrl.Url));

--- a/src/SDKs/BotService/BotService.Tests/Tests/BotServiceTests.cs
+++ b/src/SDKs/BotService/BotService.Tests/Tests/BotServiceTests.cs
@@ -28,7 +28,7 @@ namespace BotService.Tests
         }
 
         [Fact]
-        public async Task BotCreateEmailChannel()
+        public void BotCreateEmailChannel()
         {
             var handler = new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK };
 
@@ -46,7 +46,7 @@ namespace BotService.Tests
 
                 // Create bot services
                 Bot bot1 = BotServiceManagementTestUtilities.CreateAndValidateBot(botServiceMgmtClient, rgname);
-                
+
                 // Enable email channel for the demo bot
                 var emailChannel = botServiceMgmtClient.Channels.Create(rgname, bot1.Name, ChannelName.EmailChannel,
                     new BotChannel(location: "global", properties:

--- a/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/CustomDomainTests.cs
+++ b/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/CustomDomainTests.cs
@@ -67,7 +67,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List custom domains one this endpoint should return none
                 var customDomains = cdnMgmtClient.CustomDomains.ListByEndpoint(resourceGroupName, profileName, endpointName);
-                Assert.Equal(0, customDomains.Count());
+                Assert.Empty(customDomains);
 
                 // NOTE: There is a CName mapping already created for this custom domain and endpoint hostname
                 // "sdk-1-f3757d2a3e10.azureedge-test.net" maps to "endpoint-f3757d2a3e10.azureedge.net"
@@ -80,7 +80,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List custom domains one this endpoint should return one
                 customDomains = cdnMgmtClient.CustomDomains.ListByEndpoint(resourceGroupName, profileName, endpointName);
-                Assert.Equal(1, customDomains.Count());
+                Assert.Single(customDomains);
 
                 // Stop endpoint
                 cdnMgmtClient.Endpoints.Stop(resourceGroupName, profileName, endpointName);
@@ -107,7 +107,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List custom domains on endpoint should return one
                 customDomains = cdnMgmtClient.CustomDomains.ListByEndpoint(resourceGroupName, profileName, endpointName);
-                Assert.Equal(1, customDomains.Count());
+                Assert.Single(customDomains);
 
                 // Start endpoint
                 cdnMgmtClient.Endpoints.Start(resourceGroupName, profileName, endpointName);
@@ -125,7 +125,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List custom domains on endpoint should return none
                 customDomains = cdnMgmtClient.CustomDomains.ListByEndpoint(resourceGroupName, profileName, endpointName);
-                Assert.Equal(0, customDomains.Count());
+                Assert.Empty(customDomains);
 
                 // Delete resource group
                 CdnTestUtilities.DeleteResourceGroup(resourcesClient, resourceGroupName);

--- a/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/EndpointTests.cs
+++ b/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/EndpointTests.cs
@@ -703,7 +703,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List endpoints should return one
                 var endpoints = cdnMgmtClient.Endpoints.ListByProfile(resourceGroupName, profileName);
-                Assert.Equal(1, endpoints.Count());
+                Assert.Single(endpoints);
 
                 // Delete existing endpoint should succeed
                 cdnMgmtClient.Endpoints.Delete(resourceGroupName, profileName, endpointName);
@@ -713,7 +713,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List endpoints should return none
                 endpoints = cdnMgmtClient.Endpoints.ListByProfile(resourceGroupName, profileName);
-                Assert.Equal(0, endpoints.Count());
+                Assert.Empty(endpoints);
 
                 // Create a cdn endpoint and don't wait for creation to finish
                 endpointName = TestUtilities.GenerateName("endpoint");
@@ -750,7 +750,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List endpoints should return none
                 endpoints = cdnMgmtClient.Endpoints.ListByProfile(resourceGroupName, profileName);
-                Assert.Equal(0, endpoints.Count());
+                Assert.Empty(endpoints);
 
                 // Delete resource group
                 CdnTestUtilities.DeleteResourceGroup(resourcesClient, resourceGroupName);
@@ -789,7 +789,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List endpoints should return none
                 var endpoints = cdnMgmtClient.Endpoints.ListByProfile(resourceGroupName, profileName);
-                Assert.Equal(0, endpoints.Count());
+                Assert.Empty(endpoints);
 
                 // Create a cdn endpoint should succeed
                 string endpointName = TestUtilities.GenerateName("endpoint");
@@ -817,7 +817,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List endpoints should return one endpoint
                 endpoints = cdnMgmtClient.Endpoints.ListByProfile(resourceGroupName, profileName);
-                Assert.Equal(1, endpoints.Count());
+                Assert.Single(endpoints);
 
                 // Create a cdn endpoint and don't wait for creation to finish
                 string endpointName2 = TestUtilities.GenerateName("endpoint");
@@ -855,7 +855,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List endpoints should return 1 endpoint
                 endpoints = cdnMgmtClient.Endpoints.ListByProfile(resourceGroupName, profileName);
-                Assert.Equal(1, endpoints.Count());
+                Assert.Single(endpoints);
 
                 // Wait for second endpoint to complete creation
                 CdnTestUtilities.WaitIfNotInPlaybackMode();
@@ -875,7 +875,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List endpoints should return none
                 endpoints = cdnMgmtClient.Endpoints.ListByProfile(resourceGroupName, profileName);
-                Assert.Equal(0, endpoints.Count());
+                Assert.Empty(endpoints);
 
                 // Delete resource group
                 CdnTestUtilities.DeleteResourceGroup(resourcesClient, resourceGroupName);
@@ -1156,7 +1156,7 @@ namespace Cdn.Tests.ScenarioTests
                     profileName,
                     endpointName,
                     "customdomain34.azureedge-test.net");
-                Assert.Equal(output.CustomDomainValidated, true);
+                Assert.True(output.CustomDomainValidated);
 
                 // Validate non-exisiting custom domain should return false
                 output = cdnMgmtClient.Endpoints.ValidateCustomDomain(
@@ -1164,7 +1164,7 @@ namespace Cdn.Tests.ScenarioTests
                     profileName,
                     endpointName,
                     "customdomain4.hello.com");
-                Assert.Equal(output.CustomDomainValidated, false);
+                Assert.False(output.CustomDomainValidated);
 
                 // Validate invalid custom domain should fail
                 Assert.ThrowsAny<ErrorResponseException>(() => {

--- a/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/GetEdgeNodeTests.cs
+++ b/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/GetEdgeNodeTests.cs
@@ -34,8 +34,8 @@ namespace Cdn.Tests.ScenarioTests
 
                 var edgeNodes = cdnMgmtClient.EdgeNodes.List().GetEnumerator().ToIEnumerable<EdgeNode>().ToList();
 
-                Assert.Equal(0, edgeNodes.Select(e => e.Name).Except(expectedEdgeNodeNames).Count());
-                Assert.Equal(0, expectedEdgeNodeNames.Except(edgeNodes.Select(e => e.Name)).Count());
+                Assert.Empty(edgeNodes.Select(e => e.Name).Except(expectedEdgeNodeNames));
+                Assert.Empty(expectedEdgeNodeNames.Except(edgeNodes.Select(e => e.Name)));
 
                 foreach (var edgeNode in edgeNodes)
                 {

--- a/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/NameAvailabilityTests.cs
+++ b/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/NameAvailabilityTests.cs
@@ -32,7 +32,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // CheckNameAvailability should return true
                 var output = cdnMgmtClient.CheckNameAvailability(endpointName);
-                Assert.Equal(output.NameAvailable, true);
+                Assert.True(output.NameAvailable);
 
                 // Create endpoint with that name then CheckNameAvailability again
 
@@ -72,7 +72,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // CheckNameAvailability after endpoint was created should return false
                 output = cdnMgmtClient.CheckNameAvailability(endpointName);
-                Assert.Equal(output.NameAvailable, false);
+                Assert.False(output.NameAvailable);
 
                 // Delete resource group
                 CdnTestUtilities.DeleteResourceGroup(resourcesClient, resourceGroupName);

--- a/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/OperationsTest.cs
+++ b/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/OperationsTest.cs
@@ -29,7 +29,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // Verify operations are returned
                 Assert.NotNull(operations);
-                Assert.NotEqual(0, operations.Count());
+                Assert.NotEmpty(operations);
             }
         }
     }

--- a/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/OriginTests.cs
+++ b/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/OriginTests.cs
@@ -171,7 +171,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // Get origins on endpoint should return one
                 var origins = cdnMgmtClient.Origins.ListByEndpoint(resourceGroupName, profileName, endpointName);
-                Assert.Equal(1, origins.Count());
+                Assert.Single(origins);
 
                 // Delete resource group
                 CdnTestUtilities.DeleteResourceGroup(resourcesClient, resourceGroupName);

--- a/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/ProfileTests.cs
+++ b/src/SDKs/Cdn/Cdn.Tests/ScenarioTests/ProfileTests.cs
@@ -197,7 +197,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should return none
                 var profiles = cdnMgmtClient.Profiles.ListByResourceGroup(resourceGroupName);
-                Assert.Equal(0, profiles.Count());
+                Assert.Empty(profiles);
 
                 // Delete non-existing profile should succeed
                 cdnMgmtClient.Profiles.Delete(resourceGroupName, profile.Name);
@@ -232,7 +232,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should return none
                 profiles = cdnMgmtClient.Profiles.ListByResourceGroup(resourceGroupName);
-                Assert.Equal(0, profiles.Count());
+                Assert.Empty(profiles);
 
                 // Delete resource group
                 CdnTestUtilities.DeleteResourceGroup(resourcesClient, resourceGroupName);
@@ -256,7 +256,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should return none
                 var profiles = cdnMgmtClient.Profiles.ListByResourceGroup(resourceGroupName);
-                Assert.Equal(0, profiles.Count());
+                Assert.Empty(profiles);
 
                 // Create a standard cdn profile
                 string profileName = TestUtilities.GenerateName("profile");
@@ -280,7 +280,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should return one profile
                 profiles = cdnMgmtClient.Profiles.ListByResourceGroup(resourceGroupName);
-                Assert.Equal(1, profiles.Count());
+                Assert.Single(profiles);
 
                 // Create a second cdn profile and don't wait for creation to finish
                 var profileName2 = TestUtilities.GenerateName("profile");
@@ -313,7 +313,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should return only one profile
                 profiles = cdnMgmtClient.Profiles.ListByResourceGroup(resourceGroupName);
-                Assert.Equal(1, profiles.Count());
+                Assert.Single(profiles);
 
                 // Wait for second profile to complete creation
                 CdnTestUtilities.WaitIfNotInPlaybackMode();
@@ -333,7 +333,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should none
                 profiles = cdnMgmtClient.Profiles.ListByResourceGroup(resourceGroupName);
-                Assert.Equal(0, profiles.Count());
+                Assert.Empty(profiles);
 
                 // Delete resource group
                 CdnTestUtilities.DeleteResourceGroup(resourcesClient, resourceGroupName);
@@ -354,7 +354,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should return none
                 var profiles = cdnMgmtClient.Profiles.List();
-                Assert.Equal(0, profiles.Count());
+                Assert.Empty(profiles);
 
                 // Create resource group
                 var resourceGroupName1 = CdnTestUtilities.CreateResourceGroup(resourcesClient);
@@ -381,7 +381,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should return one profile
                 profiles = cdnMgmtClient.Profiles.List();
-                Assert.Equal(1, profiles.Count());
+                Assert.Single(profiles);
 
                 // Create another resource group
                 var resourceGroupName2 = CdnTestUtilities.CreateResourceGroup(resourcesClient);
@@ -411,14 +411,14 @@ namespace Cdn.Tests.ScenarioTests
 
                 // List profiles should return only one profile
                 profiles = cdnMgmtClient.Profiles.List();
-                Assert.Equal(1, profiles.Count());
+                Assert.Single(profiles);
 
                 // Delete second profile
                 cdnMgmtClient.Profiles.Delete(resourceGroupName2, profileName2);
 
                 // List profiles should none
                 profiles = cdnMgmtClient.Profiles.List();
-                Assert.Equal(0, profiles.Count());
+                Assert.Empty(profiles);
 
                 // Delete resource groups
                 CdnTestUtilities.DeleteResourceGroup(resourcesClient, resourceGroupName1);
@@ -545,7 +545,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // CheckUsage on subscription should return zero profiles
                 var subscriptionLevelUsages = cdnMgmtClient.ResourceUsage.List();
-                Assert.Equal(1, subscriptionLevelUsages.Count());
+                Assert.Single(subscriptionLevelUsages);
 
                 var defaultUsage = subscriptionLevelUsages.First();
                 Assert.Equal(25, defaultUsage.Limit);
@@ -571,7 +571,7 @@ namespace Cdn.Tests.ScenarioTests
                 VerifyProfileCreated(profile, createParameters);
 
                 subscriptionLevelUsages = cdnMgmtClient.ResourceUsage.List();
-                Assert.Equal(1, subscriptionLevelUsages.Count());
+                Assert.Single(subscriptionLevelUsages);
 
                 var usageAfterCreation = subscriptionLevelUsages.First();
                 Assert.Equal(25, usageAfterCreation.Limit);
@@ -579,7 +579,7 @@ namespace Cdn.Tests.ScenarioTests
 
                 // test Profile level usage
                 var profileLevelUsages = cdnMgmtClient.Profiles.ListResourceUsage(resourceGroupName, profileName);
-                Assert.Equal(1, profileLevelUsages.Count());
+                Assert.Single(profileLevelUsages);
 
                 var profileLevelUsage = profileLevelUsages.First();
                 Assert.Equal(10, profileLevelUsage.Limit);
@@ -605,7 +605,7 @@ namespace Cdn.Tests.ScenarioTests
                 var endpoint = cdnMgmtClient.Endpoints.Create(resourceGroupName, profileName, endpointName, endpointCreateParameters);
 
                 profileLevelUsages = cdnMgmtClient.Profiles.ListResourceUsage(resourceGroupName, profileName);
-                Assert.Equal(1, profileLevelUsages.Count());
+                Assert.Single(profileLevelUsages);
 
                 var profileLevelUsageAfterEndpointCreation = profileLevelUsages.First();
                 Assert.Equal(10, profileLevelUsageAfterEndpointCreation.Limit);
@@ -622,7 +622,7 @@ namespace Cdn.Tests.ScenarioTests
             Assert.Equal(profile.Sku.Name, parameters.Sku.Name);
             Assert.Equal(profile.Tags.Count, parameters.Tags.Count);
             Assert.True(profile.Tags.SequenceEqual(parameters.Tags));
-            Assert.Equal(profile.ProvisioningState, "Succeeded");
+            Assert.Equal("Succeeded", profile.ProvisioningState);
             Assert.Equal(profile.ResourceState, ProfileResourceState.Active);
         }
 

--- a/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch.Tests/EntitySearchTests.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Search/BingEntitySearch/BingEntitySearch.Tests/EntitySearchTests.cs
@@ -25,14 +25,14 @@ namespace SearchSDK.Tests
                 Assert.NotNull(resp);
                 Assert.NotNull(resp.Entities);
                 Assert.NotNull(resp.Entities.Value);
-                Assert.Equal(resp.Entities.Value.Count, 1);
+                Assert.Equal(1, resp.Entities.Value.Count);
 
                 Assert.NotNull(resp.Entities.Value[0].ContractualRules);
 
                 var licenseAttribution = resp.Entities.Value[0].ContractualRules.Where(rule => rule is ContractualRulesLicenseAttribution).FirstOrDefault();
 
                 Assert.NotNull(licenseAttribution);
-                Assert.Equal(licenseAttribution.TargetPropertyName, "description");
+                Assert.Equal("description", licenseAttribution.TargetPropertyName);
 
                 var image = resp.Entities.Value[0].Image;
 
@@ -42,7 +42,7 @@ namespace SearchSDK.Tests
                 var provider = image.Provider.FirstOrDefault();
 
                 Assert.NotNull(provider);
-                Assert.IsType(typeof(Organization), provider);
+                Assert.IsType<Organization>(provider);
             }
         }
     }

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Helpers/Constants.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Helpers/Constants.cs
@@ -901,7 +901,7 @@ namespace ContentModeratorTests
             Utilities u = new Utilities();
 			try
 			{
-				string tc = "Is this a crap email abcdef@abcd.com, phone: 6657789887, IP: 255.255.255.255, 1 Microsoft Way, Redmond, WA 98052 <HTML>HTML tags</HTML>";
+				//string tc = "Is this a crap email abcdef@abcd.com, phone: 6657789887, IP: 255.255.255.255, 1 Microsoft Way, Redmond, WA 98052 <HTML>HTML tags</HTML>";
 				
 				
 				TestBase.wait(2);

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Helpers/Utilities.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/Helpers/Utilities.cs
@@ -82,7 +82,7 @@ namespace ContentModeratorTests.Helpers
 
                 return contentType;
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 throw new Exception("Unable to file content Type");
             }
@@ -558,7 +558,7 @@ namespace ContentModeratorTests.Helpers
                 TestBase.ErrorMessage = error;
                 return string.IsNullOrEmpty(error);
             }
-            catch (Exception e)
+            catch (Exception)
             {
                     TestBase.ErrorMessage += $"Unable to verify BadRequestResponse. Response {JsonConvert.SerializeObject(br)}";
                     return false;

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ImageListManagement.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ImageListManagement.cs
@@ -16,7 +16,7 @@ using Microsoft.Azure.CognitiveServices.ContentModerator;
 
 namespace ContentModeratorTests
 {
-        public class ImageListManagement : TestBase
+    public class ImageListManagement : TestBase
     {
 
         ContentModeratorClient client = null;
@@ -24,7 +24,7 @@ namespace ContentModeratorTests
         static ContentModeratorAPI api;
         public static List<ImageList> allImageLists;
         public static ImageIds allImages;
-        string imageListIdToDelete, imageListIdToUpdate, imageListId, imageId;
+
 
         public ImageListManagement()
         {
@@ -32,12 +32,13 @@ namespace ContentModeratorTests
         }
 
         
+        [Fact(Skip ="Appeasing warnings")]
         public void TestSetUp()
         {
             TestSetUpConfiguration();
         }
 
-        
+        [Fact(Skip = "Appeasing warnings")]
         public void TestCleanup()
         {
             TestCleanupConfiguration();
@@ -306,7 +307,7 @@ namespace ContentModeratorTests
                         api = ContentModeratorAPI.ADD_IMAGE;
                         HttpMockServer.Initialize("ImageListManagement", "AddImage");
                         client = Constants.GenerateClient(api, HttpMockServer.CreateInstance());
-                        results = Constants.GetResponse(client, api, imageListId);
+                        results = Constants.GetResponse(client, api, null);
                     }
                     var addImgeToListId = results.AddImage;
 

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ImageListManagement.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ImageListManagement.cs
@@ -32,14 +32,12 @@ namespace ContentModeratorTests
         }
 
         
-        [Fact(Skip ="Appeasing warnings")]
-        public void TestSetUp()
+        internal void TestSetUp()
         {
             TestSetUpConfiguration();
         }
 
-        [Fact(Skip = "Appeasing warnings")]
-        public void TestCleanup()
+        internal void TestCleanup()
         {
             TestCleanupConfiguration();
         }

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ImageModerator.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ImageModerator.cs
@@ -40,8 +40,7 @@ namespace ContentModeratorTests
             
         }
 
-        [Fact(Skip = "Appeasing warnings")]
-        public void TestCleanup()
+        internal void TestCleanup()
         {
             TestCleanupConfiguration();
         }

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ImageModerator.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ImageModerator.cs
@@ -26,7 +26,6 @@ namespace ContentModeratorTests
         static ContentModeratorAPI api;
         public static List<ImageList> allImageLists;
         public static ImageIds allImages;
-        string imageListIdToDelete, imageListIdToUpdate, imageListId, imageId;
 
         
         BodyModel ImageUrlToModerate = new BodyModel ("URL", "https://pbs.twimg.com/media/BfopodJCUAAjmkU.jpg:large");
@@ -41,7 +40,7 @@ namespace ContentModeratorTests
             
         }
 
-        
+        [Fact(Skip = "Appeasing warnings")]
         public void TestCleanup()
         {
             TestCleanupConfiguration();

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ReviewAPIs.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ReviewAPIs.cs
@@ -29,7 +29,7 @@ namespace ContentModeratorTests
             TestSetUpConfiguration();
         }
 
-        
+        [Fact(Skip = "Appeasing warnings")]
         public void TestCleanup()
         {
             TestCleanupConfiguration();

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ReviewAPIs.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/ReviewAPIs.cs
@@ -29,8 +29,7 @@ namespace ContentModeratorTests
             TestSetUpConfiguration();
         }
 
-        [Fact(Skip = "Appeasing warnings")]
-        public void TestCleanup()
+        internal void TestCleanup()
         {
             TestCleanupConfiguration();
         }

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/TextListManagement.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/TextListManagement.cs
@@ -19,7 +19,7 @@ namespace ContentModeratorTests
         static ContentModeratorAPI api;
         public static List<TermList> allTermLists;
         public static Terms allTerms;
-        string TermListIdToDelete, TermListIdToUpdate, TermListId, terms;
+        string TermListIdToUpdate;
 
         public TextListManagement()
         {

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/TextModerator.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator.Tests/TextModerator.cs
@@ -23,7 +23,7 @@ namespace ContentModeratorTests
         static ContentModeratorAPI api;
         public static List<TermList> allTermLists;
         public static Terms allTerms;
-        string TermListIdToDelete, TermListIdToUpdate, TermListId, terms;
+        string TermListId;
         public TextModerator()
         {
             TestSetUpConfiguration();

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/CustomVision/Training.Tests/BaseTests.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/CustomVision/Training.Tests/BaseTests.cs
@@ -12,11 +12,21 @@
     using System.Threading.Tasks;
     using Xunit;
 
+    /// <summary>
+    /// 
+    /// </summary>
     public abstract class BaseTests : IClassFixture<ProjectIdFixture>
     {
         private static readonly string TrainingKey = "";
 
+        /// <summary>
+        /// 
+        /// </summary>
         protected static HttpRecorderMode RecorderMode = HttpRecorderMode.Playback;
+        
+        /// <summary>
+        /// 
+        /// </summary>
         protected static string ObjDetectionProjectName = "Obj Detection SDK Tests";
 
         protected static Guid FoodDomain = Guid.Parse("C151D5B5-DD07-472A-ACC8-15D29DEA8518");
@@ -51,7 +61,7 @@
             return client;
         }
 
-        public async Task<Guid> CreateTrainedImageClassificationProjectAsync(Guid? domain = null)
+        public Guid CreateTrainedImageClassificationProjectAsync(Guid? domain = null)
         {
 #if RECORD_MODE
             var client = GetTrainingClient();
@@ -108,7 +118,7 @@
 #endif
         }
 
-        public async Task<Guid> CreateTrainedObjDetectionProject()
+        public Guid CreateTrainedObjDetectionProject()
         {
 #if RECORD_MODE
             Dictionary<string, double[]> fileToRegionMap = new Dictionary<string, double[]>()

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/CustomVision/Training.Tests/Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.Tests.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/CustomVision/Training.Tests/Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.Tests.csproj
@@ -10,10 +10,6 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <NoWarn>1591;1701;1573;CS1591;CS1998</NoWarn>
-  </PropertyGroup>
-  
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
     <ProjectReference Include="..\Training\Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.csproj" />

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/CustomVision/Training.Tests/Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.Tests.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/CustomVision/Training.Tests/Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.Tests.csproj
@@ -10,6 +10,10 @@
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
   
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <NoWarn>1591;1701;1573;CS1591;CS1998</NoWarn>
+  </PropertyGroup>
+  
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
     <ProjectReference Include="..\Training\Microsoft.Azure.CognitiveServices.Vision.CustomVision.Training.csproj" />

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/CustomVision/Training.Tests/TrainingTests.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/CustomVision/Training.Tests/TrainingTests.cs
@@ -295,7 +295,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "GetIterations", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -335,7 +335,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "GetIterationPerformance", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -371,7 +371,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "ExportTests", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync(ExportableDomain);
+                var projectId = CreateTrainedImageClassificationProjectAsync(ExportableDomain);
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -407,7 +407,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "TrainProject", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -436,7 +436,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "GetTaggedImages", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -472,7 +472,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "GetUntaggedImages", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -490,7 +490,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "ImageTagManipulation", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -550,7 +550,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "QuickTests", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -585,7 +585,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "CreateImagesFromPredictions", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -609,7 +609,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "QueryPredictionResults", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -640,7 +640,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "DeletePrediction", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -663,7 +663,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "GetImagesByIds", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -697,7 +697,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "ImageCounts", RecorderMode);
 
-                var projectId = await CreateTrainedImageClassificationProjectAsync();
+                var projectId = CreateTrainedImageClassificationProjectAsync();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -722,7 +722,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "DownloadRegions", RecorderMode);
 
-                var projectId = await CreateTrainedObjDetectionProject();
+                var projectId = CreateTrainedObjDetectionProject();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -746,7 +746,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "RegionManipulation", RecorderMode);
 
-                var projectId = await CreateTrainedObjDetectionProject();
+                var projectId = CreateTrainedObjDetectionProject();
 
                 ITrainingApi client = GetTrainingClient();
 
@@ -798,7 +798,7 @@
             {
                 HttpMockServer.Initialize(this.GetType().Name, "ObjDetectionPrediction", RecorderMode);
 
-                var projectId = await CreateTrainedObjDetectionProject();
+                var projectId = CreateTrainedObjDetectionProject();
 
                 ITrainingApi client = GetTrainingClient();
 

--- a/src/SDKs/CognitiveServices/management/CognitiveServices.Tests/Helpers/CognitiveServicesManagementTestUtilities.cs
+++ b/src/SDKs/CognitiveServices/management/CognitiveServices.Tests/Helpers/CognitiveServicesManagementTestUtilities.cs
@@ -151,8 +151,8 @@ namespace CognitiveServices.Tests.Helpers
 
                 Assert.NotNull(account.Tags);
                 Assert.Equal(2, account.Tags.Count);
-                Assert.Equal(account.Tags["key1"], "value1");
-                Assert.Equal(account.Tags["key2"], "value2");
+                Assert.Equal("value1", account.Tags["key1"]);
+                Assert.Equal("value2", account.Tags["key2"]);
             }
             else
             {

--- a/src/SDKs/Compute/Compute.Tests/VMScaleSetTests/VMScaleSetVMTestsBase.cs
+++ b/src/SDKs/Compute/Compute.Tests/VMScaleSetTests/VMScaleSetVMTestsBase.cs
@@ -22,7 +22,7 @@ namespace Compute.Tests
             {
                 Assert.NotNull(vmScaleSetVMOut.Zones);
                 Assert.Equal(1, vmScaleSetVMOut.Zones.Count);
-                Assert.True(vmScaleSet.Zones.Any(vmssZone => vmssZone == vmScaleSetVMOut.Zones.First()));
+                Assert.Contains(vmScaleSet.Zones, vmssZone => vmssZone == vmScaleSetVMOut.Zones.First());
             }
         }
 

--- a/src/SDKs/ContainerRegistry/ContainerRegistry.Tests/Tests/ContainerRegistryTests.cs
+++ b/src/SDKs/ContainerRegistry/ContainerRegistry.Tests/Tests/ContainerRegistryTests.cs
@@ -130,7 +130,7 @@ namespace ContainerRegistry.Tests
             var registriesByResourceGroup = registryClient.Registries.ListByResourceGroup(resourceGroup.Name);
             registry = registriesByResourceGroup.First(
                 r => StringComparer.OrdinalIgnoreCase.Equals(r.Name, registry.Name));
-            Assert.Equal(1, registriesByResourceGroup.Count());
+            Assert.Single(registriesByResourceGroup);
             ContainerRegistryTestUtilities.ValidateResourceDefaultTags(registry);
 
             // Get the container registry
@@ -249,7 +249,7 @@ namespace ContainerRegistry.Tests
                 var webhooks = registryClient.Webhooks.List(resourceGroup.Name, registry.Name);
                 webhook = webhooks.First(
                     w => StringComparer.OrdinalIgnoreCase.Equals(w.Name, webhook.Name));
-                Assert.Equal(1, webhooks.Count());
+                Assert.Single(webhooks);
                 ContainerRegistryTestUtilities.ValidateResourceDefaultTags(webhook);
 
                 // Get the webhook

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/AuthorizationPolicyScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/AuthorizationPolicyScenarioTests.cs
@@ -70,9 +70,8 @@ namespace CustomerInsights.Tests.Tests
                 Assert.Equal(policyName, resultPolicy.PolicyName);
                 Assert.Equal(resultPolicy.Name, HubName + "/" + policyName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    resultPolicy.Type,
                     "Microsoft.CustomerInsights/hubs/AuthorizationPolicies",
-                    StringComparer.OrdinalIgnoreCase);
+                    resultPolicy.Type, StringComparer.OrdinalIgnoreCase);
 
                 TestUtilities.Wait(1000);
 
@@ -80,9 +79,8 @@ namespace CustomerInsights.Tests.Tests
                 Assert.Equal(policyName, getResultPolicy.PolicyName);
                 Assert.Equal(getResultPolicy.Name, HubName + "/" + policyName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    getResultPolicy.Type,
                     "Microsoft.CustomerInsights/hubs/AuthorizationPolicies",
-                    StringComparer.OrdinalIgnoreCase);
+                    getResultPolicy.Type, StringComparer.OrdinalIgnoreCase);
             }
         }
 
@@ -125,7 +123,7 @@ namespace CustomerInsights.Tests.Tests
                     policyName,
                     this.testPolicy);
                 Assert.Equal(resultPolicy.Name, HubName + "/" + policyName);
-                Assert.Equal(resultPolicy.Type, "Microsoft.CustomerInsights/hubs/AuthorizationPolicies");
+                Assert.Equal("Microsoft.CustomerInsights/hubs/AuthorizationPolicies", resultPolicy.Type);
 
                 var policyWithNewKey = aciClient.AuthorizationPolicies.RegeneratePrimaryKey(
                     ResourceGroupName,
@@ -151,7 +149,7 @@ namespace CustomerInsights.Tests.Tests
                     policyName,
                     this.testPolicy);
                 Assert.Equal(resultPolicy.Name, HubName + "/" + policyName);
-                Assert.Equal(resultPolicy.Type, "Microsoft.CustomerInsights/hubs/AuthorizationPolicies");
+                Assert.Equal("Microsoft.CustomerInsights/hubs/AuthorizationPolicies", resultPolicy.Type);
                 var policyWithNewKey = aciClient.AuthorizationPolicies.RegenerateSecondaryKey(
                     ResourceGroupName,
                     HubName,

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/ConnectorMappingScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/ConnectorMappingScenarioTests.cs
@@ -121,9 +121,8 @@ namespace CustomerInsights.Tests.Tests
                     HubName + "/" + connectorName + "/" + connectorMappingName,
                     StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    createdMapping.Type,
                     "Microsoft.CustomerInsights/hubs/connectors/mappings",
-                    StringComparer.OrdinalIgnoreCase);
+                    createdMapping.Type, StringComparer.OrdinalIgnoreCase);
 
                 var getMapping = aciClient.ConnectorMappings.Get(
                     ResourceGroupName,
@@ -137,14 +136,12 @@ namespace CustomerInsights.Tests.Tests
                     HubName + "/" + connectorName + "/" + connectorMappingName,
                     StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    getMapping.Type,
                     "Microsoft.CustomerInsights/hubs/connectors/mappings",
-                    StringComparer.OrdinalIgnoreCase);
+                    getMapping.Type, StringComparer.OrdinalIgnoreCase);
 
                 var result = aciClient.ConnectorMappings.ListByConnector(ResourceGroupName, HubName, connectorName);
                 Assert.True(result.ToList().Count >= 1);
-                Assert.True(
-                    result.ToList().Any(mappingReturned => connectorMappingName == mappingReturned.ConnectorMappingName));
+                Assert.Contains(result.ToList(), mappingReturned => connectorMappingName == mappingReturned.ConnectorMappingName);
 
                 var deleteMappingResponse =
                     aciClient.ConnectorMappings.DeleteWithHttpMessagesAsync(

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/ConnectorScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/ConnectorScenarioTests.cs
@@ -50,18 +50,16 @@ namespace CustomerInsights.Tests.Tests
                 Assert.Equal(connectorName, createdConnector.ConnectorName);
                 Assert.Equal(createdConnector.Name, HubName + "/" + connectorName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    createdConnector.Type,
                     "Microsoft.CustomerInsights/hubs/connectors",
-                    StringComparer.OrdinalIgnoreCase);
+                    createdConnector.Type, StringComparer.OrdinalIgnoreCase);
 
                 var getConnector = aciClient.Connectors.Get(ResourceGroupName, HubName, connectorName);
 
                 Assert.Equal(connectorName, getConnector.ConnectorName);
                 Assert.Equal(getConnector.Name, HubName + "/" + connectorName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    getConnector.Type,
                     "Microsoft.CustomerInsights/hubs/connectors",
-                    StringComparer.OrdinalIgnoreCase);
+                    getConnector.Type, StringComparer.OrdinalIgnoreCase);
 
                 var deleteConnectorResponse =
                     aciClient.Connectors.DeleteWithHttpMessagesAsync(ResourceGroupName, HubName, connectorName).Result;

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/InteractionTypeScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/InteractionTypeScenarioTests.cs
@@ -52,7 +52,7 @@ namespace CustomerInsights.Tests.Tests
 
                 Assert.Equal(interactionName, interactionResult.TypeName);
                 Assert.Equal(interactionResult.Name, HubName + "/" + interactionName);
-                Assert.Equal(interactionResult.Type, "Microsoft.CustomerInsights/hubs/interactions");
+                Assert.Equal("Microsoft.CustomerInsights/hubs/interactions", interactionResult.Type);
 
                 //Get interaction and verify
                 var interactionGetResult = aciClient.Interactions.Get(
@@ -67,9 +67,8 @@ namespace CustomerInsights.Tests.Tests
                     HubName + "/" + interactionName,
                     StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    interactionGetResult.Type,
                     "Microsoft.CustomerInsights/hubs/interactions",
-                    StringComparer.OrdinalIgnoreCase);
+                    interactionGetResult.Type, StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/KpiScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/KpiScenarioTests.cs
@@ -79,16 +79,16 @@ namespace CustomerInsights.Tests.Tests
 
                 Assert.Equal(kpiName, createKpiResult.KpiName);
                 Assert.Equal(createKpiResult.Name, HubName + "/" + kpiName);
-                Assert.Equal(createKpiResult.Type, "Microsoft.CustomerInsights/hubs/kpi");
+                Assert.Equal("Microsoft.CustomerInsights/hubs/kpi", createKpiResult.Type);
 
                 var getKpiResult = aciClient.Kpi.Get(ResourceGroupName, HubName, kpiName);
                 Assert.Equal(kpiName, getKpiResult.KpiName);
                 Assert.Equal(getKpiResult.Name, HubName + "/" + kpiName, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(getKpiResult.Type, "Microsoft.CustomerInsights/hubs/kpi", StringComparer.OrdinalIgnoreCase);
+                Assert.Equal("Microsoft.CustomerInsights/hubs/kpi", getKpiResult.Type, StringComparer.OrdinalIgnoreCase);
 
                 var listKpiResult = aciClient.Kpi.ListByHub(ResourceGroupName, HubName);
                 Assert.True(listKpiResult.ToList().Count >= 1);
-                Assert.True(listKpiResult.ToList().Any(kpiReturned => kpiName == kpiReturned.KpiName));
+                Assert.Contains(listKpiResult.ToList(), kpiReturned => kpiName == kpiReturned.KpiName);
 
                 var deleteKpiResult =
                     aciClient.Kpi.DeleteWithHttpMessagesAsync(ResourceGroupName, HubName, kpiName).Result;

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/LinksScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/LinksScenarioTests.cs
@@ -90,22 +90,20 @@ namespace CustomerInsights.Tests.Tests
                 Assert.Equal(linkName, createLinkResult.LinkName);
                 Assert.Equal(createLinkResult.Name, HubName + "/" + linkName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    createLinkResult.Type,
                     "Microsoft.CustomerInsights/hubs/links",
-                    StringComparer.OrdinalIgnoreCase);
+                    createLinkResult.Type, StringComparer.OrdinalIgnoreCase);
 
                 var getLinkResult = aciClient.Links.Get(ResourceGroupName, HubName, linkName);
                 Assert.Equal(linkName, getLinkResult.LinkName);
                 Assert.Equal(getLinkResult.Name, HubName + "/" + linkName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    getLinkResult.Type,
                     "Microsoft.CustomerInsights/hubs/links",
-                    StringComparer.OrdinalIgnoreCase);
+                    getLinkResult.Type, StringComparer.OrdinalIgnoreCase);
 
                 var listlinkResult = aciClient.Links.ListByHub(ResourceGroupName, HubName);
 
                 Assert.True(listlinkResult.ToList().Count >= 1);
-                Assert.True(listlinkResult.ToList().Any(linkReturned => linkName == linkReturned.LinkName));
+                Assert.Contains(listlinkResult.ToList(), linkReturned => linkName == linkReturned.LinkName);
             }
         }
     }

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/ProfileTypeScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/ProfileTypeScenarioTests.cs
@@ -52,9 +52,8 @@ namespace CustomerInsights.Tests.Tests
                 Assert.Equal(profileName, profileResult.TypeName);
                 Assert.Equal(profileResult.Name, HubName + "/" + profileName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    profileResult.Type,
                     "Microsoft.CustomerInsights/hubs/profiles",
-                    StringComparer.OrdinalIgnoreCase);
+                    profileResult.Type, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(ProvisioningStates.Succeeded, profileResult.ProvisioningState);
 
                 //Get profile and verify
@@ -62,9 +61,8 @@ namespace CustomerInsights.Tests.Tests
                 Assert.Equal(profileName, profileGetResult.TypeName);
                 Assert.Equal(profileGetResult.Name, HubName + "/" + profileName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    profileGetResult.Type,
                     "Microsoft.CustomerInsights/hubs/profiles",
-                    StringComparer.OrdinalIgnoreCase);
+                    profileGetResult.Type, StringComparer.OrdinalIgnoreCase);
             }
         }
 

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/RelationshipLinkScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/RelationshipLinkScenarioTests.cs
@@ -125,9 +125,8 @@ namespace CustomerInsights.Tests.Tests
                     HubName + "/" + relationshipLinkName,
                     StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    relationshipLink.Type,
                     "Microsoft.CustomerInsights/hubs/relationshipLinks",
-                    StringComparer.OrdinalIgnoreCase);
+                    relationshipLink.Type, StringComparer.OrdinalIgnoreCase);
 
                 relationshipLink = aciClient.RelationshipLinks.Get(ResourceGroupName, HubName, relationshipLinkName);
                 Assert.Equal(relationshipLinkName, relationshipLink.LinkName);
@@ -136,13 +135,12 @@ namespace CustomerInsights.Tests.Tests
                     HubName + "/" + relationshipLinkName,
                     StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    relationshipLink.Type,
                     "Microsoft.CustomerInsights/hubs/relationshipLinks",
-                    StringComparer.OrdinalIgnoreCase);
+                    relationshipLink.Type, StringComparer.OrdinalIgnoreCase);
 
                 var relationshipLinks = aciClient.RelationshipLinks.ListByHub(ResourceGroupName, HubName);
                 Assert.True(relationshipLinks.Any());
-                Assert.True(relationshipLinks.ToList().Any(item => relationshipLinkName == item.LinkName));
+                Assert.Contains(relationshipLinks.ToList(), item => relationshipLinkName == item.LinkName);
 
                 var deleteRelationshipResult =
                     aciClient.RelationshipLinks.DeleteWithHttpMessagesAsync(

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/RelationshipScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/RelationshipScenarioTests.cs
@@ -72,22 +72,20 @@ namespace CustomerInsights.Tests.Tests
                 Assert.Equal(relationshipName, relationship.RelationshipName);
                 Assert.Equal(relationship.Name, HubName + "/" + relationshipName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    relationship.Type,
                     "Microsoft.CustomerInsights/hubs/relationships",
-                    StringComparer.OrdinalIgnoreCase);
+                    relationship.Type, StringComparer.OrdinalIgnoreCase);
 
                 relationship = aciClient.Relationships.Get(ResourceGroupName, HubName, relationshipName);
                 Assert.Equal(relationshipName, relationship.RelationshipName);
                 Assert.Equal(relationship.Name, HubName + "/" + relationshipName, StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(
-                    relationship.Type,
                     "Microsoft.CustomerInsights/hubs/relationships",
-                    StringComparer.OrdinalIgnoreCase);
+                    relationship.Type, StringComparer.OrdinalIgnoreCase);
 
                 var relationships = aciClient.Relationships.ListByHub(ResourceGroupName, HubName);
 
                 Assert.True(relationships.Any());
-                Assert.True(relationships.ToList().Any(item => relationshipName == item.RelationshipName));
+                Assert.Contains(relationships.ToList(), item => relationshipName == item.RelationshipName);
 
                 var deleteRelationshipResult =
                     aciClient.Relationships.DeleteWithHttpMessagesAsync(ResourceGroupName, HubName, relationshipName)

--- a/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/RoleAssignmentScenarioTests.cs
+++ b/src/SDKs/CustomerInsights/CustomerInsights.Tests/Tests/RoleAssignmentScenarioTests.cs
@@ -54,7 +54,7 @@ namespace CustomerInsights.Tests.Tests
                     response.Type,
                     StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(response.Name, HubName + "/" + assignmentName, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(response.Role, RoleTypes.Admin);
+                Assert.Equal(RoleTypes.Admin, response.Role);
                 Assert.Equal(response.AssignmentName, assignmentName, StringComparer.OrdinalIgnoreCase);
                 Assert.True(response.Principals.Count == 2);
 
@@ -65,7 +65,7 @@ namespace CustomerInsights.Tests.Tests
                     getRbacResource.Type,
                     StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(getRbacResource.Name, HubName + "/" + assignmentName, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(getRbacResource.Role, RoleTypes.Admin);
+                Assert.Equal(RoleTypes.Admin, getRbacResource.Role);
                 Assert.True(getRbacResource.Principals.Count == 2);
                 Assert.Equal(getRbacResource.AssignmentName, assignmentName, StringComparer.OrdinalIgnoreCase);
 
@@ -81,7 +81,7 @@ namespace CustomerInsights.Tests.Tests
                     updateRbacresponse.Type,
                     StringComparer.OrdinalIgnoreCase);
                 Assert.Equal(updateRbacresponse.Name, HubName + "/" + assignmentName, StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(updateRbacresponse.Role, RoleTypes.Admin);
+                Assert.Equal(RoleTypes.Admin, updateRbacresponse.Role);
                 Assert.Equal(updateRbacresponse.AssignmentName, assignmentName, StringComparer.OrdinalIgnoreCase);
                 Assert.True(updateRbacresponse.Principals.Count == 1);
                 var getUpdateRbacResource1 = aciClient.RoleAssignments.Get(ResourceGroupName, HubName, assignmentName);
@@ -94,7 +94,7 @@ namespace CustomerInsights.Tests.Tests
                     getUpdateRbacResource1.Name,
                     HubName + "/" + assignmentName,
                     StringComparer.OrdinalIgnoreCase);
-                Assert.Equal(getUpdateRbacResource1.Role, RoleTypes.Admin);
+                Assert.Equal(RoleTypes.Admin, getUpdateRbacResource1.Role);
                 Assert.Equal(getUpdateRbacResource1.AssignmentName, assignmentName, StringComparer.OrdinalIgnoreCase);
                 Assert.True(getUpdateRbacResource1.Principals.Count == 1);
 
@@ -111,9 +111,8 @@ namespace CustomerInsights.Tests.Tests
                 catch (Exception exception)
                 {
                     Assert.Equal(
-                        ((CloudException)exception).Response.ReasonPhrase,
                         "Bad Request",
-                        StringComparer.OrdinalIgnoreCase);
+                        ((CloudException)exception).Response.ReasonPhrase, StringComparer.OrdinalIgnoreCase);
                 }
 
                 var deleteRbacResource =

--- a/src/SDKs/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
+++ b/src/SDKs/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
@@ -6,6 +6,9 @@
     <AssemblyName>DataFactory.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <NoWarn>1591;1701;1573;CS1591;CS1998</NoWarn>
+  </PropertyGroup>
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>-->

--- a/src/SDKs/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
+++ b/src/SDKs/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
@@ -6,12 +6,6 @@
     <AssemblyName>DataFactory.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <NoWarn>1591;1701;1573;CS1591;CS1998</NoWarn>
-  </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <ProjectReference Include="..\Management.DataFactory\Microsoft.Azure.Management.DataFactory.csproj" />
   </ItemGroup>

--- a/src/SDKs/DataFactory/DataFactory.Tests/UnitTests/ExamplesUnitTest.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/UnitTests/ExamplesUnitTest.cs
@@ -26,7 +26,8 @@ namespace DataFactory.Tests.UnitTests
     {
         //[Theory]
         //[InlineData(@"secrets.json", @"exampleoutput", @"exampleoutputworkarounds")]
-        public void CaptureExamples(string secretsFile, string outputDirectory, string outputDirectoryWorkarounds = null)
+        //Apeasing warnings
+        void CaptureExamples(string secretsFile, string outputDirectory, string outputDirectoryWorkarounds = null)
         {
             // Uncomment the [Theory] and [InlineData(...)] above and run this method with your favorite locations for secrets and outputs to recapture examples.  It takes about 20-30 minutes.
             ExampleCapture exampleCapture = new ExampleCapture(secretsFile, outputDirectory, outputDirectoryWorkarounds);
@@ -652,7 +653,7 @@ namespace DataFactory.Tests.UnitTests
         {
             // Compares original raw json captured "expected" response against strongly typed "actual" response from SDK method
             // Issues with workarounds noted inline
-            Assert.NotNull(response);
+            // Assert.NotNull(response);
             object expectedObject = example.Responses[responseCode.ToString()].Body;
             string expectedJson = SafeJsonConvert.SerializeObject(expectedObject);
             JToken expectedJToken = JToken.Parse(expectedJson);

--- a/src/SDKs/DataFactory/DataFactory.Tests/Utils/ExampleCapture.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/Utils/ExampleCapture.cs
@@ -535,7 +535,7 @@ namespace DataFactory.Tests.Utils
             {
                 client.IntegrationRuntimes.Delete(secrets.ResourceGroupName, secrets.FactoryName + "-linked", integrationRuntimeName + "-linked");
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
         }
@@ -547,7 +547,7 @@ namespace DataFactory.Tests.Utils
             {
                 client.IntegrationRuntimes.RemoveLinks(secrets.ResourceGroupName, secrets.FactoryName, integrationRuntimeName, new LinkedIntegrationRuntimeRequest(secrets.FactoryName + "-linked"));
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
         }

--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/AccountOperationTests.cs
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/AccountOperationTests.cs
@@ -418,7 +418,7 @@ namespace DataLakeAnalytics.Tests
 
                 // Validate compute policies are set on creation.
                 Assert.True(responseGet.ComputePolicies.Count == 1);
-                Assert.True(responseGet.ComputePolicies.ToList()[0].Name.Equals(userPolicyName));
+                Assert.Equal(responseGet.ComputePolicies.ToList()[0].Name, userPolicyName);
 
                 // Validate compute policy CRUD
                 // Add another account

--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/CatalogOperationTests.cs
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/CatalogOperationTests.cs
@@ -54,7 +54,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(dbListResponse.Count() >= 1);
 
                     // Look for the db we created
-                    Assert.True(dbListResponse.Any(db => db.Name.Equals(commonData.DatabaseName)));
+                    Assert.Contains(dbListResponse, db => db.Name.Equals(commonData.DatabaseName));
 
                     // Get the specific Database as well
                     var dbGetResponse = 
@@ -77,7 +77,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(tableListResponse.ElementAt(0).ColumnList != null && tableListResponse.ElementAt(0).ColumnList.Count() > 0);
 
                     // Look for the table we created
-                    Assert.True(tableListResponse.Any(table => table.Name.Equals(commonData.TableName)));
+                    Assert.Contains(tableListResponse, table => table.Name.Equals(commonData.TableName));
 
                     // Get the table list with only basic info
                     tableListResponse = 
@@ -102,7 +102,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(tableListResponse.ElementAt(0).ColumnList != null && tableListResponse.ElementAt(0).ColumnList.Count > 0);
                     
                     // Look for the table we created
-                    Assert.True(tableListResponse.Any(table => table.Name.Equals(commonData.TableName)));
+                    Assert.Contains(tableListResponse, table => table.Name.Equals(commonData.TableName));
                     
                     // Get the table list in the db with only basic info
                     tableListResponse = 
@@ -153,7 +153,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(tvfListResponse.Count() >= 1);
 
                     // Look for the tvf we created
-                    Assert.True(tvfListResponse.Any(tvf => tvf.Name.Equals(commonData.TvfName)));
+                    Assert.Contains(tvfListResponse, tvf => tvf.Name.Equals(commonData.TvfName));
 
                     // Get tvf list in the database
                     tvfListResponse = 
@@ -165,7 +165,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(tvfListResponse.Count() >= 1);
 
                     // look for the tvf we created
-                    Assert.True(tvfListResponse.Any(tvf => tvf.Name.Equals(commonData.TvfName)));
+                    Assert.Contains(tvfListResponse, tvf => tvf.Name.Equals(commonData.TvfName));
 
                     // Get the specific tvf as well
                     var tvfGetResponse = 
@@ -189,7 +189,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(viewListResponse.Count() >= 1);
 
                     // Look for the view we created
-                    Assert.True(viewListResponse.Any(view => view.Name.Equals(commonData.ViewName)));
+                    Assert.Contains(viewListResponse, view => view.Name.Equals(commonData.ViewName));
 
                     // Get the view list from just the database
                     viewListResponse = 
@@ -201,7 +201,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(viewListResponse.Count() >= 1);
 
                     // Look for the view we created
-                    Assert.True(viewListResponse.Any(view => view.Name.Equals(commonData.ViewName)));
+                    Assert.Contains(viewListResponse, view => view.Name.Equals(commonData.ViewName));
 
                     // Get the specific view as well
                     var viewGetResponse = 
@@ -225,7 +225,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(procListResponse.Count() >= 1);
 
                     // Look for the procedure we created
-                    Assert.True(procListResponse.Any(proc => proc.Name.Equals(commonData.ProcName)));
+                    Assert.Contains(procListResponse, proc => proc.Name.Equals(commonData.ProcName));
 
                     // Get the specific procedure as well
                     var procGetResponse = 
@@ -314,7 +314,7 @@ namespace DataLakeAnalytics.Tests
 
                     Assert.NotNull(typeGetResponse);
                     Assert.NotEmpty(typeGetResponse);
-                    Assert.False(typeGetResponse.Any(type => type.IsComplexType.Value));
+                    Assert.DoesNotContain(typeGetResponse, type => type.IsComplexType.Value);
 
                     // Prepare to grant/revoke ACLs
                     var principalId = TestUtilities.GenerateGuid();
@@ -499,7 +499,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(credListResponse.Count() >= 1);
 
                     // Look for the credential we created
-                    Assert.True(credListResponse.Any(cred => cred.Name.Equals(commonData.SecretName)));
+                    Assert.Contains(credListResponse, cred => cred.Name.Equals(commonData.SecretName));
 
                     // Get the specific credential as well
                     var credGetResponse = clientToUse.Catalog.GetCredential(

--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/JobOperationTests.cs
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/JobOperationTests.cs
@@ -182,7 +182,7 @@ namespace DataLakeAnalytics.Tests
                     );
 
                 Assert.NotNull(listJobResponse);
-                Assert.True(listJobResponse.Any(job => job.JobId == getJobResponse.JobId));
+                Assert.Contains(listJobResponse, job => job.JobId == getJobResponse.JobId);
 
                 // Validate usql job relationship retrieval (get/list pipeline and get/list recurrence)
                 var getPipeline = 
@@ -201,8 +201,8 @@ namespace DataLakeAnalytics.Tests
                         commonData.SecondDataLakeAnalyticsAccountName
                     );
 
-                Assert.Equal(1, listPipeline.Count());
-                Assert.True(listPipeline.Any(pipeline => pipeline.PipelineId == pipelineId));
+                Assert.Single(listPipeline);
+                Assert.Contains(listPipeline, pipeline => pipeline.PipelineId == pipelineId);
 
                 // Recurrence get/list
                 var getRecurrence = 
@@ -219,8 +219,8 @@ namespace DataLakeAnalytics.Tests
                         commonData.SecondDataLakeAnalyticsAccountName
                     );
 
-                Assert.Equal(1, listRecurrence.Count());
-                Assert.True(listRecurrence.Any(recurrence => recurrence.RecurrenceId == recurrenceId));
+                Assert.Single(listRecurrence);
+                Assert.Contains(listRecurrence, recurrence => recurrence.RecurrenceId == recurrenceId);
 
                 // TODO: re-enable this after the next prod push
                 // List the usql jobs with only the jobId property filled

--- a/src/SDKs/DataLake.Store/DataLakeStore.Tests/DataTransferTests/SingleSegmentUploaderTests.cs
+++ b/src/SDKs/DataLake.Store/DataLakeStore.Tests/DataTransferTests/SingleSegmentUploaderTests.cs
@@ -246,7 +246,7 @@ namespace DataLakeStore.Tests
             TestRetryBlock(5);
         }
 
-        public void TestRetryBlock(int failCount)
+        internal void TestRetryBlock(int failCount)
         {
             bool expectSuccess = failCount < SingleSegmentUploader.MaxBufferUploadAttemptCount;
 

--- a/src/SDKs/DataLake.Store/DataLakeStore.Tests/ScenarioTests/FileSystemOperationTests.cs
+++ b/src/SDKs/DataLake.Store/DataLakeStore.Tests/ScenarioTests/FileSystemOperationTests.cs
@@ -188,7 +188,7 @@ namespace DataLakeStore.Tests
             }
         }
 
-        //[Fact] commenting this out until we have a good test for validating access denied within the same tenant
+        [Fact(Skip="commenting this out until we have a good test for validating access denied within the same tenant")]
         public void DataLakeStoreFileSystemTestAccessDenied()
         {
             using (var context = MockContext.Start(this.GetType().FullName))
@@ -513,13 +513,11 @@ namespace DataLakeStore.Tests
                         fileContentsToAdd.Length*2);
 
                     // Attempt to get the files that were concatted together, which should fail and throw
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath1));
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath2));
@@ -557,13 +555,11 @@ namespace DataLakeStore.Tests
                         fileContentsToAdd.Length*2);
 
                     // Attempt to get the files that were concatted together, which should fail and throw
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath1));
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath2));
@@ -606,20 +602,17 @@ namespace DataLakeStore.Tests
                         fileContentsToAdd.Length*2);
 
                     // Attempt to get the files that were concatted together, which should fail and throw
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath1));
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath2));
 
                     // Attempt to get the folder that was created for concat, which should fail and be deleted.
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 concatFolderPath));
@@ -655,8 +648,7 @@ namespace DataLakeStore.Tests
                         fileContentsToAdd.Length);
 
                     // Ensure the old file is gone
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath));
@@ -681,8 +673,7 @@ namespace DataLakeStore.Tests
                     Assert.Equal(1, listFolderResponse.FileStatuses.FileStatus.Count);
                     Assert.Equal(FileType.FILE, listFolderResponse.FileStatuses.FileStatus[0].Type);
 
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 targetFolder1));
@@ -809,9 +800,7 @@ namespace DataLakeStore.Tests
                     var finalEntries = finalAclStatus.Entries;
                     foreach (var entry in finalEntries)
                     {
-                        Assert.True(
-                            currentAcl.AclStatus.Entries.Any(
-                                original => original.Equals(entry, StringComparison.CurrentCultureIgnoreCase)));
+                        Assert.Contains(currentAcl.AclStatus.Entries, original => original.Equals(entry, StringComparison.CurrentCultureIgnoreCase));
                     }
 
                     Assert.Equal(finalEntries.Count, currentAcl.AclStatus.Entries.Count);
@@ -937,7 +926,7 @@ namespace DataLakeStore.Tests
                     Assert.NotEmpty(aclGetResponse.AclStatus.Entries);
                     
                     Assert.Equal(currentCount + 1, aclGetResponse.AclStatus.Entries.Count);
-                    Assert.True(aclGetResponse.AclStatus.Entries.Any(entry => entry.Contains(commonData.AclUserId)));
+                    Assert.Contains(aclGetResponse.AclStatus.Entries, entry => entry.Contains(commonData.AclUserId));
                 }
             }
         }
@@ -975,7 +964,7 @@ namespace DataLakeStore.Tests
                     Assert.NotEmpty(aclGetResponse.AclStatus.Entries);
 
                     Assert.Equal(currentCount + 1, aclGetResponse.AclStatus.Entries.Count);
-                    Assert.True(aclGetResponse.AclStatus.Entries.Any(entry => entry.Contains(commonData.AclUserId)));
+                    Assert.Contains(aclGetResponse.AclStatus.Entries, entry => entry.Contains(commonData.AclUserId));
 
                     // now remove the entry
                     var aceToRemove = string.Format(",user:{0}", commonData.AclUserId);
@@ -993,7 +982,7 @@ namespace DataLakeStore.Tests
                     Assert.NotEmpty(aclGetResponse.AclStatus.Entries);
                     
                     Assert.Equal(currentCount, aclGetResponse.AclStatus.Entries.Count);
-                    Assert.False(aclGetResponse.AclStatus.Entries.Any(entry => entry.Contains(commonData.AclUserId)));
+                    Assert.DoesNotContain(aclGetResponse.AclStatus.Entries, entry => entry.Contains(commonData.AclUserId));
                 }
             }
         }

--- a/src/SDKs/Dns/Dns.Tests/ScenarioTests/RecordSetScenarioTests.cs
+++ b/src/SDKs/Dns/Dns.Tests/ScenarioTests/RecordSetScenarioTests.cs
@@ -950,7 +950,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
 
         #region Helper methods
 
-        public static void CreateRecordSets(
+        internal static void CreateRecordSets(
             SingleRecordSetTestContext testContext,
             string[] recordSetNames)
         {
@@ -1001,7 +1001,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
                 parameters: createParameters3);
         }
 
-        public static void DeleteRecordSetsAndZone(
+        internal static void DeleteRecordSetsAndZone(
             SingleRecordSetTestContext testContext,
             string[] recordSetNames)
         {

--- a/src/SDKs/Dns/Dns.Tests/ScenarioTests/ZoneScenarioTests.cs
+++ b/src/SDKs/Dns/Dns.Tests/ScenarioTests/ZoneScenarioTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
                 // Ensure that Id is parseable into resourceGroup
                 string resourceGroupName =
                     ExtractResourceGroupNameFromId(createdZone.Id);
-                Assert.True(resourceGroupName.Equals(resourceGroup.Name));
+                Assert.Equal(resourceGroupName, resourceGroup.Name);
 
                 // Retrieve the zone after create, verify response
                 var retrievedZone = dnsClient.Zones.Get(
@@ -406,10 +406,8 @@ namespace Microsoft.Azure.Management.Dns.Testing
                     dnsClient.Zones.ListByResourceGroup(resourceGroup.Name, 1);
 
                 Assert.NotNull(listresponse);
-                Assert.Equal(1, listresponse.Count());
-                Assert.True(
-                    zoneNames.Any(
-                        zoneName => zoneName == listresponse.ElementAt(0).Name));
+                Assert.Single(listresponse);
+                Assert.Contains(zoneNames, zoneName => zoneName == listresponse.ElementAt(0).Name);
 
                 ZoneScenarioTests.DeleteZones(
                     dnsClient,
@@ -463,7 +461,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
                     dnsClient.Zones.ListByResourceGroupNext(
                         (listresponse.NextPageLink));
 
-                Assert.Equal(1, listresponse.Count());
+                Assert.Single(listresponse);
 
                 ZoneScenarioTests.DeleteZones(
                     dnsClient,
@@ -635,7 +633,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
 
         #region Helper methods
 
-        public static void CreateZones(
+        internal static void CreateZones(
             DnsManagementClient dnsClient,
             ResourceGroup resourceGroup,
             string[] zoneNames,
@@ -656,7 +654,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
             }
         }
 
-        public static void CreatePrivateZones(
+        internal static void CreatePrivateZones(
             DnsManagementClient dnsClient,
             ResourceGroup resourceGroup,
             IList<string> zonesNames,
@@ -679,7 +677,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
             }
         }
 
-        public static void DeleteZones(
+        internal static void DeleteZones(
             DnsManagementClient dnsClient,
             ResourceGroup resourceGroup,
             string[] zoneNames)

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.ConsumergroupsTests.CRUD.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.ConsumergroupsTests.CRUD.cs
@@ -91,7 +91,7 @@ namespace EventHub.Tests.ScenarioTests
                 var updateconsumergroupResponse = EventHubManagementClient.ConsumerGroups.CreateOrUpdate(resourceGroup, namespaceName, eventhubName, consumergroupName, createConsumergroupResponse);
                 Assert.NotNull(updateconsumergroupResponse);
                 Assert.Equal(updateconsumergroupResponse.Name, createConsumergroupResponse.Name);
-                Assert.Equal(updateconsumergroupResponse.UserMetadata, "Updated the user meta data");
+                Assert.Equal("Updated the user meta data", updateconsumergroupResponse.UserMetadata);
 
                 // Get Created ConsumerGroup
                 var getConsumergroupResponse = EventHubManagementClient.ConsumerGroups.Get(resourceGroup, namespaceName, eventhubName, consumergroupName);

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.ConsumergroupsTests.CRUD_Length.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.ConsumergroupsTests.CRUD_Length.cs
@@ -91,7 +91,7 @@ namespace EventHub.Tests.ScenarioTests
                 var updateconsumergroupResponse = EventHubManagementClient.ConsumerGroups.CreateOrUpdate(resourceGroup, namespaceName, eventhubName, consumergroupName, createConsumergroupResponse);
                 Assert.NotNull(updateconsumergroupResponse);
                 Assert.Equal(updateconsumergroupResponse.Name, createConsumergroupResponse.Name);
-                Assert.Equal(updateconsumergroupResponse.UserMetadata, "Updated the user meta data");
+                Assert.Equal("Updated the user meta data", updateconsumergroupResponse.UserMetadata);
 
                 // Get Created ConsumerGroup
                 var getConsumergroupResponse = EventHubManagementClient.ConsumerGroups.Get(resourceGroup, namespaceName, eventhubName, consumergroupName);

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.DisasterRecoveryAlertnateNameTests.CRUD.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.DisasterRecoveryAlertnateNameTests.CRUD.cs
@@ -94,7 +94,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created namespace AuthorizationRules
@@ -103,7 +103,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 var getNamespaceAuthorizationRulesListKeysResponse = EventHubManagementClient.Namespaces.ListKeys(resourceGroup, namespaceName, authorizationRuleName);
@@ -131,12 +131,12 @@ namespace EventHub.Tests.ScenarioTests
                 //// Get the created DisasterRecovery config - Primary
                 var disasterRecoveryGetResponse = EventHubManagementClient.DisasterRecoveryConfigs.Get(resourceGroup, namespaceName, namespaceName);
                 Assert.NotNull(disasterRecoveryGetResponse);
-                Assert.Equal(disasterRecoveryGetResponse.Role, RoleDisasterRecovery.Primary);
+                Assert.Equal(RoleDisasterRecovery.Primary, disasterRecoveryGetResponse.Role);
 
                 //// Get the created DisasterRecovery config - Secondary
                 var disasterRecoveryGetResponse_Sec = EventHubManagementClient.DisasterRecoveryConfigs.Get(resourceGroup, namespaceName2, namespaceName);
                 Assert.NotNull(disasterRecoveryGetResponse_Sec);
-                Assert.Equal(disasterRecoveryGetResponse_Sec.Role, RoleDisasterRecovery.Secondary);
+                Assert.Equal(RoleDisasterRecovery.Secondary, disasterRecoveryGetResponse_Sec.Role);
 
                 //Get authorization rule thorugh Alias 
 

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.DisasterRecoveryTests.CRUD.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.DisasterRecoveryTests.CRUD.cs
@@ -96,7 +96,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created namespace AuthorizationRules
@@ -105,7 +105,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 var getNamespaceAuthorizationRulesListKeysResponse = EventHubManagementClient.Namespaces.ListKeys(resourceGroup, namespaceName, authorizationRuleName);
@@ -140,11 +140,11 @@ namespace EventHub.Tests.ScenarioTests
                     Assert.True(disasterRecoveryGetResponse.PendingReplicationOperationsCount >= 0);
                 else
                     Assert.False(disasterRecoveryGetResponse.PendingReplicationOperationsCount.HasValue);
-                Assert.Equal(disasterRecoveryGetResponse.Role, RoleDisasterRecovery.Primary);
+                Assert.Equal(RoleDisasterRecovery.Primary, disasterRecoveryGetResponse.Role);
 
                 //// Get the created DisasterRecovery config - Secondary
                 var disasterRecoveryGetResponse_Sec = EventHubManagementClient.DisasterRecoveryConfigs.Get(resourceGroup, namespaceName2, disasterRecoveryName);
-                Assert.Equal(disasterRecoveryGetResponse_Sec.Role, RoleDisasterRecovery.Secondary);
+                Assert.Equal(RoleDisasterRecovery.Secondary, disasterRecoveryGetResponse_Sec.Role);
 
                 //Get authorization rule thorugh Alias 
 

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.EventHubTests.CRUD.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.EventHubTests.CRUD.cs
@@ -81,7 +81,7 @@ namespace EventHub.Tests.ScenarioTests
                 // Get the created EventHub
                 var getEventResponse = EventHubManagementClient.EventHubs.Get(resourceGroup, namespaceName, eventhubName);
                 Assert.NotNull(getEventResponse);
-                Assert.Equal(getEventResponse.Status, EntityStatus.Active);
+                Assert.Equal(EntityStatus.Active, getEventResponse.Status);
 
                 // Get all Event Hubs for a given NameSpace
                 var getListEventHubResponse = EventHubManagementClient.EventHubs.ListByNamespace(resourceGroup, namespaceName);
@@ -103,8 +103,8 @@ namespace EventHub.Tests.ScenarioTests
                 // Get the updated EventHub and verify the properties
                 getEventResponse = EventHubManagementClient.EventHubs.Get(resourceGroup, namespaceName, eventhubName);
                 Assert.NotNull(getEventResponse);
-                Assert.Equal(getEventResponse.Status, EntityStatus.Active);
-                Assert.Equal(getEventResponse.MessageRetentionInDays, 6);
+                Assert.Equal(EntityStatus.Active, getEventResponse.Status);
+                Assert.Equal(6, getEventResponse.MessageRetentionInDays);
 
                 // Delete the Evnet Hub
                 EventHubManagementClient.EventHubs.Delete(resourceGroup, namespaceName, eventhubName);

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.EventHubsTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.EventHubsTests.CRUDAuthorizationRules.cs
@@ -97,7 +97,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(createEventhubAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createEventhubAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createEventhubAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created Eventhub AuthorizationRules
@@ -106,14 +106,14 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(getEventhubAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getEventhubAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getEventhubAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all Eventhub AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = EventHubManagementClient.EventHubs.ListAuthorizationRules(resourceGroup, namespaceName, eventhubName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
-                Assert.Equal(getAllNamespaceAuthorizationRulesResponse.Count(), 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Single(getAllNamespaceAuthorizationRulesResponse);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update Eventhub authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", EventHubManagementHelper.GenerateRandomKey());
@@ -128,7 +128,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(updateEventhubAuthorizationRuleResponse.Rights.Count == updateEventhubAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateEventhubAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateEventhubAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateEventhubAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the updated Eventhub AuthorizationRule
@@ -139,7 +139,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(getEventhubAuthorizationRuleResponse.Rights.Count == updateEventhubAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateEventhubAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getEventhubAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getEventhubAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the Eventhub for a Authorization rule created

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.EventHubsTests.CRUDAuthorizationRules_Length.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.EventHubsTests.CRUDAuthorizationRules_Length.cs
@@ -97,7 +97,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(createEventhubAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createEventhubAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createEventhubAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created Eventhub AuthorizationRules
@@ -106,14 +106,14 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(getEventhubAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getEventhubAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getEventhubAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all Eventhub AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = EventHubManagementClient.EventHubs.ListAuthorizationRules(resourceGroup, namespaceName, eventhubName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
-                Assert.Equal(getAllNamespaceAuthorizationRulesResponse.Count(), 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Single(getAllNamespaceAuthorizationRulesResponse);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update Eventhub authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", EventHubManagementHelper.GenerateRandomKey());
@@ -128,7 +128,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(updateEventhubAuthorizationRuleResponse.Rights.Count == updateEventhubAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateEventhubAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateEventhubAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateEventhubAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the updated Eventhub AuthorizationRule
@@ -139,7 +139,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(getEventhubAuthorizationRuleResponse.Rights.Count == updateEventhubAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateEventhubAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getEventhubAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getEventhubAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the Eventhub for a Authorization rule created

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
@@ -73,14 +73,14 @@ namespace EventHub.Tests.ScenarioTests
                 var getAllNamespacesResponse = EventHubManagementClient.Namespaces.ListByResourceGroupAsync(resourceGroup).Result;
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = EventHubManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Update namespace tags and make the namespace critical
                 var updateNamespaceParameter = new EHNamespace()
@@ -104,11 +104,11 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.NotNull(getNamespaceResponse);
                 Assert.Equal(location, getNamespaceResponse.Location, StringComparer.CurrentCultureIgnoreCase);
                 Assert.Equal(namespaceName, getNamespaceResponse.Name);
-                Assert.Equal(getNamespaceResponse.Tags.Count, 2);
+                Assert.Equal(2, getNamespaceResponse.Tags.Count);
                 foreach (var tag in updateNamespaceParameter.Tags)
                 {
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
                 TestUtilities.Wait(TimeSpan.FromSeconds(10));
                 // Delete namespace

--- a/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/EventHub/EventHub.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
@@ -85,16 +85,16 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get default namespace AuthorizationRules
                 var getNamespaceAuthorizationRulesResponse = EventHubManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, EventHubManagementHelper.DefaultNamespaceAuthorizationRule);
                 Assert.NotNull(getNamespaceAuthorizationRulesResponse);
                 Assert.Equal(getNamespaceAuthorizationRulesResponse.Name, EventHubManagementHelper.DefaultNamespaceAuthorizationRule);
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Listen));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Send));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Manage));
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Listen);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Send);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Manage);
 
                 // Get created namespace AuthorizationRules
                 getNamespaceAuthorizationRulesResponse = EventHubManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, authorizationRuleName);
@@ -102,15 +102,15 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all namespaces AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = EventHubManagementClient.Namespaces.ListAuthorizationRules(resourceGroup, namespaceName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() > 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(auth => auth.Name == EventHubManagementHelper.DefaultNamespaceAuthorizationRule));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, auth => auth.Name == EventHubManagementHelper.DefaultNamespaceAuthorizationRule);
 
                 // Update namespace authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", EventHubManagementHelper.GenerateRandomKey());
@@ -125,7 +125,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the updated namespace AuthorizationRule
@@ -136,7 +136,7 @@ namespace EventHub.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the namespace for a Authorization rule created

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/ApplicationAndServicePrincipalTests.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/ApplicationAndServicePrincipalTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 }
 
                 //verify the application has been deleted.
-                Assert.Throws(typeof(GraphErrorException), () => { GetApplicationByObjectId(context, application.ObjectId); });
+                Assert.Throws<GraphErrorException>(() => { GetApplicationByObjectId(context, application.ObjectId); });
             }
         }
 
@@ -83,10 +83,10 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                     // Get App credentials - should be 0
                     var keyCreds = GetAppKeyCredential(context, appObjectId);
-                    Assert.Equal(0, keyCreds.Count);
+                    Assert.Empty(keyCreds);
 
                     var passwordCreds = GetAppPasswordCredential(context, appObjectId);
-                    Assert.Equal(0, passwordCreds.Count);
+                    Assert.Empty(passwordCreds);
 
                     // Add a password credential
                     string keyId = "a687d7e2-7c5f-4411-afae-e78ae43a9395";
@@ -100,12 +100,12 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                     // Get app credentials
                     keyCreds = GetAppKeyCredential(context, appObjectId);
-                    Assert.Equal(1, keyCreds.Count);
-                    Assert.True(keyCreds.Any(c => c.KeyId == keyCredential.KeyId));
+                    Assert.Single(keyCreds);
+                    Assert.Contains(keyCreds, c => c.KeyId == keyCredential.KeyId);
 
                     passwordCreds = GetAppPasswordCredential(context, appObjectId);
-                    Assert.Equal(1, passwordCreds.Count);
-                    Assert.True(passwordCreds.Any(c => c.KeyId == passwordCredential1.KeyId));
+                    Assert.Single(passwordCreds);
+                    Assert.Contains(passwordCreds, c => c.KeyId == passwordCredential1.KeyId);
 
                     // Append a new passwordCredential to exisitng credentials
                     keyId = "71986590-87c7-45c2-b85e-f5ef022e821f";
@@ -116,8 +116,8 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     //Get
                     var fetchedpasswordCreds2 = GetAppPasswordCredential(context, appObjectId);
                     Assert.Equal(2, fetchedpasswordCreds2.Count);
-                    Assert.True(fetchedpasswordCreds2.Any(c => c.KeyId == passwordCredential2.KeyId));
-                    Assert.True(fetchedpasswordCreds2.Any(c => c.KeyId == passwordCredential1.KeyId));
+                    Assert.Contains(fetchedpasswordCreds2, c => c.KeyId == passwordCredential2.KeyId);
+                    Assert.Contains(fetchedpasswordCreds2, c => c.KeyId == passwordCredential1.KeyId);
 
                     // Add 2 new password credentils -- older should be removed
                     keyId = "7880f3aa-66ee-4e63-a427-3a89d316b039";
@@ -129,22 +129,22 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     //Get
                     var fetchedpasswordCreds3 = GetAppPasswordCredential(context, appObjectId);
                     Assert.Equal(2, fetchedpasswordCreds3.Count);
-                    Assert.True(fetchedpasswordCreds3.Any(c => c.KeyId == passwordCredential3.KeyId));
-                    Assert.True(fetchedpasswordCreds3.Any(c => c.KeyId == passwordCredential4.KeyId));
+                    Assert.Contains(fetchedpasswordCreds3, c => c.KeyId == passwordCredential3.KeyId);
+                    Assert.Contains(fetchedpasswordCreds3, c => c.KeyId == passwordCredential4.KeyId);
 
                     // Remove key credentials
                     UpdateAppKeyCredential(context, appObjectId, new List<KeyCredential>());
 
                     // Get app credentials
                     var deletedkeyCreds = GetAppKeyCredential(context, appObjectId);
-                    Assert.Equal(0, deletedkeyCreds.Count);
+                    Assert.Empty(deletedkeyCreds);
 
                     // Remove password credentials
                     UpdateAppPasswordCredential(context, appObjectId, new List<PasswordCredential>());
 
                     // Get app credentials
                     var deletedPasswordCreds = GetAppPasswordCredential(context, appObjectId);
-                    Assert.Equal(0, deletedPasswordCreds.Count);
+                    Assert.Empty(deletedPasswordCreds);
                 }
                 finally
                 {
@@ -174,10 +174,10 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                     // Get Sp credentials - should be 0
                     var keyCreds = GetSpKeyCredential(context, spObjectId);
-                    Assert.Equal(0, keyCreds.Count);
+                    Assert.Empty(keyCreds);
 
                     var passwordCreds = GetSpPasswordCredential(context, spObjectId);
-                    Assert.Equal(0, passwordCreds.Count);
+                    Assert.Empty(passwordCreds);
 
                     // Add a password credential
                     string keyId = "dbf1c168-ebe9-4b93-8b14-83462734c164";
@@ -191,12 +191,12 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                     // Get sp credentials
                     keyCreds = GetSpKeyCredential(context, spObjectId);
-                    Assert.Equal(1, keyCreds.Count);
-                    Assert.True(keyCreds.Any(c => c.KeyId == keyCredential.KeyId));
+                    Assert.Single(keyCreds);
+                    Assert.Contains(keyCreds, c => c.KeyId == keyCredential.KeyId);
 
                     passwordCreds = GetSpPasswordCredential(context, spObjectId);
-                    Assert.Equal(1, passwordCreds.Count);
-                    Assert.True(passwordCreds.Any(c => c.KeyId == passwordCredential1.KeyId));
+                    Assert.Single(passwordCreds);
+                    Assert.Contains(passwordCreds, c => c.KeyId == passwordCredential1.KeyId);
 
                     // Append a new passwordCredential to exisitng credentials
                     keyId = "debcca8c-4fa0-4b40-8d21-853a3213f328";
@@ -207,8 +207,8 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     //Get
                     var fetchedpasswordCreds2 = GetSpPasswordCredential(context, spObjectId);
                     Assert.Equal(2, fetchedpasswordCreds2.Count);
-                    Assert.True(fetchedpasswordCreds2.Any(c => c.KeyId == passwordCredential2.KeyId));
-                    Assert.True(fetchedpasswordCreds2.Any(c => c.KeyId == passwordCredential1.KeyId));
+                    Assert.Contains(fetchedpasswordCreds2, c => c.KeyId == passwordCredential2.KeyId);
+                    Assert.Contains(fetchedpasswordCreds2, c => c.KeyId == passwordCredential1.KeyId);
 
                     // Add 2 new password credentils -- older should be removed
                     keyId = "19b89f7a-b2fd-444e-bed6-41d66df7eba5";
@@ -220,22 +220,22 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     //Get
                     var fetchedpasswordCreds3 = GetSpPasswordCredential(context, spObjectId);
                     Assert.Equal(2, fetchedpasswordCreds3.Count);
-                    Assert.True(fetchedpasswordCreds3.Any(c => c.KeyId == passwordCredential3.KeyId));
-                    Assert.True(fetchedpasswordCreds3.Any(c => c.KeyId == passwordCredential4.KeyId));
+                    Assert.Contains(fetchedpasswordCreds3, c => c.KeyId == passwordCredential3.KeyId);
+                    Assert.Contains(fetchedpasswordCreds3, c => c.KeyId == passwordCredential4.KeyId);
 
                     // Remove key credentials
                     UpdateSpKeyCredential(context, spObjectId, new List<KeyCredential>());
 
                     // Get sp credentials
                     var deletedkeyCreds = GetSpKeyCredential(context, spObjectId);
-                    Assert.Equal(0, deletedkeyCreds.Count);
+                    Assert.Empty(deletedkeyCreds);
 
                     // Remove password credentials
                     UpdateSpPasswordCredential(context, spObjectId, new List<PasswordCredential>());
 
                     // Get sp credentials
                     var deletedPasswordCreds = GetSpPasswordCredential(context, spObjectId);
-                    Assert.Equal(0, deletedPasswordCreds.Count);
+                    Assert.Empty(deletedPasswordCreds);
                 }
                 finally
                 {
@@ -265,20 +265,20 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 var newKeyCredential = CreateKeyCredential();
 
                 // Get App credentials - should fail
-                Assert.Throws(typeof(GraphErrorException), () => GetAppKeyCredential(context, randomObjectId));
-                Assert.Throws(typeof(GraphErrorException), () => GetAppPasswordCredential(context, randomObjectId));
+                Assert.Throws<GraphErrorException>(() => GetAppKeyCredential(context, randomObjectId));
+                Assert.Throws<GraphErrorException>(() => GetAppPasswordCredential(context, randomObjectId));
 
                 // Add credentials on a random app - should fail
-                Assert.Throws(typeof(GraphErrorException), () => UpdateAppKeyCredential(context, randomObjectId, newKeyCredential));
-                Assert.Throws(typeof(GraphErrorException), () => UpdateAppPasswordCredential(context, randomObjectId, newPasswordCredential));
+                Assert.Throws<GraphErrorException>(() => UpdateAppKeyCredential(context, randomObjectId, newKeyCredential));
+                Assert.Throws<GraphErrorException>(() => UpdateAppPasswordCredential(context, randomObjectId, newPasswordCredential));
 
                 // Get Sp credentials - should fail
-                Assert.Throws(typeof(GraphErrorException), () => GetSpKeyCredential(context, randomObjectId));
-                Assert.Throws(typeof(GraphErrorException), () => GetAppPasswordCredential(context, randomObjectId));
+                Assert.Throws<GraphErrorException>(() => GetSpKeyCredential(context, randomObjectId));
+                Assert.Throws<GraphErrorException>(() => GetAppPasswordCredential(context, randomObjectId));
 
                 // Add credentials on a random app - should fail
-                Assert.Throws(typeof(GraphErrorException), () => UpdateSpKeyCredential(context, randomObjectId, newKeyCredential));
-                Assert.Throws(typeof(GraphErrorException), () => UpdateSpPasswordCredential(context, randomObjectId, newPasswordCredential));
+                Assert.Throws<GraphErrorException>(() => UpdateSpKeyCredential(context, randomObjectId, newKeyCredential));
+                Assert.Throws<GraphErrorException>(() => UpdateSpPasswordCredential(context, randomObjectId, newPasswordCredential));
             }
         }
 
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 }
 
                 //verify the user has been deleted.
-                Assert.Throws(typeof(GraphErrorException), () => { SearchServicePrincipal(context, sp.ObjectId); });
+                Assert.Throws<GraphErrorException>(() => { SearchServicePrincipal(context, sp.ObjectId); });
             }
         }
 

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/BasicTests.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/BasicTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 var usersByName = client.Users.List(new ODataQuery<User>(f => f.DisplayName.StartsWith(usersNoFilter.ElementAt(1).DisplayName)));
                 Assert.NotNull(usersByName);
                 Assert.NotEmpty(usersByName);
-                Assert.Equal(1, usersByName.Count());
+                Assert.Single(usersByName);
 
                 Assert.Equal(usersNoFilter.ElementAt(1).ObjectId, usersByName.ElementAt(0).ObjectId);
             }
@@ -74,19 +74,19 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 var client = GetGraphClient(context);
 
                 // Add this user through management portal before recording mocks
-                string testLiveId  = "auxtm596@live.com";
+                // string testLiveId  = "auxtm596@live.com";
 
                 // UPN for this user will be a wierd ext string e.g. auxtm596_live.com#EXT#@rbacCliTest.onmicrosoft.com
 
                 string upn = "auxtm596_live.com#EXT#@" + GetTenantAndDomain().Domain;
                 var usersByLiveId = client.Users.List(new ODataQuery<User>(f=>f.UserPrincipalName == upn));
                 Assert.NotNull(usersByLiveId);
-                Assert.Equal(1, usersByLiveId.Count());
+                Assert.Single(usersByLiveId);
                 
                 string testOrgId = "test2@" + GetTenantAndDomain().Domain;
                 var usersByOrgId = client.Users.List(new ODataQuery<User>(f => f.UserPrincipalName == testOrgId));
                 Assert.NotNull(usersByOrgId);
-                Assert.Equal(1, usersByOrgId.Count());
+                Assert.Single(usersByOrgId);
             }
         }
 
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                 var groupsByName = client.Groups.List(new ODataQuery<ADGroup>(f => f.DisplayName.StartsWith(groupsNoFilter.ElementAt(1).DisplayName)));
                 Assert.NotNull(groupsByName);
-                Assert.Equal(1, groupsByName.Count());
+                Assert.Single(groupsByName);
                 
                 Assert.Equal(
                     groupsNoFilter.ElementAt(1).ObjectId,
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     var nextPage = client.Groups.GetGroupMembersNext(firstPage.NextPageLink);
 
                     Assert.NotNull(nextPage);
-                    Assert.NotEqual(0, nextPage.Count());
+                    Assert.NotEmpty(nextPage);
 
                     foreach (var aadItem in nextPage)
                     {
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 var listResult = client.ServicePrincipals.List(new ODataQuery<ServicePrincipal>(f=> f.ServicePrincipalNames.Contains(testServicePrincipalName)));
                 ServicePrincipal servicePrincipal = listResult.First();
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.NotNull(servicePrincipal);
                 Assert.True(servicePrincipal.ObjectId == testObjectId);
                 Assert.Equal(testDisplayName, servicePrincipal.DisplayName);
@@ -407,7 +407,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     });
 
                 Assert.NotNull(objectByObject);
-                Assert.Equal(1, objectByObject.Count());
+                Assert.Single(objectByObject);
             }
         }
     }

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/GroupTests.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/GroupTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 ADGroup group = CreateGroup(context);
                 DeleteGroup(context, group.ObjectId);
                 //verify the group has been deleted.
-                Assert.Throws(typeof(GraphErrorException), () => { SearchGroup(context, group.ObjectId); });
+                Assert.Throws<GraphErrorException>(() => { SearchGroup(context, group.ObjectId); });
             }
         }
 

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/UserTests.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/UserTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 User user = CreateUser(context);
                 DeleteUser(context, user.UserPrincipalName);
                 //verify the user has been deleted.
-                Assert.Throws(typeof(GraphErrorException), () => { SearchUser(context, user.UserPrincipalName); });
+                Assert.Throws<GraphErrorException>(() => { SearchUser(context, user.UserPrincipalName); });
             }
         }
     }

--- a/src/SDKs/HDInsight/Management.HDInsight.Tests/ScenarioTests/ListTests.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight.Tests/ScenarioTests/ListTests.cs
@@ -41,8 +41,8 @@ namespace Management.HDInsight.Tests
                     try
                     {
                         var list = client.Clusters.ListByResourceGroup(rgName);
-                        Assert.False(list.Any(c => c.Name.Equals(clusterName1, StringComparison.OrdinalIgnoreCase)));
-                        Assert.False(list.Any(c => c.Name.Equals(clusterName2, StringComparison.OrdinalIgnoreCase)));
+                        Assert.DoesNotContain(list, c => c.Name.Equals(clusterName1, StringComparison.OrdinalIgnoreCase));
+                        Assert.DoesNotContain(list, c => c.Name.Equals(clusterName2, StringComparison.OrdinalIgnoreCase));
 
                         // Create one cluster with ADLS so both clusters aren't using the same storage account at the same time
                         ClusterCreateParameters parameters1 = ClusterCreateParametersHelpers.GetCustomCreateParametersIaas(testName);
@@ -52,8 +52,8 @@ namespace Management.HDInsight.Tests
                             () => client.Clusters.Create(rgName, clusterName2, parameters2));
 
                         list = client.Clusters.ListByResourceGroup(rgName);
-                        Assert.True(list.Any(c => c.Name.Equals(clusterName1, StringComparison.OrdinalIgnoreCase)));
-                        Assert.True(list.Any(c => c.Name.Equals(clusterName2, StringComparison.OrdinalIgnoreCase)));
+                        Assert.Contains(list, c => c.Name.Equals(clusterName1, StringComparison.OrdinalIgnoreCase));
+                        Assert.Contains(list, c => c.Name.Equals(clusterName2, StringComparison.OrdinalIgnoreCase));
                     }
                     finally
                     {
@@ -84,8 +84,8 @@ namespace Management.HDInsight.Tests
                     rgName2 = HDInsightManagementTestUtilities.CreateResourceGroup(resourceClient);
 
                     var list = client.Clusters.List();
-                    Assert.False(list.Any(c => c.Name.Equals(clusterName1, StringComparison.OrdinalIgnoreCase)));
-                    Assert.False(list.Any(c => c.Name.Equals(clusterName2, StringComparison.OrdinalIgnoreCase)));
+                    Assert.DoesNotContain(list, c => c.Name.Equals(clusterName1, StringComparison.OrdinalIgnoreCase));
+                    Assert.DoesNotContain(list, c => c.Name.Equals(clusterName2, StringComparison.OrdinalIgnoreCase));
 
                     // Create one cluster with ADLS so both clusters aren't using the same storage account at the same time
                     ClusterCreateParameters parameters1 = ClusterCreateParametersHelpers.GetCustomCreateParametersIaas(testName);
@@ -95,8 +95,8 @@ namespace Management.HDInsight.Tests
                         () => client.Clusters.Create(rgName2, clusterName2, parameters2));
 
                     list = client.Clusters.List();
-                    Assert.True(list.Any(c => c.Name.Equals(clusterName1, StringComparison.OrdinalIgnoreCase)));
-                    Assert.True(list.Any(c => c.Name.Equals(clusterName2, StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(list, c => c.Name.Equals(clusterName1, StringComparison.OrdinalIgnoreCase));
+                    Assert.Contains(list, c => c.Name.Equals(clusterName2, StringComparison.OrdinalIgnoreCase));
                 }
                 finally
                 {

--- a/src/SDKs/HDInsight/Management.HDInsight.Tests/ScenarioTests/ScriptActionsTests.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight.Tests/ScenarioTests/ScriptActionsTests.cs
@@ -55,7 +55,7 @@ namespace Management.HDInsight.Tests
 
                 //List script actions and validate script is persisted.
                 IPage<RuntimeScriptActionDetail> scriptActionsList = client.ScriptActions.ListPersistedScripts(rgName, clusterName);
-                Assert.Equal(1, scriptActionsList.Count());
+                Assert.Single(scriptActionsList);
                 RuntimeScriptActionDetail scriptAction = scriptActionsList.First();
                 Assert.Equal(scriptActionParams[0].Name, scriptAction.Name);
                 Assert.Equal(scriptActionParams[0].Uri, scriptAction.Uri);
@@ -66,11 +66,11 @@ namespace Management.HDInsight.Tests
 
                 //List script actions and validate script is deleted.
                 scriptActionsList = client.ScriptActions.ListPersistedScripts(rgName, clusterName);
-                Assert.Equal(0, scriptActionsList.Count());
+                Assert.Empty(scriptActionsList);
 
                 //List script action history and validate script appears there.
                 IPage<RuntimeScriptActionDetail> listHistoryResponse = client.ScriptExecutionHistory.List(rgName, clusterName);
-                Assert.Equal(1, listHistoryResponse.Count());
+                Assert.Single(listHistoryResponse);
                 scriptAction = listHistoryResponse.First();
                 Assert.Equal(1, scriptAction.ExecutionSummary.Count);
                 Assert.Equal(scriptActionParams[0].Name, scriptAction.Name);
@@ -107,7 +107,7 @@ namespace Management.HDInsight.Tests
 
                 //List script action list and validate the promoted script is the only one there.
                 scriptActionsList = client.ScriptActions.ListPersistedScripts(rgName, clusterName);
-                Assert.Equal(1, scriptActionsList.Count());
+                Assert.Single(scriptActionsList);
                 Assert.Equal(1, scriptAction.ExecutionSummary.Count);
                 Assert.Equal(scriptActionParams[0].Name, scriptAction.Name);
                 Assert.Equal(scriptActionParams[0].Uri, scriptAction.Uri);

--- a/src/SDKs/HDInsight/Management.HDInsight.Tests/UnitTests/CustomizationTests.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight.Tests/UnitTests/CustomizationTests.cs
@@ -72,6 +72,7 @@ namespace Management.HDInsight.Tests.UnitTests
             Assert.Equal(handler.Requests[0], handler.Requests[1]);
         }
 
+        [Fact(Skip ="Enabled to appease warnings, needs fixing")]
         public void TestDisableHttpCustomization()
         {
             TestDelegatingHandler handler = new TestDelegatingHandler();

--- a/src/SDKs/HDInsight/Management.HDInsight.Tests/UnitTests/CustomizationTests.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight.Tests/UnitTests/CustomizationTests.cs
@@ -72,8 +72,7 @@ namespace Management.HDInsight.Tests.UnitTests
             Assert.Equal(handler.Requests[0], handler.Requests[1]);
         }
 
-        [Fact(Skip ="Enabled to appease warnings, needs fixing")]
-        public void TestDisableHttpCustomization()
+        internal void TestDisableHttpCustomization()
         {
             TestDelegatingHandler handler = new TestDelegatingHandler();
             HDInsightManagementClient client = GetHDInsightUnitTestingClient(handler);

--- a/src/SDKs/HDInsight/Management.HDInsight.Tests/Utilities/ExtendedParameterValidators.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight.Tests/Utilities/ExtendedParameterValidators.cs
@@ -123,7 +123,7 @@ namespace Management.HDInsight.Tests.UnitTests
             Assert.NotNull(osProfile.LinuxOperatingSystemProfile);
             if (!string.IsNullOrEmpty(createParams.SshPublicKey))
             {
-                Assert.True(osProfile.LinuxOperatingSystemProfile.SshProfile.PublicKeys.Any(s => s.CertificateData == createParams.SshPublicKey));
+                Assert.Contains(osProfile.LinuxOperatingSystemProfile.SshProfile.PublicKeys, s => s.CertificateData == createParams.SshPublicKey);
             }
             Assert.Equal(createParams.SshUserName, osProfile.LinuxOperatingSystemProfile.Username);
             Assert.Equal(createParams.SshPassword, osProfile.LinuxOperatingSystemProfile.Password);

--- a/src/SDKs/HDInsight/Management.HDInsight.Tests/Utilities/HDInsightManagementTestUtilities.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight.Tests/Utilities/HDInsightManagementTestUtilities.cs
@@ -133,7 +133,7 @@ namespace Management.HDInsight.Tests
             Assert.Equal(clustername, cluster.Name);
             Assert.Equal(parameters.Properties.Tier, cluster.Properties.Tier);
             Assert.NotNull(cluster.Etag);
-            Assert.True(cluster.Id.EndsWith(clustername));
+            Assert.EndsWith(clustername, cluster.Id);
             Assert.Equal("Running", cluster.Properties.ClusterState);
             Assert.Equal("Microsoft.HDInsight/clusters", cluster.Type);
             Assert.Equal(parameters.Location, cluster.Location);

--- a/src/SDKs/Insights/Insights.Tests/BasicTests/LogProfilesTests.cs
+++ b/src/SDKs/Insights/Insights.Tests/BasicTests/LogProfilesTests.cs
@@ -155,7 +155,7 @@ namespace Insights.Tests.BasicTests
 
             if (exp == null)
             {
-                Assert.Equal(null, act);
+                Assert.Null(act);
             }
 
             Assert.False(act == null, "List can't be null");

--- a/src/SDKs/Insights/Insights.Tests/BasicTests/ServiceDiagnosticSettingsTests.cs
+++ b/src/SDKs/Insights/Insights.Tests/BasicTests/ServiceDiagnosticSettingsTests.cs
@@ -134,7 +134,7 @@ namespace Insights.Tests.BasicTests
 
             if (exp == null)
             {
-                Assert.Equal(null, act);
+                Assert.Null(act);
             }
 
             Assert.False(act == null, "Actual value can't be null");
@@ -182,7 +182,7 @@ namespace Insights.Tests.BasicTests
 
             if (exp == null)
             {
-                Assert.Equal(null, act);
+                Assert.Null(act);
             }
 
             Assert.False(act == null, "Actual value can't be null");

--- a/src/SDKs/IotHub/IotHub.Tests/ScenarioTests/IotHubLifeCycleTests.cs
+++ b/src/SDKs/IotHub/IotHub.Tests/ScenarioTests/IotHubLifeCycleTests.cs
@@ -43,7 +43,7 @@ namespace IotHub.Tests.ScenarioTests
                         IotHubTestUtilities.DefaultIotHubName);
 
                     iotHubNameAvailabilityInfo = this.iotHubClient.IotHubResource.CheckNameAvailability(operationInputs);
-                    Assert.Equal(true, iotHubNameAvailabilityInfo.NameAvailable);
+                    Assert.True(iotHubNameAvailabilityInfo.NameAvailable);
                 }
 
                 //CreateEH and AuthRule
@@ -74,7 +74,7 @@ namespace IotHub.Tests.ScenarioTests
 
                 var endpointHealth = this.iotHubClient.IotHubResource.GetEndpointHealth(IotHubTestUtilities.DefaultResourceGroupName, IotHubTestUtilities.DefaultIotHubName);
                 Assert.Equal(4, endpointHealth.Count());
-                Assert.True(endpointHealth.Any(q => q.EndpointId.Equals("events", StringComparison.OrdinalIgnoreCase)));
+                Assert.Contains(endpointHealth, q => q.EndpointId.Equals("events", StringComparison.OrdinalIgnoreCase));
 
                 TestAllRoutesInput testAllRoutesInput = new TestAllRoutesInput(RoutingSource.DeviceMessages, new RoutingMessage());
                 TestAllRoutesResult testAllRoutesResult = this.iotHubClient.IotHubResource.TestAllRoutes(testAllRoutesInput, IotHubTestUtilities.DefaultIotHubName, IotHubTestUtilities.DefaultResourceGroupName);
@@ -90,13 +90,13 @@ namespace IotHub.Tests.ScenarioTests
                     IotHubTestUtilities.DefaultIotHubName);
 
                 Assert.True(quotaMetrics.Count() > 0);
-                Assert.True(quotaMetrics.Any(q => q.Name.Equals("TotalMessages", StringComparison.OrdinalIgnoreCase) &&
+                Assert.Contains(quotaMetrics, q => q.Name.Equals("TotalMessages", StringComparison.OrdinalIgnoreCase) &&
                                                   q.CurrentValue == 0 &&
-                                                  q.MaxValue == 400000));
+                                                  q.MaxValue == 400000);
 
-                Assert.True(quotaMetrics.Any(q => q.Name.Equals("TotalDeviceCount", StringComparison.OrdinalIgnoreCase) &&
+                Assert.Contains(quotaMetrics, q => q.Name.Equals("TotalDeviceCount", StringComparison.OrdinalIgnoreCase) &&
                                                   q.CurrentValue == 0 &&
-                                                  q.MaxValue == 500000));
+                                                  q.MaxValue == 500000);
 
                 // Get all Iot Hubs in a resource group
                 var iotHubs = this.iotHubClient.IotHubResource.ListByResourceGroup(IotHubTestUtilities.DefaultResourceGroupName);
@@ -124,7 +124,7 @@ namespace IotHub.Tests.ScenarioTests
                     IotHubTestUtilities.DefaultResourceGroupName,
                     IotHubTestUtilities.DefaultIotHubName);
                 Assert.True(keys.Count() > 0);
-                Assert.True(keys.Any(k => k.KeyName.Equals("iothubowner", StringComparison.OrdinalIgnoreCase)));
+                Assert.Contains(keys, k => k.KeyName.Equals("iothubowner", StringComparison.OrdinalIgnoreCase));
 
                 // Get specific IotHub Key
                 var key = this.iotHubClient.IotHubResource.GetKeysForKeyName(
@@ -139,7 +139,7 @@ namespace IotHub.Tests.ScenarioTests
                     IotHubTestUtilities.DefaultIotHubName,
                     IotHubTestUtilities.EventsEndpointName);
                 Assert.True(ehConsumerGroups.Count() > 0);
-                Assert.True(ehConsumerGroups.Any(e => e.Name.Equals("$Default", StringComparison.OrdinalIgnoreCase)));
+                Assert.Contains(ehConsumerGroups, e => e.Name.Equals("$Default", StringComparison.OrdinalIgnoreCase));
 
                 // Add EH consumer group
                 var ehConsumerGroup = this.iotHubClient.IotHubResource.CreateEventHubConsumerGroup(
@@ -170,13 +170,13 @@ namespace IotHub.Tests.ScenarioTests
                 // Get all of the available IoT Hub REST API operations
                 var operationList = this.iotHubClient.Operations.List();
                 Assert.True(operationList.Count() > 0);
-                Assert.True(operationList.Any(e => e.Name.Equals("Microsoft.Devices/iotHubs/Read", StringComparison.OrdinalIgnoreCase)));
+                Assert.Contains(operationList, e => e.Name.Equals("Microsoft.Devices/iotHubs/Read", StringComparison.OrdinalIgnoreCase));
 
                 // Get IoT Hub REST API read operation
                 var hubReadOperation = operationList.Where(e => e.Name.Equals("Microsoft.Devices/iotHubs/Read", StringComparison.OrdinalIgnoreCase));
                 Assert.True(hubReadOperation.Count().Equals(1));
-                Assert.True(hubReadOperation.First().Display.Provider.Equals("Microsoft Devices", StringComparison.OrdinalIgnoreCase));
-                Assert.True(hubReadOperation.First().Display.Operation.Equals("Get IotHub(s)", StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("Microsoft Devices", hubReadOperation.First().Display.Provider, ignoreCase: true);
+                Assert.Equal("Get IotHub(s)", hubReadOperation.First().Display.Operation, ignoreCase: true);
             }
         }
 
@@ -205,7 +205,7 @@ namespace IotHub.Tests.ScenarioTests
                         IotHubTestUtilities.DefaultUpdateIotHubName);
 
                     iotHubNameAvailabilityInfo = this.iotHubClient.IotHubResource.CheckNameAvailability(operationInputs);
-                    Assert.Equal(true, iotHubNameAvailabilityInfo.NameAvailable);
+                    Assert.True(iotHubNameAvailabilityInfo.NameAvailable);
                 }
 
                 var iotHub = this.CreateIotHub(resourceGroup, IotHubTestUtilities.DefaultLocation, IotHubTestUtilities.DefaultUpdateIotHubName, null);
@@ -230,11 +230,11 @@ namespace IotHub.Tests.ScenarioTests
 
                 Assert.NotNull(retIotHub);
                 Assert.Equal(IotHubTestUtilities.DefaultUpdateIotHubName, retIotHub.Name);
-                Assert.Equal(retIotHub.Properties.Routing.Routes.Count, 4);
-                Assert.Equal(retIotHub.Properties.Routing.Endpoints.EventHubs.Count, 1);
-                Assert.Equal(retIotHub.Properties.Routing.Endpoints.ServiceBusTopics.Count, 1);
-                Assert.Equal(retIotHub.Properties.Routing.Endpoints.ServiceBusQueues.Count, 1);
-                Assert.Equal(retIotHub.Properties.Routing.Routes[0].Name, "route1");
+                Assert.Equal(4, retIotHub.Properties.Routing.Routes.Count);
+                Assert.Equal(1, retIotHub.Properties.Routing.Endpoints.EventHubs.Count);
+                Assert.Equal(1, retIotHub.Properties.Routing.Endpoints.ServiceBusTopics.Count);
+                Assert.Equal(1, retIotHub.Properties.Routing.Endpoints.ServiceBusQueues.Count);
+                Assert.Equal("route1", retIotHub.Properties.Routing.Routes[0].Name);
 
                 // Get an Iot Hub
                 var iotHubDesc = this.iotHubClient.IotHubResource.Get(
@@ -254,11 +254,11 @@ namespace IotHub.Tests.ScenarioTests
 
                 Assert.NotNull(retIotHub);
                 Assert.Equal(IotHubTestUtilities.DefaultUpdateIotHubName, retIotHub.Name);
-                Assert.Equal(retIotHub.Properties.Routing.Routes.Count, 4);
-                Assert.Equal(retIotHub.Properties.Routing.Endpoints.EventHubs.Count, 1);
-                Assert.Equal(retIotHub.Properties.Routing.Endpoints.ServiceBusTopics.Count, 1);
-                Assert.Equal(retIotHub.Properties.Routing.Endpoints.ServiceBusQueues.Count, 1);
-                Assert.Equal(retIotHub.Properties.Routing.Routes[0].Name, "route1");
+                Assert.Equal(4, retIotHub.Properties.Routing.Routes.Count);
+                Assert.Equal(1, retIotHub.Properties.Routing.Endpoints.EventHubs.Count);
+                Assert.Equal(1, retIotHub.Properties.Routing.Endpoints.ServiceBusTopics.Count);
+                Assert.Equal(1, retIotHub.Properties.Routing.Endpoints.ServiceBusQueues.Count);
+                Assert.Equal("route1", retIotHub.Properties.Routing.Routes[0].Name);
             }
         }
 
@@ -287,7 +287,7 @@ namespace IotHub.Tests.ScenarioTests
                         IotHubTestUtilities.DefaultCertificateIotHubName);
 
                     iotHubNameAvailabilityInfo = this.iotHubClient.IotHubResource.CheckNameAvailability(operationInputs);
-                    Assert.Equal(true, iotHubNameAvailabilityInfo.NameAvailable);
+                    Assert.True(iotHubNameAvailabilityInfo.NameAvailable);
                 }
 
                 // Create Hub

--- a/src/SDKs/IotHub/IotHub.Tests/ScenarioTests/IotHubTestBase.cs
+++ b/src/SDKs/IotHub/IotHub.Tests/ScenarioTests/IotHubTestBase.cs
@@ -79,7 +79,7 @@ namespace IotHub.Tests.ScenarioTests
                 }
             });
 
-            Assert.Equal(namespaceResource.ProvisioningState, "Succeeded");
+            Assert.Equal("Succeeded", namespaceResource.ProvisioningState);
 
             var ehResource = ehClient.EventHubs.CreateOrUpdate(resourceGroup.Name, namespaceName, ehName, new EventHubCreateOrUpdateParameters()
             {
@@ -123,7 +123,7 @@ namespace IotHub.Tests.ScenarioTests
                     }
                 });
 
-            Assert.Equal(namespaceResource.ProvisioningState, "Succeeded");
+            Assert.Equal("Succeeded", namespaceResource.ProvisioningState);
 
             var sbResource = sbClient.Queues.CreateOrUpdate(resourceGroup.Name, sbNamespaceName, sbName, new QueueCreateOrUpdateParameters()
             {

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions.Tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions.Tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
@@ -5,6 +5,7 @@
     <Description>Microsoft Azure Key Vault Extensions tests</Description>
     <VersionPrefix>3.0.0-alpha</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault.Extensions.Tests</AssemblyName>    
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions.Tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions.Tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
@@ -7,9 +7,6 @@
     <AssemblyName>Microsoft.Azure.KeyVault.Extensions.Tests</AssemblyName>    
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Tests/Microsoft.Azure.KeyVault.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Tests/Microsoft.Azure.KeyVault.Tests.csproj
@@ -5,6 +5,7 @@
     <Description>Microsoft.Azure.KeyVault.Tests Class Library</Description>
     <VersionPrefix>3.0.0-alpha</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault.Tests</AssemblyName>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountAgreementInMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountAgreementInMemoryTests.cs
@@ -264,7 +264,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateAgreementList(IPage<IntegrationAccountAgreement> result)
         {
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             this.ValidateAgreement(result.First());
             Assert.Equal(Constants.NextPageLink, result.NextPageLink);
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountCertificateInMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountCertificateInMemoryTests.cs
@@ -265,7 +265,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateCertificateList(IPage<IntegrationAccountCertificate> result)
         {            
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             this.ValidateCertificate(result.First());
             Assert.Equal(Constants.NextPageLink, result.NextPageLink);
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountInMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountInMemoryTests.cs
@@ -427,7 +427,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateIntegrationAccountList(IPage<IntegrationAccount> result)
         {            
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             this.ValidateIntegrationAccount(result.First());
             Assert.Equal(Constants.NextPageLink, result.NextPageLink);
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountMapInMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountMapInMemoryTests.cs
@@ -265,7 +265,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateMapList(IPage<IntegrationAccountMap> result)
         {            
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             this.ValidateMap(result.First());
             Assert.Equal(Constants.NextPageLink, result.NextPageLink);
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountPartnerInMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountPartnerInMemoryTests.cs
@@ -265,7 +265,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidatePartnerList(IPage<IntegrationAccountPartner> result)
         {
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             this.ValidatePartner(result.First());
             Assert.Equal(Constants.NextPageLink, result.NextPageLink);
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountSchemaInMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountSchemaInMemoryTests.cs
@@ -265,7 +265,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateSchemaList(IPage<IntegrationAccountSchema> result)
         {            
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             this.ValidateSchema(result.First());
             Assert.Equal(Constants.NextPageLink, result.NextPageLink);
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountSessionInMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/IntegrationAccountSessionInMemoryTests.cs
@@ -292,7 +292,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateSessionList(IPage<IntegrationAccountSession> result)
         {
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             this.ValidateSession(result.First());
             Assert.Equal(Constants.NextPageLink, result.NextPageLink);
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/WorkflowRunActions.InMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/WorkflowRunActions.InMemoryTests.cs
@@ -305,7 +305,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateRunActionListResponse1(IPage<WorkflowRunAction> page)
         {
-            Assert.Equal(1, page.Count());
+            Assert.Single(page);
             Assert.Equal("http://management.azure.com/actionNextLink", page.NextPageLink);
             this.ValidateRunAction1(page.First());
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/WorkflowRuns.InMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/WorkflowRuns.InMemoryTests.cs
@@ -270,7 +270,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateRunListResponse1(IPage<WorkflowRun> page)
         {
-            Assert.Equal(1, page.Count());
+            Assert.Single(page);
             Assert.Equal("http://management.azure.com/runNextLink", page.NextPageLink);
             this.ValidateRun1(page.First());
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/WorkflowTriggerHistories.InMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/WorkflowTriggerHistories.InMemoryTests.cs
@@ -278,7 +278,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateTriggerHistoryListResponse1(IPage<WorkflowTriggerHistory> page)
         {
-            Assert.Equal(1, page.Count());
+            Assert.Single(page);
             Assert.Equal("http://management.azure.com/keyNextLink", page.NextPageLink);
             this.ValidateTriggerHistory1(page.First());
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/WorkflowTriggers.InMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/WorkflowTriggers.InMemoryTests.cs
@@ -365,7 +365,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateTriggerListResponse1(IPage<WorkflowTrigger> page)
         {
-            Assert.Equal(1, page.Count());
+            Assert.Single(page);
             Assert.Equal("http://management.azure.com/triggerNextLink", page.NextPageLink);
             this.ValidateTrigger1(page.First());
         }

--- a/src/SDKs/Logic/Logic.Tests/InMemoryTests/Workflows.InMemoryTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/InMemoryTests/Workflows.InMemoryTests.cs
@@ -151,6 +151,7 @@ namespace Test.Azure.Management.Logic
             Assert.Throws<CloudException>(() => client.Workflows.ListBySubscription());
         }
 
+        [Fact]
         public void Workflows_ListBySubscription_Success()
         {
             var handler = new RecordedDelegatingHandler();
@@ -192,6 +193,7 @@ namespace Test.Azure.Management.Logic
             Assert.Throws<CloudException>(() => client.Workflows.ListBySubscriptionNext("http://management.azure.com/nextLink"));
         }
 
+        [Fact]
         public void Workflows_ListBySubscriptionNext_Success()
         {
             var handler = new RecordedDelegatingHandler();
@@ -275,6 +277,7 @@ namespace Test.Azure.Management.Logic
             Assert.Throws<CloudException>(() => client.Workflows.ListByResourceGroupNext("http://management.azure.com/nextLink"));
         }
 
+        [Fact]
         public void Workflows_ListByResourceGroupNext_Success()
         {
             var handler = new RecordedDelegatingHandler();
@@ -790,7 +793,7 @@ namespace Test.Azure.Management.Logic
 
         private void ValidateWorkflowList1(IPage<Workflow> result)
         {
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             this.ValidateWorkflow1(result.First());
             Assert.Equal("http://workflowlist1nextlink", result.NextPageLink);
         }

--- a/src/SDKs/Logic/Logic.Tests/ScenarioTests/IntegrationAccountAgreements.ScenarioTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/ScenarioTests/IntegrationAccountAgreements.ScenarioTests.cs
@@ -50,8 +50,8 @@ namespace Test.Azure.Management.Logic
                 integrationAccountAgreementName);
 
                 Assert.Equal(getAgreement.Name, integrationAccountAgreementName);
-                Assert.Equal(getAgreement.Content.AS2.ReceiveAgreement.ProtocolSettings.MdnSettings.MicHashingAlgorithm, HashingAlgorithm.MD5);
-                Assert.Equal(getAgreement.Content.AS2.SendAgreement.ProtocolSettings.MdnSettings.MicHashingAlgorithm, HashingAlgorithm.MD5);
+                Assert.Equal(HashingAlgorithm.MD5, getAgreement.Content.AS2.ReceiveAgreement.ProtocolSettings.MdnSettings.MicHashingAlgorithm);
+                Assert.Equal(HashingAlgorithm.MD5, getAgreement.Content.AS2.SendAgreement.ProtocolSettings.MdnSettings.MicHashingAlgorithm);
 
                 client.Agreements.Delete(Constants.DefaultResourceGroup, integrationAccountName,
                     integrationAccountAgreementName);
@@ -131,8 +131,8 @@ namespace Test.Azure.Management.Logic
                     integrationAccountAgreementName);
 
                 Assert.Equal(agreement.Name, getAgreement.Name);
-                Assert.Equal(agreement.Content.AS2.ReceiveAgreement.ProtocolSettings.MdnSettings.MicHashingAlgorithm, HashingAlgorithm.SHA1);
-                Assert.Equal(agreement.Content.AS2.SendAgreement.ProtocolSettings.MdnSettings.MicHashingAlgorithm, HashingAlgorithm.SHA1);
+                Assert.Equal(HashingAlgorithm.SHA1, agreement.Content.AS2.ReceiveAgreement.ProtocolSettings.MdnSettings.MicHashingAlgorithm);
+                Assert.Equal(HashingAlgorithm.SHA1, agreement.Content.AS2.SendAgreement.ProtocolSettings.MdnSettings.MicHashingAlgorithm);
 
 
                 client.IntegrationAccounts.Delete(Constants.DefaultResourceGroup, integrationAccountName);
@@ -181,7 +181,7 @@ namespace Test.Azure.Management.Logic
                 var fetchedAgreement = client.Agreements.Get(Constants.DefaultResourceGroup,
                     integrationAccountName, integrationX12AccountAgreementName);
 
-                Assert.Equal(fetchedAgreement.Content.X12.ReceiveAgreement.ProtocolSettings.EnvelopeOverrides[0].ResponsibleAgencyCode,"X");
+                Assert.Equal("X", fetchedAgreement.Content.X12.ReceiveAgreement.ProtocolSettings.EnvelopeOverrides[0].ResponsibleAgencyCode);
 
                 client.IntegrationAccounts.Delete(Constants.DefaultResourceGroup, integrationAccountName);
             }

--- a/src/SDKs/Logic/Logic.Tests/ScenarioTests/IntegrationAccountMaps.ScenarioTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/ScenarioTests/IntegrationAccountMaps.ScenarioTests.cs
@@ -130,7 +130,7 @@ namespace Test.Azure.Management.Logic
 
                 Assert.Equal(updatedMap.Name, integrationAccountMapName);
                 Assert.NotNull(updatedMap.ContentLink.Uri);
-                Assert.Equal(updatedMap.Metadata, "meta-data");
+                Assert.Equal("meta-data", updatedMap.Metadata);
 
                 client.IntegrationAccounts.Delete(Constants.DefaultResourceGroup, integrationAccountName);
             }

--- a/src/SDKs/Logic/Logic.Tests/ScenarioTests/IntegrationAccountSessions.ScenarioTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/ScenarioTests/IntegrationAccountSessions.ScenarioTests.cs
@@ -161,7 +161,7 @@ namespace Test.Azure.Management.Logic
                     sessionName: integrationAccountSessionName);
 
                 Assert.Equal(session.Name, getSession.Name);
-                Assert.Equal(session.Content, "256");
+                Assert.Equal("256", session.Content);
 
                 client.IntegrationAccounts.Delete(
                     resourceGroupName: Constants.DefaultResourceGroup,

--- a/src/SDKs/Logic/Logic.Tests/ScenarioTests/WorkflowTriggers.ScenarioTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/ScenarioTests/WorkflowTriggers.ScenarioTests.cs
@@ -36,7 +36,7 @@ namespace Test.Azure.Management.Logic
                 // List the triggers
                 var triggers = client.WorkflowTriggers.List(this.resourceGroupName, workflowName);
 
-                Assert.Equal(0, triggers.Count());
+                Assert.Empty(triggers);
 
                 // Delete the workflow
                 client.Workflows.Delete(this.resourceGroupName, workflowName);
@@ -65,7 +65,7 @@ namespace Test.Azure.Management.Logic
                 // List the triggers
                 var triggers = client.WorkflowTriggers.List(this.resourceGroupName, workflowName);
 
-                Assert.Equal(1, triggers.Count());
+                Assert.Single(triggers);
 
                 var trigger = client.WorkflowTriggers.Get(this.resourceGroupName, workflowName, "httpTrigger");
 

--- a/src/SDKs/Logic/Logic.Tests/ScenarioTests/Workflows.ScenarioTests.cs
+++ b/src/SDKs/Logic/Logic.Tests/ScenarioTests/Workflows.ScenarioTests.cs
@@ -131,7 +131,7 @@ namespace Test.Azure.Management.Logic
                 // List the workflow in resource group
                 var lists = client.Workflows.ListByResourceGroup(this.resourceGroupName, new ODataQuery<WorkflowFilter>(f => f.State == WorkflowState.Disabled) { Top = 1 });
 
-                Assert.Equal(1, lists.Count());
+                Assert.Single(lists);
 
                 // List the workflow in resource group
                 lists = client.Workflows.ListByResourceGroup(this.resourceGroupName);
@@ -229,7 +229,7 @@ namespace Test.Azure.Management.Logic
 
                 workflows = client.Workflows.ListByResourceGroup(this.resourceGroupName);
 
-                Assert.Equal(0, workflows.Count());
+                Assert.Empty(workflows);
             }
         }
 
@@ -255,7 +255,7 @@ namespace Test.Azure.Management.Logic
                 // Verify the response
                 Assert.Equal(workflowName, workflow.Name);
                 Assert.Equal(WorkflowState.Enabled, workflow.State);
-                Assert.Equal(null, workflow.Tags);
+                Assert.Null(workflow.Tags);
 
                 // Update the workflow
                 workflow = new Workflow()

--- a/src/SDKs/Logic/Logic.sln
+++ b/src/SDKs/Logic/Logic.sln
@@ -25,4 +25,7 @@ Global
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {B1EA0485-105C-4017-A917-CDDB7B138F49}
+	EndGlobalSection
 EndGlobal

--- a/src/SDKs/MachineLearning/MachineLearning.Tests/ScenarioTests/CommitmentPlanTests.cs
+++ b/src/SDKs/MachineLearning/MachineLearning.Tests/ScenarioTests/CommitmentPlanTests.cs
@@ -149,19 +149,19 @@ namespace MachineLearning.Tests.ScenarioTests
                     Assert.Equal(2, plansInGroup1.Count());
 
                     string expectedResourceId1 = string.Format(CultureInfo.InvariantCulture, CommitmentPlanTests.ResourceIdFormat, amlPlansClient.SubscriptionId, resourceGroup1Name, plan1Name);
-                    Assert.True(plansInGroup1.Any(plan => string.Equals(plan.Id, expectedResourceId1, StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(plansInGroup1, plan => string.Equals(plan.Id, expectedResourceId1, StringComparison.OrdinalIgnoreCase));
 
                     string expectedResourceId2 = string.Format(CultureInfo.InvariantCulture, CommitmentPlanTests.ResourceIdFormat, amlPlansClient.SubscriptionId, resourceGroup1Name, plan2Name);
-                    Assert.True(plansInGroup1.Any(plan => string.Equals(plan.Id, expectedResourceId2, StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(plansInGroup1, plan => string.Equals(plan.Id, expectedResourceId2, StringComparison.OrdinalIgnoreCase));
 
                     // Get plans from second resource group and validate
                     var plansInGroup2 = amlPlansClient.CommitmentPlans.ListInResourceGroup(resourceGroup2Name);
 
                     Assert.NotNull(plansInGroup2);
-                    Assert.Equal(1, plansInGroup2.Count());
+                    Assert.Single(plansInGroup2);
 
                     string expectedResourceId3 = string.Format(CultureInfo.InvariantCulture, CommitmentPlanTests.ResourceIdFormat, amlPlansClient.SubscriptionId, resourceGroup2Name, plan3Name);
-                    Assert.True(plansInGroup2.Any(plan => string.Equals(plan.Id, expectedResourceId3, StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(plansInGroup2, plan => string.Equals(plan.Id, expectedResourceId3, StringComparison.OrdinalIgnoreCase));
                 }
                 finally
                 {

--- a/src/SDKs/MachineLearning/MachineLearning.Tests/ScenarioTests/WebServiceTests.cs
+++ b/src/SDKs/MachineLearning/MachineLearning.Tests/ScenarioTests/WebServiceTests.cs
@@ -105,7 +105,7 @@ namespace MachineLearning.Tests.ScenarioTests
                     //Validate that the expected not found exception is thrown after deletion when trying to access the service
                     var expectedCloudException = Assert.Throws<CloudException>(() => amlServicesClient.WebServices.Get(resourceGroupName, webServiceName));
                     Assert.NotNull(expectedCloudException.Body);
-                    Assert.True(string.Equals(expectedCloudException.Body.Code, "NotFound"));
+                    Assert.Equal("NotFound", expectedCloudException.Body.Code);
                 }
                 catch (Exception ex)
                 {
@@ -194,7 +194,7 @@ namespace MachineLearning.Tests.ScenarioTests
                     //Validate that the expected not found exception is thrown before create the regional properties
                     var expectedCloudException = Assert.Throws<CloudException>(() => amlServicesClient.WebServices.Get(resourceGroupName, webServiceName, NewRegion));
                     Assert.NotNull(expectedCloudException.Body);
-                    Assert.True(string.Equals(expectedCloudException.Body.Code, "NotFound"));
+                    Assert.Equal("NotFound", expectedCloudException.Body.Code);
 
                     // Submit some updates to this resource
                     amlServicesClient.WebServices.CreateRegionalPropertiesWithRequestId(resourceGroupName, webServiceName, NewRegion);
@@ -264,7 +264,7 @@ namespace MachineLearning.Tests.ScenarioTests
                     //Validate that the expected not found exception is thrown after deletion when trying to access the service
                     var expectedCloudException = Assert.Throws<CloudException>(() => amlServicesClient.WebServices.Get(resourceGroupName, webServiceName));
                     Assert.NotNull(expectedCloudException.Body);
-                    Assert.True(string.Equals(expectedCloudException.Body.Code, "NotFound"));
+                    Assert.Equal("NotFound", expectedCloudException.Body.Code);
                 }
                 catch (Exception ex)
                 {
@@ -319,9 +319,9 @@ namespace MachineLearning.Tests.ScenarioTests
                     string service1ExpectedId = string.Format(CultureInfo.InvariantCulture, WebServiceTests.ResourceIdFormat, amlServicesClient.SubscriptionId, resourceGroupName, webServiceName);
                     string service2ExpectedId = string.Format(CultureInfo.InvariantCulture, WebServiceTests.ResourceIdFormat, amlServicesClient.SubscriptionId, resourceGroupName, service2Name);
                     string service3ExpectedId = string.Format(CultureInfo.InvariantCulture, WebServiceTests.ResourceIdFormat, amlServicesClient.SubscriptionId, resourceGroupName, service3Name);
-                    Assert.True(servicesList.Any(svc => string.Equals(svc.Id, service1ExpectedId, StringComparison.OrdinalIgnoreCase)));
-                    Assert.True(servicesList.Any(svc => string.Equals(svc.Id, service2ExpectedId, StringComparison.OrdinalIgnoreCase)));
-                    Assert.True(servicesList.Any(svc => string.Equals(svc.Id, service3ExpectedId, StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(servicesList, svc => string.Equals(svc.Id, service1ExpectedId, StringComparison.OrdinalIgnoreCase));
+                    Assert.Contains(servicesList, svc => string.Equals(svc.Id, service2ExpectedId, StringComparison.OrdinalIgnoreCase));
+                    Assert.Contains(servicesList, svc => string.Equals(svc.Id, service3ExpectedId, StringComparison.OrdinalIgnoreCase));
 
                     // Validate that all services are called when getting the AML service resource list for the subscription
                     var servicesInSubscription = amlServicesClient.WebServices.ListBySubscriptionIdWithHttpMessagesAsync().Result;
@@ -329,11 +329,11 @@ namespace MachineLearning.Tests.ScenarioTests
                     servicesList = servicesInSubscription.Body.ToList();
                     Assert.NotNull(servicesList);
                     Assert.True(servicesList.Count >= 4);
-                    Assert.True(servicesList.Any(svc => string.Equals(svc.Id, service1ExpectedId, StringComparison.OrdinalIgnoreCase)));
-                    Assert.True(servicesList.Any(svc => string.Equals(svc.Id, service2ExpectedId, StringComparison.OrdinalIgnoreCase)));
-                    Assert.True(servicesList.Any(svc => string.Equals(svc.Id, service3ExpectedId, StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(servicesList, svc => string.Equals(svc.Id, service1ExpectedId, StringComparison.OrdinalIgnoreCase));
+                    Assert.Contains(servicesList, svc => string.Equals(svc.Id, service2ExpectedId, StringComparison.OrdinalIgnoreCase));
+                    Assert.Contains(servicesList, svc => string.Equals(svc.Id, service3ExpectedId, StringComparison.OrdinalIgnoreCase));
                     string otherServiceExpectedId = string.Format(CultureInfo.InvariantCulture, WebServiceTests.ResourceIdFormat, amlServicesClient.SubscriptionId, otherResourceGroupName, otherServiceName);
-                    Assert.True(servicesList.Any(svc => string.Equals(svc.Id, otherServiceExpectedId, StringComparison.OrdinalIgnoreCase)));
+                    Assert.Contains(servicesList, svc => string.Equals(svc.Id, otherServiceExpectedId, StringComparison.OrdinalIgnoreCase));
                 }
                 catch(Exception ex)
                 {

--- a/src/SDKs/Network/Network.Tests/Network.Tests.csproj
+++ b/src/SDKs/Network/Network.Tests/Network.Tests.csproj
@@ -5,6 +5,7 @@
     <Description>Network.Tests Class Library</Description>
     <AssemblyName>Network.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
@@ -61,14 +61,14 @@ namespace NotificationHubs.Tests.ScenarioTests
                 var getAllNamespacesResponse = NotificationHubsManagementClient.Namespaces.List(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 //Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = NotificationHubsManagementClient.Namespaces.ListAll();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 //Update namespace tags and make the namespace critical
                 var updateNamespaceParameter = new NamespaceCreateOrUpdateParameters()
@@ -90,11 +90,11 @@ namespace NotificationHubs.Tests.ScenarioTests
                     updateNamespaceResponse.ProvisioningState.Equals("Succeeded", StringComparison.CurrentCultureIgnoreCase));
                 Assert.Equal(namespaceName, updateNamespaceResponse.Name);
                 //Regression in the service . uncomment after the fix goes out 
-                Assert.Equal(updateNamespaceResponse.Tags.Count, 4);
+                Assert.Equal(4, updateNamespaceResponse.Tags.Count);
                 foreach (var tag in updateNamespaceParameter.Tags)
                 {
-                    Assert.True(updateNamespaceResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(updateNamespaceResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(updateNamespaceResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(updateNamespaceResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
@@ -105,11 +105,11 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.Equal(NamespaceType.NotificationHub, getNamespaceResponse.NamespaceType);
                 Assert.Equal(location, getNamespaceResponse.Location, StringComparer.CurrentCultureIgnoreCase);
                 Assert.Equal(namespaceName, getNamespaceResponse.Name);
-                Assert.Equal(getNamespaceResponse.Tags.Count, 4);
+                Assert.Equal(4, getNamespaceResponse.Tags.Count);
                 foreach (var tag in updateNamespaceParameter.Tags)
                 {
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 var updateNamespacePatchParameter = new NamespacePatchParameters()
@@ -125,11 +125,11 @@ namespace NotificationHubs.Tests.ScenarioTests
                 var updateNamespacePatchResponse = NotificationHubsManagementClient.Namespaces.Patch(resourceGroup, namespaceName, updateNamespacePatchParameter);
 
                 Assert.NotNull(updateNamespacePatchResponse);
-                Assert.Equal(updateNamespacePatchResponse.Tags.Count, 2);
+                Assert.Equal(2, updateNamespacePatchResponse.Tags.Count);
                 foreach (var tag in updateNamespacePatchParameter.Tags)
                 {
-                    Assert.True(updateNamespacePatchParameter.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(updateNamespacePatchParameter.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(updateNamespacePatchParameter.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(updateNamespacePatchParameter.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
@@ -143,7 +143,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                     }
                     catch (Exception ex)
                     {
-                        Assert.True(ex.Message.Contains("NotFound"));
+                        Assert.Contains("NotFound", ex.Message);
                     }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
@@ -77,16 +77,16 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 //Get default namespace AuthorizationRules
                 var getNamespaceAuthorizationRulesResponse = NotificationHubsManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, NotificationHubsManagementHelper.DefaultNamespaceAuthorizationRule);
                 Assert.NotNull(getNamespaceAuthorizationRulesResponse);
                 Assert.Equal(getNamespaceAuthorizationRulesResponse.Name, NotificationHubsManagementHelper.DefaultNamespaceAuthorizationRule);
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Listen));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Send));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Manage));
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Listen);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Send);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Manage);
 
                 //Get created namespace AuthorizationRules
                 getNamespaceAuthorizationRulesResponse = NotificationHubsManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, authorizationRuleName);
@@ -95,15 +95,15 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 //Get all namespaces AuthorizationRules 
                 var getAllNamespaceAuthorizationRulesResponse = NotificationHubsManagementClient.Namespaces.ListAuthorizationRules(resourceGroup, namespaceName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() > 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(auth => auth.Name == NotificationHubsManagementHelper.DefaultNamespaceAuthorizationRule));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, auth => auth.Name == NotificationHubsManagementHelper.DefaultNamespaceAuthorizationRule);
 
                 //Update namespace authorizationRule
                 var updateNamespaceAuthorizationRuleParameter = new SharedAccessAuthorizationRuleCreateOrUpdateParameters()
@@ -176,7 +176,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CheckAvailability.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CheckAvailability.cs
@@ -59,7 +59,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CRUD.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CRUD.cs
@@ -85,7 +85,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 var getAllNotificationHubsResponse = NotificationHubsManagementClient.NotificationHubs.List(resourceGroup, namespaceName);
                 Assert.NotNull(getAllNotificationHubsResponse);
                 Assert.True(getAllNotificationHubsResponse.Count() >= 1);
-                Assert.True(getAllNotificationHubsResponse.Any(nh => string.Compare(nh.Name, notificationHubName, true) == 0));
+                Assert.Contains(getAllNotificationHubsResponse, nh => string.Compare(nh.Name, notificationHubName, true) == 0);
                 Assert.True(getAllNotificationHubsResponse.All(nh => nh.Id.Contains(resourceGroup)));
 
                 var getNotificationHubPnsCredentialsResponse = NotificationHubsManagementClient.NotificationHubs.GetPnsCredentials(resourceGroup, namespaceName, notificationHubName);
@@ -141,11 +141,11 @@ namespace NotificationHubs.Tests.ScenarioTests
                 //Get the updated notificationHub
                 getNotificationHubResponse = NotificationHubsManagementClient.NotificationHubs.Get(resourceGroup, namespaceName, notificationHubName);
                 Assert.NotNull(getNotificationHubResponse);
-                Assert.Equal(getNotificationHubResponse.Tags.Count, 3);
+                Assert.Equal(3, getNotificationHubResponse.Tags.Count);
                 foreach (var tag in updateNotificationHubParameter.Tags)
                 {
-                    Assert.True(getNotificationHubResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(getNotificationHubResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(getNotificationHubResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(getNotificationHubResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 //Get the updated notificationHub PNSCredentials
@@ -183,7 +183,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CRUDAuthorizationRules.cs
@@ -86,7 +86,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(createNotificationHubAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(createNotificationHubAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNotificationHubAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
@@ -98,7 +98,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(getNotificationHubAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(getNotificationHubAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNotificationHubAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 //Get all notificationHub AuthorizationRules 
@@ -106,7 +106,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                     notificationHubName);
                 Assert.NotNull(getAllNotificationHubAuthorizationRulesResponse);
                 Assert.True(getAllNotificationHubAuthorizationRulesResponse.Count() > 1);
-                Assert.True(getAllNotificationHubAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNotificationHubAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 //Update notificationHub authorizationRule 
                 var updateNotificationHubAuthorizationRuleParameter = new SharedAccessAuthorizationRuleCreateOrUpdateParameters()
@@ -125,7 +125,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(updateNotificationHubAuthorizationRuleResponse.Rights.Count == updateNotificationHubAuthorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in updateNotificationHubAuthorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(updateNotificationHubAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNotificationHubAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
@@ -138,7 +138,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(getNotificationHubAuthorizationRuleResponse.Rights.Count == updateNotificationHubAuthorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in updateNotificationHubAuthorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(getNotificationHubAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNotificationHubAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 //Get the connectionString to the namespace for a Authorization rule created at notificationHub level
@@ -146,8 +146,8 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.NotNull(listKeysResponse);
                 Assert.NotNull(listKeysResponse.PrimaryConnectionString);
                 Assert.NotNull(listKeysResponse.SecondaryConnectionString);
-                Assert.True(listKeysResponse.PrimaryConnectionString.Contains(listKeysResponse.PrimaryKey));
-                Assert.True(listKeysResponse.SecondaryConnectionString.Contains(listKeysResponse.SecondaryKey));
+                Assert.Contains(listKeysResponse.PrimaryKey, listKeysResponse.PrimaryConnectionString);
+                Assert.Contains(listKeysResponse.SecondaryKey, listKeysResponse.SecondaryConnectionString);
 
                 var policyKey = new PolicykeyResource()
                 {
@@ -159,8 +159,8 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.Equal(regenerateKeys.KeyName, authorizationRuleName);
                 Assert.NotNull(regenerateKeys.PrimaryConnectionString);
                 Assert.NotNull(regenerateKeys.SecondaryConnectionString);
-                Assert.True(regenerateKeys.PrimaryConnectionString.Contains(regenerateKeys.PrimaryKey));
-                Assert.True(regenerateKeys.SecondaryConnectionString.Contains(regenerateKeys.SecondaryKey));
+                Assert.Contains(regenerateKeys.PrimaryKey, regenerateKeys.PrimaryConnectionString);
+                Assert.Contains(regenerateKeys.SecondaryKey, regenerateKeys.SecondaryConnectionString);
                 //Bug : uncomment after the fix
                 //Assert.Equal(regenerateKeys.SecondaryConnectionString, listKeysResponse.SecondaryConnectionString);
                 Assert.NotEqual(regenerateKeys.PrimaryConnectionString, listKeysResponse.PrimaryConnectionString);
@@ -173,8 +173,8 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.Equal(listKeysAfterRegenerateResponse.KeyName, authorizationRuleName);
                 Assert.NotNull(listKeysAfterRegenerateResponse.PrimaryConnectionString);
                 Assert.NotNull(listKeysAfterRegenerateResponse.SecondaryConnectionString);
-                Assert.True(listKeysAfterRegenerateResponse.PrimaryConnectionString.Contains(listKeysAfterRegenerateResponse.PrimaryKey));
-                Assert.True(listKeysAfterRegenerateResponse.SecondaryConnectionString.Contains(listKeysAfterRegenerateResponse.SecondaryKey));
+                Assert.Contains(listKeysAfterRegenerateResponse.PrimaryKey, listKeysAfterRegenerateResponse.PrimaryConnectionString);
+                Assert.Contains(listKeysAfterRegenerateResponse.SecondaryKey, listKeysAfterRegenerateResponse.SecondaryConnectionString);
                 Assert.Equal(listKeysAfterRegenerateResponse.SecondaryConnectionString, listKeysResponse.SecondaryConnectionString);
                 Assert.NotEqual(listKeysAfterRegenerateResponse.PrimaryConnectionString, listKeysResponse.PrimaryConnectionString);
                 Assert.Equal(listKeysAfterRegenerateResponse.SecondaryKey, listKeysResponse.SecondaryKey);
@@ -204,7 +204,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CheckAvailability.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CheckAvailability.cs
@@ -66,7 +66,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/LinkedServiceOperationsTests.Scenario.cs
+++ b/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/LinkedServiceOperationsTests.Scenario.cs
@@ -56,7 +56,7 @@ namespace OperationalInsights.Test.ScenarioTests
 
                 // List the linked services in the workspace
                 var listResponse = client.LinkedServices.ListByWorkspace(resourceGroupName, workspaceName);
-                Assert.Equal(1, listResponse.Count());
+                Assert.Single(listResponse);
                 Assert.Single(listResponse.Where(w => w.ResourceId.Equals(accountResourceId, StringComparison.OrdinalIgnoreCase)));
 
                 var accountResourceId2 = string.Format(accountResourceIdFromat, subId, resourceGroupName, automationAccountName2);

--- a/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/SearchOperationsTests.Scenario.cs
+++ b/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/SearchOperationsTests.Scenario.cs
@@ -75,9 +75,9 @@ namespace OperationalInsights.Test.ScenarioTests
 
                 Assert.NotNull(schemaResult);
                 Assert.NotNull(schemaResult.Metadata);
-                Assert.Equal(schemaResult.Metadata.ResultType, "schema");
+                Assert.Equal("schema", schemaResult.Metadata.ResultType);
                 Assert.NotNull(schemaResult.Value);
-                Assert.NotEqual(schemaResult.Value.Count, 0);
+                Assert.NotEqual(0, schemaResult.Value.Count);
             }
         }
 
@@ -98,7 +98,7 @@ namespace OperationalInsights.Test.ScenarioTests
 
                 Assert.NotNull(savedSearchesResult);
                 Assert.NotNull(savedSearchesResult.Value);
-                Assert.NotEqual(savedSearchesResult.Value.Count, 0);
+                Assert.NotEqual(0, savedSearchesResult.Value.Count);
 
                 String[] idStrings = savedSearchesResult.Value[0].Id.Split('/');
                 string id = idStrings[idStrings.Length - 1];
@@ -109,17 +109,17 @@ namespace OperationalInsights.Test.ScenarioTests
                     id);
                 Assert.NotNull(savedSearchResult);
                 Assert.NotNull(savedSearchResult.Etag);
-                Assert.NotEqual(savedSearchResult.Etag, "");
+                Assert.NotEqual("", savedSearchResult.Etag);
                 Assert.NotNull(savedSearchResult.Id);
-                Assert.NotEqual(savedSearchResult.Id, "");
+                Assert.NotEqual("", savedSearchResult.Id);
                 Assert.NotNull(savedSearchResult.Query);
-                Assert.NotEqual(savedSearchResult.Query, "");
+                Assert.NotEqual("", savedSearchResult.Query);
 
                 var savedSearchResults = client.SavedSearches.GetResults(resourceGroupName, workspaceName, id);
                 Assert.NotNull(savedSearchResults);
                 Assert.NotNull(savedSearchResults.Metadata);
                 Assert.NotNull(savedSearchResults.Value);
-                Assert.NotEqual(savedSearchResults.Value.Count, 0);
+                Assert.NotEqual(0, savedSearchResults.Value.Count);
             }
         }
 
@@ -163,7 +163,7 @@ namespace OperationalInsights.Test.ScenarioTests
                 var savedSearchesResult = client.SavedSearches.ListByWorkspace(resourceGroupName, workspaceName);
                 Assert.NotNull(savedSearchesResult);
                 Assert.NotNull(savedSearchesResult.Value);
-                Assert.NotEqual(savedSearchesResult.Value.Count, 0);
+                Assert.NotEqual(0, savedSearchesResult.Value.Count);
                 Assert.NotNull(savedSearchesResult.Value[0].Id);
                 Assert.NotNull(savedSearchesResult.Value[0].Query);
                 bool foundSavedSearch = false;
@@ -202,9 +202,9 @@ namespace OperationalInsights.Test.ScenarioTests
                 savedSearchesResult = client.SavedSearches.ListByWorkspace(resourceGroupName, workspaceName);
                 Assert.NotNull(savedSearchesResult);
                 Assert.NotNull(savedSearchesResult.Value);
-                Assert.NotEqual(savedSearchesResult.Value.Count, 0);
+                Assert.NotEqual(0, savedSearchesResult.Value.Count);
                 Assert.NotNull(savedSearchesResult.Value[0].Id);
-                Assert.Equal(savedSearchesResult.Value[0].Query, "*");
+                Assert.Equal("*", savedSearchesResult.Value[0].Query);
                 foundSavedSearch = false;
                 for (int i = 0; i < savedSearchesResult.Value.Count; i++)
                 {

--- a/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/WorkspaceOperationsTests.Scenario.cs
+++ b/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/WorkspaceOperationsTests.Scenario.cs
@@ -104,11 +104,11 @@ namespace OperationalInsights.Test.ScenarioTests
 
                 // List the management groups connected to the workspace
                 var managementGroupsResponse = client.Workspaces.ListManagementGroups(resourceGroupName, workspaceName);
-                Assert.Equal(0, managementGroupsResponse.Count());
+                Assert.Empty(managementGroupsResponse);
 
                 // List the usage for a workspace
                 var usagesResponse = client.Workspaces.ListUsages(resourceGroupName, workspaceName);
-                Assert.Equal(1, usagesResponse.Count());
+                Assert.Single(usagesResponse);
 
                 var metric = usagesResponse.Single();
                 Assert.Equal("DataAnalyzed", metric.Name.Value);

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/IaasVmE2ETests.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/IaasVmE2ETests.cs
@@ -54,13 +54,13 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
                 // 2. List protected items
                 var items = testHelper.ListProtectedItems();
                 Assert.NotNull(items);
-                Assert.True(items.Any(item => itemName.ToLower().Contains(item.Name.ToLower())));
+                Assert.Contains(items, item => itemName.ToLower().Contains(item.Name.ToLower()));
 
                 // 3. Trigger backup
                 var backupJobId = testHelper.Backup(containerName, itemName);
 
                 IPage<JobResource> backupJobs = testHelper.ListBackupJobs();
-                Assert.True(backupJobs.Any(backupJob => backupJob.Name == backupJobId));
+                Assert.Contains(backupJobs, backupJob => backupJob.Name == backupJobId);
 
                 testHelper.WaitForJobCompletion(backupJobId);
 
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
                 var restoreJobId = testHelper.Restore(containerName, itemName, recoveryPoint.Name, sourceResourceId, storageAccountId);
 
                 backupJobs = testHelper.ListBackupJobs();
-                Assert.True(backupJobs.Any(backupJob => backupJob.Name == restoreJobId));
+                Assert.Contains(backupJobs, backupJob => backupJob.Name == restoreJobId);
 
                 testHelper.WaitForJobCompletion(restoreJobId);
 

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/IaasVmPolicyTests.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/IaasVmPolicyTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
             {
                 testHelper.Initialize(context);
                 List<ProtectionPolicyResource> policies = testHelper.ListAllPoliciesWithRetries();
-                Assert.True(policies.Any(policy => policy.Name.ToLower().Equals("defaultpolicy")));
+                Assert.Contains(policies, policy => policy.Name.ToLower().Equals("defaultpolicy"));
 
                 ProtectionPolicyResource defaultPolicy = testHelper.GetPolicyWithRetries("defaultpolicy");
 

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestHelper.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestHelper.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
         {
             var result = BackupClient.JobDetails.GetWithHttpMessagesAsync(VaultName, ResourceGroup, jobId).Result;
             Assert.NotNull(result);
-            Assert.Equal(result.Response.StatusCode, System.Net.HttpStatusCode.OK);
+            Assert.Equal(System.Net.HttpStatusCode.OK, result.Response.StatusCode);
             return ((AzureIaaSVMJob)result.Body.Properties).Status;
         }
 

--- a/src/SDKs/RecoveryServices/RecoveryServices.Tests/RecoveryServicesTestBase.cs
+++ b/src/SDKs/RecoveryServices/RecoveryServices.Tests/RecoveryServicesTestBase.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Tests
             {
                 resourcesClient.ResourceGroups.Get(resourceGroup);
             }
-            catch (CloudException ex)
+            catch (CloudException)
             {
                 // Doesn't exist
                 resourceGroupExists = false;

--- a/src/SDKs/RecoveryServices/RecoveryServices.Tests/ScenarioTests/VaultScenarioTests.cs
+++ b/src/SDKs/RecoveryServices/RecoveryServices.Tests/ScenarioTests/VaultScenarioTests.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Azure.Management.RecoveryServices.Tests
                     var vaults = _testFixture.ListVaults();
                     Assert.NotNull(vaults);
                     Assert.NotEmpty(vaults);
-                    Assert.True(vaults.Any(v => v.Name == vaultName));
-                    Assert.True(vaults.Any(v => v.Name == vaultName2));
+                    Assert.Contains(vaults, v => v.Name == vaultName);
+                    Assert.Contains(vaults, v => v.Name == vaultName2);
 
                     _testFixture.DeleteVault(vaultName2);
                     Assert.Throws<CloudException>(() =>

--- a/src/SDKs/RecoveryServices/RecoveryServices.Tests/ScenarioTests/VaultUsageScenarioTests.cs
+++ b/src/SDKs/RecoveryServices/RecoveryServices.Tests/ScenarioTests/VaultUsageScenarioTests.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Azure.Management.RecoveryServices.Tests
                     var vaults = _testFixture.ListVaults();
                     Assert.NotNull(vaults);
                     Assert.NotEmpty(vaults);
-                    Assert.True(vaults.Any(v => v.Name == vaultName));
+                    Assert.Contains(vaults, v => v.Name == vaultName);
 
                     var response = _testFixture.ListVaultUsages(vaultName);
 
                     Assert.NotNull(response);
-                    Assert.NotEqual(response.Count(), 0);
+                    Assert.NotEmpty(response);
                     foreach (var usage in response)
                     {
                         Assert.NotNull(usage.Name.Value);
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Tests
                     var replicationResponse = _testFixture.ListReplicationUsages(vaultName);
 
                     Assert.NotNull(replicationResponse);
-                    Assert.Equal(replicationResponse.Count(), 0);
+                    Assert.Empty(replicationResponse);
                 }
             }
         }

--- a/src/SDKs/RedisCache/RedisCache.Tests/InMemoryTests/ListTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/InMemoryTests/ListTests.cs
@@ -155,7 +155,7 @@ namespace AzureRedisCache.Tests.InMemoryTests
 
             foreach (IPage<RedisResource> responseList in list)
             {
-                Assert.Equal(0, responseList.Count());
+                Assert.Empty(responseList);
                 Assert.Null(responseList.NextPageLink);
             }
         }

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/BeginCreateFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/BeginCreateFunctionalTests.cs
@@ -39,7 +39,7 @@ namespace AzureRedisCache.Tests
 
                 Assert.Contains(redisCacheName, response.Id);
                 Assert.Equal(redisCacheName, response.Name);
-                Assert.True("creating".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("creating", response.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Premium, response.Sku.Name);
                 Assert.Equal(SkuFamily.P, response.Sku.Family);
 

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/CreateUpdateDeleteFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/CreateUpdateDeleteFunctionalTests.cs
@@ -50,7 +50,7 @@ namespace AzureRedisCache.Tests
                 Assert.Equal(fixture.RedisCacheName, responseCreate.Name);
                 Assert.Equal("Microsoft.Cache/Redis", responseCreate.Type);
 
-                Assert.True("succeeded".Equals(responseCreate.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("succeeded", responseCreate.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Basic, responseCreate.Sku.Name);
                 Assert.Equal(SkuFamily.C, responseCreate.Sku.Family);
                 Assert.Equal(0, responseCreate.Sku.Capacity);

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/GetListKeysFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/GetListKeysFunctionalTests.cs
@@ -41,7 +41,7 @@ namespace AzureRedisCache.Tests
                 Assert.Contains(fixture.RedisCacheName, response.Id);
                 Assert.Equal(fixture.RedisCacheName, response.Name);
 
-                Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Basic, response.Sku.Name);
                 Assert.Equal(SkuFamily.C, response.Sku.Family);
                 Assert.Equal(0, response.Sku.Capacity);
@@ -71,7 +71,7 @@ namespace AzureRedisCache.Tests
                         Assert.Contains(fixture.RedisCacheName, response.Id);
                         Assert.Equal(fixture.RedisCacheName, response.Name);
 
-                        Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                        Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                         Assert.Equal(SkuName.Basic, response.Sku.Name);
                         Assert.Equal(SkuFamily.C, response.Sku.Family);
                         Assert.Equal(0, response.Sku.Capacity);
@@ -104,7 +104,7 @@ namespace AzureRedisCache.Tests
                         Assert.Contains(fixture.RedisCacheName, response.Id);
                         Assert.Equal(fixture.RedisCacheName, response.Name);
 
-                        Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                        Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                         Assert.Equal(SkuName.Basic, response.Sku.Name);
                         Assert.Equal(SkuFamily.C, response.Sku.Family);
                         Assert.Equal(0, response.Sku.Capacity);

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/PatchSchedulesFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/PatchSchedulesFunctionalTests.cs
@@ -44,7 +44,7 @@ namespace AzureRedisCache.Tests
                 RedisResource response = _client.Redis.Get(resourceGroupName, redisCacheName);
                 Assert.Contains(redisCacheName, response.Id);
                 Assert.Equal(redisCacheName, response.Name);
-                Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Premium, response.Sku.Name);
                 Assert.Equal(SkuFamily.P, response.Sku.Family);
 

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/RebootFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/RebootFunctionalTests.cs
@@ -41,7 +41,7 @@ namespace AzureRedisCache.Tests
                 RedisResource response = _client.Redis.Get(resourceGroupName, redisCacheName);
                 Assert.Contains(redisCacheName, response.Id);
                 Assert.Equal(redisCacheName, response.Name);
-                Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Premium, response.Sku.Name);
                 Assert.Equal(SkuFamily.P, response.Sku.Family);
 

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.CheckNameAvailability.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.CheckNameAvailability.cs
@@ -66,8 +66,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 
@@ -87,7 +87,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUD.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUD.cs
@@ -60,8 +60,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -78,14 +78,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create HybridConnections Relay  - 
                 var hybridConnectionsName = TestUtilities.GenerateName(RelayManagementHelper.HybridPrefix);
@@ -126,7 +126,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -136,7 +136,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUDAuthorizationRules.cs
@@ -58,8 +58,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -76,14 +76,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create Relay HybridConnections  - 
                 var hybridConnectionsName = TestUtilities.GenerateName(RelayManagementHelper.HybridPrefix);
@@ -116,7 +116,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }                
 
                 // Get created HybridConnections AuthorizationRules
@@ -125,14 +125,14 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all HybridConnections AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.HybridConnections.ListAuthorizationRules(resourceGroup, namespaceName, hybridConnectionsName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() >= 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update HybridConnections authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -147,7 +147,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the HybridConnections namespace AuthorizationRule
@@ -157,7 +157,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the HybridConnections for a Authorization rule created
@@ -195,7 +195,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -205,7 +205,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUDAuthorizationRules_length.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUDAuthorizationRules_length.cs
@@ -58,8 +58,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -76,14 +76,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create Relay HybridConnections  - 
                 var hybridConnectionsName =RelayManagementHelper.HybridPrefix + "thisisthenamewithmorethan53charschecktoverifytheremovlaof50charsnamelengthlimit";
@@ -116,7 +116,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }                
 
                 // Get created HybridConnections AuthorizationRules
@@ -125,14 +125,14 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all HybridConnections AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.HybridConnections.ListAuthorizationRules(resourceGroup, namespaceName, hybridConnectionsName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() >= 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update HybridConnections authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -147,7 +147,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the HybridConnections namespace AuthorizationRule
@@ -157,7 +157,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the HybridConnections for a Authorization rule created
@@ -195,7 +195,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -205,7 +205,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
@@ -62,8 +62,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -80,14 +80,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Update namespace tags
                 var updateNamespaceParameter = new RelayUpdateParameters()
@@ -110,11 +110,11 @@ namespace Relay.Tests.ScenarioTests
                 Assert.NotNull(getNamespaceResponse);
                 Assert.Equal(location, getNamespaceResponse.Location, StringComparer.CurrentCultureIgnoreCase);
                 Assert.Equal(namespaceName, getNamespaceResponse.Name);
-                Assert.Equal(getNamespaceResponse.Tags.Count, 4);
+                Assert.Equal(4, getNamespaceResponse.Tags.Count);
                 foreach (var tag in updateNamespaceParameter.Tags)
                 {
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
                 
                 try
@@ -124,7 +124,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
@@ -83,16 +83,16 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get default namespace AuthorizationRules
                 var getNamespaceAuthorizationRulesResponse = RelayManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, RelayManagementHelper.DefaultNamespaceAuthorizationRule);
                 Assert.NotNull(getNamespaceAuthorizationRulesResponse);
                 Assert.Equal(getNamespaceAuthorizationRulesResponse.Name, RelayManagementHelper.DefaultNamespaceAuthorizationRule);
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Listen));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Send));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Manage));
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Listen);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Send);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Manage);
 
                 // Get created namespace AuthorizationRules
                 getNamespaceAuthorizationRulesResponse = RelayManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, authorizationRuleName);
@@ -100,15 +100,15 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all namespaces AuthorizationRules 
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.Namespaces.ListAuthorizationRules(resourceGroup, namespaceName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() > 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(auth => auth.Name == RelayManagementHelper.DefaultNamespaceAuthorizationRule));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, auth => auth.Name == RelayManagementHelper.DefaultNamespaceAuthorizationRule);
 
                 // Update namespace authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -122,7 +122,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the updated namespace AuthorizationRule
@@ -132,7 +132,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the namespace for a Authorization rule created
@@ -170,7 +170,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUD.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUD.cs
@@ -55,8 +55,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -74,14 +74,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                                 
                 // Create WCF Relay  - 
                 var wcfRelayName = TestUtilities.GenerateName(RelayManagementHelper.WcfPrefix);
@@ -96,7 +96,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
 
                 var getWCFRelaysResponse = RelayManagementClient.WCFRelays.Get(resourceGroup, namespaceName, wcfRelayName);
 
@@ -104,7 +104,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
 
                 //Update User Metadata for WCFRelays
                 string strUserMetadata = "usermetadata is a placeholder to store user-defined string data for the HybridConnection endpoint.e.g. it can be used to store  descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.";
@@ -114,7 +114,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
                 Assert.Equal(createdWCFRelayResponse.UserMetadata, strUserMetadata);
 
                 //Get List of all Hybridconnections in given NameSpace. 
@@ -130,7 +130,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -140,7 +140,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUDAuthorizationRules.cs
@@ -58,8 +58,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -76,14 +76,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create WCF Relay  - 
                 var wcfRelayName = TestUtilities.GenerateName(RelayManagementHelper.WcfPrefix);
@@ -98,7 +98,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
 
                 var getWCFRelaysResponse = RelayManagementClient.WCFRelays.Get(resourceGroup, namespaceName, wcfRelayName);
                 
@@ -120,7 +120,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created WCFRelay AuthorizationRules
@@ -129,14 +129,14 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all WCFRelay AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.WCFRelays.ListAuthorizationRules(resourceGroup, namespaceName,wcfRelayName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() >= 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update WCFRelay authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -151,7 +151,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the WCFRelay namespace AuthorizationRule
@@ -161,7 +161,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the WCFRelay for a Authorization rule created
@@ -197,7 +197,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -207,7 +207,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUDAuthorizationRules_legth.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUDAuthorizationRules_legth.cs
@@ -58,8 +58,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -76,14 +76,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create WCF Relay  - 
                 var wcfRelayName = RelayManagementHelper.WcfPrefix + "thisisthenamewithmorethan53charschecktoverifytheremovlaof50charsnamelengthlimit";
@@ -98,7 +98,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
 
                 var getWCFRelaysResponse = RelayManagementClient.WCFRelays.Get(resourceGroup, namespaceName, wcfRelayName);
                 
@@ -120,7 +120,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created WCFRelay AuthorizationRules
@@ -129,14 +129,14 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all WCFRelay AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.WCFRelays.ListAuthorizationRules(resourceGroup, namespaceName,wcfRelayName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() >= 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update WCFRelay authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -151,7 +151,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the WCFRelay namespace AuthorizationRule
@@ -161,7 +161,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the WCFRelay for a Authorization rule created
@@ -197,7 +197,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -207,7 +207,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/DeploymentTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/DeploymentTests.InMemory.cs
@@ -118,7 +118,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("1.0.0.0", json["properties"]["templateLink"]["contentVersion"].Value<string>());
             Assert.Equal("1.0.0.0", json["properties"]["parametersLink"]["contentVersion"].Value<string>());
             Assert.Equal("value1", json["properties"]["parameters"]["param1"].Value<string>());
-            Assert.Equal(true, json["properties"]["parameters"]["param2"].Value<bool>());
+            Assert.True(json["properties"]["parameters"]["param2"].Value<bool>());
             Assert.Equal(123, json["properties"]["parameters"]["param3"]["param3_1"].Value<int>());
             Assert.Equal("value3_2", json["properties"]["parameters"]["param3"]["param3_2"].Value<string>());
             Assert.Equal(123, json["properties"]["template"]["api-version"].Value<int>());
@@ -131,8 +131,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.Properties.Mode);
             Assert.Equal("http://wa/template.json", result.Properties.TemplateLink.Uri);
             Assert.Equal("1.0.0.0", result.Properties.TemplateLink.ContentVersion);
-            Assert.True(result.Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.Properties.Outputs.ToString());
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace ResourceGroups.Tests
                 Assert.Equal("test-release-3", result.Name);
                 Assert.Equal("Succeeded", result.Properties.ProvisioningState);
                 Assert.Equal(DeploymentMode.Incremental, result.Properties.Mode);
-                Assert.True(result.Properties.Parameters.ToString().Contains("\"value\": \"tianotest04\""));
+                Assert.Contains("\"value\": \"tianotest04\"", result.Properties.Parameters.ToString());
             }
         }
 
@@ -271,7 +271,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate response 
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("AEF2398", result.First().OperationId);
             Assert.Equal("/subscriptions/123abc/resourcegroups/foo/providers/ResourceProviderTestHost/TestResourceType/resource1", result.First().Properties.TargetResource.Id);
             Assert.Equal("mySite1", result.First().Properties.TargetResource.ResourceName);
@@ -304,7 +304,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate response 
-            Assert.Equal(0, result.Count());
+            Assert.Empty(result);
         }
 
         [Fact]
@@ -459,8 +459,8 @@ namespace ResourceGroups.Tests
             Assert.Equal("https://wa.com/subscriptions/mysubid/resourcegroups/TestRG/deployments/test-release-3/operations?$skiptoken=983fknw", handler.Uri.ToString());
 
             // Validate response 
-            Assert.Equal(0, result.Count());
-            Assert.Equal(null, result.NextPageLink);
+            Assert.Empty(result);
+            Assert.Null(result.NextPageLink);
         }
 
         [Fact]
@@ -572,7 +572,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("http://abc/def/template.json", json["properties"]["templateLink"]["uri"].Value<string>());
             Assert.Equal("1.0.0.0", json["properties"]["templateLink"]["contentVersion"].Value<string>());
             Assert.Equal("value1", json["properties"]["parameters"]["param1"].Value<string>());
-            Assert.Equal(true, json["properties"]["parameters"]["param2"].Value<bool>());
+            Assert.True(json["properties"]["parameters"]["param2"].Value<bool>());
             Assert.Equal(123, json["properties"]["parameters"]["param3"]["param3_1"].Value<int>());
             Assert.Equal("value3_2", json["properties"]["parameters"]["param3"]["param3_2"].Value<string>());
         }
@@ -799,8 +799,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.Properties.Mode);
             Assert.Equal("http://wa/template.json", result.Properties.TemplateLink.Uri.ToString());
             Assert.Equal("1.0.0.0", result.Properties.TemplateLink.ContentVersion);
-            Assert.True(result.Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.Properties.Outputs.ToString());
         }
 
         [Fact(Skip = "Parameter validation using pattern match is not supported yet at code-gen, the work is on-going.")]
@@ -916,8 +916,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.First().Properties.Mode);
             Assert.Equal("http://wa/template.json", result.First().Properties.TemplateLink.Uri.ToString());
             Assert.Equal("1.0.0.0", result.First().Properties.TemplateLink.ContentVersion);
-            Assert.True(result.First().Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.First().Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Outputs.ToString());
             Assert.Equal("https://wa/subscriptions/subId/templateDeployments?$skiptoken=983fknw", result.NextPageLink);
         }
 
@@ -1015,8 +1015,8 @@ namespace ResourceGroups.Tests
             // Validate headers
             Assert.Equal(HttpMethod.Get, handler.Method);
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
-            Assert.True(handler.Uri.ToString().Contains("$top=10"));
-            Assert.True(handler.Uri.ToString().Contains("$filter=provisioningState eq 'Succeeded'"));
+            Assert.Contains("$top=10", handler.Uri.ToString());
+            Assert.Contains("$filter=provisioningState eq 'Succeeded'", handler.Uri.ToString());
 
             // Validate result
             Assert.Equal("myrealease-3.14", result.First().Name);
@@ -1025,8 +1025,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.First().Properties.Mode);
             Assert.Equal("http://wa/template.json", result.First().Properties.TemplateLink.Uri.ToString());
             Assert.Equal("1.0.0.0", result.First().Properties.TemplateLink.ContentVersion);
-            Assert.True(result.First().Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.First().Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Outputs.ToString());
             Assert.Equal("https://wa/subscriptions/subId/templateDeployments?$skiptoken=983fknw", result.NextPageLink);
         }
 
@@ -1125,9 +1125,9 @@ namespace ResourceGroups.Tests
             // Validate headers
             Assert.Equal(HttpMethod.Get, handler.Method);
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
-            Assert.True(handler.Uri.ToString().Contains("$top=10"));
-            Assert.True(handler.Uri.ToString().Contains("$filter=provisioningState eq 'Succeeded'"));
-            Assert.True(handler.Uri.ToString().Contains("resourcegroups/foo/providers/Microsoft.Resources/deployments"));
+            Assert.Contains("$top=10", handler.Uri.ToString());
+            Assert.Contains("$filter=provisioningState eq 'Succeeded'", handler.Uri.ToString());
+            Assert.Contains("resourcegroups/foo/providers/Microsoft.Resources/deployments", handler.Uri.ToString());
 
             // Validate result
             Assert.Equal("myrealease-3.14", result.First().Name);
@@ -1136,8 +1136,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.First().Properties.Mode);
             Assert.Equal("http://wa/template.json", result.First().Properties.TemplateLink.Uri.ToString());
             Assert.Equal("1.0.0.0", result.First().Properties.TemplateLink.ContentVersion);
-            Assert.True(result.First().Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.First().Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Outputs.ToString());
             Assert.Equal("https://wa/subscriptions/subId/templateDeployments?$skiptoken=983fknw", result.NextPageLink);
         }
 

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/ProviderTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/ProviderTests.InMemory.cs
@@ -139,7 +139,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate result
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("Microsoft.Websites", result.First().NamespaceProperty);
             Assert.Equal("Registered", result.First().RegistrationState);
             Assert.Equal(2, result.First().ResourceTypes.Count);

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceGroupTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceGroupTests.InMemory.cs
@@ -305,7 +305,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate result
-            Assert.Equal(0, result.Count());
+            Assert.Empty(result);
         }
         
         [Fact]
@@ -337,7 +337,7 @@ namespace ResourceGroups.Tests
             // Validate headers
             Assert.Equal(HttpMethod.Get, handler.Method);
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
-            Assert.True(handler.Uri.ToString().Contains("$top=5"));
+            Assert.Contains("$top=5", handler.Uri.ToString());
 
             // Validate result
             Assert.Equal(2, result.Count());

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceLinkTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceLinkTests.InMemory.cs
@@ -188,7 +188,7 @@ namespace ResourceGroups.Tests
             var filteredResult = client.ResourceLinks.ListAtSubscription(new ODataQuery<ResourceLinkFilter>(f => f.TargetId == "/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm2"));
 
             // Validate result
-            Assert.Equal(1, filteredResult.Count());
+            Assert.Single(filteredResult);
             Assert.Equal("myLink", filteredResult.First().Name);
             Assert.Equal("/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm/providers/Microsoft.Resources/links/myLink", filteredResult.First().Id);
             Assert.Equal("/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm", filteredResult.First().Properties.SourceId);
@@ -226,7 +226,7 @@ namespace ResourceGroups.Tests
             Assert.Equal(HttpMethod.Get, handler.Method);
 
             // Validate result
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("myLink", result.First().Name);
             Assert.Equal("/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm/providers/Microsoft.Resources/links/myLink", result.First().Id);
             Assert.Equal("/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm", result.First().Properties.SourceId);

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceTests.InMemory.cs
@@ -66,7 +66,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("South Central US", result.Location);
             Assert.Equal("site1", result.Name);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.Id);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
             Assert.Equal("Succeeded", (result.Properties as JObject)["provisioningState"]);
             Assert.Equal("F1", result.Sku.Name);
             Assert.Equal("Free", result.Sku.Tier);
@@ -113,7 +113,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("South Central US", result.Location);
             Assert.Equal("site1", result.Name);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.Id);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
             Assert.Equal("Succeeded", (result.Properties as JObject)["provisioningState"]);
             Assert.Equal("F1", result.Sku.Name);
             Assert.Equal("Free", result.Sku.Tier);
@@ -165,7 +165,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("South Central US", result.Location);
             Assert.Equal("site1", result.Name);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.Id);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
             Assert.Null((result.Properties as JObject)["provisionState"]);
         }
 
@@ -222,7 +222,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("site1", result.First().Name);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.First().Id);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.First().Id);
-            Assert.True(result.First().Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.First().Properties.ToString());
             Assert.Equal("Succeeded", (result.First().Properties as JObject)["provisioningState"]);
         }
 
@@ -333,7 +333,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("Succeeded", (result.Properties as JObject)["provisioningState"]);
             Assert.Equal("finance", result.Tags["department"]);
             Assert.Equal("tagvalue", result.Tags["tagname"]);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
         }
 
         [Fact]
@@ -399,7 +399,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("Succeeded", (result.Properties as JObject)["provisioningState"]);
             Assert.Equal("finance", result.Tags["department"]);
             Assert.Equal("tagvalue", result.Tags["tagname"]);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
             Assert.Equal("SystemAssigned", result.Identity.Type.ToString());
             Assert.Equal("foo", result.Identity.PrincipalId);
         }
@@ -549,7 +549,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate result
-            Assert.Equal(true, result);
+            Assert.True(result);
         }
 
         [Fact]
@@ -581,7 +581,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate result
-            Assert.Equal(false, result);
+            Assert.False(result);
         }
 
         [Fact]

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/DeploymentTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/DeploymentTests.ScenarioTests.cs
@@ -364,8 +364,8 @@ namespace ResourceGroups.Tests
                 Assert.NotNull(deploymentListResult.First().Properties.ProvisioningState);
                 Assert.NotNull(deploymentGetResult.Properties.CorrelationId);
                 Assert.NotNull(deploymentListResult.First().Properties.CorrelationId);
-                Assert.True(deploymentGetResult.Properties.Parameters.ToString().Contains("mctest0101"));
-                Assert.True(deploymentListResult.First().Properties.Parameters.ToString().Contains("mctest0101"));
+                Assert.Contains("mctest0101", deploymentGetResult.Properties.Parameters.ToString());
+                Assert.Contains("mctest0101", deploymentListResult.First().Properties.Parameters.ToString());
             }
         }
 

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/ResourceGroupTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/ResourceGroupTests.ScenarioTests.cs
@@ -57,7 +57,7 @@ namespace ResourceGroups.Tests
 
                 Assert.Throws<CloudException>(() => client.Resources.ListByResourceGroup(resourceGroupName));
 
-                Assert.False(listGroupsResult.Any(rg => rg.Name == resourceGroupName));
+                Assert.DoesNotContain(listGroupsResult, rg => rg.Name == resourceGroupName);
             }
         }
 
@@ -83,7 +83,7 @@ namespace ResourceGroups.Tests
                    string.Format("Expected location '{0}' did not match actual location '{1}'", DefaultLocation, listedGroup.Location));
                 var gottenGroup = client.ResourceGroups.Get(groupName);
                 Assert.NotNull(gottenGroup);
-                Assert.Equal<string>(groupName, gottenGroup.Name);
+                Assert.Equal(groupName, gottenGroup.Name);
                 Assert.True(ResourcesManagementTestUtilities.LocationsAreEqual(DefaultLocation, gottenGroup.Location),
                     string.Format("Expected location '{0}' did not match actual location '{1}'", DefaultLocation, gottenGroup.Location));
             }
@@ -128,7 +128,7 @@ namespace ResourceGroups.Tests
                 var listResult = client.ResourceGroups.List(null);
 
                 Assert.Equal(HttpStatusCode.OK, deleteResult.Response.StatusCode);
-                Assert.False(listResult.Any(rg => rg.Name == resourceGroupName && rg.Properties.ProvisioningState != "Deleting"));
+                Assert.DoesNotContain(listResult, rg => rg.Name == resourceGroupName && rg.Properties.ProvisioningState != "Deleting");
             }
         }
     }

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/ResourceTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/ResourceTests.ScenarioTests.cs
@@ -129,7 +129,7 @@ namespace ResourceGroups.Tests
 
                 var listResult = client.Resources.ListByResourceGroup(groupName);
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.Equal(resourceName, listResult.First().Name);
                 Assert.Equal("Microsoft.Web/sites", listResult.First().Type);
                 Assert.True(ResourcesManagementTestUtilities.LocationsAreEqual(websiteLocation, listResult.First().Location),
@@ -137,7 +137,7 @@ namespace ResourceGroups.Tests
 
                 listResult = client.Resources.ListByResourceGroup(groupName, new ODataQuery<GenericResourceFilter> { Top = 10 });
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.Equal(resourceName, listResult.First().Name);
                 Assert.Equal("Microsoft.Web/sites", listResult.First().Type);
                 Assert.True(ResourcesManagementTestUtilities.LocationsAreEqual(websiteLocation, listResult.First().Location),
@@ -190,7 +190,7 @@ namespace ResourceGroups.Tests
 
                 var listResult = client.Resources.ListByResourceGroup(groupName, new ODataQuery<GenericResourceFilter>(r => r.Tagname == tagName));
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.Equal(resourceName, listResult.First().Name);
 
                 var getResult = client.Resources.Get(
@@ -255,7 +255,7 @@ namespace ResourceGroups.Tests
                 var listResult = client.Resources.ListByResourceGroup(groupName,
                     new ODataQuery<GenericResourceFilter>(r => r.Tagname == tagName && r.Tagvalue == tagValue));
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.Equal(resourceName, listResult.First().Name);
 
                 var getResult = client.Resources.Get(

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/SubscriptionTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/SubscriptionTests.ScenarioTests.cs
@@ -40,7 +40,7 @@ namespace ResourceGroups.Tests
                 var subscriptions = client.Subscriptions.List();
 
                 Assert.NotNull(subscriptions);
-                Assert.NotEqual(0, subscriptions.Count());
+                Assert.NotEmpty(subscriptions);
                 Assert.NotNull(subscriptions.First().Id);
                 Assert.NotNull(subscriptions.First().SubscriptionId);
                 Assert.NotNull(subscriptions.First().DisplayName);

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/TenantTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/TenantTests.ScenarioTests.cs
@@ -38,7 +38,7 @@ namespace ResourceGroups.Tests
                 Assert.NotNull(tenants);
                 Assert.Equal(HttpStatusCode.OK, tenants.Response.StatusCode);
                 Assert.NotNull(tenants.Body);
-                Assert.NotEqual(0, tenants.Body.Count());
+                Assert.NotEmpty(tenants.Body);
                 Assert.NotNull(tenants.Body.First().Id);
                 Assert.NotNull(tenants.Body.First().TenantId);
             }

--- a/src/SDKs/Scheduler/Scheduler.Test/ScenarioTests/JobTests.Scenario.cs
+++ b/src/SDKs/Scheduler/Scheduler.Test/ScenarioTests/JobTests.Scenario.cs
@@ -1594,12 +1594,12 @@ namespace Scheduler.Test.ScenarioTests
 
                 var disabledJob = client.Jobs.List(resourceGroupName, jobCollectionName, new ODataQuery<JobStateFilter>(filter => filter.State == JobState.Disabled) { Top = 5 });
 
-                Assert.Equal(1, disabledJob.Count());
+                Assert.Single(disabledJob);
                 Assert.True(disabledJob.All(job => job.Properties.State == JobState.Disabled));
 
                 var enabledJob = client.Jobs.List(resourceGroupName, jobCollectionName, new ODataQuery<JobStateFilter>(filter => filter.State == JobState.Enabled) { Top = 5 });
 
-                Assert.Equal(1, enabledJob.Count());
+                Assert.Single(enabledJob);
                 Assert.True(enabledJob.All(job => job.Properties.State == JobState.Enabled));
 
                 var listResult = client.Jobs.List(resourceGroupName, jobCollectionName);
@@ -1655,8 +1655,8 @@ namespace Scheduler.Test.ScenarioTests
                 var listResult = client.Jobs.ListJobHistory(resourceGroupName, existingJobCollectionName, existingJobName);
 
                 Assert.True(listResult.Count() >= 0);
-                Assert.True(listResult.ElementAt(0).Id.Contains(id));
-                Assert.True(listResult.ElementAt(0).Name.Contains(jobDefinitionName));
+                Assert.Contains(id, listResult.ElementAt(0).Id);
+                Assert.Contains(jobDefinitionName, listResult.ElementAt(0).Name);
                 Assert.Equal(historyType, listResult.ElementAt(0).Type);
                 Assert.Equal(JobHistoryActionName.MainAction, listResult.ElementAt(0).Properties.ActionName);
                 Assert.NotNull(listResult.ElementAt(0).Properties.EndTime);

--- a/src/SDKs/ServerManagement/ServerManagement.Tests/OperationsTest.cs
+++ b/src/SDKs/ServerManagement/ServerManagement.Tests/OperationsTest.cs
@@ -360,7 +360,7 @@ namespace ServerManagement.Tests
 
                     // make sure this resource group just has the one node 
                     nodes = await client.Node.ListForResourceGroupAsync(ResourceGroup);
-                    Assert.Equal(1, nodes.Count());
+                    Assert.Single(nodes);
 
                     WriteLine("Creating Session");
                     // Create a session for this node.

--- a/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.DisasterRecoveryAlternateNameTests.CRUD.cs
+++ b/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.DisasterRecoveryAlternateNameTests.CRUD.cs
@@ -93,7 +93,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created namespace AuthorizationRules
@@ -102,7 +102,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 var getNamespaceAuthorizationRulesListKeysResponse = ServiceBusManagementClient.Namespaces.ListKeys(resourceGroup, namespaceName, authorizationRuleName);
@@ -130,12 +130,12 @@ namespace ServiceBus.Tests.ScenarioTests
                 //// Get the created DisasterRecovery config - Primary
                 var disasterRecoveryGetResponse = ServiceBusManagementClient.DisasterRecoveryConfigs.Get(resourceGroup, namespaceName, namespaceName);
                 Assert.NotNull(disasterRecoveryGetResponse);
-                Assert.Equal(disasterRecoveryGetResponse.Role, RoleDisasterRecovery.Primary);
+                Assert.Equal(RoleDisasterRecovery.Primary, disasterRecoveryGetResponse.Role);
 
                 //// Get the created DisasterRecovery config - Secondary
                 var disasterRecoveryGetResponse_Sec = ServiceBusManagementClient.DisasterRecoveryConfigs.Get(resourceGroup, namespaceName2, namespaceName);
                 Assert.NotNull(disasterRecoveryGetResponse_Sec);
-                Assert.Equal(disasterRecoveryGetResponse_Sec.Role, RoleDisasterRecovery.Secondary);
+                Assert.Equal(RoleDisasterRecovery.Secondary, disasterRecoveryGetResponse_Sec.Role);
 
                 //Get authorization rule thorugh Alias 
 

--- a/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.DisasterRecoveryTests.CRUD.cs
+++ b/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.DisasterRecoveryTests.CRUD.cs
@@ -95,7 +95,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
                 
                 // Get created namespace AuthorizationRules
@@ -104,7 +104,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 var getNamespaceAuthorizationRulesListKeysResponse = ServiceBusManagementClient.Namespaces.ListKeys(resourceGroup, namespaceName, authorizationRuleName);
@@ -134,12 +134,12 @@ namespace ServiceBus.Tests.ScenarioTests
                 //// Get the created DisasterRecovery config - Primary
                 var disasterRecoveryGetResponse = ServiceBusManagementClient.DisasterRecoveryConfigs.Get(resourceGroup, namespaceName, disasterRecoveryName);
                 Assert.NotNull(disasterRecoveryGetResponse);
-                Assert.Equal(disasterRecoveryGetResponse.Role, RoleDisasterRecovery.Primary);
+                Assert.Equal(RoleDisasterRecovery.Primary, disasterRecoveryGetResponse.Role);
 
                 //// Get the created DisasterRecovery config - Secondary
                 var disasterRecoveryGetResponse_Sec = ServiceBusManagementClient.DisasterRecoveryConfigs.Get(resourceGroup, namespaceName2, disasterRecoveryName);
                 Assert.NotNull(disasterRecoveryGetResponse_Sec);
-                Assert.Equal(disasterRecoveryGetResponse_Sec.Role, RoleDisasterRecovery.Secondary);
+                Assert.Equal(RoleDisasterRecovery.Secondary, disasterRecoveryGetResponse_Sec.Role);
 
                 //Get authorization rule thorugh Alias 
 

--- a/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
+++ b/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
@@ -70,14 +70,14 @@ namespace ServiceBus.Tests.ScenarioTests
                 var getAllNamespacesResponse = ServiceBusManagementClient.Namespaces.ListByResourceGroupAsync(resourceGroup).Result;
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = ServiceBusManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 //Update namespace tags
                 var updateNamespaceParameter = new SBNamespaceUpdateParameters()
@@ -99,11 +99,11 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.NotNull(getNamespaceResponse);
                 Assert.Equal(location, getNamespaceResponse.Location, StringComparer.CurrentCultureIgnoreCase);
                 Assert.Equal(namespaceName, getNamespaceResponse.Name);
-                Assert.Equal(getNamespaceResponse.Tags.Count, 2);
+                Assert.Equal(2, getNamespaceResponse.Tags.Count);
                 foreach (var tag in updateNamespaceParameter.Tags)
                 {
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 // Delete namespace

--- a/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
@@ -77,16 +77,16 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get default namespace AuthorizationRules
                 var getNamespaceAuthorizationRulesResponse = ServiceBusManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, ServiceBusManagementHelper.DefaultNamespaceAuthorizationRule);
                 Assert.NotNull(getNamespaceAuthorizationRulesResponse);
                 Assert.Equal(getNamespaceAuthorizationRulesResponse.Name, ServiceBusManagementHelper.DefaultNamespaceAuthorizationRule);
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Listen));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Send));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Manage));
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Listen);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Send);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Manage);
 
                 // Get created namespace AuthorizationRules
                 getNamespaceAuthorizationRulesResponse = ServiceBusManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, authorizationRuleName);
@@ -94,15 +94,15 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all namespaces AuthorizationRules 
                 var getAllNamespaceAuthorizationRulesResponse = ServiceBusManagementClient.Namespaces.ListAuthorizationRules(resourceGroup, namespaceName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() > 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(auth => auth.Name == ServiceBusManagementHelper.DefaultNamespaceAuthorizationRule));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, auth => auth.Name == ServiceBusManagementHelper.DefaultNamespaceAuthorizationRule);
 
                 // Update namespace authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", ServiceBusManagementHelper.GenerateRandomKey());
@@ -117,7 +117,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the updated namespace AuthorizationRule
@@ -127,7 +127,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the namespace for a Authorization rule created

--- a/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.QueuesTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.QueuesTests.CRUDAuthorizationRules.cs
@@ -93,7 +93,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(createQueueAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createQueueAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createQueueAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created queues AuthorizationRules
@@ -102,14 +102,14 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(getQueueAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getQueueAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getQueueAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all queues AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = ServiceBusManagementClient.Queues.ListAuthorizationRules(resourceGroup, namespaceName, queueName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
-                Assert.Equal(getAllNamespaceAuthorizationRulesResponse.Count(), 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));                
+                Assert.Single(getAllNamespaceAuthorizationRulesResponse);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);                
 
                 // Update queues authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", ServiceBusManagementHelper.GenerateRandomKey());
@@ -124,7 +124,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(updateQueueAuthorizationRuleResponse.Rights.Count == updateQueuesAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateQueuesAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateQueueAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateQueueAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the updated queues AuthorizationRule
@@ -135,7 +135,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(getQueueAuthorizationRuleResponse.Rights.Count == updateQueuesAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateQueuesAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getQueueAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getQueueAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the queues for a Authorization rule created

--- a/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.TopicsTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/ServiceBus/ServiceBus.Tests/Tests/ScenarioTests.TopicsTests.CRUDAuthorizationRules.cs
@@ -91,7 +91,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(createTopicAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createTopicAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createTopicAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created Topics AuthorizationRules
@@ -100,14 +100,14 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(getTopicsAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getTopicsAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getTopicsAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all Topics AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = ServiceBusManagementClient.Topics.ListAuthorizationRules(resourceGroup, namespaceName, topicName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
-                Assert.Equal(getAllNamespaceAuthorizationRulesResponse.Count(), 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));                
+                Assert.Single(getAllNamespaceAuthorizationRulesResponse);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);                
 
                 // Update topics authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", ServiceBusManagementHelper.GenerateRandomKey());
@@ -122,7 +122,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(updateTopicAuthorizationRuleResponse.Rights.Count == updateTopicsAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateTopicsAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateTopicAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateTopicAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the updated Topics AuthorizationRule
@@ -133,7 +133,7 @@ namespace ServiceBus.Tests.ScenarioTests
                 Assert.True(getTopicAuthorizationRuleResponse.Rights.Count == updateTopicsAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateTopicsAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getTopicAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getTopicAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the Topics for a Authorization rule created

--- a/src/SDKs/SqlManagement/Sql.Tests/BlobAuditingTest.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/BlobAuditingTest.cs
@@ -159,7 +159,7 @@ namespace Sql.Tests
             else
             {
                 Assert.Equal(expected.AuditActionsAndGroups.Count, actual.AuditActionsAndGroups.Count);
-                actual.AuditActionsAndGroups.ForEach(s => Assert.True(expected.AuditActionsAndGroups.Any(es => es.Equals(s))));
+                actual.AuditActionsAndGroups.ForEach(s => Assert.Contains(expected.AuditActionsAndGroups, es => es.Equals(s)));
             }
             Assert.Equal(expected.StorageAccountSubscriptionId, actual.StorageAccountSubscriptionId);
             Assert.Equal(expected.IsStorageSecondaryKeyInUse, actual.IsStorageSecondaryKeyInUse);

--- a/src/SDKs/SqlManagement/Sql.Tests/CheckNameAvailabilityTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/CheckNameAvailabilityTests.cs
@@ -28,8 +28,8 @@ namespace Sql.Tests
 
                 Assert.True(response.Available);
                 Assert.Equal(serverName, response.Name);
-                Assert.Equal(null, response.Message);
-                Assert.Equal(null, response.Reason);
+                Assert.Null(response.Message);
+                Assert.Null(response.Reason);
             }
         }
 

--- a/src/SDKs/SqlManagement/Sql.Tests/DataMaskingScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/DataMaskingScenarioTests.cs
@@ -126,7 +126,7 @@ namespace Sql.Tests
 
                 // List data masking rules
                 rules = sqlClient.DataMaskingRules.ListByDatabase(resourceGroup.Name, server.Name, dbName);
-                Assert.Equal(1, rules.Count());
+                Assert.Single(rules);
                 
                 // Verify Policy now enabled
                 policy = sqlClient.DataMaskingPolicies.Get(resourceGroup.Name, server.Name, dbName);
@@ -144,7 +144,7 @@ namespace Sql.Tests
 
                 // Verify no rules are returned
                 rules = sqlClient.DataMaskingRules.ListByDatabase(resourceGroup.Name, server.Name, dbName);
-                Assert.Equal(0, rules.Count());
+                Assert.Empty(rules);
             };
         }
     }

--- a/src/SDKs/SqlManagement/Sql.Tests/DatabaseCrudScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/DatabaseCrudScenarioTests.cs
@@ -261,9 +261,9 @@ namespace Sql.Tests
                 //
                 AzureOperationResponse<IPage<DatabaseOperation>> response = sqlClient.DatabaseOperations.ListByDatabaseWithHttpMessagesAsync(
                     resourceGroup.Name, server.Name, dbName).Result;
-                Assert.Equal(response.Response.StatusCode, HttpStatusCode.OK);
+                Assert.Equal(HttpStatusCode.OK, response.Response.StatusCode);
                 IList<DatabaseOperation> responseObject = response.Body.ToList();
-                Assert.Equal(responseObject.Count(), 1);
+                Assert.Single(responseObject);
 
                 // Cancel the database updateslo operation
                 //
@@ -367,7 +367,7 @@ namespace Sql.Tests
                 };
                 var dbResult = sqlClient.Databases.CreateOrUpdate(resourceGroup.Name, server.Name, dbName, dbInput);
 
-                Assert.Equal(null, dbResult.ElasticPoolName);
+                Assert.Null(dbResult.ElasticPoolName);
             }
         }
 

--- a/src/SDKs/SqlManagement/Sql.Tests/DatabaseGeoBackupPolicyScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/DatabaseGeoBackupPolicyScenarioTests.cs
@@ -33,7 +33,7 @@ namespace Sql.Tests
 
                 // List Geo Backup Policy
                 IEnumerable<GeoBackupPolicy> policies = sqlClient.GeoBackupPolicies.ListByDatabase(resourceGroup.Name, server.Name, dbName);
-                Assert.Equal(1, policies.Count());
+                Assert.Single(policies);
 
                 GeoBackupPolicy policy = policies.First();
                 Assert.Equal("Default", policy.Name);
@@ -54,7 +54,7 @@ namespace Sql.Tests
 
                 // List Geo Backup Policy
                 policies = sqlClient.GeoBackupPolicies.ListByDatabase(resourceGroup.Name, server.Name, dbName);
-                Assert.Equal(1, policies.Count());
+                Assert.Single(policies);
 
                 policy = policies.First();
                 Assert.Equal("Default", policy.Name);

--- a/src/SDKs/SqlManagement/Sql.Tests/DatabaseRestoreScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/DatabaseRestoreScenarioTests.cs
@@ -217,7 +217,7 @@ namespace Sql.Tests
                 Assert.True(backups.Count() == 0);
                 backups = sqlClient.LongTermRetentionBackups.ListByDatabase(server.Location, server.Name, database.Name);
                 Assert.True(backups.Count() == 0);
-                Assert.Throws(typeof(CloudException), () => sqlClient.LongTermRetentionBackups.Get(server.Location, server.Name, database.Name, "backup"));
+                Assert.Throws<CloudException>(() => sqlClient.LongTermRetentionBackups.Get(server.Location, server.Name, database.Name, "backup"));
             }
         }
 

--- a/src/SDKs/SqlManagement/Sql.Tests/ElasticPoolActivityScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ElasticPoolActivityScenarioTests.cs
@@ -63,8 +63,8 @@ namespace Sql.Tests
                 var activity = sqlClient.ElasticPoolDatabaseActivities.ListByElasticPool(resourceGroup.Name, server.Name, epName);
 
                 Assert.Equal(2, activity.Where(a => a.DatabaseName == dbName).Count());
-                Assert.Equal(1, activity.Where(a => a.DatabaseName == dbName && a.Operation == "CREATE").Count());
-                Assert.Equal(1, activity.Where(a => a.DatabaseName == dbName && a.Operation == "UPDATE").Count());
+                Assert.Single(activity.Where(a => a.DatabaseName == dbName && a.Operation == "CREATE"));
+                Assert.Single(activity.Where(a => a.DatabaseName == dbName && a.Operation == "UPDATE"));
             }
         }
 
@@ -99,8 +99,8 @@ namespace Sql.Tests
                 // Get the Elastic Pool Activity List
                 var activity = sqlClient.ElasticPoolActivities.ListByElasticPool(resourceGroup.Name, server.Name, epName);
 
-                Assert.Equal(1, activity.Where(a => a.ElasticPoolName == epName).Count());
-                Assert.Equal(1, activity.Where(a => a.Operation == "CREATE").Count());
+                Assert.Single(activity.Where(a => a.ElasticPoolName == epName));
+                Assert.Single(activity.Where(a => a.Operation == "CREATE"));
             }
         }
 
@@ -155,8 +155,8 @@ namespace Sql.Tests
 
                 // Get the Elastic Pool Database Activity List for first pool
                 var activity = sqlClient.ElasticPoolDatabaseActivities.ListByElasticPool(resourceGroup.Name, server.Name, epName);
-                Assert.Equal(1, activity.Where(a => a.DatabaseName == dbName).Count());
-                Assert.Equal(1, activity.Where(a => a.DatabaseName == dbName && a.Operation == "CREATE").Count());
+                Assert.Single(activity.Where(a => a.DatabaseName == dbName));
+                Assert.Single(activity.Where(a => a.DatabaseName == dbName && a.Operation == "CREATE"));
 
                 // Move database to second elastic pool
                 dbInput = new Database()
@@ -169,8 +169,8 @@ namespace Sql.Tests
                 // Get the Elastic Pool Database Activity List for second pool
                 activity = sqlClient.ElasticPoolDatabaseActivities.ListByElasticPool(resourceGroup.Name, server.Name, epName2);
                 Assert.Equal(2, activity.Where(a => a.DatabaseName == dbName).Count());
-                Assert.Equal(1, activity.Where(a => a.DatabaseName == dbName && a.Operation == "CREATE").Count());
-                Assert.Equal(1, activity.Where(a => a.DatabaseName == dbName && a.Operation == "UPDATE").Count());
+                Assert.Single(activity.Where(a => a.DatabaseName == dbName && a.Operation == "CREATE"));
+                Assert.Single(activity.Where(a => a.DatabaseName == dbName && a.Operation == "UPDATE"));
             }
         }
     }

--- a/src/SDKs/SqlManagement/Sql.Tests/ElasticPoolCrudScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ElasticPoolCrudScenarioTests.cs
@@ -110,7 +110,7 @@ namespace Sql.Tests
              * In this test we only test the cancel operation on resize pool from Premium to Premium
              *    since currently we only support Cancel pool resize operation on Premium <-> Premium
              * */
-            string testPrefix = "sqlelasticpoollistcanceloperation-";
+            // string testPrefix = "sqlelasticpoollistcanceloperation-";
             using (SqlManagementTestContext context = new SqlManagementTestContext(this))
             {
                 ResourceGroup resourceGroup = context.CreateResourceGroup("West Europe");
@@ -200,8 +200,8 @@ namespace Sql.Tests
             SqlManagementTestUtilities.ValidateElasticPool(epInput, returnedEp, epName);
             var epa = sqlClient.ElasticPoolActivities.ListByElasticPool(resourceGroup.Name, server.Name, epName);
             Assert.NotNull(epa);
-            Assert.Equal(1, epa.Count());
-            Assert.Equal(1, epa.Where(a => a.Operation == "CREATE").Count());
+            Assert.Single(epa);
+            Assert.Single(epa.Where(a => a.Operation == "CREATE"));
 
             // Update elasticPool Dtu
             // 
@@ -214,8 +214,8 @@ namespace Sql.Tests
             epa = sqlClient.ElasticPoolActivities.ListByElasticPool(resourceGroup.Name, server.Name, epName);
             Assert.NotNull(epa);
             Assert.Equal(2, epa.Count());
-            Assert.Equal(1, epa.Where(a => a.Operation == "CREATE").Count());
-            Assert.Equal(1, epa.Where(a => a.Operation == "UPDATE").Count());
+            Assert.Single(epa.Where(a => a.Operation == "CREATE"));
+            Assert.Single(epa.Where(a => a.Operation == "UPDATE"));
 
             // Update elasticPool Dtu Max
             // 
@@ -227,7 +227,7 @@ namespace Sql.Tests
             epa = sqlClient.ElasticPoolActivities.ListByElasticPool(resourceGroup.Name, server.Name, epName);
             Assert.NotNull(epa);
             Assert.Equal(3, epa.Count());
-            Assert.Equal(1, epa.Where(a => a.Operation == "CREATE").Count());
+            Assert.Single(epa.Where(a => a.Operation == "CREATE"));
             Assert.Equal(2, epa.Where(a => a.Operation == "UPDATE").Count());
 
             // Update elasticPool Dtu Min
@@ -240,7 +240,7 @@ namespace Sql.Tests
             epa = sqlClient.ElasticPoolActivities.ListByElasticPool(resourceGroup.Name, server.Name, epName);
             Assert.NotNull(epa);
             Assert.Equal(4, epa.Count());
-            Assert.Equal(1, epa.Where(a => a.Operation == "CREATE").Count());
+            Assert.Single(epa.Where(a => a.Operation == "CREATE"));
             Assert.Equal(3, epa.Where(a => a.Operation == "UPDATE").Count());
         }
 

--- a/src/SDKs/SqlManagement/Sql.Tests/FailoverGroupCrudScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/FailoverGroupCrudScenarioTests.cs
@@ -119,7 +119,7 @@ namespace Sql.Tests
                 //
                 var failoverGroupsOnSecondary = sqlClient.FailoverGroups.ListByServer(resourceGroup.Name, targetServer.Name);
                 Assert.NotNull(failoverGroupsOnSecondary);
-                Assert.Equal(1, failoverGroupsOnSecondary.Count());
+                Assert.Single(failoverGroupsOnSecondary);
 
                 var primaryDatabase = sqlClient.Databases.Get(resourceGroup.Name, sourceServer.Name, databaseName);
 

--- a/src/SDKs/SqlManagement/Sql.Tests/ImportExportScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ImportExportScenarioTests.cs
@@ -33,7 +33,7 @@ namespace Sql.Tests
             TestImportExport(false, "TestImportNewDatabase");
         }
 
-        public void TestImportExport(bool preexistingDatabase, string testName)
+        internal void TestImportExport(bool preexistingDatabase, string testName)
         {
             using (SqlManagementTestContext context = new SqlManagementTestContext(this, testName))
             {

--- a/src/SDKs/SqlManagement/Sql.Tests/ManagedInstanceCrudScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ManagedInstanceCrudScenarioTests.cs
@@ -84,7 +84,7 @@ namespace Sql.Tests
                 sqlClient.ManagedInstances.Delete(resourceGroup.Name, managedInstanceName);
 
                 var listMI2 = sqlClient.ManagedInstances.ListByResourceGroup(resourceGroup.Name);
-                Assert.Equal(1, listMI2.Count());
+                Assert.Single(listMI2);
 
                 sqlClient.ManagedInstances.Delete(resourceGroup.Name, managedInstanceName2);
                 var listMI3 = sqlClient.ManagedInstances.ListByResourceGroup(resourceGroup.Name);

--- a/src/SDKs/SqlManagement/Sql.Tests/ServerCommunicationLinkScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ServerCommunicationLinkScenarioTests.cs
@@ -46,7 +46,7 @@ namespace Sql.Tests
                 // List Communication Link
                 IEnumerable<ServerCommunicationLink> links = sqlClient.ServerCommunicationLinks.ListByServer(resourceGroup.Name, server1.Name);
 
-                Assert.Equal(1, links.Count());
+                Assert.Single(links);
                 link = links.First();
                 Assert.Equal(linkName, link.Name);
                 Assert.Equal(server2.Name, link.PartnerServer);
@@ -80,7 +80,7 @@ namespace Sql.Tests
                 // List Communication Link, assert there is one
                 IEnumerable<ServerCommunicationLink> links = sqlClient.ServerCommunicationLinks.ListByServer(resourceGroup.Name, server1.Name);
 
-                Assert.Equal(1, links.Count());
+                Assert.Single(links);
                 link = links.First();
                 Assert.Equal(linkName, link.Name);
                 Assert.Equal(server2.Name, link.PartnerServer);
@@ -90,7 +90,7 @@ namespace Sql.Tests
                 links = sqlClient.ServerCommunicationLinks.ListByServer(resourceGroup.Name, server1.Name);
 
                 // Assert that no links found
-                Assert.Equal(0, links.Count());
+                Assert.Empty(links);
             }
         }
     }

--- a/src/SDKs/SqlManagement/Sql.Tests/ServerCrudScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ServerCrudScenarioTests.cs
@@ -75,7 +75,7 @@ namespace Sql.Tests
                 sqlClient.Servers.Delete(resourceGroup.Name, serverNameV12);
 
                 var listServers2 = sqlClient.Servers.ListByResourceGroup(resourceGroup.Name);
-                Assert.Equal(1, listServers2.Count());
+                Assert.Single(listServers2);
             }
         }
     }

--- a/src/SDKs/SqlManagement/Sql.Tests/ServerDnsAliasCrudScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ServerDnsAliasCrudScenarioTests.cs
@@ -38,7 +38,7 @@ namespace Sql.Tests
                 //
                 var serverDnsAliases = sqlClient.ServerDnsAliases.ListByServer(resourceGroup.Name, sourceServer.Name);
                 Assert.NotNull(serverDnsAliases);
-                Assert.Equal(1, serverDnsAliases.Count());
+                Assert.Single(serverDnsAliases);
                 Assert.Equal(serverDnsAliasName, serverDnsAliases.Select(a => a.Name).First());
 
                 // Update server to which alias is pointing

--- a/src/SDKs/SqlManagement/Sql.Tests/ServerKeyScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/ServerKeyScenarioTests.cs
@@ -58,7 +58,7 @@ namespace Sql.Tests
 
                 // Validate key is gone by listing keys
                 var keyList2 = sqlClient.ServerKeys.ListByServer(resourceGroup.Name, server.Name);
-                Assert.Equal(1, keyList2.Count());
+                Assert.Single(keyList2);
             }
         }
     }

--- a/src/SDKs/SqlManagement/Sql.Tests/Sql.Tests.csproj
+++ b/src/SDKs/SqlManagement/Sql.Tests/Sql.Tests.csproj
@@ -5,12 +5,6 @@
     <AssemblyName>Sql.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <NoWarn>1591;1701;1573;CS1591;xUnit2002</NoWarn>
-  </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.0.6" />
     <PackageReference Include="Microsoft.Azure.Management.KeyVault" Version="2.2.0-preview" />

--- a/src/SDKs/SqlManagement/Sql.Tests/Sql.Tests.csproj
+++ b/src/SDKs/SqlManagement/Sql.Tests/Sql.Tests.csproj
@@ -5,6 +5,9 @@
     <AssemblyName>Sql.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <NoWarn>1591;1701;1573;CS1591;xUnit2002</NoWarn>
+  </PropertyGroup>
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>-->

--- a/src/SDKs/SqlManagement/Sql.Tests/SyncAgentScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/SyncAgentScenarioTests.cs
@@ -48,7 +48,7 @@ namespace Sql.Tests
 
                 // List sync agent
                 IPage<SyncAgent> listAgents = sqlClient.SyncAgents.ListByServer(resourceGroup.Name, server.Name);
-                Assert.Equal(1, listAgents.Count());
+                Assert.Single(listAgents);
                 Assert.Equal(agentName, listAgents.Single().Name);
 
                 // Generate key
@@ -64,7 +64,7 @@ namespace Sql.Tests
                 // Get linked databases
                 IPage<SyncAgentLinkedDatabase> linkedDatabases = sqlClient.SyncAgents.ListLinkedDatabases(resourceGroup.Name, server.Name, agentName);
                 Assert.NotNull(linkedDatabases);
-                Assert.Equal(0, linkedDatabases.Count());
+                Assert.Empty(linkedDatabases);
 
                 // Delete the sync agent
                 sqlClient.SyncAgents.Delete(resourceGroup.Name, server.Name, agentName);

--- a/src/SDKs/SqlManagement/Sql.Tests/SyncGroupScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/SyncGroupScenarioTests.cs
@@ -67,7 +67,7 @@ namespace Sql.Tests
                 // List sync group
                 IPage<SyncGroup> listSyncGroups = sqlClient.SyncGroups.ListByDatabase(resourceGroup.Name, server.Name, testDatabaseName);
                 Assert.NotNull(listSyncGroups);
-                Assert.Equal(1, listSyncGroups.Count());
+                Assert.Single(listSyncGroups);
                 Assert.Equal(syncGroupName, listSyncGroups.Single().Name);
 
                 // Update sync group

--- a/src/SDKs/SqlManagement/Sql.Tests/SyncMemberScenarioTests.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/SyncMemberScenarioTests.cs
@@ -92,7 +92,7 @@ namespace Sql.Tests
                 // List sync members
                 IPage<SyncMember> listSyncMembers = sqlClient.SyncMembers.ListBySyncGroup(resourceGroup.Name, server.Name, testDatabaseName, syncGroupName);
                 Assert.NotNull(listSyncMembers);
-                Assert.Equal(1, listSyncMembers.Count());
+                Assert.Single(listSyncMembers);
                 Assert.Equal(syncMemberName, listSyncMembers.Single().Name);
 
                 // Update sync member

--- a/src/SDKs/SqlManagement/Sql.Tests/Utilities/SqlManagementTestUtilities.cs
+++ b/src/SDKs/SqlManagement/Sql.Tests/Utilities/SqlManagementTestUtilities.cs
@@ -66,12 +66,12 @@ namespace Sql.Tests
 
             foreach (var elem in expected)
             {
-                Assert.True(actual.Contains(elem));
+                Assert.Contains(elem, actual);
             }
 
             foreach (var elem in actual)
             {
-                Assert.True(expected.Contains(elem));
+                Assert.Contains(elem, expected);
             }
         }
 

--- a/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/StorSimple8000Series.Tests.csproj
+++ b/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/StorSimple8000Series.Tests.csproj
@@ -9,6 +9,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <NoWarn>1591;1701;1573;CS1591;xUnit1013</NoWarn>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.Compute" Version="15.0.0" />		
     <PackageReference Include="Microsoft.Azure.Management.Network" Version="10.1.0-preview" />

--- a/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/StorSimple8000Series.Tests.csproj
+++ b/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/StorSimple8000Series.Tests.csproj
@@ -9,9 +9,6 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp1.1</TargetFramework>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <NoWarn>1591;1701;1573;CS1591;xUnit1013</NoWarn>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.Compute" Version="15.0.0" />		
     <PackageReference Include="Microsoft.Azure.Management.Network" Version="10.1.0-preview" />

--- a/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/Tests/BackupRestoreAndCloneTests.cs
+++ b/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/Tests/BackupRestoreAndCloneTests.cs
@@ -76,7 +76,7 @@ namespace StorSimple8000Series.Tests
                                     this.ManagerName);
 
             Assert.NotNull(backupPolicy);
-            Assert.Equal(backupPolicy.SchedulesCount, 0);
+            Assert.Equal(0, backupPolicy.SchedulesCount);
 
             List<string> scheduleNames = new List<string>()
             {
@@ -144,7 +144,7 @@ namespace StorSimple8000Series.Tests
                                 this.ManagerName,
                                 new ODataQuery<BackupFilter>(filter));
 
-            Assert.Equal(1, backups.Count());
+            Assert.Single(backups);
 
             return backups.First() as Backup;
         }

--- a/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/Tests/CloudApplianceTests.cs
+++ b/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/Tests/CloudApplianceTests.cs
@@ -58,12 +58,12 @@ namespace StorSimple8000Series.Tests
                 var device = this.TrackScaJobByDeviceStatus(deviceName);
                 // Validate device status to be Ready to Setup
                 Assert.NotNull(device);
-                Assert.Equal(device.Status, DeviceStatus.ReadyToSetup);
+                Assert.Equal(DeviceStatus.ReadyToSetup, device.Status);
 
                 // Get job and validate if status is succeeded
                 var job = this.Client.Jobs.Get(deviceName, jobName, this.ResourceGroupName, this.ManagerName);
-                Assert.Equal(job.JobType, JobType.CreateCloudAppliance);
-                Assert.Equal(job.Status, JobStatus.Succeeded);
+                Assert.Equal(JobType.CreateCloudAppliance, job.JobType);
+                Assert.Equal(JobStatus.Succeeded, job.Status);
             }
             catch (Exception ex)
             {

--- a/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/Tests/ServiceConfigurationTests.cs
+++ b/src/SDKs/StorSimple8000Series/StorSimple8000Series.Tests/Tests/ServiceConfigurationTests.cs
@@ -139,7 +139,7 @@ namespace StorSimple8000Series.Tests
         /// <summary>
         /// Deletes and validates deletion of the specified storage account credential.
         /// </summary>
-        public void DeleteStorageAccountCredentialAndValidate(string storageAccountCredentialName)
+        internal void DeleteStorageAccountCredentialAndValidate(string storageAccountCredentialName)
         {
             var sacToDelete = this.Client.StorageAccountCredentials.Get(
                 storageAccountCredentialName.GetDoubleEncoded(),
@@ -163,7 +163,7 @@ namespace StorSimple8000Series.Tests
         /// <summary>
         /// Deletes and validates deletion of the specified access control record.
         /// </summary>
-        public void DeleteAccessControlRecordAndValidate(string acrName)
+        internal void DeleteAccessControlRecordAndValidate(string acrName)
         {
             var acrToDelete = this.Client.AccessControlRecords.Get(
                 acrName.GetDoubleEncoded(),
@@ -187,7 +187,7 @@ namespace StorSimple8000Series.Tests
         /// <summary>
         /// Deletes and validates deletion of the specified bandwidth setting.
         /// </summary>
-        public void DeleteBandwidthSettingAndValidate(string bwsName)
+        internal void DeleteBandwidthSettingAndValidate(string bwsName)
         {
             var bwsToDelete = this.Client.BandwidthSettings.Get(
                 bwsName.GetDoubleEncoded(),

--- a/src/SDKs/Storage/Storage.Tests/Helpers/StorageManagementTestUtilities.cs
+++ b/src/SDKs/Storage/Storage.Tests/Helpers/StorageManagementTestUtilities.cs
@@ -326,8 +326,8 @@ namespace Storage.Tests.Helpers
 
                 Assert.NotNull(account.Tags);
                 Assert.Equal(2, account.Tags.Count);
-                Assert.Equal(account.Tags["key1"], "value1");
-                Assert.Equal(account.Tags["key2"], "value2");
+                Assert.Equal("value1", account.Tags["key1"]);
+                Assert.Equal("value2", account.Tags["key2"]);
             }
         }
 

--- a/src/SDKs/Storage/Storage.Tests/Storage.Tests.csproj
+++ b/src/SDKs/Storage/Storage.Tests/Storage.Tests.csproj
@@ -6,13 +6,6 @@
     <AssemblyName>Storage.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <NoWarn>1591;1701;1573;CS1591;xUnit2002</NoWarn>
-  </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.3.0-preview" />

--- a/src/SDKs/Storage/Storage.Tests/Storage.Tests.csproj
+++ b/src/SDKs/Storage/Storage.Tests/Storage.Tests.csproj
@@ -6,6 +6,9 @@
     <AssemblyName>Storage.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <NoWarn>1591;1701;1573;CS1591;xUnit2002</NoWarn>
+  </PropertyGroup>
 
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>

--- a/src/SDKs/Storage/Storage.Tests/Tests/StorageAccountTests.cs
+++ b/src/SDKs/Storage/Storage.Tests/Tests/StorageAccountTests.cs
@@ -90,18 +90,18 @@ namespace Storage.Tests
                 // Verify encryption settings
                 Assert.NotNull(account.Encryption);
                 Assert.NotNull(account.Encryption.Services.Blob);
-                Assert.Equal(true, account.Encryption.Services.Blob.Enabled);
+                Assert.True(account.Encryption.Services.Blob.Enabled);
                 Assert.NotNull(account.Encryption.Services.Blob.LastEnabledTime);
 
                 Assert.NotNull(account.Encryption.Services.File);
-                Assert.Equal(true, account.Encryption.Services.File.Enabled);
+                Assert.True(account.Encryption.Services.File.Enabled);
                 Assert.NotNull(account.Encryption.Services.File.LastEnabledTime);
 
                 if (null != account.Encryption.Services.Table)
                 {
                     if (account.Encryption.Services.Table.Enabled.HasValue)
                     {
-                        Assert.Equal(false, account.Encryption.Services.Table.LastEnabledTime.HasValue);
+                        Assert.False(account.Encryption.Services.Table.LastEnabledTime.HasValue);
                     }
                 }
 
@@ -109,7 +109,7 @@ namespace Storage.Tests
                 {
                     if (account.Encryption.Services.Queue.Enabled.HasValue)
                     {
-                        Assert.Equal(false, account.Encryption.Services.Queue.LastEnabledTime.HasValue);
+                        Assert.False(account.Encryption.Services.Queue.LastEnabledTime.HasValue);
                     }
                 }
             }
@@ -374,24 +374,24 @@ namespace Storage.Tests
 
                 // List account and verify
                 var accounts = storageMgmtClient.StorageAccounts.ListByResourceGroup(rgname);
-                Assert.Equal(1, accounts.Count());
+                Assert.Single(accounts);
 
                 var account = accounts.ToArray()[0];
                 StorageManagementTestUtilities.VerifyAccountProperties(account, true);
                 Assert.NotNull(account.Encryption);
                 Assert.NotNull(account.Encryption.Services.Blob);
-                Assert.Equal(true, account.Encryption.Services.Blob.Enabled);
+                Assert.True(account.Encryption.Services.Blob.Enabled);
                 Assert.NotNull(account.Encryption.Services.Blob.LastEnabledTime);
 
                 Assert.NotNull(account.Encryption.Services.File);
-                Assert.Equal(true, account.Encryption.Services.File.Enabled);
+                Assert.True(account.Encryption.Services.File.Enabled);
                 Assert.NotNull(account.Encryption.Services.File.LastEnabledTime);
 
                 if (null != account.Encryption.Services.Table)
                 {
                     if (account.Encryption.Services.Table.Enabled.HasValue)
                     {
-                        Assert.Equal(false, account.Encryption.Services.Table.LastEnabledTime.HasValue);
+                        Assert.False(account.Encryption.Services.Table.LastEnabledTime.HasValue);
                     }
                 }
 
@@ -399,7 +399,7 @@ namespace Storage.Tests
                 {
                     if (account.Encryption.Services.Queue.Enabled.HasValue)
                     {
-                        Assert.Equal(false, account.Encryption.Services.Queue.LastEnabledTime.HasValue);
+                        Assert.False(account.Encryption.Services.Queue.LastEnabledTime.HasValue);
                     }
                 }
             }
@@ -522,14 +522,14 @@ namespace Storage.Tests
                 // Check valid name
                 string accountName = TestUtilities.GenerateName("sto");
                 var checkNameRequest = storageMgmtClient.StorageAccounts.CheckNameAvailability(accountName);
-                Assert.Equal(true, checkNameRequest.NameAvailable);
+                Assert.True(checkNameRequest.NameAvailable);
                 Assert.Null(checkNameRequest.Reason);
                 Assert.Null(checkNameRequest.Message);
 
                 // Check invalid name
                 accountName = "CAPS";
                 checkNameRequest = storageMgmtClient.StorageAccounts.CheckNameAvailability(accountName);
-                Assert.Equal(false, checkNameRequest.NameAvailable);
+                Assert.False(checkNameRequest.NameAvailable);
                 Assert.Equal(Reason.AccountNameInvalid, checkNameRequest.Reason);
                 Assert.Equal("CAPS is not a valid storage account name. Storage account name must be between 3 and 24 "
                     + "characters in length and use numbers and lower-case letters only.", checkNameRequest.Message);
@@ -567,11 +567,11 @@ namespace Storage.Tests
                     Sku = new Sku { Name = SkuName.StandardLRS }
                 };
                 var account = storageMgmtClient.StorageAccounts.Create(rgname, accountName, parameters);
-                Assert.Equal(account.Sku.Name, SkuName.StandardLRS);
+                Assert.Equal(SkuName.StandardLRS, account.Sku.Name);
 
                 // Validate
                 account = storageMgmtClient.StorageAccounts.GetProperties(rgname, accountName);
-                Assert.Equal(account.Sku.Name, SkuName.StandardLRS);
+                Assert.Equal(SkuName.StandardLRS, account.Sku.Name);
 
                 // Update storage tags
                 parameters = new StorageAccountCreateParameters
@@ -612,18 +612,18 @@ namespace Storage.Tests
                 account = storageMgmtClient.StorageAccounts.GetProperties(rgname, accountName);
                 Assert.NotNull(account.Encryption);
                 Assert.NotNull(account.Encryption.Services.Blob);
-                Assert.Equal(true, account.Encryption.Services.Blob.Enabled);
+                Assert.True(account.Encryption.Services.Blob.Enabled);
                 Assert.NotNull(account.Encryption.Services.Blob.LastEnabledTime);
 
                 Assert.NotNull(account.Encryption.Services.File);
-                Assert.Equal(true, account.Encryption.Services.File.Enabled);
+                Assert.True(account.Encryption.Services.File.Enabled);
                 Assert.NotNull(account.Encryption.Services.File.LastEnabledTime);
 
                 if (null != account.Encryption.Services.Table)
                 {
                     if (account.Encryption.Services.Table.Enabled.HasValue)
                     {
-                        Assert.Equal(false, account.Encryption.Services.Table.LastEnabledTime.HasValue);
+                        Assert.False(account.Encryption.Services.Table.LastEnabledTime.HasValue);
                     }
                 }
 
@@ -631,7 +631,7 @@ namespace Storage.Tests
                 {
                     if (account.Encryption.Services.Queue.Enabled.HasValue)
                     {
-                        Assert.Equal(false, account.Encryption.Services.Queue.LastEnabledTime.HasValue);
+                        Assert.False(account.Encryption.Services.Queue.LastEnabledTime.HasValue);
                     }
                 }
 
@@ -685,11 +685,11 @@ namespace Storage.Tests
                     Sku = new Sku { Name = SkuName.StandardLRS }
                 };
                 var account = storageMgmtClient.StorageAccounts.Update(rgname, accountName, parameters);
-                Assert.Equal(account.Sku.Name, SkuName.StandardLRS);
+                Assert.Equal(SkuName.StandardLRS, account.Sku.Name);
 
                 // Validate
                 account = storageMgmtClient.StorageAccounts.GetProperties(rgname, accountName);
-                Assert.Equal(account.Sku.Name, SkuName.StandardLRS);
+                Assert.Equal(SkuName.StandardLRS, account.Sku.Name);
 
                 // Update storage tags
                 parameters = new StorageAccountUpdateParameters
@@ -724,18 +724,18 @@ namespace Storage.Tests
                 account = storageMgmtClient.StorageAccounts.GetProperties(rgname, accountName);
                 Assert.NotNull(account.Encryption);
                 Assert.NotNull(account.Encryption.Services.Blob);
-                Assert.Equal(true, account.Encryption.Services.Blob.Enabled);
+                Assert.True(account.Encryption.Services.Blob.Enabled);
                 Assert.NotNull(account.Encryption.Services.Blob.LastEnabledTime);
 
                 Assert.NotNull(account.Encryption.Services.File);
-                Assert.Equal(true, account.Encryption.Services.File.Enabled);
+                Assert.True(account.Encryption.Services.File.Enabled);
                 Assert.NotNull(account.Encryption.Services.File.LastEnabledTime);
 
                 if (null != account.Encryption.Services.Table)
                 {
                     if (account.Encryption.Services.Table.Enabled.HasValue)
                     {
-                        Assert.Equal(false, account.Encryption.Services.Table.LastEnabledTime.HasValue);
+                        Assert.False(account.Encryption.Services.Table.LastEnabledTime.HasValue);
                     }
                 }
 
@@ -743,7 +743,7 @@ namespace Storage.Tests
                 {
                     if (account.Encryption.Services.Queue.Enabled.HasValue)
                     {
-                        Assert.Equal(false, account.Encryption.Services.Queue.LastEnabledTime.HasValue);
+                        Assert.False(account.Encryption.Services.Queue.LastEnabledTime.HasValue);
                     }
                 }
 
@@ -800,12 +800,12 @@ namespace Storage.Tests
                     }
                 };
                 var account = storageMgmtClient.StorageAccounts.Update(rgname, accountName, parameters);
-                Assert.Equal(account.Sku.Name, SkuName.StandardLRS);
+                Assert.Equal(SkuName.StandardLRS, account.Sku.Name);
                 Assert.Equal(account.Tags.Count, parameters.Tags.Count);
 
                 // Validate
                 account = storageMgmtClient.StorageAccounts.GetProperties(rgname, accountName);
-                Assert.Equal(account.Sku.Name, SkuName.StandardLRS);
+                Assert.Equal(SkuName.StandardLRS, account.Sku.Name);
                 Assert.Equal(account.Tags.Count, parameters.Tags.Count);
             }
         }
@@ -822,7 +822,7 @@ namespace Storage.Tests
 
                 // Query usage
                 var usages = storageMgmtClient.Usages.List();
-                Assert.Equal(1, usages.Count());
+                Assert.Single(usages);
                 Assert.Equal(UsageUnit.Count, usages.First().Unit);
                 Assert.NotNull(usages.First().CurrentValue);
                 Assert.Equal(250, usages.First().Limit);
@@ -832,7 +832,7 @@ namespace Storage.Tests
             }
         }
 
-        // [Fact]
+        [Fact(Skip ="Skipping test")]
         public void StorageAccountGetOperationsTest()
         {
             var handler = new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK };
@@ -842,7 +842,7 @@ namespace Storage.Tests
                 var resourcesClient = StorageManagementTestUtilities.GetResourceManagementClient(context, handler);
                 var ops = resourcesClient.ResourceProviderOperationDetails.List("Microsoft.Storage", "2015-06-15");
 
-                Assert.Equal(ops.Count(), 7);
+                Assert.Equal(7, ops.Count());
             }
         }
 
@@ -1101,11 +1101,11 @@ namespace Storage.Tests
                     Sku = new Sku { Name = SkuName.StandardLRS }
                 };
                 var account = storageMgmtClient.StorageAccounts.Update(rgname, accountName, parameters);
-                Assert.Equal(account.Sku.Name, SkuName.StandardLRS);
+                Assert.Equal(SkuName.StandardLRS, account.Sku.Name);
 
                 // Validate
                 account = storageMgmtClient.StorageAccounts.GetProperties(rgname, accountName);
-                Assert.Equal(account.Sku.Name, SkuName.StandardLRS);
+                Assert.Equal(SkuName.StandardLRS, account.Sku.Name);
 
                 // Update storage tags
                 parameters = new StorageAccountUpdateParameters
@@ -1141,11 +1141,11 @@ namespace Storage.Tests
 
                 Assert.NotNull(account.Encryption);
                 Assert.NotNull(account.Encryption.Services.Blob);
-                Assert.Equal(true, account.Encryption.Services.Blob.Enabled);
+                Assert.True(account.Encryption.Services.Blob.Enabled);
                 Assert.NotNull(account.Encryption.Services.Blob.LastEnabledTime);
 
                 Assert.NotNull(account.Encryption.Services.File);
-                Assert.Equal(true, account.Encryption.Services.File.Enabled);
+                Assert.True(account.Encryption.Services.File.Enabled);
                 Assert.NotNull(account.Encryption.Services.File.LastEnabledTime);
 
                 // 2. Restore storage encryption
@@ -1165,11 +1165,11 @@ namespace Storage.Tests
 
                 Assert.NotNull(account.Encryption);
                 Assert.NotNull(account.Encryption.Services.Blob);
-                Assert.Equal(true, account.Encryption.Services.Blob.Enabled);
+                Assert.True(account.Encryption.Services.Blob.Enabled);
                 Assert.NotNull(account.Encryption.Services.Blob.LastEnabledTime);
 
                 Assert.NotNull(account.Encryption.Services.File);
-                Assert.Equal(true, account.Encryption.Services.File.Enabled);
+                Assert.True(account.Encryption.Services.File.Enabled);
                 Assert.NotNull(account.Encryption.Services.File.LastEnabledTime);
 
                 // 3. Remove file encryption service field.
@@ -1189,11 +1189,11 @@ namespace Storage.Tests
 
                 Assert.NotNull(account.Encryption);
                 Assert.NotNull(account.Encryption.Services.Blob);
-                Assert.Equal(true, account.Encryption.Services.Blob.Enabled);
+                Assert.True(account.Encryption.Services.Blob.Enabled);
                 Assert.NotNull(account.Encryption.Services.Blob.LastEnabledTime);
 
                 Assert.NotNull(account.Encryption.Services.File);
-                Assert.Equal(true, account.Encryption.Services.File.Enabled);
+                Assert.True(account.Encryption.Services.File.Enabled);
                 Assert.NotNull(account.Encryption.Services.File.LastEnabledTime);
 
             }
@@ -1605,13 +1605,13 @@ namespace Storage.Tests
                     EnableHttpsTrafficOnly = true
                 };
                 var account = storageMgmtClient.StorageAccounts.Update(rgname, accountName, parameters);
-                Assert.Equal(account.Kind, Kind.StorageV2);
+                Assert.Equal(Kind.StorageV2, account.Kind);
                 Assert.True(account.EnableHttpsTrafficOnly);
                 Assert.NotNull(account.PrimaryEndpoints.Web);
 
                 // Validate
                 account = storageMgmtClient.StorageAccounts.GetProperties(rgname, accountName);
-                Assert.Equal(account.Kind, Kind.StorageV2);
+                Assert.Equal(Kind.StorageV2, account.Kind);
                 Assert.True(account.EnableHttpsTrafficOnly);
                 Assert.NotNull(account.PrimaryEndpoints.Web);
             }

--- a/src/SDKs/StreamAnalytics/StreamAnalytics.Tests/ScenarioTests/FunctionTests.ScenarioTests.cs
+++ b/src/SDKs/StreamAnalytics/StreamAnalytics.Tests/ScenarioTests/FunctionTests.ScenarioTests.cs
@@ -143,13 +143,13 @@ namespace StreamAnalytics.Tests
 
                 // List function and verify that the function shows up in the list
                 var listResult = streamAnalyticsManagementClient.Functions.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateFunction(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Properties.Etag);
 
                 // Get job with function expanded and verify that the function shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "functions");
-                Assert.Equal(1, getJobResponse.Functions.Count());
+                Assert.Single(getJobResponse.Functions);
                 ValidationHelper.ValidateFunction(putResponse.Body, getJobResponse.Functions.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Functions.Single().Properties.Etag);
 
@@ -158,11 +158,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the function
                 listResult = streamAnalyticsManagementClient.Functions.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with function expanded and verify that there are no functions after deleting the function
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "functions");
-                Assert.Equal(0, getJobResponse.Functions.Count());
+                Assert.Empty(getJobResponse.Functions);
             }
         }
 
@@ -221,7 +221,7 @@ namespace StreamAnalytics.Tests
                 CloudException cloudException = Assert.Throws<CloudException>(
                     () => streamAnalyticsManagementClient.Functions.RetrieveDefaultDefinition(resourceGroupName, jobName, functionName, retrieveDefaultDefinitionParameters));
                 Assert.Equal(HttpStatusCode.InternalServerError, cloudException.Response.StatusCode);
-                Assert.True(cloudException.Response.Content.Contains(@"Retrieve default definition is not supported for function type: Microsoft.StreamAnalytics/JavascriptUdf"));
+                Assert.Contains(@"Retrieve default definition is not supported for function type: Microsoft.StreamAnalytics/JavascriptUdf", cloudException.Response.Content);
 
                 // PUT function
                 var putResponse = await streamAnalyticsManagementClient.Functions.CreateOrReplaceWithHttpMessagesAsync(function, resourceGroupName, jobName, functionName);
@@ -269,13 +269,13 @@ namespace StreamAnalytics.Tests
 
                 // List function and verify that the function shows up in the list
                 var listResult = streamAnalyticsManagementClient.Functions.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateFunction(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Properties.Etag);
 
                 // Get job with function expanded and verify that the function shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "functions");
-                Assert.Equal(1, getJobResponse.Functions.Count());
+                Assert.Single(getJobResponse.Functions);
                 ValidationHelper.ValidateFunction(putResponse.Body, getJobResponse.Functions.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Functions.Single().Properties.Etag);
 
@@ -284,11 +284,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the function
                 listResult = streamAnalyticsManagementClient.Functions.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with function expanded and verify that there are no functions after deleting the function
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "functions");
-                Assert.Equal(0, getJobResponse.Functions.Count());
+                Assert.Empty(getJobResponse.Functions);
             }
         }
     }

--- a/src/SDKs/StreamAnalytics/StreamAnalytics.Tests/ScenarioTests/InputTests.ScenarioTests.cs
+++ b/src/SDKs/StreamAnalytics/StreamAnalytics.Tests/ScenarioTests/InputTests.ScenarioTests.cs
@@ -111,13 +111,13 @@ namespace StreamAnalytics.Tests
 
                 // List input and verify that the input shows up in the list
                 var listResult = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateInput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Properties.Etag);
 
                 // Get job with input expanded and verify that the input shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "inputs");
-                Assert.Equal(1, getJobResponse.Inputs.Count());
+                Assert.Single(getJobResponse.Inputs);
                 ValidationHelper.ValidateInput(putResponse.Body, getJobResponse.Inputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Inputs.Single().Properties.Etag);
 
@@ -126,11 +126,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the input
                 listResult = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with input expanded and verify that there are no inputs after deleting the input
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "inputs");
-                Assert.Equal(0, getJobResponse.Inputs.Count());
+                Assert.Empty(getJobResponse.Inputs);
             }
         }
 
@@ -221,13 +221,13 @@ namespace StreamAnalytics.Tests
 
                 // List input and verify that the input shows up in the list
                 var listResult = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateInput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Properties.Etag);
 
                 // Get job with input expanded and verify that the input shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "inputs");
-                Assert.Equal(1, getJobResponse.Inputs.Count());
+                Assert.Single(getJobResponse.Inputs);
                 ValidationHelper.ValidateInput(putResponse.Body, getJobResponse.Inputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Inputs.Single().Properties.Etag);
 
@@ -236,11 +236,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the input
                 listResult = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with input expanded and verify that there are no inputs after deleting the input
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "inputs");
-                Assert.Equal(0, getJobResponse.Inputs.Count());
+                Assert.Empty(getJobResponse.Inputs);
             }
         }
 
@@ -332,13 +332,13 @@ namespace StreamAnalytics.Tests
 
                 // List input and verify that the input shows up in the list
                 var listResult = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateInput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Properties.Etag);
 
                 // Get job with input expanded and verify that the input shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "inputs");
-                Assert.Equal(1, getJobResponse.Inputs.Count());
+                Assert.Single(getJobResponse.Inputs);
                 ValidationHelper.ValidateInput(putResponse.Body, getJobResponse.Inputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Inputs.Single().Properties.Etag);
 
@@ -347,11 +347,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the input
                 listResult = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with input expanded and verify that there are no inputs after deleting the input
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "inputs");
-                Assert.Equal(0, getJobResponse.Inputs.Count());
+                Assert.Empty(getJobResponse.Inputs);
             }
         }
 
@@ -451,13 +451,13 @@ namespace StreamAnalytics.Tests
 
                 // List input and verify that the input shows up in the list
                 var listResult = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateInput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Properties.Etag);
 
                 // Get job with input expanded and verify that the input shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "inputs");
-                Assert.Equal(1, getJobResponse.Inputs.Count());
+                Assert.Single(getJobResponse.Inputs);
                 ValidationHelper.ValidateInput(putResponse.Body, getJobResponse.Inputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Inputs.Single().Properties.Etag);
 
@@ -466,11 +466,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the input
                 listResult = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with input expanded and verify that there are no inputs after deleting the input
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "inputs");
-                Assert.Equal(0, getJobResponse.Inputs.Count());
+                Assert.Empty(getJobResponse.Inputs);
             }
         }
     }

--- a/src/SDKs/StreamAnalytics/StreamAnalytics.Tests/ScenarioTests/OutputTests.ScenarioTests.cs
+++ b/src/SDKs/StreamAnalytics/StreamAnalytics.Tests/ScenarioTests/OutputTests.ScenarioTests.cs
@@ -105,13 +105,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -120,11 +120,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
 
@@ -205,13 +205,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -220,11 +220,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
 
@@ -314,13 +314,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -329,11 +329,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
 
@@ -412,13 +412,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -427,11 +427,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
 
@@ -511,13 +511,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -526,11 +526,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
 
@@ -616,13 +616,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -631,11 +631,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
 
@@ -725,13 +725,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -740,11 +740,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
 
@@ -801,7 +801,7 @@ namespace StreamAnalytics.Tests
                 var testResult = streamAnalyticsManagementClient.Outputs.Test(resourceGroupName, jobName, outputName);
                 Assert.Equal("TestFailed", testResult.Status);
                 Assert.NotNull(testResult.Error);
-                Assert.True(testResult.Error.Message.Contains("either expired or is invalid"));
+                Assert.Contains("either expired or is invalid", testResult.Error.Message);
 
                 // PATCH output
                 var outputPatch = new Output()
@@ -826,13 +826,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -841,11 +841,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
 
@@ -908,7 +908,7 @@ namespace StreamAnalytics.Tests
                 var testResult = streamAnalyticsManagementClient.Outputs.Test(resourceGroupName, jobName, outputName);
                 Assert.Equal("TestFailed", testResult.Status);
                 Assert.NotNull(testResult.Error);
-                Assert.True(testResult.Error.Message.Contains("either expired or is invalid"));
+                Assert.Contains("either expired or is invalid", testResult.Error.Message);
 
                 // PATCH output
                 var outputPatch = new Output()
@@ -939,13 +939,13 @@ namespace StreamAnalytics.Tests
 
                 // List output and verify that the output shows up in the list
                 var listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 ValidationHelper.ValidateOutput(putResponse.Body, listResult.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listResult.Single().Etag);
 
                 // Get job with output expanded and verify that the output shows up
                 var getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(1, getJobResponse.Outputs.Count());
+                Assert.Single(getJobResponse.Outputs);
                 ValidationHelper.ValidateOutput(putResponse.Body, getJobResponse.Outputs.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, getJobResponse.Outputs.Single().Etag);
 
@@ -954,11 +954,11 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the output
                 listResult = streamAnalyticsManagementClient.Outputs.ListByStreamingJob(resourceGroupName, jobName);
-                Assert.Equal(0, listResult.Count());
+                Assert.Empty(listResult);
 
                 // Get job with output expanded and verify that there are no outputs after deleting the output
                 getJobResponse = streamAnalyticsManagementClient.StreamingJobs.Get(resourceGroupName, jobName, "outputs");
-                Assert.Equal(0, getJobResponse.Outputs.Count());
+                Assert.Empty(getJobResponse.Outputs);
             }
         }
     }

--- a/src/SDKs/StreamAnalytics/StreamAnalytics.Tests/ScenarioTests/StreamingJobTests.ScenarioTests.cs
+++ b/src/SDKs/StreamAnalytics/StreamAnalytics.Tests/ScenarioTests/StreamingJobTests.ScenarioTests.cs
@@ -100,12 +100,12 @@ namespace StreamAnalytics.Tests
 
                 // List job and verify that the job shows up in the list
                 var listByRgResponse = streamAnalyticsManagementClient.StreamingJobs.ListByResourceGroup(resourceGroupName, "inputs,outputs,transformation,functions");
-                Assert.Equal(1, listByRgResponse.Count());
+                Assert.Single(listByRgResponse);
                 ValidationHelper.ValidateStreamingJob(putResponse.Body, listByRgResponse.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listByRgResponse.Single().Etag);
 
                 var listReponse = streamAnalyticsManagementClient.StreamingJobs.List("inputs, outputs, transformation, functions");
-                Assert.Equal(1, listReponse.Count());
+                Assert.Single(listReponse);
                 ValidationHelper.ValidateStreamingJob(putResponse.Body, listReponse.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listReponse.Single().Etag);
 
@@ -114,10 +114,10 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the job
                 listByRgResponse = streamAnalyticsManagementClient.StreamingJobs.ListByResourceGroup(resourceGroupName, "inputs,outputs,transformation,functions");
-                Assert.Equal(0, listByRgResponse.Count());
+                Assert.Empty(listByRgResponse);
 
                 listReponse = streamAnalyticsManagementClient.StreamingJobs.List("inputs, outputs, transformation, functions");
-                Assert.Equal(0, listReponse.Count());
+                Assert.Empty(listReponse);
             }
         }
 
@@ -258,12 +258,12 @@ namespace StreamAnalytics.Tests
 
                 // List job and verify that the job shows up in the list
                 var listByRgResponse = streamAnalyticsManagementClient.StreamingJobs.ListByResourceGroup(resourceGroupName, "inputs,outputs,transformation,functions");
-                Assert.Equal(1, listByRgResponse.Count());
+                Assert.Single(listByRgResponse);
                 ValidationHelper.ValidateStreamingJob(putResponse.Body, listByRgResponse.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listByRgResponse.Single().Etag);
 
                 var listReponse = streamAnalyticsManagementClient.StreamingJobs.List("inputs, outputs, transformation, functions");
-                Assert.Equal(1, listReponse.Count());
+                Assert.Single(listReponse);
                 ValidationHelper.ValidateStreamingJob(putResponse.Body, listReponse.Single(), true);
                 Assert.Equal(getResponse.Headers.ETag, listReponse.Single().Etag);
 
@@ -274,7 +274,7 @@ namespace StreamAnalytics.Tests
                 };
                 CloudException cloudException = Assert.Throws<CloudException>(() => streamAnalyticsManagementClient.StreamingJobs.Start(resourceGroupName, jobName, startStreamingJobParameters));
                 Assert.Equal((HttpStatusCode)422, cloudException.Response.StatusCode);
-                Assert.True(cloudException.Response.Content.Contains("LastOutputEventTime must be available when OutputStartMode is set to LastOutputEventTime. Please make sure at least one output event has been processed."));
+                Assert.Contains("LastOutputEventTime must be available when OutputStartMode is set to LastOutputEventTime. Please make sure at least one output event has been processed.", cloudException.Response.Content);
 
                 startStreamingJobParameters.OutputStartMode = OutputStartMode.CustomTime;
                 startStreamingJobParameters.OutputStartTime = new DateTime(2012, 12, 12, 12, 12, 12, DateTimeKind.Utc);
@@ -299,7 +299,7 @@ namespace StreamAnalytics.Tests
                 // Check diagnostics
                 var inputListResponse = streamAnalyticsManagementClient.Inputs.ListByStreamingJob(resourceGroupName, jobName, "*");
                 Assert.NotNull(inputListResponse);
-                Assert.Equal(1, inputListResponse.Count());
+                Assert.Single(inputListResponse);
                 var inputFromList = inputListResponse.Single();
                 Assert.NotNull(inputFromList.Properties.Diagnostics);
                 Assert.Equal(2, inputFromList.Properties.Diagnostics.Conditions.Count());
@@ -325,10 +325,10 @@ namespace StreamAnalytics.Tests
 
                 // Verify that list operation returns an empty list after deleting the job
                 listByRgResponse = streamAnalyticsManagementClient.StreamingJobs.ListByResourceGroup(resourceGroupName, "inputs,outputs,transformation,functions");
-                Assert.Equal(0, listByRgResponse.Count());
+                Assert.Empty(listByRgResponse);
 
                 listReponse = streamAnalyticsManagementClient.StreamingJobs.List("inputs, outputs, transformation, functions");
-                Assert.Equal(0, listReponse.Count());
+                Assert.Empty(listReponse);
             }
         }
     }

--- a/src/SDKs/Subscription/Subscription.Tests/Subscription.NetCore.Tests/ScenarioTests/SubscriptionTests.ScenarioTests.cs
+++ b/src/SDKs/Subscription/Subscription.Tests/Subscription.NetCore.Tests/ScenarioTests/SubscriptionTests.ScenarioTests.cs
@@ -33,7 +33,7 @@ namespace ResourceGroups.Tests
                 var subscriptions = client.Subscriptions.List();
 
                 Assert.NotNull(subscriptions);
-                Assert.NotEqual(0, subscriptions.Count());
+                Assert.NotEmpty(subscriptions);
                 Assert.NotNull(subscriptions.First().Id);
                 Assert.NotNull(subscriptions.First().SubscriptionId);
                 Assert.NotNull(subscriptions.First().DisplayName);

--- a/src/SDKs/WebSites/WebSites.Tests/Helpers/ResourceManagementClientUndoHandlers.cs
+++ b/src/SDKs/WebSites/WebSites.Tests/Helpers/ResourceManagementClientUndoHandlers.cs
@@ -9,10 +9,12 @@ namespace Microsoft.WindowsAzure.Management.ResourceManagement.Testing
     using System.Reflection;
     using System.Threading;
 
+    /*
     /// <summary>
     /// Class used to discover and construct undo handlers available in the app domain
     /// </summary>
-    /// 
+    ///
+    */
     //[UndoHandlerFactory]
     //public static partial class UndoContextDiscoveryExtensions
     //{

--- a/src/SDKs/WebSites/WebSites.Tests/ScenarioTests/WebHostingPlan.ScenarioTests.cs
+++ b/src/SDKs/WebSites/WebSites.Tests/ScenarioTests/WebHostingPlan.ScenarioTests.cs
@@ -102,8 +102,8 @@ namespace WebSites.Tests.ScenarioTests
 
                 var whp1 = webHostingPlanResponse.First(f => f.Name == whpName1);
                 var whp2 = webHostingPlanResponse.First(f => f.Name == whpName2);
-                Assert.Equal(whp1.Sku.Tier, "Shared");
-                Assert.Equal(whp2.Sku.Tier, "Basic");
+                Assert.Equal("Shared", whp1.Sku.Tier);
+                Assert.Equal("Basic", whp2.Sku.Tier);
             }
         }
 
@@ -143,7 +143,7 @@ namespace WebSites.Tests.ScenarioTests
 
                 var webHostingPlanResponse = webSitesClient.AppServicePlans.ListByResourceGroup(resourceGroupName);
 
-                Assert.Equal(0, webHostingPlanResponse.Count());
+                Assert.Empty(webHostingPlanResponse);
             }
         }
 
@@ -253,7 +253,7 @@ namespace WebSites.Tests.ScenarioTests
 
                 var webHostingPlanResponse = webSitesClient.AppServicePlans.ListByResourceGroup(resourceGroupName);
 
-                Assert.Equal(0, webHostingPlanResponse.Count());
+                Assert.Empty(webHostingPlanResponse);
 
                 // Validate response
                 Assert.NotNull(result);

--- a/src/SDKs/WebSites/WebSites.Tests/ScenarioTests/WebSite.Backup.ScenarioTests.cs
+++ b/src/SDKs/WebSites/WebSites.Tests/ScenarioTests/WebSite.Backup.ScenarioTests.cs
@@ -55,7 +55,7 @@ namespace WebSites.Tests.ScenarioTests
                 });
 
                 var backupResponse = webSitesClient.WebApps.ListBackups(resourceGroupName, siteName);
-                Assert.Equal(0, backupResponse.Count()); // , "Backup list should be empty"
+                Assert.Empty(backupResponse); // , "Backup list should be empty"
 
                 // the following URL just have a proper format, but it is not valid - for an API test it is not needed to be valid,
                 // since we are just testing a roundtrip here
@@ -93,7 +93,7 @@ namespace WebSites.Tests.ScenarioTests
 
                 var serverFarmResponse = webSitesClient.AppServicePlans.ListByResourceGroup(resourceGroupName);
 
-                Assert.Equal(0, serverFarmResponse.Count());
+                Assert.Empty(serverFarmResponse);
             }
         }
     }

--- a/src/SDKs/WebSites/WebSites.Tests/ScenarioTests/WebSite.ScenarioTests.cs
+++ b/src/SDKs/WebSites/WebSites.Tests/ScenarioTests/WebSite.ScenarioTests.cs
@@ -54,7 +54,7 @@ namespace WebSites.Tests.ScenarioTests
                 {
                     var webSites = webSitesClient.WebApps.ListByResourceGroup(resourceGroupName, null);
 
-                    Assert.Equal(1, webSites.Count());
+                    Assert.Single(webSites);
                     Assert.Equal(webSiteName, webSites.ToList()[0].Name);
                     var serverfarmId = ResourceGroupHelper.GetServerFarmId(webSitesClient.SubscriptionId,
                     resourceGroupName, whpName);
@@ -74,12 +74,12 @@ namespace WebSites.Tests.ScenarioTests
 
                     var getWebSiteResponse = webSitesClient.WebApps.Get(resourceGroupName, webSiteName);
                     Assert.NotNull(getWebSiteResponse);
-                    Assert.Equal(getWebSiteResponse.State, "Stopped");
+                    Assert.Equal("Stopped", getWebSiteResponse.State);
 
                     webSitesClient.WebApps.Start(resourceGroupName, webSiteName);
                     getWebSiteResponse = webSitesClient.WebApps.Get(resourceGroupName, webSiteName);
                     Assert.NotNull(getWebSiteResponse);
-                    Assert.Equal(getWebSiteResponse.State, "Running");
+                    Assert.Equal("Running", getWebSiteResponse.State);
 
                     #endregion Start/Stop website
 
@@ -87,7 +87,7 @@ namespace WebSites.Tests.ScenarioTests
 
                     var webSites = webSitesClient.WebApps.ListByResourceGroup(resourceGroupName);
 
-                    Assert.Equal(0, webSites.Count());
+                    Assert.Empty(webSites);
                 });
         }
 
@@ -213,12 +213,12 @@ namespace WebSites.Tests.ScenarioTests
                         new ConnectionStringDictionary { Properties = new Dictionary<string, ConnStringValueTypePair> { { connectionStringName, connStringValueTypePair } } });
 
                     Assert.NotNull(connectionStringResponse);
-                    Assert.True(connectionStringResponse.Properties.Contains(new KeyValuePair<string, ConnStringValueTypePair>(connectionStringName, connStringValueTypePair), new ConnectionStringComparer()));
+                    Assert.Contains(new KeyValuePair<string, ConnStringValueTypePair>(connectionStringName, connStringValueTypePair), connectionStringResponse.Properties, new ConnectionStringComparer());
 
                     connectionStringResponse = webSitesClient.WebApps.ListConnectionStrings(resourceGroupName, siteName);
 
                     Assert.NotNull(connectionStringResponse);
-                    Assert.True(connectionStringResponse.Properties.Contains(new KeyValuePair<string, ConnStringValueTypePair>(connectionStringName, connStringValueTypePair), new ConnectionStringComparer()));
+                    Assert.Contains(new KeyValuePair<string, ConnStringValueTypePair>(connectionStringName, connStringValueTypePair), connectionStringResponse.Properties, new ConnectionStringComparer());
 
                     #endregion Get/Set Connection strings
 

--- a/src/SDKs/WebSites/WebSites.Tests/ScenarioTests/WebSiteSlot.ScenarioTests.cs
+++ b/src/SDKs/WebSites/WebSites.Tests/ScenarioTests/WebSiteSlot.ScenarioTests.cs
@@ -66,7 +66,7 @@ namespace WebSites.Tests.ScenarioTests
 
                 // TODO: Replace with GetSite with slotName API once its CSM related issue is resolved.
                 var webSiteSlotCollection = webSitesClient.WebApps.ListSlots(resourceGroupName, webSiteName);
-                Assert.Equal(1, webSiteSlotCollection.Count());
+                Assert.Single(webSiteSlotCollection);
                 Assert.Equal(siteSlotResourceName, webSiteSlotCollection.ToList()[0].Name);
             }
         }
@@ -121,7 +121,7 @@ namespace WebSites.Tests.ScenarioTests
 
                 var webSiteSlots = webSitesClient.WebApps.ListSlots(resourceGroupName, webSiteName);
 
-                Assert.Equal(1, webSiteSlots.Count());
+                Assert.Single(webSiteSlots);
                 Assert.Equal(siteSlotResourceName, webSiteSlots.ToList()[0].Name);
                 Assert.Equal(serverFarmId, webSiteSlots.ToList()[0].ServerFarmId, StringComparer.OrdinalIgnoreCase);
             }
@@ -179,7 +179,7 @@ namespace WebSites.Tests.ScenarioTests
 
                 var webSites = webSitesClient.WebApps.ListSlots(resourceGroupName, webSiteName);
 
-                Assert.Equal(0, webSites.Count());
+                Assert.Empty(webSites);
             }
         }
     }

--- a/src/SDKs/WebSites/WebSites.Tests/WebSites.Tests.csproj
+++ b/src/SDKs/WebSites/WebSites.Tests/WebSites.Tests.csproj
@@ -6,9 +6,6 @@
     <AssemblyName>WebSites.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
-    <NoWarn>1591;1701;1573;CS1591;CS1587</NoWarn>
-  </PropertyGroup>
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>-->

--- a/src/SDKs/WebSites/WebSites.Tests/WebSites.Tests.csproj
+++ b/src/SDKs/WebSites/WebSites.Tests/WebSites.Tests.csproj
@@ -6,6 +6,9 @@
     <AssemblyName>WebSites.Tests</AssemblyName>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp2.0|AnyCPU'">
+    <NoWarn>1591;1701;1573;CS1591;CS1587</NoWarn>
+  </PropertyGroup>
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>-->

--- a/tools/legacy/ScriptBackup/buildTargets/common.Build.props
+++ b/tools/legacy/ScriptBackup/buildTargets/common.Build.props
@@ -13,7 +13,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(LibraryToolsFolder)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
-    <NoWarn>1591;1701;1573;CS1591</NoWarn>
+    <NoWarn>1701;1573;CS1591</NoWarn>
   </PropertyGroup>
 
 


### PR DESCRIPTION
Enabling Warnings as Errors for test projects
Suppressing some warnings which were implemented incorrectly and need to be fixed by the SDK owners and warnings related to params/other comments 
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
