### PR TITLE
Treat warnings as errors n-r

### DIFF
--- a/src/SDKs/Network/Network.Tests/Helpers/ResourcesManagementTestUtilities.cs
+++ b/src/SDKs/Network/Network.Tests/Helpers/ResourcesManagementTestUtilities.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.Test
         }
 
         /// Get a default resource location for a given resource type
+        /// <summary>
         /// </summary>
         /// <param name="client">The resource management client</param>
         /// <param name="resourceType">The type of resource to create</param>

--- a/src/SDKs/Network/Network.Tests/Network.Tests.csproj
+++ b/src/SDKs/Network/Network.Tests/Network.Tests.csproj
@@ -4,11 +4,9 @@
     <PackageId>Network.Tests</PackageId>
     <Description>Network.Tests Class Library</Description>
     <AssemblyName>Network.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.OperationalInsights" Version="0.18.0-preview" />

--- a/src/SDKs/Network/Network.Tests/Tests/ApplicationGatewayTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/ApplicationGatewayTests.cs
@@ -610,7 +610,7 @@ namespace Networks.Tests
                 Assert.NotEmpty(availableWAFRuleSets.Value[0].RuleGroups);
                 Assert.NotNull(availableWAFRuleSets.Value[0].RuleGroups[0].RuleGroupName);
                 Assert.NotEmpty(availableWAFRuleSets.Value[0].RuleGroups[0].Rules);
-                Assert.NotNull(availableWAFRuleSets.Value[0].RuleGroups[0].Rules[0].RuleId);
+                // Assert.NotNull(availableWAFRuleSets.Value[0].RuleGroups[0].Rules[0].RuleId);
 
                 // Get availalbe SSL options
                 var sslOptions = networkManagementClient.ApplicationGateways.ListAvailableSslOptions();

--- a/src/SDKs/Network/Network.Tests/Tests/AvailableProvidersListTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/AvailableProvidersListTests.cs
@@ -36,7 +36,7 @@ namespace Network.Tests.Tests
 
                 var providersList = networkManagementClient.NetworkWatchers.ListAvailableProviders("NetworkWatcherRG", "NetworkWatcher", parameters);
 
-                Assert.Equal(providersList.Countries[0].CountryName, "United States");
+                Assert.Equal("United States", providersList.Countries[0].CountryName);
             }
         }
 
@@ -60,8 +60,8 @@ namespace Network.Tests.Tests
 
                 var providersList = networkManagementClient.NetworkWatchers.ListAvailableProviders("NetworkWatcherRG", "NetworkWatcher", parameters);
 
-                Assert.Equal(providersList.Countries[0].CountryName, "United States");
-                Assert.Equal(providersList.Countries[0].States[0].StateName, "washington");
+                Assert.Equal("United States", providersList.Countries[0].CountryName);
+                Assert.Equal("washington", providersList.Countries[0].States[0].StateName);
             }
         }
 
@@ -86,9 +86,9 @@ namespace Network.Tests.Tests
 
                 var providersList = networkManagementClient.NetworkWatchers.ListAvailableProviders("NetworkWatcherRG", "NetworkWatcher", parameters);
 
-                Assert.Equal(providersList.Countries[0].CountryName, "United States");
-                Assert.Equal(providersList.Countries[0].States[0].StateName, "washington");
-                Assert.Equal(providersList.Countries[0].States[0].Cities[0].CityName, "seattle");
+                Assert.Equal("United States", providersList.Countries[0].CountryName);
+                Assert.Equal("washington", providersList.Countries[0].States[0].StateName);
+                Assert.Equal("seattle", providersList.Countries[0].States[0].Cities[0].CityName);
             }
         }
     }

--- a/src/SDKs/Network/Network.Tests/Tests/AzureReachabilityReportTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/AzureReachabilityReportTests.cs
@@ -42,9 +42,9 @@ namespace Network.Tests.Tests
                 var report = networkManagementClient.NetworkWatchers.GetAzureReachabilityReport("NetworkWatcherRG", "NetworkWatcher", parameters);
 
                 //Validation
-                Assert.Equal(report.AggregationLevel, "Country");
-                Assert.Equal(report.ProviderLocation.Country, "United States");
-                Assert.Equal(report.ReachabilityReport[0].AzureLocation, "West US");
+                Assert.Equal("Country", report.AggregationLevel);
+                Assert.Equal("United States", report.ProviderLocation.Country);
+                Assert.Equal("West US", report.ReachabilityReport[0].AzureLocation);
             }
         }
 
@@ -74,10 +74,10 @@ namespace Network.Tests.Tests
                 var report = networkManagementClient.NetworkWatchers.GetAzureReachabilityReport("NetworkWatcherRG", "NetworkWatcher", parameters);
 
                 //Validation
-                Assert.Equal(report.AggregationLevel, "State");
-                Assert.Equal(report.ProviderLocation.Country, "United States");
-                Assert.Equal(report.ProviderLocation.State, "washington");
-                Assert.Equal(report.ReachabilityReport[0].AzureLocation, "West US");
+                Assert.Equal("State", report.AggregationLevel);
+                Assert.Equal("United States", report.ProviderLocation.Country);
+                Assert.Equal("washington", report.ProviderLocation.State);
+                Assert.Equal("West US", report.ReachabilityReport[0].AzureLocation);
             }
         }
 
@@ -108,11 +108,11 @@ namespace Network.Tests.Tests
                 var report = networkManagementClient.NetworkWatchers.GetAzureReachabilityReport("NetworkWatcherRG", "NetworkWatcher", parameters);
 
                 //Validation
-                Assert.Equal(report.AggregationLevel, "City");
-                Assert.Equal(report.ProviderLocation.Country, "United States");
-                Assert.Equal(report.ProviderLocation.State, "washington");
-                Assert.Equal(report.ProviderLocation.City, "seattle");
-                Assert.Equal(report.ReachabilityReport[0].AzureLocation, "West US");
+                Assert.Equal("City", report.AggregationLevel);
+                Assert.Equal("United States", report.ProviderLocation.Country);
+                Assert.Equal("washington", report.ProviderLocation.State);
+                Assert.Equal("seattle", report.ProviderLocation.City);
+                Assert.Equal("West US", report.ReachabilityReport[0].AzureLocation);
             }
         }
     }

--- a/src/SDKs/Network/Network.Tests/Tests/CheckConnectivityTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/CheckConnectivityTests.cs
@@ -89,10 +89,10 @@ namespace Network.Tests.Tests
                 var connectivityCheck = networkManagementClient.NetworkWatchers.CheckConnectivity(resourceGroupName, networkWatcherName, connectivityParameters);
 
                 //Validation
-                Assert.Equal(connectivityCheck.ConnectionStatus, "Reachable");
-                Assert.Equal(connectivityCheck.ProbesFailed, 0);
-                Assert.Equal(connectivityCheck.Hops.FirstOrDefault().Type, "Source");
-                Assert.Equal(connectivityCheck.Hops.LastOrDefault().Type, "Internet");
+                Assert.Equal("Reachable", connectivityCheck.ConnectionStatus);
+                Assert.Equal(0, connectivityCheck.ProbesFailed);
+                Assert.Equal("Source", connectivityCheck.Hops.FirstOrDefault().Type);
+                Assert.Equal("Internet", connectivityCheck.Hops.LastOrDefault().Type);
             }
         }
     }

--- a/src/SDKs/Network/Network.Tests/Tests/ExpandResourceTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/ExpandResourceTests.cs
@@ -283,7 +283,7 @@ namespace Networks.Tests
                     Assert.NotNull(ipconfig.Subnet.Id);
                     Assert.NotNull(ipconfig.Subnet.Name);
                     Assert.NotNull(ipconfig.Subnet.Etag);
-                    Assert.NotEqual(0, ipconfig.Subnet.IpConfigurations.Count());
+                    Assert.NotEmpty(ipconfig.Subnet.IpConfigurations);
                 }
 
                 // Get subnet with expanded ipconfigurations
@@ -317,7 +317,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
 
                 // Delete all NetworkInterfaces
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nic1name);

--- a/src/SDKs/Network/Network.Tests/Tests/GatewayOperationsTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/GatewayOperationsTests.cs
@@ -173,7 +173,7 @@ namespace Networks.Tests
                 // 5. ListVitualNetworkGateways API
                 var listVirtualNetworkGatewayResponse = networkManagementClient.VirtualNetworkGateways.List(resourceGroupName);
                 Console.WriteLine("ListVirtualNetworkGateways count ={0} ", listVirtualNetworkGatewayResponse.Count());
-                Assert.Equal(1, listVirtualNetworkGatewayResponse.Count());
+                Assert.Single(listVirtualNetworkGatewayResponse);
 
                 // 6A. DeleteVirtualNetworkGateway API
                 networkManagementClient.VirtualNetworkGateways.Delete(resourceGroupName, virtualNetworkGatewayName);
@@ -182,7 +182,7 @@ namespace Networks.Tests
                 listVirtualNetworkGatewayResponse = networkManagementClient.VirtualNetworkGateways.List(resourceGroupName);
 
                 Console.WriteLine("ListVirtualNetworkGateways count ={0} ", listVirtualNetworkGatewayResponse.Count());
-                Assert.Equal(0, listVirtualNetworkGatewayResponse.Count());
+                Assert.Empty(listVirtualNetworkGatewayResponse);
             }
         }
 
@@ -265,7 +265,7 @@ namespace Networks.Tests
                 // 4. ListLocalNetworkGateways API
                 var listLocalNetworkGatewayResponse = networkManagementClient.LocalNetworkGateways.List(resourceGroupName);
                 Console.WriteLine("ListLocalNetworkGateways count ={0} ", listLocalNetworkGatewayResponse.Count());
-                Assert.Equal(1, listLocalNetworkGatewayResponse.Count());
+                Assert.Single(listLocalNetworkGatewayResponse);
 
                 // 5A. DeleteLocalNetworkGateway API
                 networkManagementClient.LocalNetworkGateways.Delete(resourceGroupName, localNetworkGatewayName);
@@ -273,7 +273,7 @@ namespace Networks.Tests
                 // 5B. ListLocalNetworkGateways API after DeleteLocalNetworkGateway API was called
                 listLocalNetworkGatewayResponse = networkManagementClient.LocalNetworkGateways.List(resourceGroupName);
                 Console.WriteLine("ListLocalNetworkGateways count ={0} ", listLocalNetworkGatewayResponse.Count());
-                Assert.Equal(0, listLocalNetworkGatewayResponse.Count());
+                Assert.Empty(listLocalNetworkGatewayResponse);
             }
         }
 
@@ -431,7 +431,7 @@ namespace Networks.Tests
                 // 4. ListVitualNetworkGatewayConnections API
                 var listVirtualNetworkGatewayConectionResponse = networkManagementClient.VirtualNetworkGatewayConnections.List(resourceGroupName);
                 Console.WriteLine("ListVirtualNetworkGatewayConnections count ={0} ", listVirtualNetworkGatewayConectionResponse.Count());
-                Assert.Equal(1, listVirtualNetworkGatewayConectionResponse.Count());
+                Assert.Single(listVirtualNetworkGatewayConectionResponse);
 
                 // 5A. DeleteVirtualNetworkGatewayConnection API
                 networkManagementClient.VirtualNetworkGatewayConnections.Delete(resourceGroupName, VirtualNetworkGatewayConnectionName);
@@ -439,7 +439,7 @@ namespace Networks.Tests
                 // 5B. ListVitualNetworkGatewayConnections API after DeleteVirtualNetworkGatewayConnection API called
                 listVirtualNetworkGatewayConectionResponse = networkManagementClient.VirtualNetworkGatewayConnections.List(resourceGroupName);
                 Console.WriteLine("ListVirtualNetworkGatewayConnections count ={0} ", listVirtualNetworkGatewayConectionResponse.Count());
-                Assert.Equal(0, listVirtualNetworkGatewayConectionResponse.Count());
+                Assert.Empty(listVirtualNetworkGatewayConectionResponse);
 
             }
         }
@@ -667,7 +667,7 @@ namespace Networks.Tests
                 // 4. ListVitualNetworkGatewayConnections API
                 var listVirtualNetworkGatewayConectionResponse = networkManagementClient.VirtualNetworkGatewayConnections.List(resourceGroupName);
                 Console.WriteLine("ListVirtualNetworkGatewayConnections count ={0} ", listVirtualNetworkGatewayConectionResponse.Count());
-                Assert.Equal(1, listVirtualNetworkGatewayConectionResponse.Count());
+                Assert.Single(listVirtualNetworkGatewayConectionResponse);
 
                 // 5A. DeleteVirtualNetworkGatewayConnection API
                 networkManagementClient.VirtualNetworkGatewayConnections.Delete(resourceGroupName, VirtualNetworkGatewayConnectionName);
@@ -675,7 +675,7 @@ namespace Networks.Tests
                 // 5B. ListVitualNetworkGatewayConnections API after DeleteVirtualNetworkGatewayConnection API called
                 listVirtualNetworkGatewayConectionResponse = networkManagementClient.VirtualNetworkGatewayConnections.List(resourceGroupName);
                 Console.WriteLine("ListVirtualNetworkGatewayConnections count ={0} ", listVirtualNetworkGatewayConectionResponse.Count());
-                Assert.Equal(0, listVirtualNetworkGatewayConectionResponse.Count());
+                Assert.Empty(listVirtualNetworkGatewayConectionResponse);
             }
         }
 
@@ -851,11 +851,11 @@ namespace Networks.Tests
                 // 4A. ListVirtualNetworkGatewayConnections API
                 var listVirtualNetworkGatewayConectionResponse = networkManagementClient.VirtualNetworkGatewayConnections.List(resourceGroupName);
                 Console.WriteLine("ListVirtualNetworkGatewayConnections count ={0} ", listVirtualNetworkGatewayConectionResponse.Count());
-                Assert.Equal(1, listVirtualNetworkGatewayConectionResponse.Count());
+                Assert.Single(listVirtualNetworkGatewayConectionResponse);
 
                 // 4B. VirtualNetworkGateway ListConnections API
                 var virtualNetworkGatewayListConnectionsResponse = networkManagementClient.VirtualNetworkGateways.ListConnections(resourceGroupName, virtualNetworkGatewayName);
-                Assert.Equal(1, virtualNetworkGatewayListConnectionsResponse.Count());
+                Assert.Single(virtualNetworkGatewayListConnectionsResponse);
                 Assert.Equal(VirtualNetworkGatewayConnectionName, virtualNetworkGatewayListConnectionsResponse.First().Name);
 
                 // 5A. DeleteVirtualNetworkGatewayConnection API
@@ -864,7 +864,7 @@ namespace Networks.Tests
                 // 5B. ListVitualNetworkGatewayConnections API after DeleteVirtualNetworkGatewayConnection API called
                 listVirtualNetworkGatewayConectionResponse = networkManagementClient.VirtualNetworkGatewayConnections.List(resourceGroupName);
                 Console.WriteLine("ListVirtualNetworkGatewayConnections count ={0} ", listVirtualNetworkGatewayConectionResponse.Count());
-                Assert.Equal(0, listVirtualNetworkGatewayConectionResponse.Count());
+                Assert.Empty(listVirtualNetworkGatewayConectionResponse);
 
             }
         }
@@ -1228,7 +1228,7 @@ namespace Networks.Tests
                 Assert.Equal("Succeeded", putVirtualNetworkGatewayResponse.ProvisioningState);
                 getVirtualNetworkGatewayResponse = networkManagementClient.VirtualNetworkGateways.Get(resourceGroupName, virtualNetworkGatewayName);
                 Assert.True(getVirtualNetworkGatewayResponse.VpnClientConfiguration.VpnClientRevokedCertificates.Count() == 1);
