### PR TITLE
[Azure Traffic Manager] Do not omit Resource ID.

### DIFF
--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/ITrafficManagerManagementClient.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/ITrafficManagerManagementClient.cs
@@ -52,19 +52,20 @@ namespace Microsoft.Azure.Management.TrafficManager
         string ApiVersion { get; }
 
         /// <summary>
-        /// Gets or sets the preferred language for the response.
+        /// The preferred language for the response.
         /// </summary>
         string AcceptLanguage { get; set; }
 
         /// <summary>
-        /// Gets or sets the retry timeout in seconds for Long Running
-        /// Operations. Default value is 30.
+        /// The retry timeout in seconds for Long Running Operations. Default
+        /// value is 30.
         /// </summary>
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is generated
-        /// and included in each request. Default is true.
+        /// Whether a unique x-ms-client-request-id should be generated. When
+        /// set to true a unique x-ms-client-request-id value is generated and
+        /// included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/EndpointMonitorStatus.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/EndpointMonitorStatus.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Models
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingValue.ToString();
+            return UnderlyingValue == null ? null : UnderlyingValue.ToString();
         }
 
         /// <summary>

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/EndpointStatus.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/EndpointStatus.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Models
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingValue.ToString();
+            return UnderlyingValue == null ? null : UnderlyingValue.ToString();
         }
 
         /// <summary>

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/MonitorProtocol.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/MonitorProtocol.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Models
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingValue.ToString();
+            return UnderlyingValue == null ? null : UnderlyingValue.ToString();
         }
 
         /// <summary>

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/ProfileMonitorStatus.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/ProfileMonitorStatus.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Models
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingValue.ToString();
+            return UnderlyingValue == null ? null : UnderlyingValue.ToString();
         }
 
         /// <summary>

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/ProfileStatus.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/ProfileStatus.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Models
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingValue.ToString();
+            return UnderlyingValue == null ? null : UnderlyingValue.ToString();
         }
 
         /// <summary>

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/Resource.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/Resource.cs
@@ -50,11 +50,11 @@ namespace Microsoft.Azure.Management.TrafficManager.Models
         partial void CustomInit();
 
         /// <summary>
-        /// Gets fully qualified resource Id for the resource. Ex -
+        /// Gets or sets fully qualified resource Id for the resource. Ex -
         /// /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/trafficManagerProfiles/{resourceName}
         /// </summary>
         [JsonProperty(PropertyName = "id")]
-        public string Id { get; private set; }
+        public string Id { get; set; }
 
         /// <summary>
         /// Gets the name of the resource

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/TrafficRoutingMethod.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/TrafficRoutingMethod.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Models
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingValue.ToString();
+            return UnderlyingValue == null ? null : UnderlyingValue.ToString();
         }
 
         /// <summary>

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/TrafficViewEnrollmentStatus.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/Models/TrafficViewEnrollmentStatus.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Management.TrafficManager.Models
         /// </summary>
         public override string ToString()
         {
-            return UnderlyingValue.ToString();
+            return UnderlyingValue == null ? null : UnderlyingValue.ToString();
         }
 
         /// <summary>

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/SdkInfo_TrafficManagerManagementClient.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/SdkInfo_TrafficManagerManagementClient.cs
@@ -27,5 +27,16 @@ namespace Microsoft.Azure.Management.TrafficManager
               }.AsEnumerable();
           }
       }
+      // BEGIN: Code Generation Metadata Section
+      public static readonly String AutoRestVersion = "latest";
+      public static readonly String AutoRestBootStrapperVersion = "autorest@2.0.4283";
+      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/trafficmanager/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --opt-in-extensible-enums --csharp-sdks-folder=D:\\Source\\tatlicioglu\\azure-sdk-for-net\\src\\SDKs";
+      public static readonly String GithubForkName = "Azure";
+      public static readonly String GithubBranchName = "master";
+      public static readonly String GithubCommidId = "9e43725e0a4610bda08950c82fc9ffb36c6a5b5c";
+      public static readonly String CodeGenerationErrors = "";
+      public static readonly String GithubRepoName = "azure-rest-api-specs";
+      // END: Code Generation Metadata Section
   }
 }
+

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Generated/TrafficManagerManagementClient.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Generated/TrafficManagerManagementClient.cs
@@ -56,19 +56,20 @@ namespace Microsoft.Azure.Management.TrafficManager
         public string ApiVersion { get; private set; }
 
         /// <summary>
-        /// Gets or sets the preferred language for the response.
+        /// The preferred language for the response.
         /// </summary>
         public string AcceptLanguage { get; set; }
 
         /// <summary>
-        /// Gets or sets the retry timeout in seconds for Long Running Operations.
-        /// Default value is 30.
+        /// The retry timeout in seconds for Long Running Operations. Default value is
+        /// 30.
         /// </summary>
         public int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is generated and
-        /// included in each request. Default is true.
+        /// Whether a unique x-ms-client-request-id should be generated. When set to
+        /// true a unique x-ms-client-request-id value is generated and included in
+        /// each request. Default is true.
         /// </summary>
         public bool? GenerateClientRequestId { get; set; }
 
