### PR TITLE
Removing warnings for tests d-g

### DIFF
--- a/src/SDKs/DataBox/DataBox.Tests/DataBox.Tests.csproj
+++ b/src/SDKs/DataBox/DataBox.Tests/DataBox.Tests.csproj
@@ -5,9 +5,7 @@
     <Description>DataBox.Tests class library</Description>
     <AssemblyName>DataBox.Tests</AssemblyName>
     <VersionPrefix>1.0.0</VersionPrefix>
-  </PropertyGroup>
-  <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.Compute" Version="18.0.0" />

--- a/src/SDKs/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
+++ b/src/SDKs/DataFactory/DataFactory.Tests/DataFactory.Tests.csproj
@@ -4,15 +4,11 @@
     <PackageId>DataFactory.Tests</PackageId>
     <Description>DataFactory.Tests Class Library</Description>
     <AssemblyName>DataFactory.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <ProjectReference Include="..\Management.DataFactory\Microsoft.Azure.Management.DataFactory.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="SessionRecords\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/SDKs/DataFactory/DataFactory.Tests/UnitTests/ExamplesUnitTest.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/UnitTests/ExamplesUnitTest.cs
@@ -652,7 +652,7 @@ namespace DataFactory.Tests.UnitTests
         {
             // Compares original raw json captured "expected" response against strongly typed "actual" response from SDK method
             // Issues with workarounds noted inline
-            Assert.NotNull(response);
+            Assert.NotNull(response as Object);
             object expectedObject = example.Responses[responseCode.ToString()].Body;
             string expectedJson = SafeJsonConvert.SerializeObject(expectedObject);
             JToken expectedJToken = JToken.Parse(expectedJson);

--- a/src/SDKs/DataFactory/DataFactory.Tests/Utils/ExampleCapture.cs
+++ b/src/SDKs/DataFactory/DataFactory.Tests/Utils/ExampleCapture.cs
@@ -535,7 +535,7 @@ namespace DataFactory.Tests.Utils
             {
                 client.IntegrationRuntimes.Delete(secrets.ResourceGroupName, secrets.FactoryName + "-linked", integrationRuntimeName + "-linked");
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
         }
@@ -547,7 +547,7 @@ namespace DataFactory.Tests.Utils
             {
                 client.IntegrationRuntimes.RemoveLinks(secrets.ResourceGroupName, secrets.FactoryName, integrationRuntimeName, new LinkedIntegrationRuntimeRequest(secrets.FactoryName + "-linked"));
             }
-            catch (Exception e)
+            catch (Exception)
             {
             }
         }

--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/DataLakeAnalytics.Tests.csproj
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/DataLakeAnalytics.Tests.csproj
@@ -5,11 +5,9 @@
     <PackageId>DataLakeAnalytics.Tests</PackageId>
     <Description>DataLakeAnalytics.Tests Class Library</Description>
     <AssemblyName>DataLakeAnalytics.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />

--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/AccountOperationTests.cs
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/AccountOperationTests.cs
@@ -418,7 +418,7 @@ namespace DataLakeAnalytics.Tests
 
                 // Validate compute policies are set on creation.
                 Assert.True(responseGet.ComputePolicies.Count == 1);
-                Assert.True(responseGet.ComputePolicies.ToList()[0].Name.Equals(userPolicyName));
+                Assert.Equal(responseGet.ComputePolicies.ToList()[0].Name, userPolicyName);
 
                 // Validate compute policy CRUD
                 // Add another account

--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/CatalogOperationTests.cs
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/CatalogOperationTests.cs
@@ -54,7 +54,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(dbListResponse.Count() >= 1);
 
                     // Look for the db we created
-                    Assert.True(dbListResponse.Any(db => db.Name.Equals(commonData.DatabaseName)));
+                    Assert.Contains(dbListResponse, db => db.Name.Equals(commonData.DatabaseName));
 
                     // Get the specific Database as well
                     var dbGetResponse = 
@@ -77,7 +77,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(tableListResponse.ElementAt(0).ColumnList != null && tableListResponse.ElementAt(0).ColumnList.Count() > 0);
 
                     // Look for the table we created
-                    Assert.True(tableListResponse.Any(table => table.Name.Equals(commonData.TableName)));
+                    Assert.Contains(tableListResponse, table => table.Name.Equals(commonData.TableName));
 
                     // Get the table list with only basic info
                     tableListResponse = 
@@ -102,7 +102,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(tableListResponse.ElementAt(0).ColumnList != null && tableListResponse.ElementAt(0).ColumnList.Count > 0);
                     
                     // Look for the table we created
-                    Assert.True(tableListResponse.Any(table => table.Name.Equals(commonData.TableName)));
+                    Assert.Contains(tableListResponse, table => table.Name.Equals(commonData.TableName));
                     
                     // Get the table list in the db with only basic info
                     tableListResponse = 
