### PR TITLE
Out of memory bug.

### DIFF
--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ServiceClientTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ServiceClientTests.cs
@@ -127,6 +127,29 @@ namespace Microsoft.Rest.ClientRuntime.Tests
             Assert.Equal(2, attemptsFailed);
         }
 
+
+        [Fact]
+        public void RetryHandlerRetriesWith500ErrorsDouble()
+        {
+            var handler2 = new FakeHttpHandler();
+            var otherHandles = new DelegatingHandler[] { new RetryAfterDelegatingHandler(), new ContosoMessageHandler() };
+            var fakeClient = new FakeServiceClient(handler2, otherHandles);
+            int attemptsFailed = 0;
+
+            var retryPolicy = new RetryPolicy<FluentWrapperFailureStrategy>(2);
+            fakeClient.SetRetryPolicy(retryPolicy);
+            var retryHandler = fakeClient.HttpMessageHandlers.OfType<RetryDelegatingHandler>().FirstOrDefault();
+            retryPolicy.Retrying += (sender, args) => { attemptsFailed++; };
+
+            var result = fakeClient.DoStuffSync();
+
+            var fakeClient3 = new FakeServiceClient(handler2, otherHandles);
+
+            // Out Of Memory Exception here
+            var weird = fakeClient3.HttpMessageHandlers.ToList();
+            var fakeClient2 = new FakeServiceClient(new FakeHttpHandler(), otherHandles);
+        }
+
         [Fact]
         public void RetryAfterHandleTest()
         {
@@ -342,5 +365,13 @@ namespace Microsoft.Rest.ClientRuntime.Tests
         }
 
 #endif
+    }
+
+    public class FluentWrapperFailureStrategy : ITransientErrorDetectionStrategy
+    {
+        public bool IsTransient(Exception ex)
+        {
+            return true;
+        }
     }
 }

--- a/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ServiceClientTests.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime.Tests/ServiceClientTests.cs
@@ -143,11 +143,14 @@ namespace Microsoft.Rest.ClientRuntime.Tests
 
             var result = fakeClient.DoStuffSync();
 
+            var fakeClient2 = new FakeServiceClient(new FakeHttpHandler(), otherHandles);
+            // Out Of Memory Exception here
+            var weird1 = fakeClient2.HttpMessageHandlers.ToList();
+
             var fakeClient3 = new FakeServiceClient(handler2, otherHandles);
 
             // Out Of Memory Exception here
-            var weird = fakeClient3.HttpMessageHandlers.ToList();
-            var fakeClient2 = new FakeServiceClient(new FakeHttpHandler(), otherHandles);
+            var weird2 = fakeClient3.HttpMessageHandlers.ToList();
         }
 
         [Fact]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