-                Assert.Equal(getVirtualNetworkGatewayResponse.VpnClientConfiguration.VpnClientRevokedCertificates[0].Name, "sampleClientCert.cer");
+                Assert.Equal("sampleClientCert.cer", getVirtualNetworkGatewayResponse.VpnClientConfiguration.VpnClientRevokedCertificates[0].Name);
 
                 // 9. Unrevoke previously revoked Vpn client certificate
                 getVirtualNetworkGatewayResponse.VpnClientConfiguration.VpnClientRevokedCertificates.Clear();
@@ -1358,7 +1358,7 @@ namespace Networks.Tests
                 Assert.Equal(VpnType.RouteBased, getVirtualNetworkGatewayResponse.VpnType);
                 Assert.Equal(VirtualNetworkGatewaySkuTier.HighPerformance, getVirtualNetworkGatewayResponse.Sku.Tier);
                 Assert.Equal(2, getVirtualNetworkGatewayResponse.IpConfigurations.Count);
-                Assert.Equal(true, getVirtualNetworkGatewayResponse.ActiveActive);
+                Assert.True(getVirtualNetworkGatewayResponse.ActiveActive);
 
                 // 3. Update ActiveActive VirtualNetworkGateway to ActiveStandby
                 getVirtualNetworkGatewayResponse.ActiveActive = false;
@@ -1367,7 +1367,7 @@ namespace Networks.Tests
                 Assert.Equal("Succeeded", putVirtualNetworkGatewayResponse.ProvisioningState);
 
                 getVirtualNetworkGatewayResponse = networkManagementClient.VirtualNetworkGateways.Get(resourceGroupName, virtualNetworkGatewayName);
-                Assert.Equal(false, getVirtualNetworkGatewayResponse.ActiveActive);
+                Assert.False(getVirtualNetworkGatewayResponse.ActiveActive);
                 Assert.Equal(1, getVirtualNetworkGatewayResponse.IpConfigurations.Count);
 
                 // 4. Update ActiveStandby VirtualNetworkGateway to ActiveActive again
@@ -1377,7 +1377,7 @@ namespace Networks.Tests
                 Assert.Equal("Succeeded", putVirtualNetworkGatewayResponse.ProvisioningState);
 
                 getVirtualNetworkGatewayResponse = networkManagementClient.VirtualNetworkGateways.Get(resourceGroupName, virtualNetworkGatewayName);
-                Assert.Equal(true, getVirtualNetworkGatewayResponse.ActiveActive);
+                Assert.True(getVirtualNetworkGatewayResponse.ActiveActive);
                 Assert.Equal(2, getVirtualNetworkGatewayResponse.IpConfigurations.Count);
             }
         }

--- a/src/SDKs/Network/Network.Tests/Tests/LoadBalancerTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/LoadBalancerTests.cs
@@ -192,20 +192,20 @@ namespace Networks.Tests
                 
                 // Verify List LoadBalancer
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(1, listLoadBalancer.Count());
+                Assert.Single(listLoadBalancer);
                 Assert.Equal(lbName, listLoadBalancer.First().Name);
                 Assert.Equal(getLoadBalancer.Etag, listLoadBalancer.First().Etag);
 
                 // Verify List LoadBalancer subscription
                 var listLoadBalancerSubscription = networkManagementClient.LoadBalancers.ListAll();
-                Assert.NotEqual(0, listLoadBalancerSubscription.Count());
+                Assert.NotEmpty(listLoadBalancerSubscription);
                 Assert.Collection(listLoadBalancerSubscription, item => Assert.Equal(lbName, item.Name));
                 Assert.NotNull(listLoadBalancerSubscription.First().Name);
                 Assert.NotNull(listLoadBalancerSubscription.First().Etag);
 
                 // Verify List BackendAddressPools in LoadBalancer
                 var listLoadBalancerBackendAddressPools = networkManagementClient.LoadBalancerBackendAddressPools.List(resourceGroupName, lbName);
-                Assert.Equal(1, listLoadBalancerBackendAddressPools.Count());
+                Assert.Single(listLoadBalancerBackendAddressPools);
                 Assert.Equal(backEndAddressPoolName, listLoadBalancerBackendAddressPools.First().Name);
                 Assert.NotNull(listLoadBalancerBackendAddressPools.First().Etag);
 
@@ -216,7 +216,7 @@ namespace Networks.Tests
 
                 // Verify List FrontendIPConfigurations in LoadBalancer
                 var listLoadBalancerFrontendIPConfigurations = networkManagementClient.LoadBalancerFrontendIPConfigurations.List(resourceGroupName, lbName);
-                Assert.Equal(1, listLoadBalancerFrontendIPConfigurations.Count());
+                Assert.Single(listLoadBalancerFrontendIPConfigurations);
                 Assert.Equal(frontendIpConfigName, listLoadBalancerFrontendIPConfigurations.First().Name);
                 Assert.NotNull(listLoadBalancerFrontendIPConfigurations.First().Etag);
 
@@ -227,7 +227,7 @@ namespace Networks.Tests
 
                 // Verify List LoadBalancingRules in LoadBalancer
                 var listLoadBalancerLoadBalancingRules = networkManagementClient.LoadBalancerLoadBalancingRules.List(resourceGroupName, lbName);
-                Assert.Equal(1, listLoadBalancerLoadBalancingRules.Count());
+                Assert.Single(listLoadBalancerLoadBalancingRules);
                 Assert.Equal(loadBalancingRuleName, listLoadBalancerLoadBalancingRules.First().Name);
                 Assert.NotNull(listLoadBalancerLoadBalancingRules.First().Etag);
 
@@ -238,11 +238,11 @@ namespace Networks.Tests
 
                 // Verify List NetworkInterfaces in LoadBalancer
                 var listLoadBalancerNetworkInterfaces = networkManagementClient.LoadBalancerNetworkInterfaces.List(resourceGroupName, lbName);
-                Assert.Equal(0, listLoadBalancerNetworkInterfaces.Count());
+                Assert.Empty(listLoadBalancerNetworkInterfaces);
 
                 // Verify List Probes in LoadBalancer
                 var listLoadBalancerProbes = networkManagementClient.LoadBalancerProbes.List(resourceGroupName, lbName);
-                Assert.Equal(1, listLoadBalancerProbes.Count());
+                Assert.Single(listLoadBalancerProbes);
                 Assert.Equal(probeName, listLoadBalancerProbes.First().Name);
                 Assert.NotNull(listLoadBalancerProbes.First().Etag);
 
@@ -273,7 +273,7 @@ namespace Networks.Tests
                 Assert.Equal(3391, putInboundNatRule.FrontendPort);
                 Assert.Equal(3389, putInboundNatRule.BackendPort);
                 Assert.Equal(15, putInboundNatRule.IdleTimeoutInMinutes);
-                Assert.Equal(false, putInboundNatRule.EnableFloatingIP);
+                Assert.False(putInboundNatRule.EnableFloatingIP);
 
                 // Verify Get InboundNatRule in LoadBalancer
                 var getInboundNatRule = networkManagementClient.InboundNatRules.Get(resourceGroupName, lbName, inboundNatRule3Name);
@@ -282,7 +282,7 @@ namespace Networks.Tests
                 Assert.Equal(3391, getInboundNatRule.FrontendPort);
                 Assert.Equal(3389, getInboundNatRule.BackendPort);
                 Assert.Equal(15, getInboundNatRule.IdleTimeoutInMinutes);
-                Assert.Equal(false, getInboundNatRule.EnableFloatingIP);
+                Assert.False(getInboundNatRule.EnableFloatingIP);
 
                 // Verify List InboundNatRules in LoadBalancer
                 var listInboundNatRules = networkManagementClient.InboundNatRules.List(resourceGroupName, lbName);
@@ -301,7 +301,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
 
                 // Delete all PublicIPAddresses
                 networkManagementClient.PublicIPAddresses.Delete(resourceGroupName, lbPublicIpName);
@@ -467,13 +467,13 @@ namespace Networks.Tests
 
                 // Verify List LoadBalancer
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(1, listLoadBalancer.Count());
+                Assert.Single(listLoadBalancer);
                 Assert.Equal(lbName, listLoadBalancer.First().Name);
                 Assert.Equal(getLoadBalancer.Etag, listLoadBalancer.First().Etag);
 
                 // Verify List LoadBalancer subscription
                 var listLoadBalancerSubscription = networkManagementClient.LoadBalancers.ListAll();
-                Assert.NotEqual(0, listLoadBalancerSubscription.Count());
+                Assert.NotEmpty(listLoadBalancerSubscription);
                 Assert.NotNull(listLoadBalancerSubscription.First().Name);
                 Assert.NotNull(listLoadBalancerSubscription.First().Etag);
 
@@ -482,7 +482,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
 
                 // Delete VirtualNetwork
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
@@ -651,13 +651,13 @@ namespace Networks.Tests
 
                 // Verify List LoadBalancer
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(1, listLoadBalancer.Count());
+                Assert.Single(listLoadBalancer);
                 Assert.Equal(lbName, listLoadBalancer.First().Name);
                 Assert.Equal(getLoadBalancer.Etag, listLoadBalancer.First().Etag);
 
                 // Verify List LoadBalancer subscription
                 var listLoadBalancerSubscription = networkManagementClient.LoadBalancers.ListAll();
-                Assert.NotEqual(0, listLoadBalancerSubscription.Count());
+                Assert.NotEmpty(listLoadBalancerSubscription);
                 Assert.NotNull(listLoadBalancerSubscription.First().Name);
                 Assert.NotNull(listLoadBalancerSubscription.First().Etag);
 
@@ -666,7 +666,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
 
                 // Delete VirtualNetwork
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
@@ -835,7 +835,7 @@ namespace Networks.Tests
 
                 // Verify List LoadBalancer
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(1, listLoadBalancer.Count());
+                Assert.Single(listLoadBalancer);
                 Assert.Equal(lbName, listLoadBalancer.First().Name);
                 Assert.Equal(getLoadBalancer.Etag, listLoadBalancer.First().Etag);
 
@@ -857,7 +857,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
 
                 // Delete VirtualNetwork
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
@@ -914,7 +914,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
             }
         }
 
@@ -1062,7 +1062,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
 
                 // Delete VirtualNetwork
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
@@ -1282,8 +1282,8 @@ namespace Networks.Tests
                 // Verify the associations
                 getLoadBalancer = networkManagementClient.LoadBalancers.Get(resourceGroupName, lbName);
                 Assert.Equal(2, getLoadBalancer.BackendAddressPools.First().BackendIPConfigurations.Count);
-                Assert.True(getLoadBalancer.BackendAddressPools.First().BackendIPConfigurations.Any(ipconfig => string.Equals(ipconfig.Id, nic1.IpConfigurations[0].Id, StringComparison.OrdinalIgnoreCase)));
-                Assert.True(getLoadBalancer.BackendAddressPools.First().BackendIPConfigurations.Any(ipconfig => string.Equals(ipconfig.Id, nic2.IpConfigurations[0].Id, StringComparison.OrdinalIgnoreCase)));
+                Assert.Contains(getLoadBalancer.BackendAddressPools.First().BackendIPConfigurations, ipconfig => string.Equals(ipconfig.Id, nic1.IpConfigurations[0].Id, StringComparison.OrdinalIgnoreCase));
+                Assert.Contains(getLoadBalancer.BackendAddressPools.First().BackendIPConfigurations, ipconfig => string.Equals(ipconfig.Id, nic2.IpConfigurations[0].Id, StringComparison.OrdinalIgnoreCase));
                 Assert.Equal(nic1.IpConfigurations[0].Id, getLoadBalancer.InboundNatRules.First().BackendIPConfiguration.Id);
                 Assert.Equal(nic3.IpConfigurations[0].Id, getLoadBalancer.InboundNatRules[1].BackendIPConfiguration.Id);
 
@@ -1296,7 +1296,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
 
                 // Delete all NetworkInterfaces
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nic1name);
@@ -1429,7 +1429,7 @@ namespace Networks.Tests
 
                 // Verify Delete
                 var listLoadBalancer = networkManagementClient.LoadBalancers.List(resourceGroupName);
-                Assert.Equal(0, listLoadBalancer.Count());
+                Assert.Empty(listLoadBalancer);
 
                 // Delete all PublicIPAddresses
                 networkManagementClient.PublicIPAddresses.Delete(resourceGroupName, lbPublicIpName);

