### PR TITLE
Update Batch supporting assemblies

### DIFF
--- a/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageId>Microsoft.Azure.Batch</PackageId>
     <Description>This client library provides access to the Microsoft Azure Batch service.</Description>
-    <VersionPrefix>9.0.0</VersionPrefix>
+    <Version>9.0.0</Version>
     <DefineConstants>$(DefineConstants);CODESIGN</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Microsoft.Azure.Batch</AssemblyName>

--- a/src/SDKs/Batch/Support/FileConventions/README.md
+++ b/src/SDKs/Batch/Support/FileConventions/README.md
@@ -89,8 +89,8 @@ The job output container name is formed according to the following rules:
 * Otherwise:
   * Calculate the SHA1 hash of the normalized ID, and express it
     as a 40-character hex string.
-  * Replace all sequences of one or more hyphens or underscores in the
-    normalized ID by single hyphens, then remove any leading or trailing
+  * Replace all underscores, colons, and sequences of one or more hyphens in 
+    the normalized ID by single hyphens, then remove any leading or trailing
     hyphens.
   * If the resulting string is empty, use the string "job" instead.
   * If the resulting string is longer than 15 characters, truncate it

--- a/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/AzureBatchFileConventions.csproj
+++ b/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/AzureBatchFileConventions.csproj
@@ -8,7 +8,7 @@ by task and job id and the type of output.
     </Description>
     <AssemblyTitle>Microsoft Azure Batch File Conventions</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Batch.Conventions.Files</AssemblyName>
-    <VersionPrefix>3.1.0</VersionPrefix>
+    <Version>3.2.0</Version>
     <PackageTags>Microsoft, Azure, Batch, windowsazureofficial</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <PackageReleaseNotes>
@@ -35,8 +35,8 @@ Updated dependent libraries.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Batch" Version="[8.0.0,9.0.0)" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.1.1" />
+    <PackageReference Include="Microsoft.Azure.Batch" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="WindowsAzure.Storage" Version="[8.1.1, 10.0.0)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">

--- a/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("A convention-based library for saving and retrieving Azure Batch task output files.")]
 
 [assembly: AssemblyVersion("3.0.0.0")] 
-[assembly: AssemblyFileVersion("3.1.0.0")]
+[assembly: AssemblyFileVersion("3.2.0.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]

--- a/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/Utilities/ContainerNameUtils.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/Utilities/ContainerNameUtils.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.Utilities
 #endif
         private static readonly int MaxJobIdLengthInMungedContainerName = 15;  // must be <= 63 - "job-".Length - 1 (hyphen before hash) - length of hash string (40 for SHA1)
         private static readonly char[] ForbiddenLeadingTrailingContainerNameChars = new[] { '-' };
-        private static readonly Regex UnderscoresAndMultipleDashes = new Regex("[_-]+");
+        private static readonly Regex InvalidContainerCharacters = new Regex("[:_-]+");
         private const string ContainerPrefix = "job-";
         private static readonly int MaxUsableJobIdLength = 63 - ContainerPrefix.Length;
 
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.Utilities
             var hash = hasher().ComputeHash(Encoding.UTF8.GetBytes(str));
             var hashText = ToHex(hash);
 
-            var safeStr = MakeDashSafe(str);
+            var safeStr = MakeSafe(str);
 
             safeStr = safeStr.Trim(ForbiddenLeadingTrailingContainerNameChars);
 
@@ -93,9 +93,9 @@ namespace Microsoft.Azure.Batch.Conventions.Files.Utilities
             return safeStr + "-" + hashText;
         }
 
-        private static string MakeDashSafe(string rawString)
+        private static string MakeSafe(string rawString)
         {
-            return UnderscoresAndMultipleDashes.Replace(rawString, "-");
+            return InvalidContainerCharacters.Replace(rawString, "-");
         }
 
         private static string ToHex(byte[] bytes)

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/CloudJobExtensionsTests.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/CloudJobExtensionsTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.IntegrationTests
         [Fact]
         public async Task CloudJobOutputStorageExtensionSavesToCorrectContainer()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 var job = batchClient.JobOperations.CreateJob(_jobId, null);
 
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.IntegrationTests
         [Fact]
         public async Task CloudJobGetStorageContainerUrlExtensionSasPermitsWritingToJobOutputContainer()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 var job = batchClient.JobOperations.CreateJob(_jobId, null);
 
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.IntegrationTests
         [Fact]
         public async Task CloudJobPrepareOutputStorageExtensionCreatesCorrectContainer()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 var job = batchClient.JobOperations.CreateJob(_jobId, null);
 

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/CloudTaskExtensionsTests.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/CloudTaskExtensionsTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.IntegrationTests
                 Url = $"http://contoso.noregion.batch.azure.com/jobs/{_jobId}/tasks/{_taskId}",  // TODO: remove if .NET client library can surface CloudTask.JobId directly
             };
 
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient(taskResponse)))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient(taskResponse)))
             {
                 var task = await batchClient.JobOperations.GetTaskAsync(_jobId, _taskId);
 

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/JobOutputStorageTests.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/JobOutputStorageTests.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.IntegrationTests
         [Fact]
         public async Task IfARetryPolicyIsSpecifiedInTheContainerUrlConstructor_ThenItIsUsed()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 var job = batchClient.JobOperations.CreateJob(_jobId, null);
                 var container = job.GetOutputStorageContainerUrl(StorageAccount, TimeSpan.FromMinutes(2));

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/TaskOutputStorageTests.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/TaskOutputStorageTests.cs
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.IntegrationTests
         [Fact]
         public async Task IfARetryPolicyIsSpecifiedInTheContainerUrlConstructor_ThenItIsUsed()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 var job = batchClient.JobOperations.CreateJob(_jobId, null);
                 var container = job.GetOutputStorageContainerUrl(StorageAccount, TimeSpan.FromMinutes(2));

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/CloudJobExtensionsUnitTests.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/CloudJobExtensionsUnitTests.cs
@@ -40,9 +40,9 @@ namespace Microsoft.Azure.Batch.Conventions.Files.UnitTests
         }
 
         [Fact]