@@ -153,7 +153,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(tvfListResponse.Count() >= 1);
 
                     // Look for the tvf we created
-                    Assert.True(tvfListResponse.Any(tvf => tvf.Name.Equals(commonData.TvfName)));
+                    Assert.Contains(tvfListResponse, tvf => tvf.Name.Equals(commonData.TvfName));
 
                     // Get tvf list in the database
                     tvfListResponse = 
@@ -165,7 +165,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(tvfListResponse.Count() >= 1);
 
                     // look for the tvf we created
-                    Assert.True(tvfListResponse.Any(tvf => tvf.Name.Equals(commonData.TvfName)));
+                    Assert.Contains(tvfListResponse, tvf => tvf.Name.Equals(commonData.TvfName));
 
                     // Get the specific tvf as well
                     var tvfGetResponse = 
@@ -189,7 +189,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(viewListResponse.Count() >= 1);
 
                     // Look for the view we created
-                    Assert.True(viewListResponse.Any(view => view.Name.Equals(commonData.ViewName)));
+                    Assert.Contains(viewListResponse, view => view.Name.Equals(commonData.ViewName));
 
                     // Get the view list from just the database
                     viewListResponse = 
@@ -201,7 +201,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(viewListResponse.Count() >= 1);
 
                     // Look for the view we created
-                    Assert.True(viewListResponse.Any(view => view.Name.Equals(commonData.ViewName)));
+                    Assert.Contains(viewListResponse, view => view.Name.Equals(commonData.ViewName));
 
                     // Get the specific view as well
                     var viewGetResponse = 
@@ -225,7 +225,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(procListResponse.Count() >= 1);
 
                     // Look for the procedure we created
-                    Assert.True(procListResponse.Any(proc => proc.Name.Equals(commonData.ProcName)));
+                    Assert.Contains(procListResponse, proc => proc.Name.Equals(commonData.ProcName));
 
                     // Get the specific procedure as well
                     var procGetResponse = 
@@ -314,7 +314,7 @@ namespace DataLakeAnalytics.Tests
 
                     Assert.NotNull(typeGetResponse);
                     Assert.NotEmpty(typeGetResponse);
-                    Assert.False(typeGetResponse.Any(type => type.IsComplexType.Value));
+                    Assert.DoesNotContain(typeGetResponse, type => type.IsComplexType.Value);
 
                     // Prepare to grant/revoke ACLs
                     var principalId = TestUtilities.GenerateGuid();
@@ -499,7 +499,7 @@ namespace DataLakeAnalytics.Tests
                     Assert.True(credListResponse.Count() >= 1);
 
                     // Look for the credential we created
-                    Assert.True(credListResponse.Any(cred => cred.Name.Equals(commonData.SecretName)));
+                    Assert.Contains(credListResponse, cred => cred.Name.Equals(commonData.SecretName));
 
                     // Get the specific credential as well
                     var credGetResponse = clientToUse.Catalog.GetCredential(

--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/JobOperationTests.cs
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/ScenarioTests/JobOperationTests.cs
@@ -182,7 +182,7 @@ namespace DataLakeAnalytics.Tests
                     );
 
                 Assert.NotNull(listJobResponse);
-                Assert.True(listJobResponse.Any(job => job.JobId == getJobResponse.JobId));
+                Assert.Contains(listJobResponse, job => job.JobId == getJobResponse.JobId);
 
                 // Validate usql job relationship retrieval (get/list pipeline and get/list recurrence)
                 var getPipeline = 
@@ -201,8 +201,8 @@ namespace DataLakeAnalytics.Tests
                         commonData.SecondDataLakeAnalyticsAccountName
                     );
 
-                Assert.Equal(1, listPipeline.Count());
-                Assert.True(listPipeline.Any(pipeline => pipeline.PipelineId == pipelineId));
+                Assert.Single(listPipeline);
+                Assert.Contains(listPipeline, pipeline => pipeline.PipelineId == pipelineId);
 
                 // Recurrence get/list
                 var getRecurrence = 
@@ -219,8 +219,8 @@ namespace DataLakeAnalytics.Tests
                         commonData.SecondDataLakeAnalyticsAccountName
                     );
 
-                Assert.Equal(1, listRecurrence.Count());
-                Assert.True(listRecurrence.Any(recurrence => recurrence.RecurrenceId == recurrenceId));
+                Assert.Single(listRecurrence);
+                Assert.Contains(listRecurrence, recurrence => recurrence.RecurrenceId == recurrenceId);
 
                 // TODO: re-enable this after the next prod push
                 // List the usql jobs with only the jobId property filled