--- a/src/SDKs/Network/Network.Tests/Tests/NetworkInterfaceTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/NetworkInterfaceTests.cs
@@ -142,7 +142,7 @@ namespace Networks.Tests
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
                 Assert.Equal(getNicResponse.Name, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
                 Assert.Null(getNicResponse.VirtualMachine);
                 Assert.Null(getNicResponse.MacAddress);
 
@@ -156,7 +156,7 @@ namespace Networks.Tests
 
                 // Verify List IpConfigurations in NetworkInterface
                 var listNicIpConfigurations = networkManagementClient.NetworkInterfaceIPConfigurations.List(resourceGroupName, nicName);
-                Assert.Equal(1, listNicIpConfigurations.Count());
+                Assert.Single(listNicIpConfigurations);
                 Assert.Equal(ipConfigName, listNicIpConfigurations.First().Name);
                 Assert.NotNull(listNicIpConfigurations.First().Etag);
 
@@ -167,24 +167,24 @@ namespace Networks.Tests
 
                 // Verify List LoadBalancers in NetworkInterface
                 var listNicLoadBalancers = networkManagementClient.NetworkInterfaceLoadBalancers.List(resourceGroupName, nicName);
-                Assert.Equal(0, listNicLoadBalancers.Count());
+                Assert.Empty(listNicLoadBalancers);
 
                 // Get all Nics
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(1, getListNicResponse.Count());
+                Assert.Single(getListNicResponse);
                 Assert.Equal(getNicResponse.Name, getListNicResponse.First().Name);
                 Assert.Equal(getNicResponse.Etag, getListNicResponse.First().Etag);
                 Assert.Equal(getNicResponse.IpConfigurations[0].Etag, getListNicResponse.First().IpConfigurations[0].Etag);
 
                 // Get all Nics in subscription
                 var listNicSubscription = networkManagementClient.NetworkInterfaces.ListAll();
-                Assert.NotEqual(0, listNicSubscription.Count());
+                Assert.NotEmpty(listNicSubscription);
 
                 // Delete Nic
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete PublicIPAddress
                 networkManagementClient.PublicIPAddresses.Delete(resourceGroupName, publicIpName);
@@ -288,7 +288,7 @@ namespace Networks.Tests
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
                 Assert.Equal(getNicResponse.Name, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
                 Assert.Null(getNicResponse.VirtualMachine);
                 Assert.Null(getNicResponse.MacAddress);
                 Assert.Equal(1, getNicResponse.IpConfigurations.Count);
@@ -297,7 +297,7 @@ namespace Networks.Tests
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete VirtualNetwork
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
@@ -433,14 +433,14 @@ namespace Networks.Tests
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
                 Assert.Equal(getNicResponse.Name, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
                 Assert.Null(getNicResponse.VirtualMachine);
                 Assert.Null(getNicResponse.MacAddress);
-                Assert.Equal(true, getNicResponse.IpConfigurations[0].Primary);
+                Assert.True(getNicResponse.IpConfigurations[0].Primary);
                 Assert.Equal(2, getNicResponse.IpConfigurations.Count);
                 Assert.Equal(ipConfigName, getNicResponse.IpConfigurations[0].Name);
                 Assert.Equal(ipconfigName2, getNicResponse.IpConfigurations[1].Name);
-                Assert.Equal(false, getNicResponse.IpConfigurations[1].Primary);
+                Assert.False(getNicResponse.IpConfigurations[1].Primary);
                 Assert.Equal(getPublicIpAddressResponse.Id, getNicResponse.IpConfigurations[0].PublicIPAddress.Id);
                 Assert.Equal(getSubnetResponse.Id, getNicResponse.IpConfigurations[0].Subnet.Id);
                 Assert.Equal(getSubnetResponse.Id, getNicResponse.IpConfigurations[1].Subnet.Id);
@@ -448,7 +448,7 @@ namespace Networks.Tests
 
                 // Get all Nics
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(1, getListNicResponse.Count());
+                Assert.Single(getListNicResponse);
                 Assert.Equal(getNicResponse.Name, getListNicResponse.First().Name);
                 Assert.Equal(getNicResponse.Etag, getListNicResponse.First().Etag);
                 Assert.Equal(getNicResponse.IpConfigurations[0].Etag, getListNicResponse.First().IpConfigurations[0].Etag);
@@ -456,13 +456,13 @@ namespace Networks.Tests
 
                 // Get all Nics in subscription
                 var listNicSubscription = networkManagementClient.NetworkInterfaces.ListAll();
-                Assert.NotEqual(0, listNicSubscription.Count());
+                Assert.NotEmpty(listNicSubscription);
 
                 // Delete Nic
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete PublicIPAddress
                 networkManagementClient.PublicIPAddresses.Delete(resourceGroupName, publicIpName);
@@ -693,7 +693,7 @@ namespace Networks.Tests
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
                 Assert.Equal(getNicResponse.Name, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
                 Assert.Null(getNicResponse.VirtualMachine);
                 Assert.Null(getNicResponse.MacAddress);
                 Assert.Equal(1, getNicResponse.IpConfigurations.Count);
@@ -710,16 +710,16 @@ namespace Networks.Tests
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete VirtualNetwork
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
             }
         }
 
-        [Fact(Skip = "NRP check should be removed to check for multiple ipv4")]
         /// currently this test is failing because of nrp valdiation check:cannot have multiple IPv4 IpConfigurations if it specifies a Ipv6 IpConfigurations. Ipv4 Ipconfig Count: 2
         /// will remove ignore tag once the check in nrp is removed.
+        [Fact(Skip = "NRP check should be removed to check for multiple ipv4")]
         public void NetworkInterfaceApiIPv6MultiCATest()
         {
             var handler1 = new RecordedDelegatingHandler { StatusCodeToReturn = HttpStatusCode.OK };
@@ -833,7 +833,7 @@ namespace Networks.Tests
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
                 Assert.Equal(getNicResponse.Name, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
                 Assert.Null(getNicResponse.VirtualMachine);
                 Assert.Null(getNicResponse.MacAddress);
                 Assert.Equal(ipConfigName, getNicResponse.IpConfigurations[0].Name);
@@ -844,14 +844,14 @@ namespace Networks.Tests
                 // Ipv6 specific asserts
                 Assert.Equal(2, getNicResponse.IpConfigurations.Count);
                 Assert.Equal(ipv6IpConfigName, getNicResponse.IpConfigurations[1].Name);
-                Assert.Equal(true, getNicResponse.IpConfigurations[1].Primary);
-                Assert.Equal(false, getNicResponse.IpConfigurations[0].Primary);
+                Assert.True(getNicResponse.IpConfigurations[1].Primary);
+                Assert.False(getNicResponse.IpConfigurations[0].Primary);
                 Assert.Null(getNicResponse.IpConfigurations[1].Subnet);
                 Assert.Equal(IPVersion.IPv6, getNicResponse.IpConfigurations[1].PrivateIPAddressVersion);
 
                 // Get all Nics
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(1, getListNicResponse.Count());
+                Assert.Single(getListNicResponse);
                 Assert.Equal(getNicResponse.Name, getListNicResponse.First().Name);
                 Assert.Equal(getNicResponse.Etag, getListNicResponse.First().Etag);
                 Assert.Equal(getNicResponse.IpConfigurations[0].Etag, getListNicResponse.First().IpConfigurations[0].Etag);
@@ -859,13 +859,13 @@ namespace Networks.Tests
 
                 // Get all Nics in subscription
                 var listNicSubscription = networkManagementClient.NetworkInterfaces.ListAll();
-                Assert.NotEqual(0, listNicSubscription.Count());
+                Assert.NotEmpty(listNicSubscription);
 
                 // Delete Nic
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete PublicIPAddress
                 networkManagementClient.PublicIPAddresses.Delete(resourceGroupName, publicIpName);
@@ -970,7 +970,7 @@ namespace Networks.Tests
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
                 Assert.Equal(getNicResponse.Name, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
                 Assert.Null(getNicResponse.VirtualMachine);
                 Assert.Null(getNicResponse.MacAddress);
                 Assert.Equal(1, getNicResponse.IpConfigurations.Count);
@@ -989,7 +989,7 @@ namespace Networks.Tests
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete VirtualNetwork
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
@@ -1086,7 +1086,7 @@ namespace Networks.Tests
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
                 Assert.Equal(getNicResponse.Name, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
                 Assert.Null(getNicResponse.VirtualMachine);
                 Assert.Null(getNicResponse.MacAddress);
                 Assert.Equal(1, getNicResponse.IpConfigurations.Count);
@@ -1103,7 +1103,7 @@ namespace Networks.Tests
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete VirtualNetwork
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
@@ -1227,7 +1227,7 @@ namespace Networks.Tests
                 var putNicResponse = networkManagementClient.NetworkInterfaces.CreateOrUpdate(resourceGroupName, nicName, nicParameters);
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
 
                 var getNsgResponse = networkManagementClient.NetworkSecurityGroups.Get(resourceGroupName, networkSecurityGroupName);
 
@@ -1239,7 +1239,7 @@ namespace Networks.Tests
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete NSG
                 networkManagementClient.NetworkSecurityGroups.Delete(resourceGroupName, networkSecurityGroupName);
@@ -1366,7 +1366,7 @@ namespace Networks.Tests
                 var putNicResponse = networkManagementClient.NetworkInterfaces.CreateOrUpdate(resourceGroupName, nicName, nicParameters);
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
 
                 var getNsgResponse = networkManagementClient.NetworkSecurityGroups.Get(resourceGroupName, networkSecurityGroupName);
 
@@ -1382,7 +1382,7 @@ namespace Networks.Tests
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete NSG
                 networkManagementClient.NetworkSecurityGroups.Delete(resourceGroupName, networkSecurityGroupName);
@@ -1499,7 +1499,7 @@ namespace Networks.Tests
                 var putNicResponse = networkManagementClient.NetworkInterfaces.CreateOrUpdate(resourceGroupName, nicName, nicParameters);
 
                 var getNicResponse = networkManagementClient.NetworkInterfaces.Get(resourceGroupName, nicName);
-                Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+                Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
 
                 // Get effective NSGs
                 var effectiveRouteTable = networkManagementClient.NetworkInterfaces.GetEffectiveRouteTable(resourceGroupName, nicName);
@@ -1509,7 +1509,7 @@ namespace Networks.Tests
                 networkManagementClient.NetworkInterfaces.Delete(resourceGroupName, nicName);
 
                 var getListNicResponse = networkManagementClient.NetworkInterfaces.List(resourceGroupName);
-                Assert.Equal(0, getListNicResponse.Count());
+                Assert.Empty(getListNicResponse);
 
                 // Delete routetable
                 networkManagementClient.RouteTables.Delete(resourceGroupName, routeTableName);

--- a/src/SDKs/Network/Network.Tests/Tests/NetworkSecurityGroupTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/NetworkSecurityGroupTests.cs
@@ -77,7 +77,7 @@ namespace Networks.Tests
 
                 // List NSG
                 var listNsgResponse = networkManagementClient.NetworkSecurityGroups.List(resourceGroupName);
-                Assert.Equal(1, listNsgResponse.Count());
+                Assert.Single(listNsgResponse);
                 Assert.Equal(networkSecurityGroupName, listNsgResponse.First().Name);
                 Assert.Equal(6, listNsgResponse.First().DefaultSecurityRules.Count);
                 Assert.Equal("AllowVnetInBound", listNsgResponse.First().DefaultSecurityRules[0].Name);
@@ -90,14 +90,14 @@ namespace Networks.Tests
 
                 // List NSG in a subscription
                 var listNsgSubsciptionResponse = networkManagementClient.NetworkSecurityGroups.ListAll();
-                Assert.NotEqual(0, listNsgSubsciptionResponse.Count());
+                Assert.NotEmpty(listNsgSubsciptionResponse);
 
                 // Delete NSG
                 networkManagementClient.NetworkSecurityGroups.Delete(resourceGroupName, networkSecurityGroupName);
                 
                 // List NSG
                 listNsgResponse = networkManagementClient.NetworkSecurityGroups.List(resourceGroupName);
-                Assert.Equal(0, listNsgResponse.Count());
+                Assert.Empty(listNsgResponse);
             }
         }
 
@@ -177,7 +177,7 @@ namespace Networks.Tests
 
                 // List NSG
                 var listNsgResponse = networkManagementClient.NetworkSecurityGroups.List(resourceGroupName);
-                Assert.Equal(1, listNsgResponse.Count());
+                Assert.Single(listNsgResponse);
                 Assert.Equal(networkSecurityGroupName, listNsgResponse.First().Name);
                 Assert.Equal(6, listNsgResponse.First().DefaultSecurityRules.Count);
                 Assert.Equal("AllowVnetInBound", listNsgResponse.First().DefaultSecurityRules[0].Name);
@@ -190,7 +190,7 @@ namespace Networks.Tests
 
                 // List NSG in a subscription
                 var listNsgSubsciptionResponse = networkManagementClient.NetworkSecurityGroups.ListAll();
-                Assert.NotEqual(0, listNsgSubsciptionResponse.Count());
+                Assert.NotEmpty(listNsgSubsciptionResponse);
 
                 // Add a new security rule
                 var SecurityRule = new SecurityRule()
@@ -228,7 +228,7 @@ namespace Networks.Tests
 
                 // List Default Security Groups
                 var listDefaultSecurityGroups = networkManagementClient.DefaultSecurityRules.List(resourceGroupName, networkSecurityGroupName);
-                Assert.NotEqual(0, listDefaultSecurityGroups.Count());
+                Assert.NotEmpty(listDefaultSecurityGroups);
 
                 // Get Defaul Security Group
                 var getDefaultSecurityGroups = networkManagementClient.DefaultSecurityRules.Get(resourceGroupName, networkSecurityGroupName, listDefaultSecurityGroups.First().Name);
@@ -239,7 +239,7 @@ namespace Networks.Tests
                 
                 // List NSG
                 listNsgResponse = networkManagementClient.NetworkSecurityGroups.List(resourceGroupName);
-                Assert.Equal(0, listNsgResponse.Count());
+                Assert.Empty(listNsgResponse);
             }
         }
     }

--- a/src/SDKs/Network/Network.Tests/Tests/NetworkWatcherTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/NetworkWatcherTests.cs
@@ -66,13 +66,13 @@ namespace Network.Tests.Tests
                 Assert.Equal("Succeeded", getNetworkWatcherByName.ProvisioningState);
 
                 //Verify the number of Network Watchers in the resource group (should be 1)
-                Assert.Equal(getNetworkWatchersByResourceGroup.Count(), 1);
+                Assert.Single(getNetworkWatchersByResourceGroup);
 
                 //Verify the number of Network Watchers in the subscription
-                Assert.Equal(getNetworkWatchersBySubscription.Count(), 2);
+                Assert.Equal(2, getNetworkWatchersBySubscription.Count());
 
                 //Verify the number of Network Watchers in the subscription after deleting one which was created in the test
-                Assert.Equal(getNetworkWatcherBySubscriptionAfterDeleting.Count(), 1);
+                Assert.Single(getNetworkWatcherBySubscriptionAfterDeleting);
             }
         }
     }

--- a/src/SDKs/Network/Network.Tests/Tests/PacketCaptureTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/PacketCaptureTests.cs
@@ -110,7 +110,7 @@ namespace Network.Tests.Tests
                 Assert.Equal(2, listPCByRg1.Count());
                 Assert.Equal("Stopped", queryPCAfterStop.PacketCaptureStatus);
                 Assert.Equal("Manual", queryPCAfterStop.StopReason);
-                Assert.Equal(1, listPCByRg2.Count());
+                Assert.Single(listPCByRg2);
             }
         }
     }

--- a/src/SDKs/Network/Network.Tests/Tests/PublicIpAddressTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/PublicIpAddressTests.cs
@@ -70,19 +70,19 @@ namespace Networks.Tests
 
                 // Get List of PublicIPAddress 
                 var getPublicIpAddressListResponse = networkManagementClient.PublicIPAddresses.List(resourceGroupName);
-                Assert.Equal(1, getPublicIpAddressListResponse.Count());
+                Assert.Single(getPublicIpAddressListResponse);
                 ArePublicIpAddressesEqual(getPublicIpAddressResponse, getPublicIpAddressListResponse.First());
 
                 // Get List of PublicIPAddress in a subscription
                 var getPublicIpAddressListSubscriptionResponse = networkManagementClient.PublicIPAddresses.ListAll();
-                Assert.NotEqual(0, getPublicIpAddressListSubscriptionResponse.Count());
+                Assert.NotEmpty(getPublicIpAddressListSubscriptionResponse);
                 
                 // Delete PublicIPAddress
                 networkManagementClient.PublicIPAddresses.Delete(resourceGroupName, publicIpName);
                 
                 // Get PublicIPAddress
                 getPublicIpAddressListResponse = networkManagementClient.PublicIPAddresses.List(resourceGroupName);
-                Assert.Equal(0, getPublicIpAddressListResponse.Count());
+                Assert.Empty(getPublicIpAddressListResponse);
             }
         }
 
@@ -147,19 +147,19 @@ namespace Networks.Tests
 
                 // Get List of PublicIPAddress 
                 var getPublicIpAddressListResponse = networkManagementClient.PublicIPAddresses.List(resourceGroupName);
-                Assert.Equal(1, getPublicIpAddressListResponse.Count());
+                Assert.Single(getPublicIpAddressListResponse);
                 ArePublicIpAddressesEqual(getPublicIpAddressResponse, getPublicIpAddressListResponse.First());
 
                 // Get List of PublicIPAddress in a subscription
                 var getPublicIpAddressListSubscriptionResponse = networkManagementClient.PublicIPAddresses.ListAll();
-                Assert.NotEqual(0, getPublicIpAddressListSubscriptionResponse.Count());
+                Assert.NotEmpty(getPublicIpAddressListSubscriptionResponse);
                 
                 // Delete PublicIPAddress
                 networkManagementClient.PublicIPAddresses.Delete(resourceGroupName, publicIpName);
                 
                 // Get PublicIPAddress
                 getPublicIpAddressListResponse = networkManagementClient.PublicIPAddresses.List(resourceGroupName);
-                Assert.Equal(0, getPublicIpAddressListResponse.Count());
+                Assert.Empty(getPublicIpAddressListResponse);
 
             }
         }
@@ -218,19 +218,19 @@ namespace Networks.Tests
 
                 // Get List of PublicIPAddress 
                 var getPublicIpAddressListResponse = networkManagementClient.PublicIPAddresses.List(resourceGroupName);
