### PR TITLE
[GuestConfiguration] minor fix for SDK publish job failure

### DIFF
--- a/src/SDKs/GuestConfiguration/AzSdk.RP.props
+++ b/src/SDKs/GuestConfiguration/AzSdk.RP.props
@@ -3,6 +3,5 @@
   <PropertyGroup>
     <AzureApiTag>Compute_2018-06-30-preview;GuestConfiguration_2018-06-30-preview;</AzureApiTag>
     <PackageTags>$(PackageTags);$(CommonTags);$(AzureApiTag);</PackageTags>
-    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
 </Project>

--- a/src/SDKs/GuestConfiguration/GuestConfiguration.Tests/ScenarioTests/GuestConfigurationTests.cs
+++ b/src/SDKs/GuestConfiguration/GuestConfiguration.Tests/ScenarioTests/GuestConfigurationTests.cs
@@ -10,7 +10,7 @@ namespace GuestConfiguration.Tests.ScenarioTests
     using Microsoft.Rest.ClientRuntime.Azure.TestFramework;
     using Xunit;
 
-    public class AutomationTest 
+    public class GuestConfigurationTest 
     {
         private const string ResourceGroupName = "GCSDKTests";
         private const string VMName = "GCSDKTests0";


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