--- a/src/SDKs/DataLake.Store/DataLakeStore.Tests/DataLakeStore.Tests.csproj
+++ b/src/SDKs/DataLake.Store/DataLakeStore.Tests/DataLakeStore.Tests.csproj
@@ -4,13 +4,9 @@
     <Description>DataLakeStore.Tests Class Library</Description>
     <AssemblyName>DataLakeStore.Tests</AssemblyName>
     <PackageId>DataLakeStore.Tests</PackageId>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
-
   <ItemGroup>
     <ProjectReference Include="..\Management.DataLake.Store\Microsoft.Azure.Management.DataLake.Store.csproj" />
   </ItemGroup>

--- a/src/SDKs/DataLake.Store/DataLakeStore.Tests/DataTransferTests/SingleSegmentUploaderTests.cs
+++ b/src/SDKs/DataLake.Store/DataLakeStore.Tests/DataTransferTests/SingleSegmentUploaderTests.cs
@@ -246,7 +246,7 @@ namespace DataLakeStore.Tests
             TestRetryBlock(5);
         }
 
-        public void TestRetryBlock(int failCount)
+        internal void TestRetryBlock(int failCount)
         {
             bool expectSuccess = failCount < SingleSegmentUploader.MaxBufferUploadAttemptCount;
 

--- a/src/SDKs/DataLake.Store/DataLakeStore.Tests/ScenarioTests/FileSystemOperationTests.cs
+++ b/src/SDKs/DataLake.Store/DataLakeStore.Tests/ScenarioTests/FileSystemOperationTests.cs
@@ -188,7 +188,7 @@ namespace DataLakeStore.Tests
             }
         }
 
-        //[Fact] commenting this out until we have a good test for validating access denied within the same tenant
+        [Fact(Skip = "skipping this out until we have a good test for validating access denied within the same tenant")] 
         public void DataLakeStoreFileSystemTestAccessDenied()
         {
             using (var context = MockContext.Start(this.GetType().FullName))
@@ -513,13 +513,11 @@ namespace DataLakeStore.Tests
                         fileContentsToAdd.Length*2);
 
                     // Attempt to get the files that were concatted together, which should fail and throw
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath1));
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath2));
@@ -557,13 +555,11 @@ namespace DataLakeStore.Tests
                         fileContentsToAdd.Length*2);
 
                     // Attempt to get the files that were concatted together, which should fail and throw
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath1));
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath2));
@@ -606,20 +602,17 @@ namespace DataLakeStore.Tests
                         fileContentsToAdd.Length*2);
 
                     // Attempt to get the files that were concatted together, which should fail and throw
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath1));
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath2));
 
                     // Attempt to get the folder that was created for concat, which should fail and be deleted.
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 concatFolderPath));
@@ -655,8 +648,7 @@ namespace DataLakeStore.Tests
                         fileContentsToAdd.Length);
 
                     // Ensure the old file is gone
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 filePath));
@@ -681,8 +673,7 @@ namespace DataLakeStore.Tests
                     Assert.Equal(1, listFolderResponse.FileStatuses.FileStatus.Count);
                     Assert.Equal(FileType.FILE, listFolderResponse.FileStatuses.FileStatus[0].Type);
 
-                    Assert.Throws(typeof (AdlsErrorException),
-                        () =>
+                    Assert.Throws<AdlsErrorException>(() =>
                             commonData.DataLakeStoreFileSystemClient.FileSystem.GetFileStatus(
                                 commonData.DataLakeStoreFileSystemAccountName,
                                 targetFolder1));
@@ -809,9 +800,7 @@ namespace DataLakeStore.Tests
                     var finalEntries = finalAclStatus.Entries;
                     foreach (var entry in finalEntries)
                     {
-                        Assert.True(
-                            currentAcl.AclStatus.Entries.Any(
-                                original => original.Equals(entry, StringComparison.CurrentCultureIgnoreCase)));
+                        Assert.Contains(currentAcl.AclStatus.Entries, original => original.Equals(entry, StringComparison.CurrentCultureIgnoreCase));
                     }
 
                     Assert.Equal(finalEntries.Count, currentAcl.AclStatus.Entries.Count);
@@ -937,7 +926,7 @@ namespace DataLakeStore.Tests
                     Assert.NotEmpty(aclGetResponse.AclStatus.Entries);
                     
                     Assert.Equal(currentCount + 1, aclGetResponse.AclStatus.Entries.Count);
-                    Assert.True(aclGetResponse.AclStatus.Entries.Any(entry => entry.Contains(commonData.AclUserId)));
+                    Assert.Contains(aclGetResponse.AclStatus.Entries, entry => entry.Contains(commonData.AclUserId));
                 }
             }
         }
@@ -975,7 +964,7 @@ namespace DataLakeStore.Tests
                     Assert.NotEmpty(aclGetResponse.AclStatus.Entries);
 
                     Assert.Equal(currentCount + 1, aclGetResponse.AclStatus.Entries.Count);