-                Assert.Equal(1, getPublicIpAddressListResponse.Count());
+                Assert.Single(getPublicIpAddressListResponse);
                 ArePublicIpAddressesEqual(getPublicIpAddressResponse, getPublicIpAddressListResponse.First());
 
                 // Get List of PublicIPAddress in a subscription
                 var getPublicIpAddressListSubscriptionResponse = networkManagementClient.PublicIPAddresses.ListAll();
-                Assert.NotEqual(0, getPublicIpAddressListSubscriptionResponse.Count());
+                Assert.NotEmpty(getPublicIpAddressListSubscriptionResponse);
 
                 // Delete PublicIPAddress
                 networkManagementClient.PublicIPAddresses.Delete(resourceGroupName, ipv6PublicIpName);
 
                 // Get PublicIPAddress
                 getPublicIpAddressListResponse = networkManagementClient.PublicIPAddresses.List(resourceGroupName);
-                Assert.Equal(0, getPublicIpAddressListResponse.Count());
+                Assert.Empty(getPublicIpAddressListResponse);
 
                 // Also check IPv4 PublicIP
                 // Create the parameter for PUT PublicIPAddress

--- a/src/SDKs/Network/Network.Tests/Tests/RouteTableTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/RouteTableTests.cs
@@ -66,7 +66,7 @@ namespace Network.Tests.Tests
                 // List RouteTable
                 var listRouteTableResponse = networkManagementClient.RouteTables.List(resourceGroupName);
 
-                Assert.Equal(1, listRouteTableResponse.Count());
+                Assert.Single(listRouteTableResponse);
                 Assert.Equal(getRouteTableResponse.Name, listRouteTableResponse.First().Name);
                 Assert.Equal(getRouteTableResponse.Id, listRouteTableResponse.First().Id);
 
@@ -76,7 +76,7 @@ namespace Network.Tests.Tests
                 // Verify delete
                 listRouteTableResponse = networkManagementClient.RouteTables.List(resourceGroupName);
 
-                Assert.Equal(0, listRouteTableResponse.Count());
+                Assert.Empty(listRouteTableResponse);
             }
         }
 
@@ -186,7 +186,7 @@ namespace Network.Tests.Tests
                 // Verify delete
                 var listRouteTableResponse = networkManagementClient.RouteTables.List(resourceGroupName);
 
-                Assert.Equal(0, listRouteTableResponse.Count());
+                Assert.Empty(listRouteTableResponse);
             }
         }
 

--- a/src/SDKs/Network/Network.Tests/Tests/RouteTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/RouteTests.cs
@@ -144,7 +144,7 @@ namespace Network.Tests.Tests
                     resourceGroupName,
                     routeTableName);
 
-                Assert.Equal(1, listRouteResponse.Count());
+                Assert.Single(listRouteResponse);
                 Assert.Equal(getRouteResponse2.Name, listRouteResponse.First().Name);
                 Assert.Equal(getRouteResponse2.AddressPrefix, listRouteResponse.First().AddressPrefix);
                 Assert.Equal(getRouteResponse2.NextHopIpAddress, listRouteResponse.First().NextHopIpAddress);
@@ -160,7 +160,7 @@ namespace Network.Tests.Tests
                     resourceGroupName,
                     routeTableName);
 
-                Assert.Equal(0, listRouteResponse.Count());
+                Assert.Empty(listRouteResponse);
 
                 // Delete RouteTable
                 networkManagementClient.RouteTables.Delete(
@@ -170,7 +170,7 @@ namespace Network.Tests.Tests
                 // Verify delete
                 var listRouteTableResponse = networkManagementClient.RouteTables.List(resourceGroupName);
 
-                Assert.Equal(0, listRouteTableResponse.Count());
+                Assert.Empty(listRouteTableResponse);
             }
         }
 
@@ -289,7 +289,7 @@ namespace Network.Tests.Tests
                 // Verify delete
                 var listRouteTableResponse = networkManagementClient.RouteTables.List(resourceGroupName);
 
-                Assert.Equal(0, listRouteTableResponse.Count());
+                Assert.Empty(listRouteTableResponse);
             }
         }
     }

--- a/src/SDKs/Network/Network.Tests/Tests/SecurityRuleTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/SecurityRuleTests.cs
@@ -133,14 +133,14 @@ namespace Networks.Tests
                 
                 getsecurityRules = networkManagementClient.SecurityRules.List(resourceGroupName, networkSecurityGroupName);
                 
-                Assert.Equal(1, getsecurityRules.Count());
+                Assert.Single(getsecurityRules);
 
                // Delete NSG
                 networkManagementClient.NetworkSecurityGroups.Delete(resourceGroupName, networkSecurityGroupName);
                 
                 // List NSG
                 var listNsgResponse = networkManagementClient.NetworkSecurityGroups.List(resourceGroupName);
-                Assert.Equal(0, listNsgResponse.Count());
+                Assert.Empty(listNsgResponse);
             }
         }
 

--- a/src/SDKs/Network/Network.Tests/Tests/SubnetTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/SubnetTests.cs
@@ -109,7 +109,7 @@ namespace Networks.Tests
                 // Verify that the deletion was successful
                 getSubnetListResponse = networkManagementClient.Subnets.List(resourceGroupName, vnetName);
                 
-                Assert.Equal(1, getSubnetListResponse.Count());
+                Assert.Single(getSubnetListResponse);
                 Assert.Equal(subnet1Name, getSubnetListResponse.ElementAt(0).Name);
 
                 #endregion

--- a/src/SDKs/Network/Network.Tests/Tests/TestHelper.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/TestHelper.cs
@@ -265,9 +265,9 @@ namespace Networks.Tests
             Assert.Equal(getNicResponse.Name, name);
 
             // because its a single CA nic, primaryOnCA is always true
-            Assert.Equal(getNicResponse.IpConfigurations[0].Primary, true);
+            Assert.True(getNicResponse.IpConfigurations[0].Primary);
 
-            Assert.Equal(getNicResponse.ProvisioningState, "Succeeded");
+            Assert.Equal("Succeeded", getNicResponse.ProvisioningState);
 
             return getNicResponse;
         }

--- a/src/SDKs/Network/Network.Tests/Tests/VirtualNetworkPeeringTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/VirtualNetworkPeeringTests.cs
@@ -102,7 +102,7 @@ namespace Networks.Tests
 
                 // Get Peerings in the vnet
                 var listPeering = networkManagementClient.VirtualNetworkPeerings.List(resourceGroupName, vnetName);
-                Assert.Equal(0, listPeering.Count());
+                Assert.Empty(listPeering);
 
                 var peering = new VirtualNetworkPeering();
                 peering.Name = vnetPeeringName;
@@ -119,8 +119,8 @@ namespace Networks.Tests
                 Assert.Equal(remoteVirtualNetwork.Id, putPeering.RemoteVirtualNetwork.Id);
                 Assert.Equal(peering.AllowForwardedTraffic, putPeering.AllowForwardedTraffic);
                 Assert.Equal(peering.AllowVirtualNetworkAccess, putPeering.AllowVirtualNetworkAccess);
-                Assert.Equal(false, putPeering.UseRemoteGateways);
-                Assert.Equal(false, putPeering.AllowGatewayTransit);
+                Assert.False(putPeering.UseRemoteGateways);
+                Assert.False(putPeering.AllowGatewayTransit);
                 Assert.Equal(VirtualNetworkPeeringState.Initiated, putPeering.PeeringState);
 
                 // get peering
@@ -131,27 +131,27 @@ namespace Networks.Tests
                 Assert.Equal(remoteVirtualNetwork.Id, getPeering.RemoteVirtualNetwork.Id);
                 Assert.Equal(peering.AllowForwardedTraffic, getPeering.AllowForwardedTraffic);
                 Assert.Equal(peering.AllowVirtualNetworkAccess, getPeering.AllowVirtualNetworkAccess);
-                Assert.Equal(false, getPeering.UseRemoteGateways);
-                Assert.Equal(false, getPeering.AllowGatewayTransit);
+                Assert.False(getPeering.UseRemoteGateways);
+                Assert.False(getPeering.AllowGatewayTransit);
                 Assert.Equal(VirtualNetworkPeeringState.Initiated, getPeering.PeeringState);
 
                 // list peering
                 listPeering = networkManagementClient.VirtualNetworkPeerings.List(resourceGroupName, vnetName);
 
-                Assert.Equal(1, listPeering.Count());
+                Assert.Single(listPeering);
                 Assert.Equal(listPeering.ElementAt(0).Etag, putPeering.Etag);
                 Assert.Equal(vnetPeeringName, listPeering.ElementAt(0).Name);
                 Assert.Equal(remoteVirtualNetwork.Id, listPeering.ElementAt(0).RemoteVirtualNetwork.Id);
                 Assert.Equal(peering.AllowForwardedTraffic, listPeering.ElementAt(0).AllowForwardedTraffic);
                 Assert.Equal(peering.AllowVirtualNetworkAccess, listPeering.ElementAt(0).AllowVirtualNetworkAccess);
-                Assert.Equal(false, listPeering.ElementAt(0).UseRemoteGateways);
-                Assert.Equal(false, listPeering.ElementAt(0).AllowGatewayTransit);
+                Assert.False(listPeering.ElementAt(0).UseRemoteGateways);
+                Assert.False(listPeering.ElementAt(0).AllowGatewayTransit);
                 Assert.Equal(VirtualNetworkPeeringState.Initiated, listPeering.ElementAt(0).PeeringState);
 
                 // delete peering
                 networkManagementClient.VirtualNetworkPeerings.Delete(resourceGroupName, vnetName, vnetPeeringName);
                 listPeering = networkManagementClient.VirtualNetworkPeerings.List(resourceGroupName, vnetName);
-                Assert.Equal(0, listPeering.Count());
+                Assert.Empty(listPeering);
 
                 // Delete Vnet
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
@@ -159,7 +159,7 @@ namespace Networks.Tests
 
                 // Get all Vnets
                 getAllVnets = networkManagementClient.VirtualNetworks.List(resourceGroupName);
-                Assert.Equal(0, getAllVnets.Count());
+                Assert.Empty(getAllVnets);
             }
         }
     }

--- a/src/SDKs/Network/Network.Tests/Tests/VirtualNetworkTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/VirtualNetworkTests.cs
@@ -104,14 +104,14 @@ namespace Networks.Tests
 
                 // Get all Vnets in a subscription
                 var getAllVnetInSubscription = networkManagementClient.VirtualNetworks.ListAll();
-                Assert.NotEqual(0, getAllVnetInSubscription.Count());
+                Assert.NotEmpty(getAllVnetInSubscription);
 
                 // Delete Vnet
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnetName);
                 
                 // Get all Vnets
                 getAllVnets = networkManagementClient.VirtualNetworks.List(resourceGroupName);
-                Assert.Equal(0, getAllVnets.Count());
+                Assert.Empty(getAllVnets);
             }
         }
 
@@ -330,30 +330,30 @@ namespace Networks.Tests
                 // Get Peering
                 var getPeer = networkManagementClient.VirtualNetworkPeerings.Get(resourceGroupName, vnet1Name, "peer1");
                 Assert.Equal("peer1", getPeer.Name);
-                Assert.Equal(true, getPeer.AllowForwardedTraffic);
-                Assert.Equal(true, getPeer.AllowVirtualNetworkAccess);
-                Assert.Equal(false, getPeer.AllowGatewayTransit);
+                Assert.True(getPeer.AllowForwardedTraffic);
+                Assert.True(getPeer.AllowVirtualNetworkAccess);
+                Assert.False(getPeer.AllowGatewayTransit);
                 Assert.NotNull(getPeer.RemoteVirtualNetwork);
                 Assert.Equal(putVnet2.Id, getPeer.RemoteVirtualNetwork.Id);
 
                 // List Peering
                 var listPeer = networkManagementClient.VirtualNetworkPeerings.List(resourceGroupName, vnet1Name).ToList();
-                Assert.Equal(1, listPeer.Count);
+                Assert.Single(listPeer);
                 Assert.Equal("peer1", listPeer[0].Name);
-                Assert.Equal(true, listPeer[0].AllowForwardedTraffic);
-                Assert.Equal(true, listPeer[0].AllowVirtualNetworkAccess);
-                Assert.Equal(false, listPeer[0].AllowGatewayTransit);
+                Assert.True(listPeer[0].AllowForwardedTraffic);
+                Assert.True(listPeer[0].AllowVirtualNetworkAccess);
+                Assert.False(listPeer[0].AllowGatewayTransit);
                 Assert.NotNull(listPeer[0].RemoteVirtualNetwork);
                 Assert.Equal(putVnet2.Id, listPeer[0].RemoteVirtualNetwork.Id);
 
                 // Get peering from GET vnet
                 var peeringVnet = networkManagementClient.VirtualNetworks.Get(resourceGroupName, vnet1Name);
                 Assert.Equal(vnet1Name, peeringVnet.Name);
-                Assert.Equal(1, peeringVnet.VirtualNetworkPeerings.Count());
+                Assert.Single(peeringVnet.VirtualNetworkPeerings);
                 Assert.Equal("peer1", peeringVnet.VirtualNetworkPeerings[0].Name);
-                Assert.Equal(true, peeringVnet.VirtualNetworkPeerings[0].AllowForwardedTraffic);
-                Assert.Equal(true, peeringVnet.VirtualNetworkPeerings[0].AllowVirtualNetworkAccess);
-                Assert.Equal(false, peeringVnet.VirtualNetworkPeerings[0].AllowGatewayTransit);
+                Assert.True(peeringVnet.VirtualNetworkPeerings[0].AllowForwardedTraffic);
+                Assert.True(peeringVnet.VirtualNetworkPeerings[0].AllowVirtualNetworkAccess);
+                Assert.False(peeringVnet.VirtualNetworkPeerings[0].AllowGatewayTransit);
                 Assert.NotNull(peeringVnet.VirtualNetworkPeerings[0].RemoteVirtualNetwork);
                 Assert.Equal(putVnet2.Id, peeringVnet.VirtualNetworkPeerings[0].RemoteVirtualNetwork.Id);
 
@@ -361,11 +361,11 @@ namespace Networks.Tests
                 networkManagementClient.VirtualNetworkPeerings.Delete(resourceGroupName, vnet1Name, "peer1");
 
                 listPeer = networkManagementClient.VirtualNetworkPeerings.List(resourceGroupName, vnet1Name).ToList();
-                Assert.Equal(0, listPeer.Count);
+                Assert.Empty(listPeer);
 
                 peeringVnet = networkManagementClient.VirtualNetworks.Get(resourceGroupName, vnet1Name);
                 Assert.Equal(vnet1Name, peeringVnet.Name);
-                Assert.Equal(0, peeringVnet.VirtualNetworkPeerings.Count());
+                Assert.Empty(peeringVnet.VirtualNetworkPeerings);
 
                 // Delete Vnets
                 networkManagementClient.VirtualNetworks.Delete(resourceGroupName, vnet1Name);

--- a/src/SDKs/Network/Network.Tests/Tests/VmssNetworkInterfaceTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/VmssNetworkInterfaceTests.cs
@@ -87,7 +87,7 @@ namespace Networks.Tests
 				// Verify nics on a vm level
 				var listNicPerVm = networkManagementClient.NetworkInterfaces.ListVirtualMachineScaleSetVMNetworkInterfaces(resourceGroupName, virtualMachineScaleSetName, vmIndex).ToList();
 				Assert.NotNull(listNicPerVm);