-        public async Task CannotCreateOutputStorageForNullStorageAccount()
+        public void CannotCreateOutputStorageForNullStorageAccount()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 CloudJob job = batchClient.JobOperations.CreateJob();
                 job.Id = "fakejob";
@@ -92,9 +92,9 @@ namespace Microsoft.Azure.Batch.Conventions.Files.UnitTests
         }
 
         [Fact]
-        public async Task CannotGetOutputStorageUrlForNullStorageAccount()
+        public void CannotGetOutputStorageUrlForNullStorageAccount()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 CloudJob job = batchClient.JobOperations.CreateJob();
                 job.Id = "fakejob";
@@ -105,9 +105,9 @@ namespace Microsoft.Azure.Batch.Conventions.Files.UnitTests
         }
 
         [Fact]
-        public async Task CannotGetOutputStorageUrlWithZeroExpiryTime()
+        public void CannotGetOutputStorageUrlWithZeroExpiryTime()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 CloudJob job = batchClient.JobOperations.CreateJob();
                 job.Id = "fakejob";
@@ -118,9 +118,9 @@ namespace Microsoft.Azure.Batch.Conventions.Files.UnitTests
         }
 
         [Fact]
-        public async Task CannotGetOutputStorageUrlWithNegativeExpiryTime()
+        public void CannotGetOutputStorageUrlWithNegativeExpiryTime()
         {
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient()))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient()))
             {
                 CloudJob job = batchClient.JobOperations.CreateJob();
                 job.Id = "fakejob";

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/CloudTaskExtensionsUnitTests.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/CloudTaskExtensionsUnitTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.UnitTests
         }
 
         [Fact]