-                    Assert.True(aclGetResponse.AclStatus.Entries.Any(entry => entry.Contains(commonData.AclUserId)));
+                    Assert.Contains(aclGetResponse.AclStatus.Entries, entry => entry.Contains(commonData.AclUserId));
 
                     // now remove the entry
                     var aceToRemove = string.Format(",user:{0}", commonData.AclUserId);
@@ -993,7 +982,7 @@ namespace DataLakeStore.Tests
                     Assert.NotEmpty(aclGetResponse.AclStatus.Entries);
                     
                     Assert.Equal(currentCount, aclGetResponse.AclStatus.Entries.Count);
-                    Assert.False(aclGetResponse.AclStatus.Entries.Any(entry => entry.Contains(commonData.AclUserId)));
+                    Assert.DoesNotContain(aclGetResponse.AclStatus.Entries, entry => entry.Contains(commonData.AclUserId));
                 }
             }
         }

--- a/src/SDKs/DataMigration/DataMigration.Tests/DataMigration.Tests.csproj
+++ b/src/SDKs/DataMigration/DataMigration.Tests/DataMigration.Tests.csproj
@@ -2,6 +2,9 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.test.reference.props'))" />
   <PropertyGroup>
     <PackageId>DataMigration.Tests</PackageId>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AssemblyName>DataMigration.Tests</AssemblyName>
     <Description>DataMigration.Tests Class Library</Description>
     <AssemblyName>DataMigration.Tests</AssemblyName>
     <Version>1.0.0</Version>

--- a/src/SDKs/DevTestLabs/DevTestLabs.Tests/DevTestLabs.Tests.csproj
+++ b/src/SDKs/DevTestLabs/DevTestLabs.Tests/DevTestLabs.Tests.csproj
@@ -4,12 +4,9 @@
     <Description>DevTestLabs.Tests Class Library</Description>
     <PackageId>DevTestLabs.Tests</PackageId>
     <AssemblyName>DevTestLabs.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.DevTestLabs" Version="1.2.0" />-->

--- a/src/SDKs/DeviceProvisioningServices/DeviceProvisioningServices.Tests/DeviceProvisioningServices.Tests.csproj
+++ b/src/SDKs/DeviceProvisioningServices/DeviceProvisioningServices.Tests/DeviceProvisioningServices.Tests.csproj
@@ -4,12 +4,9 @@
     <PackageId>DeviceProvisioningServices.Tests</PackageId>
     <Description>DeviceProvisioningServices.Tests Class Library</Description>
     <AssemblyName>DeviceProvisioningServices.Tests</AssemblyName>
-    <VersionPrefix>1.0.0</VersionPrefix>    
+    <Version>1.0.0</Version>    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.EventHub" Version="2.0.2" />

--- a/src/SDKs/Dns/Dns.Tests/Dns.Tests.csproj
+++ b/src/SDKs/Dns/Dns.Tests/Dns.Tests.csproj
@@ -2,13 +2,11 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.test.reference.props'))" />
   <PropertyGroup>
     <PackageId>Dns.Tests</PackageId>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
     <AssemblyName>Dns.Tests</AssemblyName>
     <Description>Dns.Tests Class Library</Description>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.Network" Version="14.0.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />

--- a/src/SDKs/Dns/Dns.Tests/ScenarioTests/RecordSetScenarioTests.cs
+++ b/src/SDKs/Dns/Dns.Tests/ScenarioTests/RecordSetScenarioTests.cs
@@ -950,7 +950,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
 
         #region Helper methods
 
-        public static void CreateRecordSets(
+        internal static void CreateRecordSets(
             SingleRecordSetTestContext testContext,
             string[] recordSetNames)
         {
@@ -1001,7 +1001,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
                 parameters: createParameters3);
         }
 