-				Assert.Equal(1, listNicPerVm.Count);
+				Assert.Single(listNicPerVm);
 
 				foreach (var nic in listNicPerVm)
 				{

--- a/src/SDKs/Network/Network.Tests/Tests/VmssPublicIpAddressTests.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/VmssPublicIpAddressTests.cs
@@ -79,7 +79,7 @@ namespace Networks.Tests
                     resourceGroupName, virtualMachineScaleSetName, vmIndex, nicName, ipConfigName);
                 var vmssListResult = vmssListPageResult.ToList();
 
-                Assert.Equal(1, vmssListResult.Count);
+                Assert.Single(vmssListResult);
 
                 var vmssGetResult = networkManagementClient.PublicIPAddresses.GetVirtualMachineScaleSetPublicIPAddress(
                     resourceGroupName, virtualMachineScaleSetName, vmIndex, nicName, ipConfigName, ipName);

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/NotificationHubs.Tests.csproj
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/NotificationHubs.Tests.csproj
@@ -4,12 +4,10 @@
     <PackageId>NotificationHubs.Tests</PackageId>
     <Description>NotificationHubs.Tests Class Library</Description>
     <AssemblyName>NotificationHubs.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>    
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>    
   </PropertyGroup>
 
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.NotificationHubs" Version="2.2.0-preview" />-->
     

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
@@ -61,14 +61,14 @@ namespace NotificationHubs.Tests.ScenarioTests
                 var getAllNamespacesResponse = NotificationHubsManagementClient.Namespaces.List(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 //Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = NotificationHubsManagementClient.Namespaces.ListAll();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 //Update namespace tags and make the namespace critical
                 var updateNamespaceParameter = new NamespaceCreateOrUpdateParameters()
@@ -90,11 +90,11 @@ namespace NotificationHubs.Tests.ScenarioTests
                     updateNamespaceResponse.ProvisioningState.Equals("Succeeded", StringComparison.CurrentCultureIgnoreCase));
                 Assert.Equal(namespaceName, updateNamespaceResponse.Name);
                 //Regression in the service . uncomment after the fix goes out 
-                Assert.Equal(updateNamespaceResponse.Tags.Count, 4);
+                Assert.Equal(4, updateNamespaceResponse.Tags.Count);
                 foreach (var tag in updateNamespaceParameter.Tags)
                 {
-                    Assert.True(updateNamespaceResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(updateNamespaceResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(updateNamespaceResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(updateNamespaceResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
@@ -105,11 +105,11 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.Equal(NamespaceType.NotificationHub, getNamespaceResponse.NamespaceType);
                 Assert.Equal(location, getNamespaceResponse.Location, StringComparer.CurrentCultureIgnoreCase);
                 Assert.Equal(namespaceName, getNamespaceResponse.Name);
-                Assert.Equal(getNamespaceResponse.Tags.Count, 4);
+                Assert.Equal(4, getNamespaceResponse.Tags.Count);
                 foreach (var tag in updateNamespaceParameter.Tags)
                 {
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 var updateNamespacePatchParameter = new NamespacePatchParameters()
@@ -125,11 +125,11 @@ namespace NotificationHubs.Tests.ScenarioTests
                 var updateNamespacePatchResponse = NotificationHubsManagementClient.Namespaces.Patch(resourceGroup, namespaceName, updateNamespacePatchParameter);
 
                 Assert.NotNull(updateNamespacePatchResponse);
-                Assert.Equal(updateNamespacePatchResponse.Tags.Count, 2);
+                Assert.Equal(2, updateNamespacePatchResponse.Tags.Count);
                 foreach (var tag in updateNamespacePatchParameter.Tags)
                 {
-                    Assert.True(updateNamespacePatchParameter.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(updateNamespacePatchParameter.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(updateNamespacePatchParameter.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(updateNamespacePatchParameter.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
@@ -143,7 +143,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                     }
                     catch (Exception ex)
                     {
-                        Assert.True(ex.Message.Contains("NotFound"));
+                        Assert.Contains("NotFound", ex.Message);
                     }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
@@ -77,16 +77,16 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 //Get default namespace AuthorizationRules
                 var getNamespaceAuthorizationRulesResponse = NotificationHubsManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, NotificationHubsManagementHelper.DefaultNamespaceAuthorizationRule);
                 Assert.NotNull(getNamespaceAuthorizationRulesResponse);
                 Assert.Equal(getNamespaceAuthorizationRulesResponse.Name, NotificationHubsManagementHelper.DefaultNamespaceAuthorizationRule);
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Listen));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Send));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Manage));
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Listen);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Send);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Manage);
 
                 //Get created namespace AuthorizationRules
                 getNamespaceAuthorizationRulesResponse = NotificationHubsManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, authorizationRuleName);
@@ -95,15 +95,15 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 //Get all namespaces AuthorizationRules 
                 var getAllNamespaceAuthorizationRulesResponse = NotificationHubsManagementClient.Namespaces.ListAuthorizationRules(resourceGroup, namespaceName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() > 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(auth => auth.Name == NotificationHubsManagementHelper.DefaultNamespaceAuthorizationRule));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, auth => auth.Name == NotificationHubsManagementHelper.DefaultNamespaceAuthorizationRule);
 
                 //Update namespace authorizationRule
                 var updateNamespaceAuthorizationRuleParameter = new SharedAccessAuthorizationRuleCreateOrUpdateParameters()
@@ -176,7 +176,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CheckAvailability.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NamespaceTests.CheckAvailability.cs
@@ -59,7 +59,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CRUD.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CRUD.cs
@@ -85,7 +85,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 var getAllNotificationHubsResponse = NotificationHubsManagementClient.NotificationHubs.List(resourceGroup, namespaceName);
                 Assert.NotNull(getAllNotificationHubsResponse);
                 Assert.True(getAllNotificationHubsResponse.Count() >= 1);
-                Assert.True(getAllNotificationHubsResponse.Any(nh => string.Compare(nh.Name, notificationHubName, true) == 0));
+                Assert.Contains(getAllNotificationHubsResponse, nh => string.Compare(nh.Name, notificationHubName, true) == 0);
                 Assert.True(getAllNotificationHubsResponse.All(nh => nh.Id.Contains(resourceGroup)));
 
                 var getNotificationHubPnsCredentialsResponse = NotificationHubsManagementClient.NotificationHubs.GetPnsCredentials(resourceGroup, namespaceName, notificationHubName);
@@ -141,11 +141,11 @@ namespace NotificationHubs.Tests.ScenarioTests
                 //Get the updated notificationHub
                 getNotificationHubResponse = NotificationHubsManagementClient.NotificationHubs.Get(resourceGroup, namespaceName, notificationHubName);
                 Assert.NotNull(getNotificationHubResponse);
