### PR TITLE
Fix default location of raw build assets

### DIFF
--- a/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/BootstrapTasks/GetBuildTools.cs
+++ b/tools/BuildAssets/BuildTasks/Microsoft.Azure.Sdk.Build.Tasks/BootstrapTasks/GetBuildTools.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Build.BootstrapTasks
         const string LKG_AKAMS_URI = @"http://aka.ms/AzNetSDKBuildTools";
         const string LATEST_AKAMS_URI = @"http://aka.ms/LatestBuildTools";
 
-        const string COPY_TO_RELATIVEPATH = @"tools\SdkBuildTools\";
+        const string COPY_TO_RELATIVEPATH = @"tools\BuildToolsForSdk\";
         const string COPY_FROM_RELATIVEPATH = @"tools\BuildAssets\";
         const string DEFAULT_REMOTE_ROOT_DIR = "https://raw.githubusercontent.com/Azure/azure-sdk-for-net/";
         //const string DEFAULT_REMOTE_ROOT_DIR = "https://raw.githubusercontent.com/Azure/azure-sdk-for-net/SdkBuildTools/";


### PR DESCRIPTION
Wrong branch hard-coded into task "SdkBuildTools". Took me a while but I found the correct branch name, "BuildToolsForSdk".

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
