### PR TITLE
Fix for metadata generation script

### DIFF
--- a/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
@@ -205,11 +205,13 @@ function Populate-Metadata {
     $metadataTemplate = $metadataTemplate.Replace("{{CodeGenerationErrors}}", "")
     $metadataTemplate= $metadataTemplate.TrimEnd()
     $metadataTemplate = $metadataTemplate.Replace('\', '\\')
+    $metadataTemplate = $metadataTemplate + "`n"
     return $metadataTemplate
 }
 
 function Get-MetadataCode {
-    param([string] $sdkInfo)
+    param([string] $sdkInfo,
+          [string] $metadataTemplate)
         # If there is no regex match, we need to insert it for the first time
         # We need to find the third } which is where we now insert the template
         $substr = $sdkInfo
@@ -295,8 +297,7 @@ function Start-MetadataGeneration {
             $metadataDict.Add("{{AutoRestVersion}}", $AutoRestVersion)
             $metadataDict.Add("{{AutoRestCmdExecuted}}", $AutoRestCommandExecuted)
             $metadataDict.Add("{{AutoRestBootStrapperVersion}}", $ver)
-            $metadataTemplate = Populate-Metadata $metadataTemplate $metadataDict
-                
+            $metadataTemplate = Populate-Metadata $metadataTemplate $metadataDict 
             $sdkInfo = Get-Content $sdkInfoFile -Raw
             if($sdkInfo -cmatch '(.*)\/\/ BEGIN: Code Generation Metadata Section(\n|.)*\/\/ END: Code Generation Metadata Section')
             {
@@ -309,14 +310,14 @@ function Start-MetadataGeneration {
                 {
                     Foreach($info in $sdkInfo)
                     {
-                        $newSdkInfo = Get-MetadataCode $info
-                        Set-Content -Path $sdkInfoFile -Value $newSdkInfo.Trim()
+                        $newSdkInfo = Get-MetadataCode $info $metadataTemplate
+                        Set-Content -Path $sdkInfoFile -Value $newSdkInfo
                     }
                 }
                 else 
                 {
-                    $sdkInfo = Get-MetadataCode $sdkInfo $
-                    Set-Content -Path $sdkInfoFile -Value $sdkInfo.Trim()
+                    $sdkInfo = Get-MetadataCode $sdkInfo $metadataTemplate
+                    Set-Content -Path $sdkInfoFile -Value $sdkInfo
                 }
             }
         }        

--- a/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/MetadataFieldsTemplate.txt
+++ b/tools/BuildAssets/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/MetadataFieldsTemplate.txt
@@ -8,3 +8,4 @@
       public static readonly String CodeGenerationErrors = "{{CodeGenerationErrors}}";
       public static readonly String GithubRepoName = "{{GithubRepoName}}";
       // END: Code Generation Metadata Section
+      


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