-        public static void DeleteRecordSetsAndZone(
+        internal static void DeleteRecordSetsAndZone(
             SingleRecordSetTestContext testContext,
             string[] recordSetNames)
         {

--- a/src/SDKs/Dns/Dns.Tests/ScenarioTests/ZoneScenarioTests.cs
+++ b/src/SDKs/Dns/Dns.Tests/ScenarioTests/ZoneScenarioTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
                 // Ensure that Id is parseable into resourceGroup
                 string resourceGroupName =
                     ExtractResourceGroupNameFromId(createdZone.Id);
-                Assert.True(resourceGroupName.Equals(resourceGroup.Name));
+                Assert.Equal(resourceGroupName, resourceGroup.Name);
 
                 // Retrieve the zone after create, verify response
                 var retrievedZone = dnsClient.Zones.Get(
@@ -406,10 +406,8 @@ namespace Microsoft.Azure.Management.Dns.Testing
                     dnsClient.Zones.ListByResourceGroup(resourceGroup.Name, 1);
 
                 Assert.NotNull(listresponse);
-                Assert.Equal(1, listresponse.Count());
-                Assert.True(
-                    zoneNames.Any(
-                        zoneName => zoneName == listresponse.ElementAt(0).Name));
+                Assert.Single(listresponse);
+                Assert.Contains(zoneNames, zoneName => zoneName == listresponse.ElementAt(0).Name);
 
                 ZoneScenarioTests.DeleteZones(
                     dnsClient,
@@ -463,7 +461,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
                     dnsClient.Zones.ListByResourceGroupNext(
                         (listresponse.NextPageLink));
 
-                Assert.Equal(1, listresponse.Count());
+                Assert.Single(listresponse);
 
                 ZoneScenarioTests.DeleteZones(
                     dnsClient,
@@ -635,7 +633,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
 
         #region Helper methods
 
-        public static void CreateZones(
+        internal static void CreateZones(
             DnsManagementClient dnsClient,
             ResourceGroup resourceGroup,
             string[] zoneNames,
@@ -656,7 +654,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
             }
         }
 
-        public static void CreatePrivateZones(
+        internal static void CreatePrivateZones(
             DnsManagementClient dnsClient,
             ResourceGroup resourceGroup,
             IList<string> zonesNames,
@@ -679,7 +677,7 @@ namespace Microsoft.Azure.Management.Dns.Testing
             }
         }
 
-        public static void DeleteZones(
+        internal static void DeleteZones(
             DnsManagementClient dnsClient,
             ResourceGroup resourceGroup,
             string[] zoneNames)

--- a/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Microsoft.Azure.EventGrid.Tests.csproj
+++ b/src/SDKs/EventGrid/DataPlane/Microsoft.Azure.EventGrid.Tests/Microsoft.Azure.EventGrid.Tests.csproj
@@ -2,14 +2,12 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.test.reference.props'))" />
   <PropertyGroup>
     <PackageId>Microsoft.Azure.EventGrid.Tests</PackageId>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Microsoft.Azure.EventGrid.Tests Class Library</Description>
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>Microsoft.Azure.EventGrid.Tests</AssemblyName>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <ProjectReference Include="..\..\management\Management.EventGrid\Microsoft.Azure.Management.EventGrid.csproj" />

--- a/src/SDKs/EventGrid/management/EventGrid.Tests/Microsoft.Azure.Management.EventGrid.Tests.csproj
+++ b/src/SDKs/EventGrid/management/EventGrid.Tests/Microsoft.Azure.Management.EventGrid.Tests.csproj
@@ -2,15 +2,12 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.test.reference.props'))" />
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.EventGrid.Tests</PackageId>
-    <VersionPrefix>1.2.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
     <Description>EventGrid.Tests Class Library</Description>
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>Microsoft.Azure.Management.EventGrid.Tests</AssemblyName>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
-
   <ItemGroup>
     <ProjectReference Include="..\Management.EventGrid\Microsoft.Azure.Management.EventGrid.csproj" />
   </ItemGroup>

--- a/src/SDKs/EventHub/EventHub.Tests/EventHub.Tests.csproj
+++ b/src/SDKs/EventHub/EventHub.Tests/EventHub.Tests.csproj
@@ -2,10 +2,11 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.test.reference.props'))" />  
   <PropertyGroup>
     <PackageId>EventHub.Tests</PackageId>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
     <Description>EventHub.Tests Class Library</Description>
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>EventHub.Tests</AssemblyName>    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>  
   <ItemGroup>
     <Compile Remove="Tests\ScenarioTests.ConsumergroupsTests.CRUD_Length.cs" />
@@ -17,10 +18,6 @@
     <Compile Remove="Tests\ScenarioTests.EventHubTests.CRUD.cs" />
     <Compile Remove="Tests\ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs" />
   </ItemGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->  
-
 
   <ItemGroup>
     <!-- <PackageReference Include="Microsoft.Azure.Management.EventHub" Version="1.2.0" /> -->

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Graph.RBAC.Tests.csproj
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Graph.RBAC.Tests.csproj
@@ -2,14 +2,12 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.test.reference.props'))" />
   <PropertyGroup>
     <PackageId>Graph.RBAC.Tests</PackageId>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Description>Graph.RBAC.Tests Class Library</Description>
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>Graph.RBAC.Tests</AssemblyName>    
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Graph.RBAC" Version="3.3.0-preview" />-->
     <ProjectReference Include="..\Graph.RBAC\Microsoft.Azure.Graph.RBAC.csproj" />

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/ApplicationAndServicePrincipalTests.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/ApplicationAndServicePrincipalTests.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 }
 
                 //verify the application has been deleted.
-                Assert.Throws(typeof(GraphErrorException), () => { GetApplicationByObjectId(context, application.ObjectId); });
+                Assert.Throws<GraphErrorException>(() => { GetApplicationByObjectId(context, application.ObjectId); });
             }
         }
 
@@ -83,10 +83,10 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                     // Get App credentials - should be 0
                     var keyCreds = GetAppKeyCredential(context, appObjectId);
-                    Assert.Equal(0, keyCreds.Count);
+                    Assert.Empty(keyCreds);
 
                     var passwordCreds = GetAppPasswordCredential(context, appObjectId);
-                    Assert.Equal(0, passwordCreds.Count);
+                    Assert.Empty(passwordCreds);
 
                     // Add a password credential
                     string keyId = "a687d7e2-7c5f-4411-afae-e78ae43a9395";
@@ -100,12 +100,12 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                     // Get app credentials
                     keyCreds = GetAppKeyCredential(context, appObjectId);
-                    Assert.Equal(1, keyCreds.Count);
-                    Assert.True(keyCreds.Any(c => c.KeyId == keyCredential.KeyId));
+                    Assert.Single(keyCreds);
+                    Assert.Contains(keyCreds, c => c.KeyId == keyCredential.KeyId);
 
                     passwordCreds = GetAppPasswordCredential(context, appObjectId);
-                    Assert.Equal(1, passwordCreds.Count);
-                    Assert.True(passwordCreds.Any(c => c.KeyId == passwordCredential1.KeyId));
+                    Assert.Single(passwordCreds);
+                    Assert.Contains(passwordCreds, c => c.KeyId == passwordCredential1.KeyId);
 
                     // Append a new passwordCredential to exisitng credentials
                     keyId = "71986590-87c7-45c2-b85e-f5ef022e821f";
@@ -116,8 +116,8 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     //Get
                     var fetchedpasswordCreds2 = GetAppPasswordCredential(context, appObjectId);
                     Assert.Equal(2, fetchedpasswordCreds2.Count);
-                    Assert.True(fetchedpasswordCreds2.Any(c => c.KeyId == passwordCredential2.KeyId));
-                    Assert.True(fetchedpasswordCreds2.Any(c => c.KeyId == passwordCredential1.KeyId));
+                    Assert.Contains(fetchedpasswordCreds2, c => c.KeyId == passwordCredential2.KeyId);
+                    Assert.Contains(fetchedpasswordCreds2, c => c.KeyId == passwordCredential1.KeyId);
 
                     // Add 2 new password credentils -- older should be removed
                     keyId = "7880f3aa-66ee-4e63-a427-3a89d316b039";
@@ -129,22 +129,22 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     //Get
                     var fetchedpasswordCreds3 = GetAppPasswordCredential(context, appObjectId);
                     Assert.Equal(2, fetchedpasswordCreds3.Count);
-                    Assert.True(fetchedpasswordCreds3.Any(c => c.KeyId == passwordCredential3.KeyId));
-                    Assert.True(fetchedpasswordCreds3.Any(c => c.KeyId == passwordCredential4.KeyId));
+                    Assert.Contains(fetchedpasswordCreds3, c => c.KeyId == passwordCredential3.KeyId);
+                    Assert.Contains(fetchedpasswordCreds3, c => c.KeyId == passwordCredential4.KeyId);
 
                     // Remove key credentials
                     UpdateAppKeyCredential(context, appObjectId, new List<KeyCredential>());
 
                     // Get app credentials
                     var deletedkeyCreds = GetAppKeyCredential(context, appObjectId);
-                    Assert.Equal(0, deletedkeyCreds.Count);
+                    Assert.Empty(deletedkeyCreds);
 
                     // Remove password credentials
                     UpdateAppPasswordCredential(context, appObjectId, new List<PasswordCredential>());
 
                     // Get app credentials
                     var deletedPasswordCreds = GetAppPasswordCredential(context, appObjectId);
-                    Assert.Equal(0, deletedPasswordCreds.Count);
+                    Assert.Empty(deletedPasswordCreds);
                 }
                 finally
                 {
@@ -174,10 +174,10 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                     // Get Sp credentials - should be 0
                     var keyCreds = GetSpKeyCredential(context, spObjectId);
-                    Assert.Equal(0, keyCreds.Count);
+                    Assert.Empty(keyCreds);
 
                     var passwordCreds = GetSpPasswordCredential(context, spObjectId);
-                    Assert.Equal(0, passwordCreds.Count);
+                    Assert.Empty(passwordCreds);
 
                     // Add a password credential
                     string keyId = "dbf1c168-ebe9-4b93-8b14-83462734c164";
@@ -191,12 +191,12 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                     // Get sp credentials
                     keyCreds = GetSpKeyCredential(context, spObjectId);
-                    Assert.Equal(1, keyCreds.Count);
-                    Assert.True(keyCreds.Any(c => c.KeyId == keyCredential.KeyId));
+                    Assert.Single(keyCreds);
+                    Assert.Contains(keyCreds, c => c.KeyId == keyCredential.KeyId);
 
                     passwordCreds = GetSpPasswordCredential(context, spObjectId);
-                    Assert.Equal(1, passwordCreds.Count);
-                    Assert.True(passwordCreds.Any(c => c.KeyId == passwordCredential1.KeyId));
+                    Assert.Single(passwordCreds);
+                    Assert.Contains(passwordCreds, c => c.KeyId == passwordCredential1.KeyId);
 
                     // Append a new passwordCredential to exisitng credentials
                     keyId = "debcca8c-4fa0-4b40-8d21-853a3213f328";
@@ -207,8 +207,8 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     //Get
                     var fetchedpasswordCreds2 = GetSpPasswordCredential(context, spObjectId);
                     Assert.Equal(2, fetchedpasswordCreds2.Count);
-                    Assert.True(fetchedpasswordCreds2.Any(c => c.KeyId == passwordCredential2.KeyId));
-                    Assert.True(fetchedpasswordCreds2.Any(c => c.KeyId == passwordCredential1.KeyId));
+                    Assert.Contains(fetchedpasswordCreds2, c => c.KeyId == passwordCredential2.KeyId);
+                    Assert.Contains(fetchedpasswordCreds2, c => c.KeyId == passwordCredential1.KeyId);
 
                     // Add 2 new password credentils -- older should be removed
                     keyId = "19b89f7a-b2fd-444e-bed6-41d66df7eba5";
@@ -220,22 +220,22 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     //Get
                     var fetchedpasswordCreds3 = GetSpPasswordCredential(context, spObjectId);
                     Assert.Equal(2, fetchedpasswordCreds3.Count);
-                    Assert.True(fetchedpasswordCreds3.Any(c => c.KeyId == passwordCredential3.KeyId));
-                    Assert.True(fetchedpasswordCreds3.Any(c => c.KeyId == passwordCredential4.KeyId));
+                    Assert.Contains(fetchedpasswordCreds3, c => c.KeyId == passwordCredential3.KeyId);
+                    Assert.Contains(fetchedpasswordCreds3, c => c.KeyId == passwordCredential4.KeyId);
 
                     // Remove key credentials
                     UpdateSpKeyCredential(context, spObjectId, new List<KeyCredential>());
 
                     // Get sp credentials
                     var deletedkeyCreds = GetSpKeyCredential(context, spObjectId);
-                    Assert.Equal(0, deletedkeyCreds.Count);
+                    Assert.Empty(deletedkeyCreds);
 
                     // Remove password credentials
                     UpdateSpPasswordCredential(context, spObjectId, new List<PasswordCredential>());
 
                     // Get sp credentials
                     var deletedPasswordCreds = GetSpPasswordCredential(context, spObjectId);
-                    Assert.Equal(0, deletedPasswordCreds.Count);
+                    Assert.Empty(deletedPasswordCreds);
                 }
                 finally
                 {
@@ -265,20 +265,20 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 var newKeyCredential = CreateKeyCredential();
 
                 // Get App credentials - should fail
-                Assert.Throws(typeof(GraphErrorException), () => GetAppKeyCredential(context, randomObjectId));
-                Assert.Throws(typeof(GraphErrorException), () => GetAppPasswordCredential(context, randomObjectId));
+                Assert.Throws<GraphErrorException>(() => GetAppKeyCredential(context, randomObjectId));
+                Assert.Throws<GraphErrorException>(() => GetAppPasswordCredential(context, randomObjectId));
 
                 // Add credentials on a random app - should fail
-                Assert.Throws(typeof(GraphErrorException), () => UpdateAppKeyCredential(context, randomObjectId, newKeyCredential));
-                Assert.Throws(typeof(GraphErrorException), () => UpdateAppPasswordCredential(context, randomObjectId, newPasswordCredential));
+                Assert.Throws<GraphErrorException>(() => UpdateAppKeyCredential(context, randomObjectId, newKeyCredential));
+                Assert.Throws<GraphErrorException>(() => UpdateAppPasswordCredential(context, randomObjectId, newPasswordCredential));
 
                 // Get Sp credentials - should fail
-                Assert.Throws(typeof(GraphErrorException), () => GetSpKeyCredential(context, randomObjectId));
-                Assert.Throws(typeof(GraphErrorException), () => GetAppPasswordCredential(context, randomObjectId));
+                Assert.Throws<GraphErrorException>(() => GetSpKeyCredential(context, randomObjectId));
+                Assert.Throws<GraphErrorException>(() => GetAppPasswordCredential(context, randomObjectId));
 
                 // Add credentials on a random app - should fail
-                Assert.Throws(typeof(GraphErrorException), () => UpdateSpKeyCredential(context, randomObjectId, newKeyCredential));
-                Assert.Throws(typeof(GraphErrorException), () => UpdateSpPasswordCredential(context, randomObjectId, newPasswordCredential));
+                Assert.Throws<GraphErrorException>(() => UpdateSpKeyCredential(context, randomObjectId, newKeyCredential));
+                Assert.Throws<GraphErrorException>(() => UpdateSpPasswordCredential(context, randomObjectId, newPasswordCredential));
             }
         }
 
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 }
 
                 //verify the user has been deleted.