@@ -96,6 +97,19 @@ namespace Microsoft.Azure.Management.TrafficManager
         /// Gets the ITrafficManagerUserMetricsKeysOperations.
         /// </summary>
         public virtual ITrafficManagerUserMetricsKeysOperations TrafficManagerUserMetricsKeys { get; private set; }
+
+        /// <summary>
+        /// Initializes a new instance of the TrafficManagerManagementClient class.
+        /// </summary>
+        /// <param name='httpClient'>
+        /// HttpClient to be used
+        /// </param>
+        /// <param name='disposeHttpClient'>
+        /// True: will dispose the provided httpClient on calling TrafficManagerManagementClient.Dispose(). False: will not dispose provided httpClient</param>
+        protected TrafficManagerManagementClient(HttpClient httpClient, bool disposeHttpClient) : base(httpClient, disposeHttpClient)
+        {
+            Initialize();
+        }
 
         /// <summary>
         /// Initializes a new instance of the TrafficManagerManagementClient class.
@@ -180,6 +194,33 @@ namespace Microsoft.Azure.Management.TrafficManager
         /// Thrown when a required parameter is null
         /// </exception>
         public TrafficManagerManagementClient(ServiceClientCredentials credentials, params DelegatingHandler[] handlers) : this(handlers)
+        {
+            if (credentials == null)
+            {
+                throw new System.ArgumentNullException("credentials");
+            }
+            Credentials = credentials;
+            if (Credentials != null)
+            {
+                Credentials.InitializeServiceClient(this);
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the TrafficManagerManagementClient class.
+        /// </summary>
+        /// <param name='credentials'>
+        /// Required. Credentials needed for the client to connect to Azure.
+        /// </param>
+        /// <param name='httpClient'>
+        /// HttpClient to be used
+        /// </param>
+        /// <param name='disposeHttpClient'>
+        /// True: will dispose the provided httpClient on calling TrafficManagerManagementClient.Dispose(). False: will not dispose provided httpClient</param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        public TrafficManagerManagementClient(ServiceClientCredentials credentials, HttpClient httpClient, bool disposeHttpClient) : this(httpClient, disposeHttpClient)
         {
             if (credentials == null)
             {

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Microsoft.Azure.Management.TrafficManager.csproj
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Microsoft.Azure.Management.TrafficManager.csproj
@@ -7,11 +7,12 @@
 		<PackageId>Microsoft.Azure.Management.TrafficManager</PackageId>
 		<Description>Microsoft Azure Management TrafficManager Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.TrafficManager</AssemblyName>
-		<Version>2.5.0</Version>
+		<Version>2.5.1</Version>
 		<PackageTags>Microsoft Azure TrafficManager management;TrafficManager;TrafficManager management;</PackageTags>
         <PackageReleaseNotes>
             <![CDATA[
                 This is the Azure Traffic Manager SDK for API version 2018-04-01.
+				Resource IDs are settable.
             ]]>
         </PackageReleaseNotes>
 	</PropertyGroup>

--- a/src/SDKs/TrafficManager/Management.TrafficManager/Properties/AssemblyInfo.cs
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Traffic Manager management functions for managing the Microsoft Azure Traffic Manager service.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.5.0.0")]
+[assembly: AssemblyFileVersion("2.5.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]

--- a/src/SDKs/TrafficManager/Management.TrafficManager/generate.ps1
+++ b/src/SDKs/TrafficManager/Management.TrafficManager/generate.ps1
@@ -1,1 +1,1 @@
-Start-AutoRestCodeGeneration -ResourceProvider "trafficmanager/resource-manager" -AutoRestVersion "latest"
+Start-AutoRestCodeGeneration -ResourceProvider "trafficmanager/resource-manager" -AutoRestVersion "latest" -AutoRestCodeGenerationFlags  "--opt-in-extensible-enums"

--- a/src/SDKs/_metadata/trafficmanager_resource-manager.txt
+++ b/src/SDKs/_metadata/trafficmanager_resource-manager.txt
@@ -3,18 +3,12 @@ AutoRest installed successfully.
 Commencing code generation
 Generating CSharp code
 Executing AutoRest command
-cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/trafficmanager/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=E:\GitHub\AllenFork\azure-sdk-for-net\src\SDKs
-2018-07-20 18:05:48 UTC
-1) azure-rest-api-specs repository information
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/trafficmanager/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --opt-in-extensible-enums --csharp-sdks-folder=D:\Source\tatlicioglu\azure-sdk-for-net\src\SDKs
+2018-09-25 22:41:39 UTC
+Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      ad8ff141e1b55aa5578567ed625d3a2a70bff1ae
-
-2) AutoRest information
+Commit:      9e43725e0a4610bda08950c82fc9ffb36c6a5b5c
+AutoRest information
 Requested version: latest
-Bootstrapper version:    autorest@2.0.4280
-
-
-Latest installed version:    
-
-
+Bootstrapper version:    autorest@2.0.4283


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