-        public async Task CannotCreateOutputStorageForNullStorageAccount()
+        public void CannotCreateOutputStorageForNullStorageAccount()
         {
             var taskResponse = new Batch.Protocol.Models.CloudTask
             {
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.UnitTests
                 Url = $"http://contoso.noregion.batch.azure.com/jobs/fakejob/tasks/faketask",  // TODO: remove if .NET client library can surface CloudTask.JobId directly
             };
 
-            using (var batchClient = await BatchClient.OpenAsync(new FakeBatchServiceClient(taskResponse)))
+            using (var batchClient = BatchClient.Open(new FakeBatchServiceClient(taskResponse)))
             {
                 CloudTask task = batchClient.JobOperations.GetTask("fakejob", "faketask");
                 CloudStorageAccount storageAccount = null;

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/Generators/BatchIdGenerator.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/Generators/BatchIdGenerator.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.UnitTests.Generators
             Enumerable.Range((int)'A', 26).Concat(
             Enumerable.Range((int)'a', 26)).Concat(
             Enumerable.Range((int)'0', 10)).Concat(
-            new int[] { '-', '_' })
+            new int[] { '-', '_', ':' })
             .Select(i => (char)i)  // Need to use Select because Cast<char> fails with InvalidCastException
             .ToList().AsReadOnly();
 

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging.Tests/FileStagingIntegrationTests.cs
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging.Tests/FileStagingIntegrationTests.cs
@@ -48,7 +48,7 @@ namespace Batch.FileStaging.Tests
         {
             StagingStorageAccount storageCreds = TestUtilities.GetStorageCredentialsFromEnvironment();
 
-            using (BatchClient batchCli = TestUtilities.OpenBatchClientAsync(TestUtilities.GetCredentialsFromEnvironment()).Result)
+            using (BatchClient batchCli = TestUtilities.OpenBatchClient(TestUtilities.GetCredentialsFromEnvironment()))
             {
                 string jobId = "TestTaskWithFilesToStage-" + TestUtilities.GetMyName();
 
@@ -176,7 +176,7 @@ namespace Batch.FileStaging.Tests
                 });
 
                 StagingStorageAccount storageCredentials = TestUtilities.GetStorageCredentialsFromEnvironment();
-                using (BatchClient batchCli = await TestUtilities.OpenBatchClientFromEnvironmentAsync())
+                using (BatchClient batchCli = TestUtilities.OpenBatchClientFromEnvironment())
                 {
                     await this.AddTasksSimpleTestAsync(
                         batchCli,

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging.Tests/Fixtures/PoolFixture.cs
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging.Tests/Fixtures/PoolFixture.cs
@@ -38,7 +38,7 @@ namespace Batch.FileStaging.Tests.Fixtures
         protected PoolFixture(string poolId)
         {
             this.PoolId = poolId;
-            this.client = TestUtilities.OpenBatchClientFromEnvironmentAsync().Result;
+            this.client = TestUtilities.OpenBatchClientFromEnvironment();
         }
 
         public void Dispose()

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging.Tests/IntegrationTestUtilities/TestUtilities.cs
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging.Tests/IntegrationTestUtilities/TestUtilities.cs
@@ -15,24 +15,12 @@
 namespace Batch.FileStaging.Tests.IntegrationTestUtilities
 {
     using System;
-    using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
     using System.Net;
-    using System.Reflection;
-    using System.Threading;
     using System.Threading.Tasks;
-
     using Microsoft.Azure.Batch;
     using Microsoft.Azure.Batch.Auth;
     using Microsoft.Azure.Batch.Common;
     using Microsoft.Azure.Batch.FileStaging;
-    using Newtonsoft.Json;
-    using Xunit;
-    using Xunit.Abstractions;
-    using Xunit.Sdk;
-
-    using Constants = Microsoft.Azure.Batch.Constants;
 
     public static class TestUtilities
     {
@@ -46,9 +34,9 @@ namespace Batch.FileStaging.Tests.IntegrationTestUtilities
                 TestCommon.Configuration.BatchAccountKey);
         }
 
-        public static async Task<BatchClient> OpenBatchClientAsync(BatchSharedKeyCredentials sharedKeyCredentials, bool addDefaultRetryPolicy = true)
+        public static BatchClient OpenBatchClient(BatchSharedKeyCredentials sharedKeyCredentials, bool addDefaultRetryPolicy = true)
         {
-            BatchClient client = await BatchClient.OpenAsync(sharedKeyCredentials);
+            BatchClient client = BatchClient.Open(sharedKeyCredentials);
 
             //Force us to get exception if the server returns something we don't expect
             //TODO: To avoid including this test assembly via "InternalsVisibleTo" we resort to some reflection trickery... maybe this property
@@ -66,10 +54,9 @@ namespace Batch.FileStaging.Tests.IntegrationTestUtilities
             return client;
         }
 
-        public static async Task<BatchClient> OpenBatchClientFromEnvironmentAsync()
+        public static BatchClient OpenBatchClientFromEnvironment()
         {
-            BatchClient client = await OpenBatchClientAsync(GetCredentialsFromEnvironment());
-
+            BatchClient client = OpenBatchClient(GetCredentialsFromEnvironment());
             return client;
         }
 

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/AssemblyAttributes.cs
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/AssemblyAttributes.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Client library for uploading resource files for tasks in the Azure Batch service.")]
 
 [assembly: AssemblyVersion("8.0.0.0")]
-[assembly: AssemblyFileVersion("8.0.0.0")]
+[assembly: AssemblyFileVersion("8.1.0.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/Batch.FileStaging.csproj
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/Batch.FileStaging.csproj
@@ -8,7 +8,7 @@ Visit our home page for more detail - http://azure.microsoft.com/services/batch/
 For technical overview, see http://azure.microsoft.com/documentation/articles/batch-technical-overview/.
 
 API reference can be found at http://go.microsoft.com/fwlink/?LinkId=717949.</Description>
-    <VersionPrefix>8.0.1</VersionPrefix>
+    <Version>8.1.0</Version>
     <DefineConstants>$(DefineConstants);CODESIGN</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Microsoft.Azure.Batch.FileStaging</AssemblyName>
@@ -33,8 +33,8 @@ API reference can be found at http://go.microsoft.com/fwlink/?LinkId=717949.</De
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" Version="8.1.1" />
-    <PackageReference Include="Azure.Batch" Version="[8.0.0,9.0.0)" />
+    <PackageReference Include="WindowsAzure.Storage" Version="[8.1.1, 10.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Batch" Version="[9.0.0,10.0.0)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Web" />


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
