### PR TITLE
Treating warnings as errors for test projects Part-1

### DIFF
--- a/src/SDKs/AnalysisServices/AnalysisServices.Tests/AnalysisServices.Tests.csproj
+++ b/src/SDKs/AnalysisServices/AnalysisServices.Tests/AnalysisServices.Tests.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>AnalysisServices.Tests</AssemblyName>
     <PackageId>AnalysisServices.Tests</PackageId>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Management.Analysis\Microsoft.Azure.Management.Analysis.csproj" />

--- a/src/SDKs/ApiManagement/ApiManagement.Tests/ApiManagement.Tests.csproj
+++ b/src/SDKs/ApiManagement/ApiManagement.Tests/ApiManagement.Tests.csproj
@@ -7,11 +7,9 @@
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>ApiManagementManagement.Tests</AssemblyName>    
   </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
-
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.ApiManagement" Version="2.1.0-ForTest" />-->
     <ProjectReference Include="..\Management.ApiManagement\Microsoft.Azure.Management.ApiManagement.csproj" />

--- a/src/SDKs/ApiManagement/ApiManagement.Tests/ManagementApiTests/ApiExportImportTests.cs
+++ b/src/SDKs/ApiManagement/ApiManagement.Tests/ManagementApiTests/ApiExportImportTests.cs
@@ -16,7 +16,7 @@ namespace ApiManagement.Tests.ManagementApiTests
     public class ApiExportImportTests : TestBase
     {
         [Fact]
-        public async Task SwaggerTest()
+        public void SwaggerTest()
         {
             Environment.SetEnvironmentVariable("AZURE_TEST_MODE", "Playback");
             using (MockContext context = MockContext.Start(this.GetType().FullName))
@@ -76,7 +76,7 @@ namespace ApiManagement.Tests.ManagementApiTests
         }
 
         [Fact]
-        public async Task WadlTest()
+        public void WadlTest()
         {
             Environment.SetEnvironmentVariable("AZURE_TEST_MODE", "Playback");
             using (MockContext context = MockContext.Start(this.GetType().FullName))
@@ -138,7 +138,7 @@ namespace ApiManagement.Tests.ManagementApiTests
         }
 
         [Fact]
-        public async Task WsdlTest()
+        public void WsdlTest()
         {
             Environment.SetEnvironmentVariable("AZURE_TEST_MODE", "Playback");
             using (MockContext context = MockContext.Start(this.GetType().FullName))

--- a/src/SDKs/ApiManagement/ApiManagement.Tests/ManagementApiTests/ReportTests.cs
+++ b/src/SDKs/ApiManagement/ApiManagement.Tests/ManagementApiTests/ReportTests.cs
@@ -16,7 +16,7 @@ namespace ApiManagement.Tests.ManagementApiTests
     public class ReportTests : TestBase
     {
         [Fact]
-        public async Task Query()
+        public void Query()
         {
             Environment.SetEnvironmentVariable("AZURE_TEST_MODE", "Playback");
             using (MockContext context = MockContext.Start(this.GetType().FullName))

--- a/src/SDKs/ApplicationInsights/DataPlane/Data.ApplicationInsights.Tests/Data.ApplicationInsights.Tests.csproj
+++ b/src/SDKs/ApplicationInsights/DataPlane/Data.ApplicationInsights.Tests/Data.ApplicationInsights.Tests.csproj
@@ -5,7 +5,6 @@
     <Description>Data.ApplicationInsights.Tests Class library</Description>
     <PackageId>Data.ApplicationInsights.Tests</PackageId>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
-    <!--<TargetFrameworks>netcoreapp1.1</TargetFrameworks>-->
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ApplicationInsights.Tests.csproj
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ApplicationInsights.Tests.csproj
@@ -5,7 +5,7 @@
     <Description>ApplicationInsights.Tests Class library</Description>
     <PackageId>ApplicationInsights.Tests</PackageId>
     <VersionPrefix>1.0.0-preview</VersionPrefix>
-    <!--<TargetFrameworks>netcoreapp1.1</TargetFrameworks>-->
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="[1.6.0-preview, 2.0.0)" />

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/APIKeysTests.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/APIKeysTests.cs
@@ -56,7 +56,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                 .GetAwaiter()
                                                 .GetResult();
 
-                Assert.Equal(1, getAllAPIKeys.Body.Count());
+                Assert.Single(getAllAPIKeys.Body);
                 AreEqual(apiKeyProperties, getAllAPIKeys.Body.ElementAt(0));
 
                 string fullkeyId = getAllAPIKeys.Body.ElementAt(0).Id;
@@ -85,7 +85,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                         .GetResult();
 
                 //get API again, should get an NOT found exception
-                Assert.Throws(typeof(CloudException), () =>
+                Assert.Throws<CloudException>(() =>
                 {
                     getAPIKey = insightsClient
                                             .APIKeys
@@ -109,12 +109,13 @@ namespace ApplicationInsights.Tests.Scenarios
             Assert.True(response.LinkedWriteProperties.Count >= request.LinkedWriteProperties.Count);
             foreach (var readaccess in request.LinkedReadProperties)
             {
-                Assert.True(response.LinkedReadProperties.Any(r => r == readaccess));
+                Assert.Contains(response.LinkedReadProperties, r => r == readaccess);
+
             }
 
             foreach (var writeaccess in request.LinkedWriteProperties)
             {
-                Assert.True(response.LinkedWriteProperties.Any(w => w == writeaccess));
+                Assert.Contains(response.LinkedWriteProperties, w => w == writeaccess);
             }
         }
 

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/ComponentsTests.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/ComponentsTests.cs
@@ -111,7 +111,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                     .GetResult();
 
                 //get component again, should get an exception
-                Assert.Throws(typeof(CloudException), () =>
+                Assert.Throws<CloudException>(() =>
                 {
                     getComponentResponse = insightsClient
                                                         .Components

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/ContinuousExportsTests.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/ContinuousExportsTests.cs
@@ -45,7 +45,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                             createContinuousExportProperties)
                                                         .GetAwaiter()
                                                         .GetResult();
-                Assert.Equal(1, createContinuousExportResponse.Body.Count());
+                Assert.Single(createContinuousExportResponse.Body);
                 AreEqual(createContinuousExportProperties, createContinuousExportResponse.Body.FirstOrDefault());
 
                 //get all continuous exports
@@ -57,7 +57,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                 .GetAwaiter()
                                                 .GetResult();
 
-                Assert.Equal(1, getAllContinuousExports.Body.Count());
+                Assert.Single(getAllContinuousExports.Body);
                 AreEqual(createContinuousExportProperties, getAllContinuousExports.Body.FirstOrDefault());
 
                 string exportId = getAllContinuousExports.Body.FirstOrDefault().ExportId;

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/TestBase.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/TestBase.cs
@@ -86,7 +86,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                 .GetResult();
 
             //get component again, should get an exception
-            Assert.Throws(typeof(CloudException), () =>
+            Assert.Throws<CloudException>(() =>
             {
                 var getComponentResponse = insightsClient
                                                     .Components

--- a/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/WebtestsTests.cs
+++ b/src/SDKs/ApplicationInsights/Management/ApplicationInsights.Tests/ScenarioTests/WebtestsTests.cs
@@ -103,7 +103,7 @@ namespace ApplicationInsights.Tests.Scenarios
                                                 .GetResult();
 
                 //get webtest again, should get an exception
-                Assert.Throws(typeof(CloudException), () =>
+                Assert.Throws<CloudException>(() =>
                 {
                     getWebTestResponse = insightsClient
                                                 .WebTests

--- a/src/SDKs/Authorization/Authorization.Tests/Authorization.Tests.csproj
+++ b/src/SDKs/Authorization/Authorization.Tests/Authorization.Tests.csproj
@@ -5,9 +5,9 @@
     <AssemblyName>Authorization.Tests</AssemblyName>
     <PackageId>Authorization.Tests</PackageId>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Graph.RBAC" Version="3.4.0-preview" />

--- a/src/SDKs/Authorization/Authorization.Tests/Tests/BasicTests.cs
+++ b/src/SDKs/Authorization/Authorization.Tests/Tests/BasicTests.cs
@@ -56,8 +56,8 @@ namespace Authorization.Tests
                 {
                     Assert.NotNull(classicAdmin);
                     Assert.NotNull(classicAdmin.Id);
-                    Assert.True(classicAdmin.Id.Contains("/providers/Microsoft.Authorization/classicAdministrators/"));
-                    Assert.True(classicAdmin.Id.Contains("/subscriptions/" + client.SubscriptionId));
+                    Assert.Contains("/providers/Microsoft.Authorization/classicAdministrators/", classicAdmin.Id);
+                    Assert.Contains("/subscriptions/" + client.SubscriptionId, classicAdmin.Id);
                     Assert.NotNull(classicAdmin.Name);
                     Assert.NotNull(classicAdmin.Type);
                     Assert.Equal("Microsoft.Authorization/classicAdministrators", classicAdmin.Type);
@@ -436,7 +436,7 @@ namespace Authorization.Tests
                     var nextPage = client.RoleAssignments.ListNext(firstPage.NextPageLink);
 
                     Assert.NotNull(nextPage);
-                    Assert.NotEqual(0, nextPage.Count());
+                    Assert.NotEmpty(nextPage);
 
                     foreach (var roleAssignment in nextPage)
                     {

--- a/src/SDKs/Automation/Automation.Tests/Automation.Tests.csproj
+++ b/src/SDKs/Automation/Automation.Tests/Automation.Tests.csproj
@@ -7,9 +7,9 @@
     <Description>Test Project for Automation tests</Description>
   </PropertyGroup>
   
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.Network" Version="[14.0.0-preview,16.0)" />


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