-                Assert.Equal(getNotificationHubResponse.Tags.Count, 3);
+                Assert.Equal(3, getNotificationHubResponse.Tags.Count);
                 foreach (var tag in updateNotificationHubParameter.Tags)
                 {
-                    Assert.True(getNotificationHubResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(getNotificationHubResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(getNotificationHubResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(getNotificationHubResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
 
                 //Get the updated notificationHub PNSCredentials
@@ -183,7 +183,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CRUDAuthorizationRules.cs
@@ -86,7 +86,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(createNotificationHubAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(createNotificationHubAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNotificationHubAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
@@ -98,7 +98,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(getNotificationHubAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(getNotificationHubAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNotificationHubAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 //Get all notificationHub AuthorizationRules 
@@ -106,7 +106,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                     notificationHubName);
                 Assert.NotNull(getAllNotificationHubAuthorizationRulesResponse);
                 Assert.True(getAllNotificationHubAuthorizationRulesResponse.Count() > 1);
-                Assert.True(getAllNotificationHubAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNotificationHubAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 //Update notificationHub authorizationRule 
                 var updateNotificationHubAuthorizationRuleParameter = new SharedAccessAuthorizationRuleCreateOrUpdateParameters()
@@ -125,7 +125,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(updateNotificationHubAuthorizationRuleResponse.Rights.Count == updateNotificationHubAuthorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in updateNotificationHubAuthorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(updateNotificationHubAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNotificationHubAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
@@ -138,7 +138,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.True(getNotificationHubAuthorizationRuleResponse.Rights.Count == updateNotificationHubAuthorizationRuleParameter.Properties.Rights.Count);
                 foreach (var right in updateNotificationHubAuthorizationRuleParameter.Properties.Rights)
                 {
-                    Assert.True(getNotificationHubAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNotificationHubAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 //Get the connectionString to the namespace for a Authorization rule created at notificationHub level
@@ -146,8 +146,8 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.NotNull(listKeysResponse);
                 Assert.NotNull(listKeysResponse.PrimaryConnectionString);
                 Assert.NotNull(listKeysResponse.SecondaryConnectionString);
-                Assert.True(listKeysResponse.PrimaryConnectionString.Contains(listKeysResponse.PrimaryKey));
-                Assert.True(listKeysResponse.SecondaryConnectionString.Contains(listKeysResponse.SecondaryKey));
+                Assert.Contains(listKeysResponse.PrimaryKey, listKeysResponse.PrimaryConnectionString);
+                Assert.Contains(listKeysResponse.SecondaryKey, listKeysResponse.SecondaryConnectionString);
 
                 var policyKey = new PolicykeyResource()
                 {
@@ -159,8 +159,8 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.Equal(regenerateKeys.KeyName, authorizationRuleName);
                 Assert.NotNull(regenerateKeys.PrimaryConnectionString);
                 Assert.NotNull(regenerateKeys.SecondaryConnectionString);
-                Assert.True(regenerateKeys.PrimaryConnectionString.Contains(regenerateKeys.PrimaryKey));
-                Assert.True(regenerateKeys.SecondaryConnectionString.Contains(regenerateKeys.SecondaryKey));
+                Assert.Contains(regenerateKeys.PrimaryKey, regenerateKeys.PrimaryConnectionString);
+                Assert.Contains(regenerateKeys.SecondaryKey, regenerateKeys.SecondaryConnectionString);
                 //Bug : uncomment after the fix
                 //Assert.Equal(regenerateKeys.SecondaryConnectionString, listKeysResponse.SecondaryConnectionString);
                 Assert.NotEqual(regenerateKeys.PrimaryConnectionString, listKeysResponse.PrimaryConnectionString);
@@ -173,8 +173,8 @@ namespace NotificationHubs.Tests.ScenarioTests
                 Assert.Equal(listKeysAfterRegenerateResponse.KeyName, authorizationRuleName);
                 Assert.NotNull(listKeysAfterRegenerateResponse.PrimaryConnectionString);
                 Assert.NotNull(listKeysAfterRegenerateResponse.SecondaryConnectionString);
-                Assert.True(listKeysAfterRegenerateResponse.PrimaryConnectionString.Contains(listKeysAfterRegenerateResponse.PrimaryKey));
-                Assert.True(listKeysAfterRegenerateResponse.SecondaryConnectionString.Contains(listKeysAfterRegenerateResponse.SecondaryKey));
+                Assert.Contains(listKeysAfterRegenerateResponse.PrimaryKey, listKeysAfterRegenerateResponse.PrimaryConnectionString);
+                Assert.Contains(listKeysAfterRegenerateResponse.SecondaryKey, listKeysAfterRegenerateResponse.SecondaryConnectionString);
                 Assert.Equal(listKeysAfterRegenerateResponse.SecondaryConnectionString, listKeysResponse.SecondaryConnectionString);
                 Assert.NotEqual(listKeysAfterRegenerateResponse.PrimaryConnectionString, listKeysResponse.PrimaryConnectionString);
                 Assert.Equal(listKeysAfterRegenerateResponse.SecondaryKey, listKeysResponse.SecondaryKey);
@@ -204,7 +204,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CheckAvailability.cs
+++ b/src/SDKs/NotificationHubs/NotificationHubs.Tests/Tests/ScenarioTests.NotificationHubTests.CheckAvailability.cs
@@ -66,7 +66,7 @@ namespace NotificationHubs.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/OperationalInsights/DataPlane/OperationalInsights.Tests/OperationalInsights.Tests.csproj
+++ b/src/SDKs/OperationalInsights/DataPlane/OperationalInsights.Tests/OperationalInsights.Tests.csproj
@@ -4,11 +4,9 @@
     <PackageId>Microsoft.Azure.OperationalInsights.Tests</PackageId>
     <Description>Microsoft.Azure.OperationalInsights.Tests Class Library</Description>
     <AssemblyName>Microsoft.Azure.OperationalInsights.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <None Update="SessionRecords\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/OperationalInsights.Test.csproj
+++ b/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/OperationalInsights.Test.csproj
@@ -4,11 +4,9 @@
     <PackageId>OperationalInsights.Test</PackageId>
     <Description>OperationalInsights.Tests Class Library</Description>
     <AssemblyName>OperationalInsights.Test</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>    
-  </PropertyGroup>  
-  <!-- <PropertyGroup> -->
-    <!-- <TargetFrameworks>netcoreapp1.1</TargetFrameworks> -->
-  <!-- </PropertyGroup> -->
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>    
+  </PropertyGroup>
 
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.OperationalInsights" Version="0.18.0-preview" />-->

--- a/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/LinkedServiceOperationsTests.Scenario.cs
+++ b/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/LinkedServiceOperationsTests.Scenario.cs
@@ -56,7 +56,7 @@ namespace OperationalInsights.Test.ScenarioTests
 
                 // List the linked services in the workspace
                 var listResponse = client.LinkedServices.ListByWorkspace(resourceGroupName, workspaceName);
-                Assert.Equal(1, listResponse.Count());
+                Assert.Single(listResponse);
                 Assert.Single(listResponse.Where(w => w.ResourceId.Equals(accountResourceId, StringComparison.OrdinalIgnoreCase)));
 
                 var accountResourceId2 = string.Format(accountResourceIdFromat, subId, resourceGroupName, automationAccountName2);

--- a/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/SearchOperationsTests.Scenario.cs
+++ b/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/SearchOperationsTests.Scenario.cs
@@ -75,9 +75,9 @@ namespace OperationalInsights.Test.ScenarioTests
 
                 Assert.NotNull(schemaResult);
                 Assert.NotNull(schemaResult.Metadata);
-                Assert.Equal(schemaResult.Metadata.ResultType, "schema");
+                Assert.Equal("schema", schemaResult.Metadata.ResultType);
                 Assert.NotNull(schemaResult.Value);
-                Assert.NotEqual(schemaResult.Value.Count, 0);
+                Assert.NotEqual(0, schemaResult.Value.Count);
             }
         }
 
@@ -98,7 +98,7 @@ namespace OperationalInsights.Test.ScenarioTests
 
                 Assert.NotNull(savedSearchesResult);
                 Assert.NotNull(savedSearchesResult.Value);
-                Assert.NotEqual(savedSearchesResult.Value.Count, 0);
+                Assert.NotEqual(0, savedSearchesResult.Value.Count);
 
                 String[] idStrings = savedSearchesResult.Value[0].Id.Split('/');
                 string id = idStrings[idStrings.Length - 1];
@@ -109,17 +109,17 @@ namespace OperationalInsights.Test.ScenarioTests
                     id);
                 Assert.NotNull(savedSearchResult);
                 Assert.NotNull(savedSearchResult.Etag);
-                Assert.NotEqual(savedSearchResult.Etag, "");
+                Assert.NotEqual("", savedSearchResult.Etag);
                 Assert.NotNull(savedSearchResult.Id);
-                Assert.NotEqual(savedSearchResult.Id, "");
+                Assert.NotEqual("", savedSearchResult.Id);
                 Assert.NotNull(savedSearchResult.Query);
-                Assert.NotEqual(savedSearchResult.Query, "");
+                Assert.NotEqual("", savedSearchResult.Query);
 
                 var savedSearchResults = client.SavedSearches.GetResults(resourceGroupName, workspaceName, id);
                 Assert.NotNull(savedSearchResults);
                 Assert.NotNull(savedSearchResults.Metadata);
                 Assert.NotNull(savedSearchResults.Value);
-                Assert.NotEqual(savedSearchResults.Value.Count, 0);
+                Assert.NotEqual(0, savedSearchResults.Value.Count);
             }
         }
 
@@ -163,7 +163,7 @@ namespace OperationalInsights.Test.ScenarioTests
                 var savedSearchesResult = client.SavedSearches.ListByWorkspace(resourceGroupName, workspaceName);
                 Assert.NotNull(savedSearchesResult);
                 Assert.NotNull(savedSearchesResult.Value);
-                Assert.NotEqual(savedSearchesResult.Value.Count, 0);
+                Assert.NotEqual(0, savedSearchesResult.Value.Count);
                 Assert.NotNull(savedSearchesResult.Value[0].Id);
                 Assert.NotNull(savedSearchesResult.Value[0].Query);
                 bool foundSavedSearch = false;
@@ -202,9 +202,9 @@ namespace OperationalInsights.Test.ScenarioTests
                 savedSearchesResult = client.SavedSearches.ListByWorkspace(resourceGroupName, workspaceName);
                 Assert.NotNull(savedSearchesResult);
                 Assert.NotNull(savedSearchesResult.Value);
-                Assert.NotEqual(savedSearchesResult.Value.Count, 0);
+                Assert.NotEqual(0, savedSearchesResult.Value.Count);
                 Assert.NotNull(savedSearchesResult.Value[0].Id);
-                Assert.Equal(savedSearchesResult.Value[0].Query, "*");
+                Assert.Equal("*", savedSearchesResult.Value[0].Query);
                 foundSavedSearch = false;
                 for (int i = 0; i < savedSearchesResult.Value.Count; i++)
                 {

--- a/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/WorkspaceOperationsTests.Scenario.cs
+++ b/src/SDKs/OperationalInsights/Management/OperationalInsights.Test/ScenarioTests/WorkspaceOperationsTests.Scenario.cs
@@ -104,11 +104,11 @@ namespace OperationalInsights.Test.ScenarioTests
 
                 // List the management groups connected to the workspace
                 var managementGroupsResponse = client.Workspaces.ListManagementGroups(resourceGroupName, workspaceName);
-                Assert.Equal(0, managementGroupsResponse.Count());
+                Assert.Empty(managementGroupsResponse);
 
                 // List the usage for a workspace
                 var usagesResponse = client.Workspaces.ListUsages(resourceGroupName, workspaceName);
-                Assert.Equal(1, usagesResponse.Count());
+                Assert.Single(usagesResponse);
 
                 var metric = usagesResponse.Single();
                 Assert.Equal("DataAnalyzed", metric.Name.Value);

--- a/src/SDKs/PolicyInsights/Management/PolicyInsights.Tests/PolicyInsights.Tests.csproj
+++ b/src/SDKs/PolicyInsights/Management/PolicyInsights.Tests/PolicyInsights.Tests.csproj
@@ -5,10 +5,8 @@
     <Description>PolicyInsights.Tests Class Library</Description>
     <AssemblyName>PolicyInsights.Tests</AssemblyName>
     <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <ProjectReference Include="..\Management.PolicyInsights\Microsoft.Azure.Management.PolicyInsights.csproj" />
   </ItemGroup>

--- a/src/SDKs/PostgreSQL/PostgreSQL.Tests/PostgreSQL.Tests.csproj
+++ b/src/SDKs/PostgreSQL/PostgreSQL.Tests/PostgreSQL.Tests.csproj
@@ -2,13 +2,11 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.test.reference.props'))" />
   <PropertyGroup>
     <PackageId>PostgreSQL.Tests</PackageId>
-    <VersionPrefix>0.9.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
     <AssemblyName>PostgreSQL.Tests</AssemblyName>
     <Description>PostgreSQL.Tests Class Library</Description>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.3.2" />

--- a/src/SDKs/PowerBIDedicated/PowerBIDedicated.Tests/PowerBIDedicated.Tests.csproj
+++ b/src/SDKs/PowerBIDedicated/PowerBIDedicated.Tests/PowerBIDedicated.Tests.csproj
@@ -2,14 +2,11 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('AzSdk.test.reference.props'))" />  
   <PropertyGroup>
     <PackageId>PowerBIDedicated.Tests</PackageId>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <Version>1.0.0</Version>
     <Description>PowerBIDedicated.Tests Class Library</Description>
     <AssemblyName>PowerBIDedicated.Tests</AssemblyName>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <ProjectReference Include="..\Management.PowerBIDedicated\Microsoft.Azure.Management.PowerBIDedicated.csproj" />

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/RecoveryServices.Backup.Tests.csproj
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/RecoveryServices.Backup.Tests.csproj
@@ -4,11 +4,9 @@
     <PackageId>RecoveryServices.Backup.Tests</PackageId>
     <Description>RecoveryServices.Backup.Tests Class Library</Description>
     <AssemblyName>RecoveryServices.Backup.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Version>1.0.0</Version>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.RecoveryServices" Version="4.2.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/IaasVmE2ETests.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/IaasVmE2ETests.cs
@@ -54,13 +54,13 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
                 // 2. List protected items
                 var items = testHelper.ListProtectedItems();
                 Assert.NotNull(items);
-                Assert.True(items.Any(item => itemName.ToLower().Contains(item.Name.ToLower())));
+                Assert.Contains(items, item => itemName.ToLower().Contains(item.Name.ToLower()));
 
                 // 3. Trigger backup
                 var backupJobId = testHelper.Backup(containerName, itemName);
 
                 IPage<JobResource> backupJobs = testHelper.ListBackupJobs();
-                Assert.True(backupJobs.Any(backupJob => backupJob.Name == backupJobId));
+                Assert.Contains(backupJobs, backupJob => backupJob.Name == backupJobId);
 
                 testHelper.WaitForJobCompletion(backupJobId);
 
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
                 var restoreJobId = testHelper.Restore(containerName, itemName, recoveryPoint.Name, sourceResourceId, storageAccountId);
 
                 backupJobs = testHelper.ListBackupJobs();
-                Assert.True(backupJobs.Any(backupJob => backupJob.Name == restoreJobId));
+                Assert.Contains(backupJobs, backupJob => backupJob.Name == restoreJobId);
 
                 testHelper.WaitForJobCompletion(restoreJobId);
 

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/IaasVmPolicyTests.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/ScenarioTests/IaasVmPolicyTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
             {
                 testHelper.Initialize(context);
                 List<ProtectionPolicyResource> policies = testHelper.ListAllPoliciesWithRetries();
-                Assert.True(policies.Any(policy => policy.Name.ToLower().Equals("defaultpolicy")));
+                Assert.Contains(policies, policy => policy.Name.ToLower().Equals("defaultpolicy"));
 
                 ProtectionPolicyResource defaultPolicy = testHelper.GetPolicyWithRetries("defaultpolicy");
 

--- a/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestHelper.cs
+++ b/src/SDKs/RecoveryServices.Backup/RecoveryServices.Backup.Tests/TestHelpers/TestHelper.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Backup.Tests
         {
             var result = BackupClient.JobDetails.GetWithHttpMessagesAsync(VaultName, ResourceGroup, jobId).Result;
             Assert.NotNull(result);
-            Assert.Equal(result.Response.StatusCode, System.Net.HttpStatusCode.OK);
+            Assert.Equal(System.Net.HttpStatusCode.OK, result.Response.StatusCode);
             return ((AzureIaaSVMJob)result.Body.Properties).Status;
         }
 

--- a/src/SDKs/RecoveryServices.SiteRecovery/RecoveryServices.SiteRecovery.Tests/RecoveryServices.SiteRecovery.Tests.csproj
+++ b/src/SDKs/RecoveryServices.SiteRecovery/RecoveryServices.SiteRecovery.Tests/RecoveryServices.SiteRecovery.Tests.csproj
@@ -4,11 +4,9 @@
     <PackageId>RecoveryServices.SiteRecovery.Tests</PackageId>
     <Description>RecoveryServices.SiteRecovery.Tests Class Library</Description>
     <AssemblyName>RecoveryServices.SiteRecovery.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <ProjectReference Include="..\Management.RecoveryServices.SiteRecovery\Microsoft.Azure.Management.RecoveryServices.SiteRecovery.csproj" />
   </ItemGroup>

--- a/src/SDKs/RecoveryServices/RecoveryServices.Tests/RecoveryServices.Tests.csproj
+++ b/src/SDKs/RecoveryServices/RecoveryServices.Tests/RecoveryServices.Tests.csproj
@@ -4,11 +4,9 @@
     <PackageId>RecoveryServices.Tests</PackageId>
     <Description>RecoveryServices.Tests Class Library</Description>
     <AssemblyName>RecoveryServices.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>    
+    <Version>1.0.0</Version>    
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.RecoveryServices" Version="4.1.0-preview" />-->
     

--- a/src/SDKs/RecoveryServices/RecoveryServices.Tests/RecoveryServicesTestBase.cs
+++ b/src/SDKs/RecoveryServices/RecoveryServices.Tests/RecoveryServicesTestBase.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Tests
             {
                 resourcesClient.ResourceGroups.Get(resourceGroup);
             }
-            catch (CloudException ex)
+            catch (CloudException)
             {
                 // Doesn't exist
                 resourceGroupExists = false;

--- a/src/SDKs/RecoveryServices/RecoveryServices.Tests/ScenarioTests/VaultScenarioTests.cs
+++ b/src/SDKs/RecoveryServices/RecoveryServices.Tests/ScenarioTests/VaultScenarioTests.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Azure.Management.RecoveryServices.Tests
                     var vaults = _testFixture.ListVaults();
                     Assert.NotNull(vaults);
                     Assert.NotEmpty(vaults);
-                    Assert.True(vaults.Any(v => v.Name == vaultName));
-                    Assert.True(vaults.Any(v => v.Name == vaultName2));
+                    Assert.Contains(vaults, v => v.Name == vaultName);
+                    Assert.Contains(vaults, v => v.Name == vaultName2);
 
                     _testFixture.DeleteVault(vaultName2);
                     Assert.Throws<CloudException>(() =>

--- a/src/SDKs/RecoveryServices/RecoveryServices.Tests/ScenarioTests/VaultUsageScenarioTests.cs
+++ b/src/SDKs/RecoveryServices/RecoveryServices.Tests/ScenarioTests/VaultUsageScenarioTests.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Azure.Management.RecoveryServices.Tests
                     var vaults = _testFixture.ListVaults();
                     Assert.NotNull(vaults);
                     Assert.NotEmpty(vaults);
-                    Assert.True(vaults.Any(v => v.Name == vaultName));
+                    Assert.Contains(vaults, v => v.Name == vaultName);
 
                     var response = _testFixture.ListVaultUsages(vaultName);
 
                     Assert.NotNull(response);
-                    Assert.NotEqual(response.Count(), 0);
+                    Assert.NotEmpty(response);
                     foreach (var usage in response)
                     {
                         Assert.NotNull(usage.Name.Value);
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Management.RecoveryServices.Tests
                     var replicationResponse = _testFixture.ListReplicationUsages(vaultName);
 
                     Assert.NotNull(replicationResponse);
-                    Assert.Equal(replicationResponse.Count(), 0);
+                    Assert.Empty(replicationResponse);
                 }
             }
         }

--- a/src/SDKs/RedisCache/RedisCache.Tests/InMemoryTests/ListTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/InMemoryTests/ListTests.cs
@@ -155,7 +155,7 @@ namespace AzureRedisCache.Tests.InMemoryTests
 
             foreach (IPage<RedisResource> responseList in list)
             {
-                Assert.Equal(0, responseList.Count());
+                Assert.Empty(responseList);
                 Assert.Null(responseList.NextPageLink);
             }
         }

--- a/src/SDKs/RedisCache/RedisCache.Tests/RedisCache.Tests.csproj
+++ b/src/SDKs/RedisCache/RedisCache.Tests/RedisCache.Tests.csproj
@@ -4,11 +4,9 @@
     <PackageId>RedisCache.Tests</PackageId>
     <Description>AzureRedisCache.Tests Class Library</Description>
     <AssemblyName>RedisCache.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
   </ItemGroup>

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/BeginCreateFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/BeginCreateFunctionalTests.cs
@@ -39,7 +39,7 @@ namespace AzureRedisCache.Tests
 
                 Assert.Contains(redisCacheName, response.Id);
                 Assert.Equal(redisCacheName, response.Name);
-                Assert.True("creating".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("creating", response.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Premium, response.Sku.Name);
                 Assert.Equal(SkuFamily.P, response.Sku.Family);
 

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/CreateUpdateDeleteFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/CreateUpdateDeleteFunctionalTests.cs
@@ -50,7 +50,7 @@ namespace AzureRedisCache.Tests
                 Assert.Equal(fixture.RedisCacheName, responseCreate.Name);
                 Assert.Equal("Microsoft.Cache/Redis", responseCreate.Type);
 
-                Assert.True("succeeded".Equals(responseCreate.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("succeeded", responseCreate.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Basic, responseCreate.Sku.Name);
                 Assert.Equal(SkuFamily.C, responseCreate.Sku.Family);
                 Assert.Equal(0, responseCreate.Sku.Capacity);

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/GetListKeysFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/GetListKeysFunctionalTests.cs
@@ -41,7 +41,7 @@ namespace AzureRedisCache.Tests
                 Assert.Contains(fixture.RedisCacheName, response.Id);
                 Assert.Equal(fixture.RedisCacheName, response.Name);
 
-                Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Basic, response.Sku.Name);
                 Assert.Equal(SkuFamily.C, response.Sku.Family);
                 Assert.Equal(0, response.Sku.Capacity);
@@ -71,7 +71,7 @@ namespace AzureRedisCache.Tests
                         Assert.Contains(fixture.RedisCacheName, response.Id);
                         Assert.Equal(fixture.RedisCacheName, response.Name);
 
-                        Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                        Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                         Assert.Equal(SkuName.Basic, response.Sku.Name);
                         Assert.Equal(SkuFamily.C, response.Sku.Family);
                         Assert.Equal(0, response.Sku.Capacity);
@@ -104,7 +104,7 @@ namespace AzureRedisCache.Tests
                         Assert.Contains(fixture.RedisCacheName, response.Id);
                         Assert.Equal(fixture.RedisCacheName, response.Name);
 
-                        Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                        Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                         Assert.Equal(SkuName.Basic, response.Sku.Name);
                         Assert.Equal(SkuFamily.C, response.Sku.Family);
                         Assert.Equal(0, response.Sku.Capacity);

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/PatchSchedulesFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/PatchSchedulesFunctionalTests.cs
@@ -44,7 +44,7 @@ namespace AzureRedisCache.Tests
                 RedisResource response = _client.Redis.Get(resourceGroupName, redisCacheName);
                 Assert.Contains(redisCacheName, response.Id);
                 Assert.Equal(redisCacheName, response.Name);
-                Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Premium, response.Sku.Name);
                 Assert.Equal(SkuFamily.P, response.Sku.Family);
 

--- a/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/RebootFunctionalTests.cs
+++ b/src/SDKs/RedisCache/RedisCache.Tests/ScenarioTests/RebootFunctionalTests.cs
@@ -41,7 +41,7 @@ namespace AzureRedisCache.Tests
                 RedisResource response = _client.Redis.Get(resourceGroupName, redisCacheName);
                 Assert.Contains(redisCacheName, response.Id);
                 Assert.Equal(redisCacheName, response.Name);
-                Assert.True("succeeded".Equals(response.ProvisioningState, StringComparison.OrdinalIgnoreCase));
+                Assert.Equal("succeeded", response.ProvisioningState, ignoreCase: true);
                 Assert.Equal(SkuName.Premium, response.Sku.Name);
                 Assert.Equal(SkuFamily.P, response.Sku.Family);
 

--- a/src/SDKs/Relay/Relay.Tests/Relay.Tests.csproj
+++ b/src/SDKs/Relay/Relay.Tests/Relay.Tests.csproj
@@ -4,12 +4,9 @@
     <PackageId>Relay.Tests</PackageId>
     <Description>Relay.Tests Class Library</Description>
     <AssemblyName>Relay.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.Relay" Version="0.0.1-preview" />-->
     

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.CheckNameAvailability.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.CheckNameAvailability.cs
@@ -66,8 +66,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 
@@ -87,7 +87,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUD.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUD.cs
@@ -60,8 +60,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -78,14 +78,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create HybridConnections Relay  - 
                 var hybridConnectionsName = TestUtilities.GenerateName(RelayManagementHelper.HybridPrefix);
@@ -126,7 +126,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -136,7 +136,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUDAuthorizationRules.cs
@@ -58,8 +58,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -76,14 +76,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create Relay HybridConnections  - 
                 var hybridConnectionsName = TestUtilities.GenerateName(RelayManagementHelper.HybridPrefix);
@@ -116,7 +116,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }                
 
                 // Get created HybridConnections AuthorizationRules
@@ -125,14 +125,14 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all HybridConnections AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.HybridConnections.ListAuthorizationRules(resourceGroup, namespaceName, hybridConnectionsName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() >= 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update HybridConnections authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -147,7 +147,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the HybridConnections namespace AuthorizationRule
@@ -157,7 +157,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the HybridConnections for a Authorization rule created
@@ -195,7 +195,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -205,7 +205,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUDAuthorizationRules_length.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.HybridConnectionsTests.CRUDAuthorizationRules_length.cs
@@ -58,8 +58,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -76,14 +76,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create Relay HybridConnections  - 
                 var hybridConnectionsName =RelayManagementHelper.HybridPrefix + "thisisthenamewithmorethan53charschecktoverifytheremovlaof50charsnamelengthlimit";
@@ -116,7 +116,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }                
 
                 // Get created HybridConnections AuthorizationRules
@@ -125,14 +125,14 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all HybridConnections AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.HybridConnections.ListAuthorizationRules(resourceGroup, namespaceName, hybridConnectionsName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() >= 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update HybridConnections authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -147,7 +147,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the HybridConnections namespace AuthorizationRule
@@ -157,7 +157,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the HybridConnections for a Authorization rule created
@@ -195,7 +195,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -205,7 +205,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.NamespaceTests.CRUD.cs
@@ -62,8 +62,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -80,14 +80,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Update namespace tags
                 var updateNamespaceParameter = new RelayUpdateParameters()
@@ -110,11 +110,11 @@ namespace Relay.Tests.ScenarioTests
                 Assert.NotNull(getNamespaceResponse);
                 Assert.Equal(location, getNamespaceResponse.Location, StringComparer.CurrentCultureIgnoreCase);
                 Assert.Equal(namespaceName, getNamespaceResponse.Name);
-                Assert.Equal(getNamespaceResponse.Tags.Count, 4);
+                Assert.Equal(4, getNamespaceResponse.Tags.Count);
                 foreach (var tag in updateNamespaceParameter.Tags)
                 {
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Key.Equals(tag.Key)));
-                    Assert.True(getNamespaceResponse.Tags.Any(t => t.Value.Equals(tag.Value)));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Key.Equals(tag.Key));
+                    Assert.Contains(getNamespaceResponse.Tags, t => t.Value.Equals(tag.Value));
                 }
                 
                 try
@@ -124,7 +124,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.NamespaceTests.CRUDAuthorizationRules.cs
@@ -83,16 +83,16 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get default namespace AuthorizationRules
                 var getNamespaceAuthorizationRulesResponse = RelayManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, RelayManagementHelper.DefaultNamespaceAuthorizationRule);
                 Assert.NotNull(getNamespaceAuthorizationRulesResponse);
                 Assert.Equal(getNamespaceAuthorizationRulesResponse.Name, RelayManagementHelper.DefaultNamespaceAuthorizationRule);
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Listen));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Send));
-                Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == AccessRights.Manage));
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Listen);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Send);
+                Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == AccessRights.Manage);
 
                 // Get created namespace AuthorizationRules
                 getNamespaceAuthorizationRulesResponse = RelayManagementClient.Namespaces.GetAuthorizationRule(resourceGroup, namespaceName, authorizationRuleName);
