### PR TITLE
Fixed customization for Hive/Oozie metastores

### DIFF
--- a/src/SDKs/HDInsight/Management.HDInsight/Management.HDInsight.csproj
+++ b/src/SDKs/HDInsight/Management.HDInsight/Management.HDInsight.csproj
@@ -7,11 +7,11 @@
 		<PackageId>Microsoft.Azure.Management.HDInsight</PackageId>
 		<Description>Azure HDInsight Management SDK Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.HDInsight</AssemblyName>
-		<Version>3.1.0-preview</Version>
+		<Version>3.1.1-preview</Version>
 		<PackageTags>Microsoft Azure HDInsight Management;HDInsight;HDInsight Management</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[
-        This is a public preview release of the Azure HDInsight SDK. Fixed customization support for ADLS Gen 2.
+        This is a public preview release of the Azure HDInsight SDK. Fixed customization related to Hive/Oozie metastores and duplicate configurations.
       ]]>
 		</PackageReleaseNotes>
     

--- a/src/SDKs/HDInsight/Management.HDInsight/Properties/AssemblyInfo.cs
+++ b/src/SDKs/HDInsight/Management.HDInsight/Properties/AssemblyInfo.cs
@@ -22,7 +22,7 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft Azure HDInsight Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure HDInsight.")]
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.1.0.0")]
+[assembly: AssemblyFileVersion("3.1.1.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.Management.HDInsight.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 


### PR DESCRIPTION


<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

There was a bug that would occur if a user specified an Hive/Oozie metastore when they had configurations like hive-site. This change will fix this scenario so the configurations are merged, but still raise an exception when there are duplicate configurations. There is no regeneration necessary for this change.

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
