### PR TITLE
Fixing metadatagen for batch

### DIFF
--- a/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
@@ -623,7 +623,7 @@ function Start-CodeGeneration {
     finally {
         Get-OutputStream | Out-File -FilePath $logFile -Encoding utf8 | Out-Null
         $errors = Get-ErrorStream
-        $errors | Out-File -FilePath $logFile -Encoding utf8 | Out-Null
+        $errors = $errors.Trim()
         if(-not [string]::IsNullOrWhiteSpace($errors) -and $generateSDKMetadata)
         {
             $errors | Out-File -FilePath $logFile -Append -Encoding utf8 | Out-Null
@@ -640,10 +640,7 @@ function Start-CodeGeneration {
         }
         
         Clear-OutputStreams
-        if(!$generateSDKMetadata)
-        {
-            Write-Host "Log file can be found at location $logFile"
-        }
+        Write-Host "Log file can be found at location $logFile"
     }
 }
 

--- a/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
@@ -324,11 +324,11 @@ function Start-MetadataGeneration {
 }
 
 function Get-ErrorStream {
-    $errorStream.ToString()
+    $errorStream.ToString().Trim()
 }
 
 function Get-OutputStream {
-    $outputStream.ToString()
+    $outputStream.ToString().Trim()
 }
 
 <#
@@ -447,7 +447,7 @@ function Start-AutoRestCodeGeneration {
         
         if([string]::IsNullOrWhiteSpace($SdkDirectory) -or $SdkDirectory.Contains("Documents\WindowsPowerShell\Modules"))
         {
-            Write-Error "Could not find default output directory since script is not run from a sdk repo, please provide one!"
+            Write-Error "Could not find root for output directory since script is not run from SDK repo, please provide this using the -SdkRepoPath parameter!"
             return
         }
         Start-CodeGeneration -ResourceProvider $ResourceProvider -SdkDirectory $SdkDirectory -Namespace $Namespace -ConfigFileTag $ConfigFileTag -SpecsRepoFork $SpecsRepoFork -SpecsRepoName $SpecsRepoName -SpecsRepoBranch $SpecsRepoBranch -SdkGenerationType $SdkGenerationType -AutoRestVersion $AutoRestVersion -AutoRestCodeGenerationFlags $AutoRestCodeGenerationFlags -SdkRepoRootPath $SdkRepoRootPath
@@ -623,7 +623,6 @@ function Start-CodeGeneration {
     finally {
         Get-OutputStream | Out-File -FilePath $logFile -Encoding utf8 | Out-Null
         $errors = Get-ErrorStream
-        $errors = $errors.Trim()
         if(-not [string]::IsNullOrWhiteSpace($errors) -and $generateSDKMetadata)
         {
             $errors | Out-File -FilePath $logFile -Append -Encoding utf8 | Out-Null


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