@@ -100,15 +100,15 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all namespaces AuthorizationRules 
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.Namespaces.ListAuthorizationRules(resourceGroup, namespaceName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() > 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(auth => auth.Name == RelayManagementHelper.DefaultNamespaceAuthorizationRule));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, auth => auth.Name == RelayManagementHelper.DefaultNamespaceAuthorizationRule);
 
                 // Update namespace authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -122,7 +122,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the updated namespace AuthorizationRule
@@ -132,7 +132,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the namespace for a Authorization rule created
@@ -170,7 +170,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUD.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUD.cs
@@ -55,8 +55,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -74,14 +74,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                                 
                 // Create WCF Relay  - 
                 var wcfRelayName = TestUtilities.GenerateName(RelayManagementHelper.WcfPrefix);
@@ -96,7 +96,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
 
                 var getWCFRelaysResponse = RelayManagementClient.WCFRelays.Get(resourceGroup, namespaceName, wcfRelayName);
 
@@ -104,7 +104,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
 
                 //Update User Metadata for WCFRelays
                 string strUserMetadata = "usermetadata is a placeholder to store user-defined string data for the HybridConnection endpoint.e.g. it can be used to store  descriptive data, such as list of teams and their contact information also user-defined configuration settings can be stored.";
@@ -114,7 +114,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
                 Assert.Equal(createdWCFRelayResponse.UserMetadata, strUserMetadata);
 
                 //Get List of all Hybridconnections in given NameSpace. 
@@ -130,7 +130,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -140,7 +140,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUDAuthorizationRules.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUDAuthorizationRules.cs
@@ -58,8 +58,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -76,14 +76,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create WCF Relay  - 
                 var wcfRelayName = TestUtilities.GenerateName(RelayManagementHelper.WcfPrefix);
@@ -98,7 +98,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
 
                 var getWCFRelaysResponse = RelayManagementClient.WCFRelays.Get(resourceGroup, namespaceName, wcfRelayName);
                 
@@ -120,7 +120,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created WCFRelay AuthorizationRules
@@ -129,14 +129,14 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all WCFRelay AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.WCFRelays.ListAuthorizationRules(resourceGroup, namespaceName,wcfRelayName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() >= 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update WCFRelay authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -151,7 +151,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the WCFRelay namespace AuthorizationRule
@@ -161,7 +161,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the WCFRelay for a Authorization rule created
@@ -197,7 +197,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -207,7 +207,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUDAuthorizationRules_legth.cs
+++ b/src/SDKs/Relay/Relay.Tests/Tests/ScenarioTests.WCFRelayTests.CRUDAuthorizationRules_legth.cs
@@ -58,8 +58,8 @@ namespace Relay.Tests.ScenarioTests
 
                 Assert.NotNull(createNamespaceResponse);
                 Assert.Equal(createNamespaceResponse.Name, namespaceName);
-                Assert.Equal(createNamespaceResponse.Tags.Count, 2);
-                Assert.Equal(createNamespaceResponse.Type, "Microsoft.Relay/Namespaces");
+                Assert.Equal(2, createNamespaceResponse.Tags.Count);
+                Assert.Equal("Microsoft.Relay/Namespaces", createNamespaceResponse.Type);
                 TestUtilities.Wait(TimeSpan.FromSeconds(5));
 
                 // Get the created namespace
@@ -76,14 +76,14 @@ namespace Relay.Tests.ScenarioTests
                 var getAllNamespacesResponse = RelayManagementClient.Namespaces.ListByResourceGroup(resourceGroup);
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
                 Assert.True(getAllNamespacesResponse.All(ns => ns.Id.Contains(resourceGroup)));
 
                 // Get all namespaces created within the subscription irrespective of the resourceGroup
                 getAllNamespacesResponse = RelayManagementClient.Namespaces.List();
                 Assert.NotNull(getAllNamespacesResponse);
                 Assert.True(getAllNamespacesResponse.Count() >= 1);
-                Assert.True(getAllNamespacesResponse.Any(ns => ns.Name == namespaceName));
+                Assert.Contains(getAllNamespacesResponse, ns => ns.Name == namespaceName);
 
                 // Create WCF Relay  - 
                 var wcfRelayName = RelayManagementHelper.WcfPrefix + "thisisthenamewithmorethan53charschecktoverifytheremovlaof50charsnamelengthlimit";
@@ -98,7 +98,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.Equal(createdWCFRelayResponse.Name, wcfRelayName);
                 Assert.True(createdWCFRelayResponse.RequiresClientAuthorization);
                 Assert.True(createdWCFRelayResponse.RequiresTransportSecurity);
-                Assert.Equal(createdWCFRelayResponse.RelayType, Relaytype.NetTcp);
+                Assert.Equal(Relaytype.NetTcp, createdWCFRelayResponse.RelayType);
 
                 var getWCFRelaysResponse = RelayManagementClient.WCFRelays.Get(resourceGroup, namespaceName, wcfRelayName);
                 
@@ -120,7 +120,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(createNamespaceAuthorizationRuleResponse.Rights.Any(r => r == right));
+                    Assert.Contains(createNamespaceAuthorizationRuleResponse.Rights, r => r == right);
                 }
 
                 // Get created WCFRelay AuthorizationRules
@@ -129,14 +129,14 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Count == createAutorizationRuleParameter.Rights.Count);
                 foreach (var right in createAutorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRulesResponse.Rights.Any(r => r == right));
+                    Assert.Contains(getNamespaceAuthorizationRulesResponse.Rights, r => r == right);
                 }
 
                 // Get all WCFRelay AuthorizationRules
                 var getAllNamespaceAuthorizationRulesResponse = RelayManagementClient.WCFRelays.ListAuthorizationRules(resourceGroup, namespaceName,wcfRelayName);
                 Assert.NotNull(getAllNamespaceAuthorizationRulesResponse);
                 Assert.True(getAllNamespaceAuthorizationRulesResponse.Count() >= 1);
-                Assert.True(getAllNamespaceAuthorizationRulesResponse.Any(ns => ns.Name == authorizationRuleName));
+                Assert.Contains(getAllNamespaceAuthorizationRulesResponse, ns => ns.Name == authorizationRuleName);
 
                 // Update WCFRelay authorizationRule
                 string updatePrimaryKey = HttpMockServer.GetVariable("UpdatePrimaryKey", RelayManagementHelper.GenerateRandomKey());
@@ -151,7 +151,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(updateNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(updateNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the WCFRelay namespace AuthorizationRule
@@ -161,7 +161,7 @@ namespace Relay.Tests.ScenarioTests
                 Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Count == updateNamespaceAuthorizationRuleParameter.Rights.Count);
                 foreach (var right in updateNamespaceAuthorizationRuleParameter.Rights)
                 {
-                    Assert.True(getNamespaceAuthorizationRuleResponse.Rights.Any(r => r.Equals(right)));
+                    Assert.Contains(getNamespaceAuthorizationRuleResponse.Rights, r => r.Equals(right));
                 }
 
                 // Get the connectionString to the WCFRelay for a Authorization rule created
@@ -197,7 +197,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
 
                 try
@@ -207,7 +207,7 @@ namespace Relay.Tests.ScenarioTests
                 }
                 catch (Exception ex)
                 {
-                    Assert.True(ex.Message.Contains("NotFound"));
+                    Assert.Contains("NotFound", ex.Message);
                 }
             }
         }

--- a/src/SDKs/Reservations/Reservations.Tests/Reservations.Tests.csproj
+++ b/src/SDKs/Reservations/Reservations.Tests/Reservations.Tests.csproj
@@ -5,8 +5,8 @@
     <Description>Reservations.Tests Class Library</Description>
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>Reservations.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/DeploymentTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/DeploymentTests.InMemory.cs
@@ -118,7 +118,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("1.0.0.0", json["properties"]["templateLink"]["contentVersion"].Value<string>());
             Assert.Equal("1.0.0.0", json["properties"]["parametersLink"]["contentVersion"].Value<string>());
             Assert.Equal("value1", json["properties"]["parameters"]["param1"].Value<string>());
-            Assert.Equal(true, json["properties"]["parameters"]["param2"].Value<bool>());
+            Assert.True(json["properties"]["parameters"]["param2"].Value<bool>());
             Assert.Equal(123, json["properties"]["parameters"]["param3"]["param3_1"].Value<int>());
             Assert.Equal("value3_2", json["properties"]["parameters"]["param3"]["param3_2"].Value<string>());
             Assert.Equal(123, json["properties"]["template"]["api-version"].Value<int>());
@@ -131,8 +131,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.Properties.Mode);
             Assert.Equal("http://wa/template.json", result.Properties.TemplateLink.Uri);
             Assert.Equal("1.0.0.0", result.Properties.TemplateLink.ContentVersion);
-            Assert.True(result.Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.Properties.Outputs.ToString());
         }
 
         [Fact]
@@ -225,7 +225,7 @@ namespace ResourceGroups.Tests
                 Assert.Equal("test-release-3", result.Name);
                 Assert.Equal("Succeeded", result.Properties.ProvisioningState);
                 Assert.Equal(DeploymentMode.Incremental, result.Properties.Mode);
-                Assert.True(result.Properties.Parameters.ToString().Contains("\"value\": \"tianotest04\""));
+                Assert.Contains("\"value\": \"tianotest04\"", result.Properties.Parameters.ToString());
             }
         }
 
@@ -271,7 +271,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate response 
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("AEF2398", result.First().OperationId);
             Assert.Equal("/subscriptions/123abc/resourcegroups/foo/providers/ResourceProviderTestHost/TestResourceType/resource1", result.First().Properties.TargetResource.Id);
             Assert.Equal("mySite1", result.First().Properties.TargetResource.ResourceName);
@@ -304,7 +304,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate response 
-            Assert.Equal(0, result.Count());
+            Assert.Empty(result);
         }
 
         [Fact]
@@ -459,8 +459,8 @@ namespace ResourceGroups.Tests
             Assert.Equal("https://wa.com/subscriptions/mysubid/resourcegroups/TestRG/deployments/test-release-3/operations?$skiptoken=983fknw", handler.Uri.ToString());
 
             // Validate response 
-            Assert.Equal(0, result.Count());
-            Assert.Equal(null, result.NextPageLink);
+            Assert.Empty(result);
+            Assert.Null(result.NextPageLink);
         }
 
         [Fact]
@@ -572,7 +572,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("http://abc/def/template.json", json["properties"]["templateLink"]["uri"].Value<string>());
             Assert.Equal("1.0.0.0", json["properties"]["templateLink"]["contentVersion"].Value<string>());
             Assert.Equal("value1", json["properties"]["parameters"]["param1"].Value<string>());