-                Assert.Throws(typeof(GraphErrorException), () => { SearchServicePrincipal(context, sp.ObjectId); });
+                Assert.Throws<GraphErrorException>(() => { SearchServicePrincipal(context, sp.ObjectId); });
             }
         }
 

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/BasicTests.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/BasicTests.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 var usersByName = client.Users.List(new ODataQuery<User>(f => f.DisplayName.StartsWith(usersNoFilter.ElementAt(1).DisplayName)));
                 Assert.NotNull(usersByName);
                 Assert.NotEmpty(usersByName);
-                Assert.Equal(1, usersByName.Count());
+                Assert.Single(usersByName);
 
                 Assert.Equal(usersNoFilter.ElementAt(1).ObjectId, usersByName.ElementAt(0).ObjectId);
             }
@@ -74,19 +74,19 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 var client = GetGraphClient(context);
 
                 // Add this user through management portal before recording mocks
-                string testLiveId  = "auxtm596@live.com";
+                // string testLiveId  = "auxtm596@live.com";
 
                 // UPN for this user will be a wierd ext string e.g. auxtm596_live.com#EXT#@rbacCliTest.onmicrosoft.com
 
                 string upn = "auxtm596_live.com#EXT#@" + GetTenantAndDomain().Domain;
                 var usersByLiveId = client.Users.List(new ODataQuery<User>(f=>f.UserPrincipalName == upn));
                 Assert.NotNull(usersByLiveId);
