### PR TITLE
Fix ContentModerator Release Notes.

### DIFF
--- a/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Microsoft.Azure.CognitiveServices.ContentModerator.csproj
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/ContentModerator/ContentModerator/Microsoft.Azure.CognitiveServices.ContentModerator.csproj
@@ -11,11 +11,11 @@
     <PackageTags>ContentModerator;Content Moderator;</PackageTags>
     <PackageReleaseNotes>
     <![CDATA[
-    This is a preview release of the Cognitive Services Content Moderator SDK.
-    
-    Changes in this release:
-    1. Supported customizing service endpoints by assigning the endpoint string to ContentModeratorClient.Endpoint. The endpoint string can be found on Azure Portal, it should contain only protocol and hostname, for example: https://westus.api.cognitive.microsoft.com.
-    2. Body.Metadata, ImageList.Metadata, TermList.Metadata, members of RefreshIndex.Metadata are now IDictionary<string, string>.
+This is a preview release of the Cognitive Services Content Moderator SDK.
+
+Changes in this release:
+1. Supported customizing service endpoints by assigning the endpoint string to ContentModeratorClient.Endpoint. The endpoint string can be found on Azure Portal, it should contain only protocol and hostname, for example: https://westus.api.cognitive.microsoft.com.
+2. Body.Metadata, ImageList.Metadata, TermList.Metadata, members of RefreshIndex.AdvancedInfo are now IDictionary<string, string>.
     ]]>
 	</PackageReleaseNotes>
   </PropertyGroup>


### PR DESCRIPTION
When I was double checking before publishing the SDK, I noticed 2 issues in release note.
Since I haven't generated the NuGet yet, send this small PR to fix them.

1. Fix a mistake in release note (RefreshIndex.Metadata should be RefreshIndex.AdvancedInfo)
2. Fix intents of release note (to look better in Nuget page)

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