-            Assert.Equal(true, json["properties"]["parameters"]["param2"].Value<bool>());
+            Assert.True(json["properties"]["parameters"]["param2"].Value<bool>());
             Assert.Equal(123, json["properties"]["parameters"]["param3"]["param3_1"].Value<int>());
             Assert.Equal("value3_2", json["properties"]["parameters"]["param3"]["param3_2"].Value<string>());
         }
@@ -799,8 +799,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.Properties.Mode);
             Assert.Equal("http://wa/template.json", result.Properties.TemplateLink.Uri.ToString());
             Assert.Equal("1.0.0.0", result.Properties.TemplateLink.ContentVersion);
-            Assert.True(result.Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.Properties.Outputs.ToString());
         }
 
         [Fact(Skip = "Parameter validation using pattern match is not supported yet at code-gen, the work is on-going.")]
@@ -916,8 +916,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.First().Properties.Mode);
             Assert.Equal("http://wa/template.json", result.First().Properties.TemplateLink.Uri.ToString());
             Assert.Equal("1.0.0.0", result.First().Properties.TemplateLink.ContentVersion);
-            Assert.True(result.First().Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.First().Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Outputs.ToString());
             Assert.Equal("https://wa/subscriptions/subId/templateDeployments?$skiptoken=983fknw", result.NextPageLink);
         }
 
@@ -1015,8 +1015,8 @@ namespace ResourceGroups.Tests
             // Validate headers
             Assert.Equal(HttpMethod.Get, handler.Method);
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
-            Assert.True(handler.Uri.ToString().Contains("$top=10"));
-            Assert.True(handler.Uri.ToString().Contains("$filter=provisioningState eq 'Succeeded'"));
+            Assert.Contains("$top=10", handler.Uri.ToString());
+            Assert.Contains("$filter=provisioningState eq 'Succeeded'", handler.Uri.ToString());
 
             // Validate result
             Assert.Equal("myrealease-3.14", result.First().Name);
@@ -1025,8 +1025,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.First().Properties.Mode);
             Assert.Equal("http://wa/template.json", result.First().Properties.TemplateLink.Uri.ToString());
             Assert.Equal("1.0.0.0", result.First().Properties.TemplateLink.ContentVersion);
-            Assert.True(result.First().Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.First().Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Outputs.ToString());
             Assert.Equal("https://wa/subscriptions/subId/templateDeployments?$skiptoken=983fknw", result.NextPageLink);
         }
 
@@ -1125,9 +1125,9 @@ namespace ResourceGroups.Tests
             // Validate headers
             Assert.Equal(HttpMethod.Get, handler.Method);
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
-            Assert.True(handler.Uri.ToString().Contains("$top=10"));
-            Assert.True(handler.Uri.ToString().Contains("$filter=provisioningState eq 'Succeeded'"));
-            Assert.True(handler.Uri.ToString().Contains("resourcegroups/foo/providers/Microsoft.Resources/deployments"));
+            Assert.Contains("$top=10", handler.Uri.ToString());
+            Assert.Contains("$filter=provisioningState eq 'Succeeded'", handler.Uri.ToString());
+            Assert.Contains("resourcegroups/foo/providers/Microsoft.Resources/deployments", handler.Uri.ToString());
 
             // Validate result
             Assert.Equal("myrealease-3.14", result.First().Name);
@@ -1136,8 +1136,8 @@ namespace ResourceGroups.Tests
             Assert.Equal(DeploymentMode.Incremental, result.First().Properties.Mode);
             Assert.Equal("http://wa/template.json", result.First().Properties.TemplateLink.Uri.ToString());
             Assert.Equal("1.0.0.0", result.First().Properties.TemplateLink.ContentVersion);
-            Assert.True(result.First().Properties.Parameters.ToString().Contains("\"type\": \"string\""));
-            Assert.True(result.First().Properties.Outputs.ToString().Contains("\"type\": \"string\""));
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Parameters.ToString());
+            Assert.Contains("\"type\": \"string\"", result.First().Properties.Outputs.ToString());
             Assert.Equal("https://wa/subscriptions/subId/templateDeployments?$skiptoken=983fknw", result.NextPageLink);
         }
 

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/ProviderTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/ProviderTests.InMemory.cs
@@ -139,7 +139,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate result
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("Microsoft.Websites", result.First().NamespaceProperty);
             Assert.Equal("Registered", result.First().RegistrationState);
             Assert.Equal(2, result.First().ResourceTypes.Count);

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceGroupTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceGroupTests.InMemory.cs
@@ -305,7 +305,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate result
-            Assert.Equal(0, result.Count());
+            Assert.Empty(result);
         }
         
         [Fact]
@@ -337,7 +337,7 @@ namespace ResourceGroups.Tests
             // Validate headers
             Assert.Equal(HttpMethod.Get, handler.Method);
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
-            Assert.True(handler.Uri.ToString().Contains("$top=5"));
+            Assert.Contains("$top=5", handler.Uri.ToString());
 
             // Validate result
             Assert.Equal(2, result.Count());

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceLinkTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceLinkTests.InMemory.cs
@@ -188,7 +188,7 @@ namespace ResourceGroups.Tests
             var filteredResult = client.ResourceLinks.ListAtSubscription(new ODataQuery<ResourceLinkFilter>(f => f.TargetId == "/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm2"));
 
             // Validate result
-            Assert.Equal(1, filteredResult.Count());
+            Assert.Single(filteredResult);
             Assert.Equal("myLink", filteredResult.First().Name);
             Assert.Equal("/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm/providers/Microsoft.Resources/links/myLink", filteredResult.First().Id);
             Assert.Equal("/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm", filteredResult.First().Properties.SourceId);
@@ -226,7 +226,7 @@ namespace ResourceGroups.Tests
             Assert.Equal(HttpMethod.Get, handler.Method);
 
             // Validate result
-            Assert.Equal(1, result.Count());
+            Assert.Single(result);
             Assert.Equal("myLink", result.First().Name);
             Assert.Equal("/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm/providers/Microsoft.Resources/links/myLink", result.First().Id);
             Assert.Equal("/subscriptions/abc123/resourcegroups/myGroup/providers/Microsoft.Web/serverFarms/myFarm", result.First().Properties.SourceId);

--- a/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceTests.InMemory.cs
+++ b/src/SDKs/Resource/Resource.Tests/InMemoryTests/ResourceTests.InMemory.cs
@@ -66,7 +66,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("South Central US", result.Location);
             Assert.Equal("site1", result.Name);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.Id);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
             Assert.Equal("Succeeded", (result.Properties as JObject)["provisioningState"]);
             Assert.Equal("F1", result.Sku.Name);
             Assert.Equal("Free", result.Sku.Tier);
@@ -113,7 +113,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("South Central US", result.Location);
             Assert.Equal("site1", result.Name);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.Id);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
             Assert.Equal("Succeeded", (result.Properties as JObject)["provisioningState"]);
             Assert.Equal("F1", result.Sku.Name);
             Assert.Equal("Free", result.Sku.Tier);
@@ -165,7 +165,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("South Central US", result.Location);
             Assert.Equal("site1", result.Name);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.Id);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
             Assert.Null((result.Properties as JObject)["provisionState"]);
         }
 
@@ -222,7 +222,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("site1", result.First().Name);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.First().Id);
             Assert.Equal("/subscriptions/12345/resourceGroups/foo/providers/Microsoft.Web/Sites/site1", result.First().Id);
-            Assert.True(result.First().Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.First().Properties.ToString());
             Assert.Equal("Succeeded", (result.First().Properties as JObject)["provisioningState"]);
         }
 
@@ -333,7 +333,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("Succeeded", (result.Properties as JObject)["provisioningState"]);
             Assert.Equal("finance", result.Tags["department"]);
             Assert.Equal("tagvalue", result.Tags["tagname"]);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
         }
 
         [Fact]
@@ -399,7 +399,7 @@ namespace ResourceGroups.Tests
             Assert.Equal("Succeeded", (result.Properties as JObject)["provisioningState"]);
             Assert.Equal("finance", result.Tags["department"]);
             Assert.Equal("tagvalue", result.Tags["tagname"]);
-            Assert.True(result.Properties.ToString().Contains("Dedicated"));
+            Assert.Contains("Dedicated", result.Properties.ToString());
             Assert.Equal("SystemAssigned", result.Identity.Type.ToString());
             Assert.Equal("foo", result.Identity.PrincipalId);
         }
@@ -549,7 +549,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate result
-            Assert.Equal(true, result);
+            Assert.True(result);
         }
 
         [Fact]
@@ -581,7 +581,7 @@ namespace ResourceGroups.Tests
             Assert.NotNull(handler.RequestHeaders.GetValues("Authorization"));
 
             // Validate result
-            Assert.Equal(false, result);
+            Assert.False(result);
         }
 
         [Fact]

--- a/src/SDKs/Resource/Resource.Tests/Resource.Tests.csproj
+++ b/src/SDKs/Resource/Resource.Tests/Resource.Tests.csproj
@@ -4,11 +4,9 @@
     <PackageId>Resource.Tests</PackageId>
     <Description>Resources.Tests Class Library</Description>
     <AssemblyName>Resource.Tests</AssemblyName>
-    <VersionPrefix>1.0.0-preview</VersionPrefix>
+    <Version>1.0.0</Version>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
 
   <ItemGroup>
     <!--<PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.5.0-preview" />-->

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/DeploymentTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/DeploymentTests.ScenarioTests.cs
@@ -364,8 +364,8 @@ namespace ResourceGroups.Tests
                 Assert.NotNull(deploymentListResult.First().Properties.ProvisioningState);
                 Assert.NotNull(deploymentGetResult.Properties.CorrelationId);
                 Assert.NotNull(deploymentListResult.First().Properties.CorrelationId);
-                Assert.True(deploymentGetResult.Properties.Parameters.ToString().Contains("mctest0101"));
-                Assert.True(deploymentListResult.First().Properties.Parameters.ToString().Contains("mctest0101"));
+                Assert.Contains("mctest0101", deploymentGetResult.Properties.Parameters.ToString());
+                Assert.Contains("mctest0101", deploymentListResult.First().Properties.Parameters.ToString());
             }
         }
 

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/ResourceGroupTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/ResourceGroupTests.ScenarioTests.cs
@@ -57,7 +57,7 @@ namespace ResourceGroups.Tests
 
                 Assert.Throws<CloudException>(() => client.Resources.ListByResourceGroup(resourceGroupName));
 
-                Assert.False(listGroupsResult.Any(rg => rg.Name == resourceGroupName));
+                Assert.DoesNotContain(listGroupsResult, rg => rg.Name == resourceGroupName);
             }
         }
 
@@ -83,7 +83,7 @@ namespace ResourceGroups.Tests
                    string.Format("Expected location '{0}' did not match actual location '{1}'", DefaultLocation, listedGroup.Location));
                 var gottenGroup = client.ResourceGroups.Get(groupName);
                 Assert.NotNull(gottenGroup);
-                Assert.Equal<string>(groupName, gottenGroup.Name);
+                Assert.Equal(groupName, gottenGroup.Name);
                 Assert.True(ResourcesManagementTestUtilities.LocationsAreEqual(DefaultLocation, gottenGroup.Location),
                     string.Format("Expected location '{0}' did not match actual location '{1}'", DefaultLocation, gottenGroup.Location));
             }
@@ -128,7 +128,7 @@ namespace ResourceGroups.Tests
                 var listResult = client.ResourceGroups.List(null);
 
                 Assert.Equal(HttpStatusCode.OK, deleteResult.Response.StatusCode);
-                Assert.False(listResult.Any(rg => rg.Name == resourceGroupName && rg.Properties.ProvisioningState != "Deleting"));
+                Assert.DoesNotContain(listResult, rg => rg.Name == resourceGroupName && rg.Properties.ProvisioningState != "Deleting");
             }
         }
     }

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/ResourceTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/ResourceTests.ScenarioTests.cs
@@ -129,7 +129,7 @@ namespace ResourceGroups.Tests
 
                 var listResult = client.Resources.ListByResourceGroup(groupName);
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.Equal(resourceName, listResult.First().Name);
                 Assert.Equal("Microsoft.Web/sites", listResult.First().Type);
                 Assert.True(ResourcesManagementTestUtilities.LocationsAreEqual(websiteLocation, listResult.First().Location),
@@ -137,7 +137,7 @@ namespace ResourceGroups.Tests
 
                 listResult = client.Resources.ListByResourceGroup(groupName, new ODataQuery<GenericResourceFilter> { Top = 10 });
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.Equal(resourceName, listResult.First().Name);
                 Assert.Equal("Microsoft.Web/sites", listResult.First().Type);
                 Assert.True(ResourcesManagementTestUtilities.LocationsAreEqual(websiteLocation, listResult.First().Location),
@@ -190,7 +190,7 @@ namespace ResourceGroups.Tests
 
                 var listResult = client.Resources.ListByResourceGroup(groupName, new ODataQuery<GenericResourceFilter>(r => r.Tagname == tagName));
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.Equal(resourceName, listResult.First().Name);
 
                 var getResult = client.Resources.Get(
@@ -255,7 +255,7 @@ namespace ResourceGroups.Tests
                 var listResult = client.Resources.ListByResourceGroup(groupName,
                     new ODataQuery<GenericResourceFilter>(r => r.Tagname == tagName && r.Tagvalue == tagValue));
 
-                Assert.Equal(1, listResult.Count());
+                Assert.Single(listResult);
                 Assert.Equal(resourceName, listResult.First().Name);
 
                 var getResult = client.Resources.Get(

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/SubscriptionTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/SubscriptionTests.ScenarioTests.cs
@@ -40,7 +40,7 @@ namespace ResourceGroups.Tests
                 var subscriptions = client.Subscriptions.List();
 
                 Assert.NotNull(subscriptions);
-                Assert.NotEqual(0, subscriptions.Count());
+                Assert.NotEmpty(subscriptions);
                 Assert.NotNull(subscriptions.First().Id);
                 Assert.NotNull(subscriptions.First().SubscriptionId);
                 Assert.NotNull(subscriptions.First().DisplayName);

--- a/src/SDKs/Resource/Resource.Tests/ScenarioTests/TenantTests.ScenarioTests.cs
+++ b/src/SDKs/Resource/Resource.Tests/ScenarioTests/TenantTests.ScenarioTests.cs
@@ -38,7 +38,7 @@ namespace ResourceGroups.Tests
                 Assert.NotNull(tenants);
                 Assert.Equal(HttpStatusCode.OK, tenants.Response.StatusCode);
                 Assert.NotNull(tenants.Body);
-                Assert.NotEqual(0, tenants.Body.Count());
+                Assert.NotEmpty(tenants.Body);
                 Assert.NotNull(tenants.Body.First().Id);
                 Assert.NotNull(tenants.Body.First().TenantId);
             }

--- a/src/SDKs/ResourceGraph/Management/ResourceGraph.Tests/Microsoft.Azure.Management.ResourceGraph.Tests.csproj
+++ b/src/SDKs/ResourceGraph/Management/ResourceGraph.Tests/Microsoft.Azure.Management.ResourceGraph.Tests.csproj
@@ -6,6 +6,7 @@
     <Description>ResourceGraph.Tests Class Library</Description>
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>Microsoft.Azure.Management.ResourceGraph.Tests</AssemblyName>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="SessionRecords\ResourceGraph.Tests.ScenarioTests.ScenarioTests\**" />


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