-                Assert.Equal(1, usersByLiveId.Count());
+                Assert.Single(usersByLiveId);
                 
                 string testOrgId = "test2@" + GetTenantAndDomain().Domain;
                 var usersByOrgId = client.Users.List(new ODataQuery<User>(f => f.UserPrincipalName == testOrgId));
                 Assert.NotNull(usersByOrgId);
-                Assert.Equal(1, usersByOrgId.Count());
+                Assert.Single(usersByOrgId);
             }
         }
 
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
 
                 var groupsByName = client.Groups.List(new ODataQuery<ADGroup>(f => f.DisplayName.StartsWith(groupsNoFilter.ElementAt(1).DisplayName)));
                 Assert.NotNull(groupsByName);
-                Assert.Equal(1, groupsByName.Count());
+                Assert.Single(groupsByName);
                 
                 Assert.Equal(
                     groupsNoFilter.ElementAt(1).ObjectId,
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     var nextPage = client.Groups.GetGroupMembersNext(firstPage.NextPageLink);
 
                     Assert.NotNull(nextPage);
-                    Assert.NotEqual(0, nextPage.Count());
+                    Assert.NotEmpty(nextPage);
 
                     foreach (var aadItem in nextPage)
                     {
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 var listResult = client.ServicePrincipals.List(new ODataQuery<ServicePrincipal>(f=> f.ServicePrincipalNames.Contains(testServicePrincipalName)));
                 ServicePrincipal servicePrincipal = listResult.First();
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.NotNull(servicePrincipal);
                 Assert.True(servicePrincipal.ObjectId == testObjectId);
                 Assert.Equal(testDisplayName, servicePrincipal.DisplayName);
@@ -407,7 +407,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                     });
 
                 Assert.NotNull(objectByObject);
-                Assert.Equal(1, objectByObject.Count());
+                Assert.Single(objectByObject);
             }
         }
     }

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/GroupTests.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/GroupTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 ADGroup group = CreateGroup(context);
                 DeleteGroup(context, group.ObjectId);
                 //verify the group has been deleted.
-                Assert.Throws(typeof(GraphErrorException), () => { SearchGroup(context, group.ObjectId); });
+                Assert.Throws<GraphErrorException>(() => { SearchGroup(context, group.ObjectId); });
             }
         }
 

--- a/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/UserTests.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC.Tests/Tests/UserTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Graph.RBAC.Tests
                 User user = CreateUser(context);
                 DeleteUser(context, user.UserPrincipalName);
                 //verify the user has been deleted.
-                Assert.Throws(typeof(GraphErrorException), () => { SearchUser(context, user.UserPrincipalName); });
+                Assert.Throws<GraphErrorException>(() => { SearchUser(context, user.UserPrincipalName); });
             }
         }
     }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
