### PR TITLE
New features for AppAuthentication library

### DIFF
--- a/Documentation/sdk-for-net-packages.md
+++ b/Documentation/sdk-for-net-packages.md
@@ -74,6 +74,7 @@ Below are the packages maintained in this repository.
 
 | Azure Common Library               | Package Name                                        | NuGet Download |
 | ---------------------------------- | --------------------------------------------------- | -------------- |
+| AppAuthentication                  | `Microsoft.Azure.Services.AppAuthentication`        | [![ClientRuntime](https://img.shields.io/nuget/vpre/Microsoft.Azure.Services.AppAuthentication.svg)](https://www.nuget.org/packages/Microsoft.Azure.Services.AppAuthentication) |
 | ClientRuntime                      | `Microsoft.Rest.ClientRuntime`                      | [![ClientRuntime](https://img.shields.io/nuget/vpre/Microsoft.Rest.ClientRuntime.svg)](https://www.nuget.org/packages/Microsoft.Rest.ClientRuntime) |
 | ClientRuntime.Azure                | `Microsoft.Rest.ClientRuntime.Azure`                | [![ClientRuntime.Azure](https://img.shields.io/nuget/vpre/Microsoft.Rest.ClientRuntime.Azure.svg)](https://www.nuget.org/packages/Microsoft.Rest.ClientRuntime.Azure) |
 | ClientRuntime.Azure.Authentication | `Microsoft.Rest.ClientRuntime.Azure.Authentication` | [![ClientRuntime.Azure.Authentication](https://img.shields.io/nuget/vpre/Microsoft.Rest.ClientRuntime.Azure.Authentication.svg)](https://www.nuget.org/packages/Microsoft.Rest.ClientRuntime.Azure.Authentication) |

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/EndtoEndPositiveTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/EndtoEndPositiveTests.cs
@@ -11,6 +11,10 @@ using Microsoft.Azure.KeyVault;
 using Microsoft.Azure.Services.AppAuthentication.IntegrationTests.Helpers;
 using Microsoft.Azure.Services.AppAuthentication.IntegrationTests.Models;
 using Microsoft.Azure.Services.AppAuthentication.TestCommon;
+#if net472
+using System.Data;
+using System.Data.SqlClient;
+#endif
 
 namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
 {
@@ -76,11 +80,11 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
             {
                 foreach (var resourceId in resourceIdList)
                 {
-                    string token =
+                    var authResult =
                         await
-                            astp.GetAccessTokenAsync(resourceId);
+                            astp.GetAuthenticationResultAsync(resourceId);
 
-                    Validator.ValidateToken(token, astp.PrincipalUsed, Constants.UserType, _tenantId);
+                    Validator.ValidateToken(authResult.AccessToken, astp.PrincipalUsed, Constants.UserType, _tenantId, expiresOn: authResult.ExpiresOn);
                 }
                 
                 var callback = astp.KeyVaultTokenCallback;
@@ -117,15 +121,15 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
             for (int i = 0; i < 100; i++)
             {
                 // Get token using active directory integrated authentication
-                string token =
+                var authResult =
                     await
-                        astp.GetAccessTokenAsync(Constants.GraphResourceId);
+                        astp.GetAuthenticationResultAsync(Constants.GraphResourceId);
 
                 // This will not cause IWA. Token for SQL will be used to get token for Graph API (MRRT)
                 AzureServiceTokenProvider astp1 = new AzureServiceTokenProvider(Constants.IntegratedAuthConnectionString);
                 await astp1.GetAccessTokenAsync(Constants.SqlAzureResourceId);
 
-                Validator.ValidateToken(token, astp.PrincipalUsed, Constants.UserType, astp1.PrincipalUsed.TenantId);
+                Validator.ValidateToken(authResult.AccessToken, astp.PrincipalUsed, Constants.UserType, astp1.PrincipalUsed.TenantId, expiresOn: authResult.ExpiresOn);
             }
         }
 #endif
@@ -151,7 +155,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
             Application app = await graphHelper.CreateApplicationAsync(cert).ConfigureAwait(false);
 
             // Get token using service principal, this will cache the cert
-            string token = string.Empty;
+            AppAuthenticationResult authResult = null;
             int count = 5;
 
             string thumbprint = cert.Thumbprint?.ToLower();
@@ -165,13 +169,13 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
             // Import the certificate
             CertUtil.ImportCertificate(cert);
 
-            while (string.IsNullOrEmpty(token) && count > 0)
+            while (authResult == null && count > 0)
             {
                 try
                 {
                     await astp.GetAccessTokenAsync(Constants.KeyVaultResourceId);
 
-                    token = await astp.GetAccessTokenAsync(Constants.SqlAzureResourceId, _tenantId);
+                    authResult = await astp.GetAuthenticationResultAsync(Constants.SqlAzureResourceId, _tenantId);
                 }
                 catch
                 {
@@ -186,7 +190,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
             CertUtil.DeleteCertificate(cert.Thumbprint);
 
             var deletedCert = CertUtil.GetCertificate(cert.Thumbprint);
-            Assert.Equal(null, deletedCert);
+            Assert.Null(deletedCert);
 
             // Get token again using a cert which is deleted, but in the cache
             await astp.GetAccessTokenAsync(Constants.SqlAzureResourceId, _tenantId);
@@ -194,7 +198,8 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
             // Delete the application and service principal
             await graphHelper.DeleteApplicationAsync(app);
 
-            Validator.ValidateToken(token, astp.PrincipalUsed, Constants.AppType, _tenantId, app.AppId, cert.Thumbprint);
+            Validator.ValidateToken(authResult.AccessToken, astp.PrincipalUsed, Constants.AppType, _tenantId,
+                app.AppId, cert.Thumbprint, expiresOn: authResult.ExpiresOn);
         }
 
         [Fact]
@@ -217,17 +222,17 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
             Application app = await graphHelper.CreateApplicationAsync(secret);
 
             // Get token using service principal
-            string token = string.Empty;
+            AppAuthenticationResult authResult = null;
             int count = 5;
 
             Environment.SetEnvironmentVariable(Constants.ConnectionStringEnvironmentVariableName, $"RunAs=App;TenantId={_tenantId};AppId={app.AppId};AppKey={secret}");
             AzureServiceTokenProvider astp = new AzureServiceTokenProvider();
 
-            while (string.IsNullOrEmpty(token) && count > 0)
+            while (authResult == null && count > 0)
             {
                 try
                 {
-                    token = await astp.GetAccessTokenAsync(Constants.SqlAzureResourceId, _tenantId);
+                    authResult = await astp.GetAuthenticationResultAsync(Constants.SqlAzureResourceId, _tenantId);
 
                     await astp.GetAccessTokenAsync(Constants.KeyVaultResourceId);
 
@@ -247,7 +252,31 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
 
             Environment.SetEnvironmentVariable(Constants.ConnectionStringEnvironmentVariableName, null);
 
-            Validator.ValidateToken(token, astp.PrincipalUsed, Constants.AppType, _tenantId, app.AppId);
+            Validator.ValidateToken(authResult.AccessToken, astp.PrincipalUsed, Constants.AppType, _tenantId, app.AppId, expiresOn: authResult.ExpiresOn);
         }
+
+#if net472
+        /// <summary>
+        /// One must be logged in using Azure CLI and set AppAuthenticationTestSqlDbEndpoint to a SQL Azure database endpoint before running this test.
+        /// The test validates that it can open a connection with the SQL database using SqlAzureAuthProvider, which implements the SqlAuthenticationProvider interface.
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task ConnectToSqlDbWithSqlAppAuthProvider()
+        {
+            // register SqlAzureAppAuthProvider and create the connection string
+            SqlAuthenticationProvider.SetProvider(SqlAuthenticationMethod.ActiveDirectoryInteractive, new SqlAppAuthenticationProvider());
+            string connectionString = $"server={Environment.GetEnvironmentVariable(Constants.TestSqlDbEndpoint)};Authentication=Active Directory Interactive;UID=";
+
+            // verify the connection can be successfully opened
+            var sqlConnection = new SqlConnection(connectionString);
+            await sqlConnection.OpenAsync();
+            Assert.Equal(ConnectionState.Open, sqlConnection.State);
+
+            // verify connection can be successfully closed
+            sqlConnection.Close();
+            Assert.Equal(ConnectionState.Closed, sqlConnection.State);
+        }
+#endif
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/EndtoEndPositiveTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/EndtoEndPositiveTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
 #if FullNetFx
         /// <summary>
         /// Test case where token is fetched using Integrated Windows Authentication. 
-        /// Person runnning the test must be using domain joined machine, where domain is federated with Azure AD. 
+        /// Person running the test must be using domain joined machine, where domain is federated with Azure AD. 
         /// </summary>
         /// <returns></returns>
         [Fact]

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/Helpers/KeyVaultHelper.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/Helpers/KeyVaultHelper.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests.Helpers
             if (0 == string.CompareOrdinal(certContentSecret.ContentType, CertificateContentType.Pfx))
             {
                 return certContentSecret.Value;
-
             }
 
             throw new Exception($"Certificate not found at {secretUrl}");

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/Microsoft.Azure.Services.AppAuthentication.IntegrationTests.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/Microsoft.Azure.Services.AppAuthentication.IntegrationTests.csproj
@@ -1,8 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;net452;net472</TargetFrameworks>
     </PropertyGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+		<DefineConstants>net472;FullNetFx</DefineConstants>		
+		<OutputPath>bin\$(Configuration)\</OutputPath>
+		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+	</PropertyGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.Azure.KeyVault" Version="2.3.2" />
     </ItemGroup>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/Microsoft.Azure.Services.AppAuthentication.IntegrationTests.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/Microsoft.Azure.Services.AppAuthentication.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.0;net452;net472</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     </PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
 		<DefineConstants>net472;FullNetFx</DefineConstants>		

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Constants.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Constants.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         // Azure AD related constants
         public static readonly string TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47";
         public static readonly string TestAppId = "f0b1f84a-ec74-4cef-8034-adbad168ce33";
+        public static readonly string TestUserAssignedManagedIdentityId = "942343b1-4af2-490c-b6d9-9250b8f2808c";
         public static readonly string AzureAdInstance = "https://login.microsoftonline.com/";
 
         // Error messages
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         public static readonly string NoConnectionString = "[No connection string specified]";
         public static readonly string ConnectionStringEmpty = "Connection string is empty.";
         public static readonly string InvalidCertLocationError = "is not valid. Valid values are CurrentUser and LocalMachine.";
-        public static readonly string ConnectionStringNotHaveAtLeastOneRequiredKey = "is not valid. Must contain at least one of";
+        public static readonly string ConnectionStringMissingCertLocation = "attribute and it must not be empty when using";
         public static readonly string KeyRepeatedInConnectionString = "is repeated";
         public static readonly string InvalidConnectionString = "is not valid";
         public static readonly string Redacted = "<<Redacted>>";
@@ -43,6 +44,8 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         public static readonly string DeveloperToolError = "You are not logged in.";
         public static readonly string JsonParseErrorException = "There was an error deserializing the object of type";
         public static readonly string TokenNotInExpectedFormatError = "Index was outside the bounds of the array";
+        public static readonly string SqlAppAuthProviderInvalidAuthority = "The Azure AD instance could not be parsed";
+        public static readonly string SqlAppAuthProviderInvalidResource = "A resource must be specified";
 
         // Connection strings
         public static readonly string ClientSecret = "Secret";
@@ -59,6 +62,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         public static readonly string AzureCliConnectionStringNoRunAs = "DeveloperTool=AzureCLI";
         public static readonly string ActiveDirectoryIntegratedConnectionString = "RunAs=CurrentUser;";
         public static readonly string ManagedServiceIdentityConnectionString = "RunAs=App;";
+        public static readonly string ManagedUserAssignedIdentityConnectionString = $"RunAs=App;AppId={TestUserAssignedManagedIdentityId};TenantId={TenantId}";
         public static readonly string CertificateConnStringThumbprintLocalMachine = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateThumbprint=123;CertificateStoreLocation=LocalMachine";
         public static readonly string CertificateConnStringThumbprintInvalidLocation = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateThumbprint=123;CertificateStoreLocation=InvalidLocation";
         public static readonly string AppConnStringNoLocationOrAppKey = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateThumbprint=123;";
@@ -100,7 +104,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         public static readonly string LocalAppDataEnv = "LOCALAPPDATA";
         public static readonly string TokenProviderFileNotFound = "Visual Studio Token provider file not found at ";
         public static readonly string TokenProviderExceptionMessage = "Exception for Visual Studio token provider";
-        public static readonly string PreferenceNotFound= "'Preference' was not found";
+        public static readonly string PreferenceNotFound = "'Preference' was not found";
         public static readonly string TokenProviderFileFormatExceptionMessage = "VisualStudio Token Provider File is not in the expected format.";
 
         // Test files path

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Constants.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Constants.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
 
         // Error messages
         public static readonly string AdalException = "Adal Exception";
-        public static readonly string CertificateNotFoundError = "Specified certificate was not found. ";
+        public static readonly string LocalCertificateNotFoundError = "Specified certificate was not found.";
         public static readonly string IncorrectSecretError = "Secret not correct";
         public static readonly string MsiFailureError = "MSI failed to get token";
         public static readonly string IncorrectFormatError = "Incorrect format";
@@ -68,10 +68,14 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         public static readonly string AppConnStringNoLocationOrAppKey = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateThumbprint=123;";
         public static readonly string CertificateConnStringThumbprintCurrentUser = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateThumbprint=123;CertificateStoreLocation=CurrentUser";
         public static readonly string CertificateConnStringSubjectNameCurrentUser = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateSubjectName=123;CertificateStoreLocation=CurrentUser";
+        public static readonly string CertificateConnStringKeyVaultSecretIdentifier = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};KeyVaultSecretIdentifier=SecretIdentifier";
         public static readonly string ClientSecretConnString = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};AppKey={ClientSecret}";
         public static readonly string ConnectionStringEnvironmentVariableName = "AzureServicesAuthConnectionString";
         public static readonly string CurrentUserStore = "CurrentUser";
         public static readonly string InvalidString = "Invalid";
+
+        // Key Vault related constants
+        public static readonly string TestKeyVaultSecretIdentifier = "https://test.vault.azure.net/secrets/testcert/c9328cfacb39440cb1c7a92308dc63de";
 
         // Http related constants
         public static readonly string JsonContentType = "application/json";

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Constants.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Constants.cs
@@ -89,6 +89,10 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         // The AppAuthenticationTestCertUrl environment variable should point to a cert in key vault. 
         public static readonly string TestCertUrlEnv = "AppAuthenticationTestCertUrl";
 
+        // End to end test SQL database connection string environment variable
+        // The AppAuthenticationTestSqlDbEndpoint environment variable should point to a SQL Azure database endpoint. 
+        public static readonly string TestSqlDbEndpoint = "AppAuthenticationTestSqlDbEndpoint";
+
         // Visual Studio related constants
         public static readonly string TokenProviderPath = "C:\\Users\\johndoe\\AppData\\Local\\Microsoft\\VisualStudio\\15.0_5b4bdc86\\Extensions\\lyzwtlta.zzj\\TokenService\\Microsoft.Asal.TokenService.exe";
         public static readonly string ServiceConfigFileArgument = "C:\\Program Files (x86)\\Microsoft Visual Studio\\Preview\\Enterprise\\Common7\\servicehub.config.json";

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Microsoft.Azure.Services.AppAuthentication.TestCommon.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Microsoft.Azure.Services.AppAuthentication.TestCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-        <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>     
+        <TargetFrameworks>netcoreapp2.0;net452;net472</TargetFrameworks>     
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Azure.Services.AppAuthentication\Microsoft.Azure.Services.AppAuthentication.csproj" />

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Microsoft.Azure.Services.AppAuthentication.TestCommon.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Microsoft.Azure.Services.AppAuthentication.TestCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.0;net452;net472</TargetFrameworks>     
+        <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>     
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Azure.Services.AppAuthentication\Microsoft.Azure.Services.AppAuthentication.csproj" />

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Validator.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Validator.cs
@@ -1,12 +1,73 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
+using System.Globalization;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
 using Xunit;
 
 namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
 {
     public class Validator
     {
+        private const char Base64PadCharacter = '=';
+        private const char Base64Character62 = '+';
+        private const char Base64Character63 = '/';
+        private const char Base64UrlCharacter62 = '-';
+        private const char Base64UrlCharacter63 = '_';
+        private static readonly string DoubleBase64PadCharacter = string.Format(CultureInfo.InvariantCulture, "{0}{0}", Base64PadCharacter);
+
+        private static DateTimeOffset UnixTimeEpoch => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        [DataContract]
+        private class AccessToken
+        {
+            [DataMember(Name = "exp", IsRequired = true)]
+            public long Expiration { get; private set; }
+        }
+
+        private static byte[] DecodeBytes(string arg)
+        {
+            string s = arg;
+            s = s.Replace(Base64UrlCharacter62, Base64Character62);
+            s = s.Replace(Base64UrlCharacter63, Base64Character63);
+
+            switch (s.Length % 4)
+            {
+                // Pad 
+                case 0:
+                    break; // No pad chars in this case
+                case 2:
+                    s += DoubleBase64PadCharacter;
+                    break; // Two pad chars
+                case 3:
+                    s += Base64PadCharacter;
+                    break; // One pad char
+                default:
+                    throw new ArgumentException("Illegal base64url string!", nameof(arg));
+            }
+
+            return Convert.FromBase64String(s);
+        }
+
+        private static DateTimeOffset GetTokenExpiration(string accessTokenString)
+        {
+            string[] tokenParts = accessTokenString.Split('.');
+            string tokenBody = tokenParts[1];
+            byte[] tokenBodyBytes = DecodeBytes(tokenBody);
+
+            AccessToken accessToken = null;
+            using (MemoryStream memoryStream = new MemoryStream(tokenBodyBytes))
+            {
+                DataContractJsonSerializer ser = new DataContractJsonSerializer(typeof(AccessToken));
+                accessToken = (AccessToken)ser.ReadObject(memoryStream);
+            }
+
+            return UnixTimeEpoch.AddSeconds(accessToken.Expiration);
+        }
+
         /// <summary>
         /// Checks if the token fetched and principalUsed are as expected. 
         /// </summary>
@@ -16,15 +77,17 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         /// <param name="tenantId"></param>
         /// <param name="appId"></param>
         /// <param name="thumbprint"></param>
+        /// <param name="expiresOn"></param>
         public static void ValidateToken(string token, Principal principalUsed, string type,
-            string tenantId, string appId = default(string), string thumbprint = default(string))
+            string tenantId, string appId = default(string), string thumbprint = default(string),
+            DateTimeOffset expiresOn = default(DateTimeOffset))
         {
             Assert.Equal("eyJ0eXAiOiJKV1Qi", token.Substring(0, "eyJ0eXAiOiJKV1Qi".Length));
             Assert.Contains(".", token);
 
             // These will always be present
             Assert.Equal(type, principalUsed.Type);
-            Assert.Equal(true, principalUsed.IsAuthenticated);
+            Assert.True(principalUsed.IsAuthenticated);
             Assert.Equal(tenantId, principalUsed.TenantId);
 
             string thumbprintPart = string.Empty;
@@ -34,7 +97,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
             if (string.Equals(type, "App"))
             {
                 Assert.Equal(appId, principalUsed.AppId);
-                Assert.Equal(null, principalUsed.UserPrincipalName);
+                Assert.Null(principalUsed.UserPrincipalName);
                 appIdPart = $" AppId:{principalUsed.AppId}";
 
                 if (!string.IsNullOrEmpty(thumbprint))
@@ -45,9 +108,19 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
             }
             else
             {
-                Assert.Equal(null, principalUsed.AppId);
+                Assert.Null(principalUsed.AppId);
                 Assert.Contains("@", principalUsed.UserPrincipalName);
                 upnPart = $" UserPrincipalName:{principalUsed.UserPrincipalName}";
+            }
+
+            if (expiresOn != default(DateTimeOffset))
+            {
+                DateTimeOffset expiration = GetTokenExpiration(token);
+
+                var delta = expiration.UtcDateTime - expiresOn.UtcDateTime;
+
+                // the expirations can differ a fraction of a second
+                Assert.True(delta < TimeSpan.FromSeconds(1));
             }
 
             Assert.Equal($"IsAuthenticated:True Type:{type}{appIdPart} TenantId:{principalUsed.TenantId}{thumbprintPart}{upnPart}",

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Validator.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Validator.cs
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
 
                 var delta = expiration.UtcDateTime - expiresOn.UtcDateTime;
 
-                // the expirations can differ a fraction of a second
+                // the expirations can differ a fraction of a second for integration/E2E tests
                 Assert.True(delta < TimeSpan.FromSeconds(1));
             }
 

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Validator.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Validator.cs
@@ -115,9 +115,9 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
 
             if (expiresOn != default(DateTimeOffset))
             {
-                DateTimeOffset expiration = GetTokenExpiration(token);
+                DateTimeOffset tokenExpiration = GetTokenExpiration(token);
 
-                var delta = expiration.UtcDateTime - expiresOn.UtcDateTime;
+                var delta = tokenExpiration.UtcDateTime - expiresOn.UtcDateTime;
 
                 // the expirations can differ a fraction of a second for integration/E2E tests
                 Assert.True(delta < TimeSpan.FromSeconds(1));

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureCliAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureCliAccessTokenProviderTests.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
 
             // Get token and validate it
-            var token = await azureCliAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
+            var authResult = await azureCliAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
-            Validator.ValidateToken(token, azureCliAccessTokenProvider.PrincipalUsed, Constants.UserType, Constants.TenantId);
+            Validator.ValidateToken(authResult.AccessToken, azureCliAccessTokenProvider.PrincipalUsed, Constants.UserType, Constants.TenantId);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => azureCliAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => azureCliAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(Constants.ProgramNotFoundError, exception.Message);
         }
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => azureCliAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => azureCliAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(Constants.FailedToGetTokenError, exception.Message);
             Assert.Contains(Constants.DeveloperToolError, exception.Message);
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => azureCliAccessTokenProvider.GetTokenAsync("https://test^", Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => azureCliAccessTokenProvider.GetAuthResultAsync("https://test^", Constants.TenantId)));
 
             Assert.Contains(Constants.NotInExpectedFormatError, exception.Message);
         }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderFactoryTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderFactoryTests.cs
@@ -180,6 +180,11 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             Assert.NotNull(provider);
             Assert.Equal(Constants.CertificateConnStringSubjectNameCurrentUser, provider.ConnectionString);
             Assert.IsType<ClientCertificateAzureServiceTokenProvider>(provider);
+
+            provider = AzureServiceTokenProviderFactory.Create(Constants.CertificateConnStringKeyVaultSecretIdentifier, Constants.AzureAdInstance);
+            Assert.NotNull(provider);
+            Assert.Equal(Constants.CertificateConnStringKeyVaultSecretIdentifier, provider.ConnectionString);
+            Assert.IsType<ClientCertificateAzureServiceTokenProvider>(provider);
         }
 
         [Fact]

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderFactoryTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderFactoryTests.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         {
             var exception = Assert.Throws<ArgumentException>(() => AzureServiceTokenProviderFactory.Create(Constants.InvalidDeveloperToolConnectionString, Constants.AzureAdInstance));
 
-            Assert.Contains(Constants.InvalidConnectionString, exception.ToString());           
+            Assert.Contains(Constants.InvalidConnectionString, exception.ToString());
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         {
             var exception = Assert.Throws<ArgumentException>(() => AzureServiceTokenProviderFactory.Create(Constants.AppConnStringNoLocationOrAppKey, Constants.AzureAdInstance));
 
-            Assert.Contains(Constants.ConnectionStringNotHaveAtLeastOneRequiredKey, exception.ToString());
+            Assert.Contains(Constants.ConnectionStringMissingCertLocation, exception.ToString());
         }
 
         /// <summary>
@@ -151,6 +151,15 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             var provider = AzureServiceTokenProviderFactory.Create(Constants.ManagedServiceIdentityConnectionString, Constants.AzureAdInstance);
             Assert.NotNull(provider);
             Assert.Equal(Constants.ManagedServiceIdentityConnectionString, provider.ConnectionString);
+            Assert.IsType<MsiAccessTokenProvider>(provider);
+        }
+
+        [Fact]
+        public void ManagedUserAssignedIdentityValidTest()
+        {
+            var provider = AzureServiceTokenProviderFactory.Create(Constants.ManagedUserAssignedIdentityConnectionString, Constants.AzureAdInstance);
+            Assert.NotNull(provider);
+            Assert.Equal(Constants.ManagedUserAssignedIdentityConnectionString, provider.ConnectionString);
             Assert.IsType<MsiAccessTokenProvider>(provider);
         }
 

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderFactoryTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderFactoryTests.cs
@@ -19,12 +19,12 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             var provider = AzureServiceTokenProviderFactory.Create(Constants.AzureCliConnectionString, Constants.AzureAdInstance);
             Assert.NotNull(provider);
             Assert.Equal(Constants.AzureCliConnectionString, provider.ConnectionString);
-            Assert.IsType(typeof(AzureCliAccessTokenProvider), provider);
+            Assert.IsType<AzureCliAccessTokenProvider>(provider);
 
             provider = AzureServiceTokenProviderFactory.Create(Constants.AzureCliConnectionStringWithSpaces, Constants.AzureAdInstance);
             Assert.NotNull(provider);
             Assert.Equal(Constants.AzureCliConnectionStringWithSpaces, provider.ConnectionString);
-            Assert.IsType(typeof(AzureCliAccessTokenProvider), provider);
+            Assert.IsType<AzureCliAccessTokenProvider>(provider);
         }
 
         /// <summary>
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             Assert.NotNull(provider);
             Assert.Equal(Constants.AzureCliConnectionStringEndingWithSemiColonAndSpace, provider.ConnectionString);
-            Assert.IsType(typeof(AzureCliAccessTokenProvider), provider);
+            Assert.IsType<AzureCliAccessTokenProvider>(provider);
         }
 
         [Fact]
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             var provider = AzureServiceTokenProviderFactory.Create(Constants.ManagedServiceIdentityConnectionString, Constants.AzureAdInstance);
             Assert.NotNull(provider);
             Assert.Equal(Constants.ManagedServiceIdentityConnectionString, provider.ConnectionString);
-            Assert.IsType(typeof(MsiAccessTokenProvider), provider);
+            Assert.IsType<MsiAccessTokenProvider>(provider);
         }
 
         [Fact]
@@ -160,17 +160,17 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             var provider = AzureServiceTokenProviderFactory.Create(Constants.CertificateConnStringThumbprintLocalMachine, Constants.AzureAdInstance);
             Assert.NotNull(provider);
             Assert.Equal(Constants.CertificateConnStringThumbprintLocalMachine, provider.ConnectionString);
-            Assert.IsType(typeof(ClientCertificateAzureServiceTokenProvider), provider);
+            Assert.IsType<ClientCertificateAzureServiceTokenProvider>(provider);
 
             provider = AzureServiceTokenProviderFactory.Create(Constants.CertificateConnStringThumbprintCurrentUser, Constants.AzureAdInstance);
             Assert.NotNull(provider);
             Assert.Equal(Constants.CertificateConnStringThumbprintCurrentUser, provider.ConnectionString);
-            Assert.IsType(typeof(ClientCertificateAzureServiceTokenProvider), provider);
+            Assert.IsType<ClientCertificateAzureServiceTokenProvider>(provider);
 
             provider = AzureServiceTokenProviderFactory.Create(Constants.CertificateConnStringSubjectNameCurrentUser, Constants.AzureAdInstance);
             Assert.NotNull(provider);
             Assert.Equal(Constants.CertificateConnStringSubjectNameCurrentUser, provider.ConnectionString);
-            Assert.IsType(typeof(ClientCertificateAzureServiceTokenProvider), provider);
+            Assert.IsType<ClientCertificateAzureServiceTokenProvider>(provider);
         }
 
         [Fact]
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             var provider = AzureServiceTokenProviderFactory.Create(Constants.ClientSecretConnString, Constants.AzureAdInstance);
             Assert.NotNull(provider);
             Assert.Equal(Constants.ClientSecretConnString, provider.ConnectionString);
-            Assert.IsType(typeof(ClientSecretAccessTokenProvider), provider);
+            Assert.IsType<ClientSecretAccessTokenProvider>(provider);
         }
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
 
             // Mock MSI is being asked to act like MSI was able to get token. 
-            MockMsi mockMsi = new MockMsi(MockMsi.MsiTestType.MsiAppServicesSuccess);
+            MockMsi mockMsi = new MockMsi(MockMsi.MsiTestType.MsiAzureVmSuccess);
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/AzureServiceTokenProviderTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         public void Dispose()
         {
             // Clear the cache after running each test.
-            AccessTokenCache.Clear();
+            AppAuthResultCache.Clear();
 
             // Delete environment variable
             Environment.SetEnvironmentVariable(Constants.TestCertUrlEnv, null);
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         /// </summary>
         /// <returns></returns>
         [Fact]
-        public async Task GetTokenCacheTest()
+        public async Task GetAppAuthResultCacheTest()
         {
             // Create two instances of AzureServiceTokenProvider based on AzureCliAccessTokenProvider. 
             MockProcessManager mockProcessManager = new MockProcessManager(MockProcessManager.MockProcessManagerRequestType.Success);
@@ -89,9 +89,11 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Update the cache entry, to simulate token expiration. This updated token will expire in just less than 5 minutes. 
             // In a real scenario, the token will expire after some time. 
-            // AccessTokenCache should not return this, since it is about to expire. 
-            AccessTokenCache.AddOrUpdate("ConnectionString:;Authority:;Resource:https://vault.azure.net/", 
-                new Tuple<AccessToken, Principal>(AccessToken.Parse(TokenHelper.GetUserTokenResponse(5 * 60 - 2)), null));
+            // AppAuthResultCache should not return this, since it is about to expire. 
+            var tokenResponse = TokenResponse.Parse(TokenHelper.GetUserTokenResponse(5 * 60 - 2));
+            var authResult = AppAuthenticationResult.Create(tokenResponse, TokenResponse.DateFormat.DateTimeString);
+            AppAuthResultCache.AddOrUpdate("ConnectionString:;Authority:;Resource:https://vault.azure.net/", 
+                new Tuple<AppAuthenticationResult, Principal>(authResult, null));
             
             // Get the token again. 
             for (int i = 0; i < 5; i++)
@@ -193,7 +195,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             var provider = new AzureServiceTokenProvider();
 
             Assert.NotNull(provider);
-            Assert.IsType(typeof(AzureServiceTokenProvider), provider);
+            Assert.IsType<AzureServiceTokenProvider>(provider);
         }
 
         [Fact]

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientCertificateAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientCertificateAccessTokenProviderTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             // Delete the cert, since testing is done. 
             CertUtil.DeleteCertificate(cert.Thumbprint);
 
-            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint);
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint, expiresOn: authResult.ExpiresOn);
         }
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             // Delete the cert, since testing is done. 
             CertUtil.DeleteCertificate(cert.Thumbprint);
 
-            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint);
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint, expiresOn: authResult.ExpiresOn);
         }
 
         /// <summary>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientCertificateAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientCertificateAccessTokenProviderTests.cs
@@ -2,10 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Microsoft.Azure.Services.AppAuthentication.TestCommon;
 using Xunit;
+using CertificateIdentifierType = Microsoft.Azure.Services.AppAuthentication.ClientCertificateAzureServiceTokenProvider.CertificateIdentifierType;
 
 namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 {
@@ -36,7 +38,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Create ClientCertificateAzureServiceTokenProvider instance
             ClientCertificateAzureServiceTokenProvider provider = new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId, 
-                cert.Thumbprint, true, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
+                cert.Thumbprint, CertificateIdentifierType.Thumbprint, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Get the token. This will test that ClientCertificateAzureServiceTokenProvider could fetch the cert from CurrentUser store based on thumbprint in the connection string. 
             var authResult = await provider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
@@ -62,7 +64,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Create ClientCertificateAzureServiceTokenProvider instance
             ClientCertificateAzureServiceTokenProvider provider = new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                cert.Thumbprint, true, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
+                cert.Thumbprint, CertificateIdentifierType.Thumbprint, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Ensure exception is thrown when getting the token
             var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => provider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId));
@@ -87,12 +89,12 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Create ClientCertificateAzureServiceTokenProvider instance
             var exception = Assert.Throws<ArgumentNullException>(() => new ClientCertificateAzureServiceTokenProvider(null,
-                cert.Thumbprint, true, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
+                cert.Thumbprint, CertificateIdentifierType.Thumbprint, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
 
             Assert.Contains(Constants.CannotBeNullError, exception.ToString());
 
             exception = Assert.Throws<ArgumentNullException>(() => new ClientCertificateAzureServiceTokenProvider(string.Empty,
-                cert.Thumbprint, true, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
+                cert.Thumbprint, CertificateIdentifierType.Thumbprint, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
 
             Assert.Contains(Constants.CannotBeNullError, exception.ToString());
         }
@@ -112,12 +114,12 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Create ClientCertificateAzureServiceTokenProvider instance
             var exception = Assert.Throws<ArgumentNullException>(() => new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                cert.Thumbprint, true, null, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
+                cert.Thumbprint, CertificateIdentifierType.Thumbprint, null, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
 
             Assert.Contains(Constants.CannotBeNullError, exception.ToString());
 
             exception = Assert.Throws<ArgumentNullException>(() => new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                cert.Thumbprint, true, string.Empty, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
+                cert.Thumbprint, CertificateIdentifierType.Thumbprint, string.Empty, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
 
             Assert.Contains(Constants.CannotBeNullError, exception.ToString());
         }
@@ -133,12 +135,12 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Create ClientCertificateAzureServiceTokenProvider instance
             var exception = Assert.Throws<ArgumentNullException>(() => new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                null, true, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
+                null, CertificateIdentifierType.Thumbprint, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
 
             Assert.Contains(Constants.CannotBeNullError, exception.ToString());
 
             exception = Assert.Throws<ArgumentNullException>(() => new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                string.Empty, true, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
+                string.Empty, CertificateIdentifierType.Thumbprint, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
 
             Assert.Contains(Constants.CannotBeNullError, exception.ToString());
         }
@@ -158,7 +160,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Create ClientCertificateAzureServiceTokenProvider instance
             var exception = Assert.Throws<ArgumentException>(() => new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                cert.Thumbprint, true, Constants.InvalidString, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
+                cert.Thumbprint, CertificateIdentifierType.Thumbprint, Constants.InvalidString, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext));
 
             Assert.Contains(Constants.InvalidCertLocationError, exception.ToString());
         }
@@ -175,7 +177,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Create ClientCertificateAzureServiceTokenProvider instance with a subject name
             ClientCertificateAzureServiceTokenProvider provider = new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                cert.Subject, false, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
+                cert.Subject, CertificateIdentifierType.SubjectName, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Get the token. This will test that ClientCertificateAzureServiceTokenProvider could fetch the cert from CurrentUser store based on subject name in the connection string. 
             var authResult = await provider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
@@ -202,7 +204,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             // Create ClientCertificateAzureServiceTokenProvider instance with a subject name
             ClientCertificateAzureServiceTokenProvider provider = new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                cert.Subject, false, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
+                cert.Subject, CertificateIdentifierType.SubjectName, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Get the token. This will test that ClientCertificateAzureServiceTokenProvider could fetch the cert from CurrentUser store based on subject name in the connection string. 
             var exception = Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => provider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty));
@@ -224,14 +226,65 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             MockAuthenticationContext mockAuthenticationContext = new MockAuthenticationContext(MockAuthenticationContext.MockAuthenticationContextTestType.AcquireTokenAsyncClientCertificateSuccess);
 
             ClientCertificateAzureServiceTokenProvider provider = new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
-                Guid.NewGuid().ToString(), false, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
+                Guid.NewGuid().ToString(), CertificateIdentifierType.SubjectName, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => provider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(Constants.KeyVaultResourceId, exception.Message);
             Assert.Contains(Constants.TenantId, exception.Message);
-            Assert.Contains(Constants.CertificateNotFoundError, exception.Message);
+            Assert.Contains(Constants.LocalCertificateNotFoundError, exception.Message);
         }
 
+        [Fact]
+        public async Task KeyVaultSecretIdentifierSuccessTest()
+        {
+            X509Certificate2 cert = new X509Certificate2(Convert.FromBase64String(Constants.TestCert), string.Empty);
+
+            // MockAuthenticationContext is being asked to act like client cert auth suceeded. 
+            MockAuthenticationContext mockAuthenticationContext = new MockAuthenticationContext(MockAuthenticationContext.MockAuthenticationContextTestType.AcquireTokenAsyncClientCertificateSuccess);
+
+            // Create KeyVaultCLient with MockKeyVault to mock successful calls to KeyVault
+            MockKeyVault mockKeyVault = new MockKeyVault(MockKeyVault.KeyVaultClientTestType.CertificateSecretIdentifierSuccess);
+            HttpClient httpClient = new HttpClient(mockKeyVault);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient);
+
+            // Create ClientCertificateAzureServiceTokenProvider instance with a subject name
+            ClientCertificateAzureServiceTokenProvider provider = new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
+                Constants.TestKeyVaultSecretIdentifier, CertificateIdentifierType.KeyVaultSecretIdentifier, null, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext, keyVaultClient);
+
+            // Get the token. This will test that ClientCertificateAzureServiceTokenProvider could fetch the cert from CurrentUser store based on subject name in the connection string. 
+            var authResult = await provider.GetAuthResultAsync(Constants.ArmResourceId, string.Empty).ConfigureAwait(false);
+
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint, expiresOn: authResult.ExpiresOn);
+        }
+
+        /// <summary>
+        /// Test that exception when cert is not found is as expected. 
+        /// </summary>
+        /// <returns></returns>
+        [Fact]
+        public async Task KeyVaultCertificateNotFoundTest()
+        {
+            MockAuthenticationContext mockAuthenticationContext = new MockAuthenticationContext(MockAuthenticationContext.MockAuthenticationContextTestType.AcquireTokenAsyncClientCertificateSuccess);
+
+            MockProcessManager mockProcessManager = new MockProcessManager(MockProcessManager.MockProcessManagerRequestType.Success);
+            AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
+
+            MockKeyVault mockKeyVault = new MockKeyVault(MockKeyVault.KeyVaultClientTestType.SecretNotFound);
+            HttpClient httpClient = new HttpClient(mockKeyVault);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient, azureCliAccessTokenProvider);
+
+            string SecretIdentifier = "https://testbedkeyvault.vault.azure.net/secrets/secret/";
+            ClientCertificateAzureServiceTokenProvider provider = new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
+               SecretIdentifier, CertificateIdentifierType.KeyVaultSecretIdentifier, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext, keyVaultClient);
+
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => provider.GetAuthResultAsync(Constants.ArmResourceId, Constants.TenantId)));
+
+            Assert.Contains(Constants.ArmResourceId, exception.Message);
+            Assert.Contains(Constants.TenantId, exception.Message);
+            Assert.Contains(AzureServiceTokenProviderException.KeyVaultCertificateRetrievalError, exception.Message);
+            Assert.Contains(KeyVaultClient.KeyVaultResponseError, exception.Message);
+            Assert.Contains(MockKeyVault.SecretNotFoundErrorMessage, exception.Message);
+        }
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientCertificateAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientCertificateAccessTokenProviderTests.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                 cert.Thumbprint, true, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Get the token. This will test that ClientCertificateAzureServiceTokenProvider could fetch the cert from CurrentUser store based on thumbprint in the connection string. 
-            string token = await provider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
+            var authResult = await provider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
             
             // Delete the cert, since testing is done. 
             CertUtil.DeleteCertificate(cert.Thumbprint);
 
-            Validator.ValidateToken(token, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint);
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint);
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                 cert.Thumbprint, true, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Ensure exception is thrown when getting the token
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => provider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => provider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId));
 
             Assert.Contains(AzureServiceTokenProviderException.GenericErrorMessage, exception.ToString());
             // Delete the cert, since testing is done. 
@@ -178,12 +178,12 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                 cert.Subject, false, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Get the token. This will test that ClientCertificateAzureServiceTokenProvider could fetch the cert from CurrentUser store based on subject name in the connection string. 
-            string token = await provider.GetTokenAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
+            var authResult = await provider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
 
             // Delete the cert, since testing is done. 
             CertUtil.DeleteCertificate(cert.Thumbprint);
 
-            Validator.ValidateToken(token, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint);
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, cert.Thumbprint);
         }
 
         /// <summary>
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                 cert.Subject, false, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Get the token. This will test that ClientCertificateAzureServiceTokenProvider could fetch the cert from CurrentUser store based on subject name in the connection string. 
-            var exception = Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => provider.GetTokenAsync(Constants.KeyVaultResourceId, string.Empty));
+            var exception = Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => provider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty));
 
             // Delete the cert, since testing is done. 
             CertUtil.DeleteCertificate(cert.Thumbprint);
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             ClientCertificateAzureServiceTokenProvider provider = new ClientCertificateAzureServiceTokenProvider(Constants.TestAppId,
                 Guid.NewGuid().ToString(), false, Constants.CurrentUserStore, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => provider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => provider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(Constants.KeyVaultResourceId, exception.Message);
             Assert.Contains(Constants.TenantId, exception.Message);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientSecretAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientSecretAccessTokenProviderTests.cs
@@ -23,10 +23,10 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             ClientSecretAccessTokenProvider clientSecretAccessTokenProvider = new ClientSecretAccessTokenProvider(Constants.TestAppId, Constants.ClientSecret, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
 
             // Get the token
-            var token = await clientSecretAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
+            var authResult = await clientSecretAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
             // Check if the principal used and type were as expected. 
-            Validator.ValidateToken(token, clientSecretAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId);
+            Validator.ValidateToken(authResult.AccessToken, clientSecretAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         {
             MockAuthenticationContext mockAuthenticationContext = new MockAuthenticationContext(MockAuthenticationContext.MockAuthenticationContextTestType.AcquireTokenAsyncClientCredentialFail);
             ClientSecretAccessTokenProvider clientSecretAccessTokenProvider = new ClientSecretAccessTokenProvider(Constants.TestAppId, Constants.ClientSecret, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => clientSecretAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, string.Empty)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => clientSecretAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty)));
 
             Assert.Contains(Constants.KeyVaultResourceId, exception.Message);
             Assert.Contains(Constants.TenantId, exception.Message);
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         {
             MockAuthenticationContext mockAuthenticationContext = new MockAuthenticationContext(MockAuthenticationContext.MockAuthenticationContextTestType.AcquireTokenAsyncException);
             ClientSecretAccessTokenProvider clientSecretAccessTokenProvider = new ClientSecretAccessTokenProvider(Constants.TestAppId, Constants.ClientSecret, Constants.TenantId, Constants.AzureAdInstance, mockAuthenticationContext);
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => clientSecretAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => clientSecretAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(Constants.KeyVaultResourceId, exception.Message);
             Assert.Contains(Constants.TenantId, exception.Message);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientSecretAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientSecretAccessTokenProviderTests.cs
@@ -71,8 +71,8 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         public async Task ClientSecretRedactionTest()
         {
             AzureServiceTokenProvider azureServiceTokenProvider = new AzureServiceTokenProvider(Constants.ClientSecretConnString);
-            
-                var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => azureServiceTokenProvider.GetAccessTokenAsync(Constants.KeyVaultResourceId)));
+
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => azureServiceTokenProvider.GetAccessTokenAsync(Constants.KeyVaultResourceId)));
 
             Assert.Contains(Constants.KeyVaultResourceId, exception.Message);
             Assert.Contains(Constants.TenantId, exception.Message);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientSecretAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/ClientSecretAccessTokenProviderTests.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             var authResult = await clientSecretAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
             // Check if the principal used and type were as expected. 
-            Validator.ValidateToken(authResult.AccessToken, clientSecretAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId);
+            Validator.ValidateToken(authResult.AccessToken, clientSecretAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId, expiresOn: authResult.ExpiresOn);
         }
 
         /// <summary>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/KeyVaultClientTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/KeyVaultClientTests.cs
@@ -109,10 +109,13 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         [Fact]
         public async Task InvalidKeyVaultSecretType()
         {
+            MockProcessManager mockProcessManager = new MockProcessManager(MockProcessManager.MockProcessManagerRequestType.Success);
+            AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
+
             // use a secret identifier, but return secret bundle for password/secret and not certificate
             MockKeyVault mockKeyVault = new MockKeyVault(TestType.PasswordSecretIdentifierSuccess);
             HttpClient httpClient = new HttpClient(mockKeyVault);
-            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient, azureCliAccessTokenProvider);
 
             var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(Constants.TestKeyVaultSecretIdentifier)));
             Assert.Contains(KeyVaultClient.SecretBundleInvalidContentTypeError, exception.Message);
@@ -121,9 +124,12 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         [Fact]
         public async Task SecretNotFoundTest()
         {
+            MockProcessManager mockProcessManager = new MockProcessManager(MockProcessManager.MockProcessManagerRequestType.Success);
+            AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
+
             MockKeyVault mockKeyVault = new MockKeyVault(TestType.SecretNotFound);
             HttpClient httpClient = new HttpClient(mockKeyVault);
-            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient, azureCliAccessTokenProvider);
 
             var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(Constants.TestKeyVaultSecretIdentifier)));
             Assert.Contains(KeyVaultClient.KeyVaultResponseError, exception.Message);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/KeyVaultClientTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/KeyVaultClientTests.cs
@@ -1,0 +1,133 @@
+﻿using Microsoft.Azure.Services.AppAuthentication.TestCommon;
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+using TestType = Microsoft.Azure.Services.AppAuthentication.Unit.Tests.MockKeyVault.KeyVaultClientTestType;
+
+namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
+{
+    public class KeyVaultClientTests
+    {
+        [Fact]
+        public async Task KeyVaultUnavailable()
+        {
+            MockKeyVault mockKeyVault = new MockKeyVault(TestType.KeyVaultUnavailable);
+            HttpClient httpClient = new HttpClient(mockKeyVault);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient);
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(Constants.TestKeyVaultSecretIdentifier)));
+            Assert.Contains(KeyVaultClient.EndpointNotAvailableError, exception.Message);
+        }
+
+        [Fact]
+        public async Task SecretIdentifierInvalidUriTest()
+        {
+            KeyVaultClient keyVaultClient = new KeyVaultClient();
+
+            string secretIdentifier = Constants.TestKeyVaultSecretIdentifier.Replace("https://", string.Empty);
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(secretIdentifier)));
+            Assert.Contains(KeyVaultClient.SecretIdentifierInvalidUriError, exception.Message);
+        }
+
+        [Fact]
+        public async Task SecretIdentifierInvalidSchemeTest()
+        {
+            KeyVaultClient keyVaultClient = new KeyVaultClient();
+
+            string secretIdentifier = Constants.TestKeyVaultSecretIdentifier.Replace("https://", "http://");
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(secretIdentifier)));
+            Assert.Contains(KeyVaultClient.SecretIdentifierInvalidSchemeError, exception.Message);
+        }
+
+        [Fact]
+        public async Task SecretIdentifierInvalidHostTest()
+        {
+            KeyVaultClient keyVaultClient = new KeyVaultClient();
+
+            string secretIdentifier = Constants.TestKeyVaultSecretIdentifier.Replace("vault.azure.net", "vault.baddudes.net");
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(secretIdentifier)));
+            Assert.Contains(KeyVaultClient.SecretIdentifierInvalidHostError, exception.Message);
+        }
+
+        [Fact]
+        public async Task SecretIdentifierInvalidTypeTest()
+        {
+            KeyVaultClient keyVaultClient = new KeyVaultClient();
+
+            string secretIdentifier = Constants.TestKeyVaultSecretIdentifier.Replace("/secrets/", "/keys/");
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(secretIdentifier)));
+            Assert.Contains(KeyVaultClient.SecretIdentifierInvalidTypeError, exception.Message);
+        }
+
+        [Fact]
+        public async Task HttpBearerChallengeMissingTest()
+        {
+            MockKeyVault mockKeyVault = new MockKeyVault(TestType.HttpBearerChallengMissing);
+            HttpClient httpClient = new HttpClient(mockKeyVault);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient);
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(Constants.TestKeyVaultSecretIdentifier)));
+            Assert.Contains(KeyVaultClient.KeyVaultAccessTokenRetrievalError, exception.Message);
+            Assert.Contains(KeyVaultClient.BearerChallengeMissingOrInvalidError, exception.Message);
+        }
+
+        [Fact]
+        public async Task HttpBearerChallengeInvalidTest()
+        {
+            MockKeyVault mockKeyVault = new MockKeyVault(TestType.HttpBearerChallengeInvalid);
+            HttpClient httpClient = new HttpClient(mockKeyVault);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient);
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(Constants.TestKeyVaultSecretIdentifier)));
+            Assert.Contains(KeyVaultClient.KeyVaultAccessTokenRetrievalError, exception.Message);
+            Assert.Contains(KeyVaultClient.BearerChallengeMissingOrInvalidError, exception.Message);
+        }
+
+        [Fact]
+        public async Task KeyVaultTokenProviderErrorTest()
+        {
+            MockProcessManager mockProcessManager = new MockProcessManager(MockProcessManager.MockProcessManagerRequestType.Failure);
+            AzureCliAccessTokenProvider azureCliAccessTokenProvider = new AzureCliAccessTokenProvider(mockProcessManager);
+
+            MockKeyVault mockKeyVault = new MockKeyVault(TestType.CertificateSecretIdentifierSuccess);
+            HttpClient httpClient = new HttpClient(mockKeyVault);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient, azureCliAccessTokenProvider);
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(Constants.TestKeyVaultSecretIdentifier)));
+            Assert.Contains(AzureServiceTokenProviderException.GenericErrorMessage, exception.Message);
+            Assert.Contains(KeyVaultClient.KeyVaultAccessTokenRetrievalError, exception.Message);
+            Assert.Contains(string.Format(KeyVaultClient.TokenProviderErrorsFormat, 1), exception.Message);
+            Assert.Contains(Constants.DeveloperToolError, exception.Message);
+        }
+
+        [Fact]
+        public async Task InvalidKeyVaultSecretType()
+        {
+            // use a secret identifier, but return secret bundle for password/secret and not certificate
+            MockKeyVault mockKeyVault = new MockKeyVault(TestType.PasswordSecretIdentifierSuccess);
+            HttpClient httpClient = new HttpClient(mockKeyVault);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient);
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(Constants.TestKeyVaultSecretIdentifier)));
+            Assert.Contains(KeyVaultClient.SecretBundleInvalidContentTypeError, exception.Message);
+        }
+
+        [Fact]
+        public async Task SecretNotFoundTest()
+        {
+            MockKeyVault mockKeyVault = new MockKeyVault(TestType.SecretNotFound);
+            HttpClient httpClient = new HttpClient(mockKeyVault);
+            KeyVaultClient keyVaultClient = new KeyVaultClient(httpClient);
+
+            var exception = await Assert.ThrowsAnyAsync<Exception>(() => Task.Run(() => keyVaultClient.GetCertificateAsync(Constants.TestKeyVaultSecretIdentifier)));
+            Assert.Contains(KeyVaultClient.KeyVaultResponseError, exception.Message);
+            Assert.Contains(MockKeyVault.SecretNotFoundErrorMessage, exception.Message);
+        }
+    }
+}

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Microsoft.Azure.Services.AppAuthentication.Unit.Tests.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Microsoft.Azure.Services.AppAuthentication.Unit.Tests.csproj
@@ -3,12 +3,17 @@
     <PropertyGroup>
         <TargetFrameworks>netcoreapp2.0;net452;net472</TargetFrameworks>
     </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="System.Net.Http" />
-    </ItemGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+		<DefineConstants>net472;FullNetFx</DefineConstants>		
+		<OutputPath>bin\$(Configuration)\</OutputPath>
+		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+	</PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Azure.Services.AppAuthentication.TestCommon\Microsoft.Azure.Services.AppAuthentication.TestCommon.csproj" />
         <ProjectReference Include="..\Azure.Services.AppAuthentication\Microsoft.Azure.Services.AppAuthentication.csproj" />
+    </ItemGroup>
+    <ItemGroup>
+        <Reference Include="System.Net.Http" />
     </ItemGroup>
     <ItemGroup>
         <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Microsoft.Azure.Services.AppAuthentication.Unit.Tests.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Microsoft.Azure.Services.AppAuthentication.Unit.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-        <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;net452;net472</TargetFrameworks>
     </PropertyGroup>
-  <ItemGroup>
+    <ItemGroup>
         <Reference Include="System.Net.Http" />
     </ItemGroup>
     <ItemGroup>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Microsoft.Azure.Services.AppAuthentication.Unit.Tests.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Microsoft.Azure.Services.AppAuthentication.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.0;net452;net472</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
     </PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
 		<DefineConstants>net472;FullNetFx</DefineConstants>		

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockAuthenticationContext.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockAuthenticationContext.cs
@@ -41,50 +41,56 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         /// Returns an access token depending on the type requested for testing. 
         /// </summary>
         /// <returns></returns>
-        private Task<string> AcquireTokenAsync()
+        private Task<AppAuthenticationResult> AcquireTokenAsync()
         {
+            AppAuthenticationResult authResult;
+
             switch (_mockAuthenticationContextTestType)
             {
                 case MockAuthenticationContextTestType.AcquireTokenSilentAsyncFail:
                 case MockAuthenticationContextTestType.AcquireTokenAsyncClientCertificateFail:
                 case MockAuthenticationContextTestType.AcquireTokenAsyncClientCredentialFail:
                 case MockAuthenticationContextTestType.AcquireTokenAsyncUserCredentialFail:
-                    return Task.FromResult<string>(null);
+                    return Task.FromResult<AppAuthenticationResult>(null);
 
                 case MockAuthenticationContextTestType.AcquireInvalidTokenAsyncFail:
-                    return Task.FromResult(TokenHelper.GetInvalidAppToken());
+                    authResult = AppAuthenticationResult.Create(TokenHelper.GetInvalidAppToken());
+                    return Task.FromResult(authResult);
 
                 case MockAuthenticationContextTestType.AcquireTokenAsyncException:
                     throw new Exception(Constants.AdalException);
 
                 case MockAuthenticationContextTestType.AcquireTokenSilentAsyncSuccess:
                 case MockAuthenticationContextTestType.AcquireTokenAsyncUserCredentialSuccess:
-                    return Task.FromResult(TokenHelper.GetUserToken());
+                    authResult = AppAuthenticationResult.Create(TokenHelper.GetUserToken());
+                    return Task.FromResult(authResult);
 
                 case MockAuthenticationContextTestType.AcquireTokenAsyncClientCertificateSuccess:
                 case MockAuthenticationContextTestType.AcquireTokenAsyncClientCredentialSuccess:
-                    return Task.FromResult(TokenHelper.GetAppToken());
-                
+                    authResult = AppAuthenticationResult.Create(TokenHelper.GetAppToken());
+                    return Task.FromResult(authResult);
+
             }
 
             return null;
         }
-        public Task<string> AcquireTokenSilentAsync(string authority, string resource, string clientId)
+
+        public Task<AppAuthenticationResult> AcquireTokenSilentAsync(string authority, string resource, string clientId)
         {
             return AcquireTokenAsync();
         }
 
-        public Task<string> AcquireTokenAsync(string authority, string resource, string clientId, UserCredential userCredential)
+        public Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, string clientId, UserCredential userCredential)
         {
             return AcquireTokenAsync();
         }
 
-        public Task<string> AcquireTokenAsync(string authority, string resource, ClientCredential clientCredential)
+        public Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, ClientCredential clientCredential)
         {
             return AcquireTokenAsync();
         }
 
-        public Task<string> AcquireTokenAsync(string authority, string resource, IClientAssertionCertificate clientCertificate)
+        public Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, IClientAssertionCertificate clientCertificate)
         {
             return AcquireTokenAsync();
         }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockKeyVault.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockKeyVault.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using Microsoft.Azure.Services.AppAuthentication.TestCommon;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
+{
+    internal class MockKeyVault : HttpMessageHandler
+    {
+        internal const string SecretNotFoundErrorMessage = "{\"error\":{\"code\":\"SecretNotFound\",\"message\":\"Secret not found: testcrt\"}}";
+
+        internal enum KeyVaultClientTestType
+        {
+            HttpBearerChallengMissing,
+            HttpBearerChallengeInvalid,
+            KeyVaultUnavailable,
+
+            CertificateSecretIdentifierSuccess,
+            PasswordSecretIdentifierSuccess,
+            SecretNotFound
+        }
+
+        private readonly KeyVaultClientTestType _keyVaultClientTestType;
+
+        internal MockKeyVault(KeyVaultClientTestType keyVaultClientTestType)
+        {
+            _keyVaultClientTestType = keyVaultClientTestType;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            HttpResponseMessage response = null;
+
+            if (!request.Headers.Contains("Authorization"))
+            {
+                response = GetUnauthenticatedKeyVaultResponse();
+            }
+            else
+            {
+                response = GetAuthenticatedKeyVaultResponse();
+            }
+
+            response.RequestMessage = request;
+            return Task.FromResult(response);
+        }
+
+        private HttpResponseMessage GetUnauthenticatedKeyVaultResponse()
+        {
+            HttpResponseMessage response = null;
+
+            switch (_keyVaultClientTestType)
+            {
+                case KeyVaultClientTestType.HttpBearerChallengeInvalid:
+                    response = new HttpResponseMessage(HttpStatusCode.OK);
+                    response.Headers.Add("WWW-Authenticate", "Bearer param1=\"value1\", param2=\"value2\"");
+                    break;
+
+                case KeyVaultClientTestType.HttpBearerChallengMissing:
+                    response = new HttpResponseMessage(HttpStatusCode.OK);
+                    break;
+
+                case KeyVaultClientTestType.KeyVaultUnavailable:
+                    throw new HttpRequestException();
+
+                default:
+                    response = new HttpResponseMessage(HttpStatusCode.OK);
+                    response.Headers.Add("WWW-Authenticate", "Bearer authorization=\"https://login.windows.net/72f988bf-86f1-41af-91ab-2d7cd011db47\", resource=\"https://vault.azure.net\"");
+                    break;
+            }
+
+            return response;
+        }
+
+        private HttpResponseMessage GetAuthenticatedKeyVaultResponse()
+        {
+            HttpResponseMessage response = null;
+
+            switch (_keyVaultClientTestType)
+            {
+                case KeyVaultClientTestType.CertificateSecretIdentifierSuccess:
+                    response = new HttpResponseMessage(HttpStatusCode.OK);
+                    response.Content = new StringContent("{\"value\":\"" + Constants.TestCert + "\",\"contentType\":\"application/x-pkcs12\",\"id\":\"dummyId\",\"managed\":true,\"attributes\":{\"enabled\":true,\"nbf\":1531943910,\"exp\":1595102910,\"created\":1531944510,\"updated\":1531944510,\"recoveryLevel\":\"Purgeable\"},\"kid\":\"dummyKid\"}",
+                        Encoding.UTF8,
+                        Constants.JsonContentType);
+                    break;
+
+                case KeyVaultClientTestType.PasswordSecretIdentifierSuccess:
+                    response = new HttpResponseMessage(HttpStatusCode.OK);
+                    response.Content = new StringContent("{\"value\":\"aBadPassword\",\"id\":\"dummyId\",\"attributes\":{\"enabled\":true,\"created\":1531175956,\"updated\":1531175956,\"recoveryLevel\":\"Purgeable\"}}",
+                        Encoding.UTF8,
+                        Constants.JsonContentType);
+                    break;
+
+                case KeyVaultClientTestType.SecretNotFound:
+                    response = new HttpResponseMessage(HttpStatusCode.NotFound);
+                    response.Content = new StringContent(SecretNotFoundErrorMessage);
+                    break;
+            }
+
+            return response;
+        }
+    }
+}

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockMsi.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockMsi.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
     /// https://docs.microsoft.com/en-us/azure/app-service/app-service-managed-service-identity
     /// https://docs.microsoft.com/en-us/azure/active-directory/msi-overview
     /// </summary>
-    class MockMsi : HttpMessageHandler
+    internal class MockMsi : HttpMessageHandler
     {
         // HitCount is used to test if the cache is hit as expected.
         public int HitCount;
@@ -64,6 +64,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                             Constants.JsonContentType)
                     };
                     break;
+
                 case MsiTestType.MsiAppServicesFailure:
                     throw new HttpRequestException();
 
@@ -84,6 +85,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                             Constants.JsonContentType)
                     };
                     break;
+
                 case MsiTestType.MsiAppServicesSuccess:
                 case MsiTestType.MsiAzureVmSuccess:
                     responseMessage = new HttpResponseMessage

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockMsi.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockMsi.cs
@@ -87,10 +87,18 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                     break;
 
                 case MsiTestType.MsiAppServicesSuccess:
+                    responseMessage = new HttpResponseMessage
+                    {
+                        Content = new StringContent(TokenHelper.GetMsiAppServicesTokenResponse(),
+                            Encoding.UTF8,
+                            Constants.JsonContentType)
+                    };
+                    break;
+
                 case MsiTestType.MsiAzureVmSuccess:
                     responseMessage = new HttpResponseMessage
                     {
-                        Content = new StringContent(TokenHelper.GetMsiTokenResponse(),
+                        Content = new StringContent(TokenHelper.GetMsiAzureVmTokenResponse(),
                             Encoding.UTF8,
                             Constants.JsonContentType)
                     };

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockMsi.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockMsi.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             MsiAppServicesSuccess,
             MsiAppServicesFailure,
             MsiAzureVmSuccess,
+            MsiUserAssignedIdentityAzureVmSuccess,
             MsiAppJsonParseFailure,
             MsiMissingToken,
             MsiAppServicesIncorrectRequest
@@ -88,6 +89,15 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                     responseMessage = new HttpResponseMessage
                     {
                         Content = new StringContent(TokenHelper.GetMsiTokenResponse(),
+                            Encoding.UTF8,
+                            Constants.JsonContentType)
+                    };
+                    break;
+
+                case MsiTestType.MsiUserAssignedIdentityAzureVmSuccess:
+                    responseMessage = new HttpResponseMessage
+                    {
+                        Content = new StringContent(TokenHelper.GetManagedIdentityTokenResponse(),
                             Encoding.UTF8,
                             Constants.JsonContentType)
                     };

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/MsiAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/MsiAccessTokenProviderTests.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 
             // Get token.
-            var token = await msiAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId,Constants.TenantId).ConfigureAwait(false);
+            var authResult = await msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
             // Check if the principalused and type are as expected. 
-            Validator.ValidateToken(token, msiAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId);
+            Validator.ValidateToken(authResult.AccessToken, msiAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId);
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 
             // Ensure exception is thrown when getting the token
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => msiAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId));
 
             Assert.Contains(Constants.TokenResponseFormatExceptionMessage, exception.ToString());
             Assert.Contains(Constants.JsonParseErrorException, exception.ToString());
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 
             // Ensure exception is thrown when getting the token
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => msiAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId));
 
             Assert.Contains(Constants.FailedToGetTokenError, exception.ToString());
             Assert.Contains(Constants.CannotBeNullError, exception.ToString());
@@ -88,13 +88,13 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 
             // Get token. This confirms that the environment variables are being read. 
-            var token = await msiAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
+            var authResult = await msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
             // Delete the environment variables
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, null);
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceSecretEnv, null);
 
-            Validator.ValidateToken(token, msiAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId);
+            Validator.ValidateToken(authResult.AccessToken, msiAccessTokenProvider.PrincipalUsed, Constants.AppType, Constants.TenantId, Constants.TestAppId);
         }
 
         /// <summary>
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => msiAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             // Delete the environment variables
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, null);
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => msiAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             // Delete the environment variables
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, null);
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             HttpClient httpClient = new HttpClient(mockMsi);
             MsiAccessTokenProvider msiAccessTokenProvider = new MsiAccessTokenProvider(httpClient);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => msiAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => msiAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             // Delete the environment variables
             Environment.SetEnvironmentVariable(Constants.MsiAppServiceEndpointEnv, null);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/SqlAppAuthenticationProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/SqlAppAuthenticationProviderTests.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#if net472
+using Microsoft.Azure.Services.AppAuthentication.TestCommon;
+using System;
+using Xunit;
+
+namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
+{
+    public class SqlAppAuthenticationProviderTests
+    {
+        [Fact]
+        public async void InvalidAuthority()
+        {
+            // Provide authority parameter value that will not parse properly
+            var parameters = new SqlAppAuthenticationParameters("http://badauthority", Constants.KeyVaultResourceId);
+
+            // Ensure exception is thrown when getting the token
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => (new SqlAppAuthenticationProvider()).AcquireTokenAsync(parameters));
+
+            Assert.Contains(Constants.SqlAppAuthProviderInvalidAuthority, exception.ToString());
+        }
+
+        [Fact]
+        public async void MissingResource()
+        {
+            // Do not provide any resource parameter value
+            var parameters = new SqlAppAuthenticationParameters($"{Constants.AzureAdInstance}{Constants.TenantId}", string.Empty);
+
+            // Ensure exception is thrown when getting the token
+            var exception = await Assert.ThrowsAsync<ArgumentException>(() => (new SqlAppAuthenticationProvider()).AcquireTokenAsync(parameters));
+
+            Assert.Contains(Constants.SqlAppAuthProviderInvalidResource, exception.ToString());
+        }
+    }
+}
+#endif

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
@@ -74,6 +74,16 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
+        ///  The response has claims as expected from MSI response with user-assigned managed identity
+        /// </summary>
+        /// <returns></returns>
+        internal static string GetManagedIdentityTokenResponse()
+        {
+            return
+                "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjdfWnVmMXR2a3dMeFlhSFMzcTZsVWpVWUlHdyIsImtpZCI6IjdfWnVmMXR2a3dMeFlhSFMzcTZsVWpVWUlHdyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNTM2MDkxMTk1LCJuYmYiOjE1MzYwOTExOTUsImV4cCI6MTUzNjEyMDI5NSwiYWlvIjoiNDJCZ1lJaW8zK3N1cE1XOVcrZWd4UGZNK3pFbUFBPT0iLCJhcHBpZCI6Ijk0MjM0M2IxLTRhZjItNDkwYy1iNmQ5LTkyNTBiOGYyODA4YyIsImFwcGlkYWNyIjoiMiIsImVfZXhwIjoyODgwMDAsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJvaWQiOiJiMzllNTZiZS1jZThiLTQyYjAtYjY3ZS0xYWI5YmU4ODUxZmQiLCJzdWIiOiJiMzllNTZiZS1jZThiLTQyYjAtYjY3ZS0xYWI5YmU4ODUxZmQiLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1dGkiOiJtcVk3QnJfOENVS3hnd1JteW11RkFBIiwidmVyIjoiMS4wIiwieG1zX21pcmlkIjoiL3N1YnNjcmlwdGlvbnMvYmRkNzg5ZjMtZDlkMS00YmVhLWFjMTQtMzBhMzllZDY2ZDMzL3Jlc291cmNlZ3JvdXBzL3Rlc3RiZWQvcHJvdmlkZXJzL01pY3Jvc29mdC5NYW5hZ2VkSWRlbnRpdHkvdXNlckFzc2lnbmVkSWRlbnRpdGllcy9UZXN0QmVkTWFuYWdlZElkZW50aXR5In0.ic31ZbWlTJ72DLGDmwbuPQJi1Lw_pw7UdBUauXD9MpDznSts2j3GXpa9mldiEeTeUAKtygt2ncnjStUaIlxfh94wxT37V5NElEwE2yVjY1mD1yRkTN9MIB8QQijkzNgzKms6y-zWn0i7oLCV6fdOZInrSLB9zd_X4AJI4LAGLvpzzt7cemNYRtNH4OJa3tTQP6vxh5wLY_gVlfSnOe1zX2RCXcOX3SC4YgOdo-L0n9w4iMV4HrQo6sfN5F5Rtaqi4MlwsuNuMiPZO0S8B73Qy3SFMQD3P2j_u47c5TI-PBa69ORqIEtbdg9FUIjY1_dBKgruJCXSm9tA0WvX-P0u5A\",\"client_id\":\"942343b1-4af2-490c-b6d9-9250b8f2808c\",\"expires_in\":\"28799\",\"expires_on\":\"1536120295\",\"ext_expires_in\":\"288000\",\"not_before\":\"1536091195\",\"resource\":\"https://vault.azure.net/\",\"token_type\":\"Bearer\"}";
+        }
+
+        /// <summary>
         ///  The response from MSI missing token
         /// </summary>
         /// <returns></returns>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
@@ -64,10 +64,20 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        ///  The response has claims as expected from MSI response
+        ///  The response has claims as expected from Azure App Service MSI response
         /// </summary>
         /// <returns></returns>
-        internal static string GetMsiTokenResponse()
+        internal static string GetMsiAppServicesTokenResponse()
+        {
+            return
+                "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImEzUU4wQlpTN3M0bk4tQmRyamJGMFlfTGRNTSIsImtpZCI6ImEzUU4wQlpTN3M0bk4tQmRyamJGMFlfTGRNTSJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpYXQiOjE0OTIyNjYwNjEsIm5iZiI6MTQ5MjI2NjA2MSwiZXhwIjoxNDkyMjY5OTYxLCJhaW8iOiJZMlpnWUNoTk91Yy9ZKzJMOVM3Ty8yWTBDL2lhQUFBPSIsImFwcGlkIjoiZjBiMWY4NGEtZWM3NC00Y2VmLTgwMzQtYWRiYWQxNjhjZTMzIiwiYXBwaWRhY3IiOiIyIiwiZV9leHAiOjI2MjgwMCwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3LyIsIm9pZCI6ImY4NDYwMGM1LWE5ZDgtNDEyOS1hMTk5LWNjNDE4MDYwNzQxMSIsInN1YiI6ImY4NDYwMGM1LWE5ZDgtNDEyOS1hMTk5LWNjNDE4MDYwNzQxMSIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInZlciI6IjEuMCJ9.TjnKtpTJ_dvQc3GQO9QSA0Sm9MISNakF8IT9-abzkaWqmwruhB2Tls9QTHe-P_xp09Jrt6JPhC8Z5mTTWgKqV_LV-KbJe_NmlYMTU_X5AcaPIQoi2ctSv62-wnnl-2IQjEEkyX7Vc0ixnPdWOG5LCO4ctTmURRO-tWN_jIK5up-wb0-ks1STFSBGJZtJ0xNTdTb9SSG4HpHzbLdkEmg-oAvOBX2OmwaNbBsU3chi4G5MoLtm5oXvL36z9vsf2bN_H7Sg-mss1Ua7OOwFVPMrx0rrIqXzKYQUSvNFAHLebKcp2SccpYWrgp7lKQGrbQhJsYYkzl-R-NTB5fUPUB7B3Q\",\"expires_on\":\"04/15/2017 3:26:01 PM +00:00\",\"resource\":\"https://vault.azure.net\",\"token_type\":\"Bearer\"}";
+        }
+
+        /// <summary>
+        ///  The response has claims as expected from Azure VM MSI response
+        /// </summary>
+        /// <returns></returns>
+        internal static string GetMsiAzureVmTokenResponse()
         {
             return
                 "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6ImEzUU4wQlpTN3M0bk4tQmRyamJGMFlfTGRNTSIsImtpZCI6ImEzUU4wQlpTN3M0bk4tQmRyamJGMFlfTGRNTSJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldCIsImlzcyI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJpYXQiOjE0OTIyNjYwNjEsIm5iZiI6MTQ5MjI2NjA2MSwiZXhwIjoxNDkyMjY5OTYxLCJhaW8iOiJZMlpnWUNoTk91Yy9ZKzJMOVM3Ty8yWTBDL2lhQUFBPSIsImFwcGlkIjoiZjBiMWY4NGEtZWM3NC00Y2VmLTgwMzQtYWRiYWQxNjhjZTMzIiwiYXBwaWRhY3IiOiIyIiwiZV9leHAiOjI2MjgwMCwiaWRwIjoiaHR0cHM6Ly9zdHMud2luZG93cy5uZXQvNzJmOTg4YmYtODZmMS00MWFmLTkxYWItMmQ3Y2QwMTFkYjQ3LyIsIm9pZCI6ImY4NDYwMGM1LWE5ZDgtNDEyOS1hMTk5LWNjNDE4MDYwNzQxMSIsInN1YiI6ImY4NDYwMGM1LWE5ZDgtNDEyOS1hMTk5LWNjNDE4MDYwNzQxMSIsInRpZCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsInZlciI6IjEuMCJ9.TjnKtpTJ_dvQc3GQO9QSA0Sm9MISNakF8IT9-abzkaWqmwruhB2Tls9QTHe-P_xp09Jrt6JPhC8Z5mTTWgKqV_LV-KbJe_NmlYMTU_X5AcaPIQoi2ctSv62-wnnl-2IQjEEkyX7Vc0ixnPdWOG5LCO4ctTmURRO-tWN_jIK5up-wb0-ks1STFSBGJZtJ0xNTdTb9SSG4HpHzbLdkEmg-oAvOBX2OmwaNbBsU3chi4G5MoLtm5oXvL36z9vsf2bN_H7Sg-mss1Ua7OOwFVPMrx0rrIqXzKYQUSvNFAHLebKcp2SccpYWrgp7lKQGrbQhJsYYkzl-R-NTB5fUPUB7B3Q\",\"refresh_token\":\"\",\"expires_in\":\"3600\",\"expires_on\":\"1492269961\",\"not_before\":\"1492266061\",\"resource\":\"https://vault.azure.net\",\"token_type\":\"Bearer\"}";

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
@@ -49,13 +49,15 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         internal static string GetUserTokenResponse(long secondsFromCurrent, bool formatForVisualStudio = false)
         {
             string tokenResult =
-                "{  \"accessToken\": \"{accesstoken}\",  \"expiresOn\": \"2017-08-19 18:52:40.624222\",  \"subscription\": \"1135bf8c-f190-46f2-bfd6-d57c57852c04\",  \"tenant\": \"72f988bf-86f1-41af-91ab-2d7cd011db47\",  \"tokenType\": \"Bearer\"}";
+                "{  \"accessToken\": \"{accesstoken}\",  \"expiresOn\": \"{expireson}\",  \"subscription\": \"1135bf8c-f190-46f2-bfd6-d57c57852c04\",  \"tenant\": \"72f988bf-86f1-41af-91ab-2d7cd011db47\",  \"tokenType\": \"Bearer\"}";
 
             tokenResult = tokenResult.Replace("{accesstoken}", GetUserToken(secondsFromCurrent));
+            tokenResult = tokenResult.Replace("{expireson}", DateTimeOffset.Now.AddSeconds(secondsFromCurrent).ToString());
 
             if (formatForVisualStudio)
             {
                 tokenResult = tokenResult.Replace("accessToken", "access_token");
+                tokenResult = tokenResult.Replace("expiresOn", "expires_on");
             }
 
             return tokenResult;

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/UriHelperTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/UriHelperTests.cs
@@ -5,25 +5,51 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
     public class UriHelperTests
     {
         [Fact]
-        public void ValidAuthorityTest()
+        public void GetAzureAdInstanceValidAuthorityTest()
         {
-           Assert.Equal("abc", UriHelper.GetTenantByAuthority("https://login.microsoftonline.com/abc"));
-           Assert.Equal("abc", UriHelper.GetTenantByAuthority("https://login.microsoftonline.com/abc/"));
-           Assert.Equal("abc", UriHelper.GetTenantByAuthority("https://login.microsoftonline.com/abc/def"));
+            Assert.Equal("https://login.microsoftonline.com/",
+                UriHelper.GetAzureAdInstanceByAuthority("https://login.microsoftonline.com/abc"));
+            Assert.Equal("https://login.microsoftonline.us/",
+                UriHelper.GetAzureAdInstanceByAuthority("https://login.microsoftonline.us/abc/"));
         }
 
         [Fact]
-        public void InvalidAuthorityTest()
+        public void GetAzureAdInstanceInvalidAuthorityTest()
         {
-            Assert.Equal(null, UriHelper.GetTenantByAuthority("https://login.microsoftonline.com/"));
-            Assert.Equal(null, UriHelper.GetTenantByAuthority("login.microsoftonline.com"));
+            Assert.Null(UriHelper.GetAzureAdInstanceByAuthority("http://login.microsoftonline.com/abc"));
+            Assert.Null(UriHelper.GetAzureAdInstanceByAuthority("https://login.microsoftonline.com/"));
+            Assert.Null(UriHelper.GetAzureAdInstanceByAuthority("login.microsoftonline.com"));
         }
 
         [Fact]
-        public void NullAuthorityTest()
+        public void GetAzureAdInstanceNullAuthorityTest()
         {
-            Assert.Equal(null, UriHelper.GetTenantByAuthority(string.Empty));
-            Assert.Equal(null, UriHelper.GetTenantByAuthority(null));
+            Assert.Null(UriHelper.GetAzureAdInstanceByAuthority(" "));
+            Assert.Null(UriHelper.GetAzureAdInstanceByAuthority(string.Empty));
+            Assert.Null(UriHelper.GetAzureAdInstanceByAuthority(null));
+        }
+
+        [Fact]
+        public void GetTenantValidAuthorityTest()
+        {
+            Assert.Equal("abc", UriHelper.GetTenantByAuthority("https://login.microsoftonline.com/abc"));
+            Assert.Equal("abc", UriHelper.GetTenantByAuthority("https://login.microsoftonline.com/abc/"));
+            Assert.Equal("abc", UriHelper.GetTenantByAuthority("https://login.microsoftonline.com/abc/def"));
+        }
+
+        [Fact]
+        public void GetTenantInvalidAuthorityTest()
+        {
+            Assert.Null(UriHelper.GetTenantByAuthority("https://login.microsoftonline.com/"));
+            Assert.Null(UriHelper.GetTenantByAuthority("login.microsoftonline.com"));
+        }
+
+        [Fact]
+        public void GetTenantNullAuthorityTest()
+        {
+            Assert.Null(UriHelper.GetTenantByAuthority(" "));
+            Assert.Null(UriHelper.GetTenantByAuthority(string.Empty));
+            Assert.Null(UriHelper.GetTenantByAuthority(null));
         }
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/VisualStudioAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/VisualStudioAccessTokenProviderTests.cs
@@ -30,9 +30,9 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             VisualStudioAccessTokenProvider visualStudioAccessTokenProvider = new VisualStudioAccessTokenProvider(mockProcessManager, _visualStudioTokenProviderFile);
 
             // Get token and validate it
-            var token = await visualStudioAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
+            var authResult = await visualStudioAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
-            Validator.ValidateToken(token, visualStudioAccessTokenProvider.PrincipalUsed, Constants.UserType, Constants.TenantId);
+            Validator.ValidateToken(authResult.AccessToken, visualStudioAccessTokenProvider.PrincipalUsed, Constants.UserType, Constants.TenantId);
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             string path = Guid.NewGuid().ToString();
             Environment.SetEnvironmentVariable(Constants.LocalAppDataEnv, path);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => visualStudioAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => visualStudioAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(path, exception.Message);
             Assert.Contains(Constants.FailedToGetTokenError, exception.Message);
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             // VisualStudioAccessTokenProvider has in internal only constructor to allow for unit testing. 
             VisualStudioAccessTokenProvider visualStudioAccessTokenProvider = new VisualStudioAccessTokenProvider(mockProcessManager, _visualStudioTokenProviderFile);
             
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => visualStudioAccessTokenProvider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => visualStudioAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(Constants.FailedToGetTokenError, exception.Message);
             Assert.Contains(Constants.DeveloperToolError, exception.Message);
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             // VisualStudioAccessTokenProvider has in internal only constructor to allow for unit testing. 
             VisualStudioAccessTokenProvider visualStudioAccessTokenProvider = new VisualStudioAccessTokenProvider(mockProcessManager, _visualStudioTokenProviderFile);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => visualStudioAccessTokenProvider.GetTokenAsync("https://test^", Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => visualStudioAccessTokenProvider.GetAuthResultAsync("https://test^", Constants.TenantId)));
 
             Assert.Contains(Constants.NotInExpectedFormatError, exception.Message);
         }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/VisualStudioAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/VisualStudioAccessTokenProviderTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
             // Get token and validate it
             var authResult = await visualStudioAccessTokenProvider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId).ConfigureAwait(false);
 
-            Validator.ValidateToken(authResult.AccessToken, visualStudioAccessTokenProvider.PrincipalUsed, Constants.UserType, Constants.TenantId);
+            Validator.ValidateToken(authResult.AccessToken, visualStudioAccessTokenProvider.PrincipalUsed, Constants.UserType, Constants.TenantId, expiresOn: authResult.ExpiresOn);
         }
 
         /// <summary>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/VisualStudioTokenProviderFileTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/VisualStudioTokenProviderFileTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             Assert.NotNull(visualStudioTokenProviderFile);
             Assert.NotNull(visualStudioTokenProviderFile.TokenProviders);
-            Assert.Equal(1, visualStudioTokenProviderFile.TokenProviders.Count);
+            Assert.Single(visualStudioTokenProviderFile.TokenProviders);
 
             Assert.Equal(Constants.TokenProviderPath, visualStudioTokenProviderFile.TokenProviders[0].Path);
             Assert.NotNull(visualStudioTokenProviderFile.TokenProviders[0].Arguments);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/WindowsAuthenticationAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/WindowsAuthenticationAccessTokenProviderTests.cs
@@ -23,9 +23,9 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             WindowsAuthenticationAzureServiceTokenProvider provider = new WindowsAuthenticationAzureServiceTokenProvider(authenticationContext, Constants.AzureAdInstance);
 
-            var token = await provider.GetTokenAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
+            var authResult = await provider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
 
-            Validator.ValidateToken(token, provider.PrincipalUsed, Constants.UserType, Constants.TenantId);
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.UserType, Constants.TenantId);
         }
 
         /// <summary>
@@ -39,9 +39,9 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             WindowsAuthenticationAzureServiceTokenProvider provider = new WindowsAuthenticationAzureServiceTokenProvider(authenticationContext, Constants.AzureAdInstance);
 
-            var token = await provider.GetTokenAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
+            var authResult = await provider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
 
-            Validator.ValidateToken(token, provider.PrincipalUsed, Constants.UserType, Constants.TenantId);
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.UserType, Constants.TenantId);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             WindowsAuthenticationAzureServiceTokenProvider provider = new WindowsAuthenticationAzureServiceTokenProvider(authenticationContext, Constants.AzureAdInstance);
             
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => provider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => provider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(Constants.KeyVaultResourceId, exception.Message);
             Assert.Contains(Constants.TenantId, exception.Message);
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             WindowsAuthenticationAzureServiceTokenProvider provider = new WindowsAuthenticationAzureServiceTokenProvider(authenticationContext, Constants.AzureAdInstance);
 
-            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => provider.GetTokenAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
+            var exception = await Assert.ThrowsAsync<AzureServiceTokenProviderException>(() => Task.Run(() => provider.GetAuthResultAsync(Constants.KeyVaultResourceId, Constants.TenantId)));
 
             Assert.Contains(Constants.KeyVaultResourceId, exception.Message);
             Assert.Contains(Constants.TenantId, exception.Message);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/WindowsAuthenticationAccessTokenProviderTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/WindowsAuthenticationAccessTokenProviderTests.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             var authResult = await provider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
 
-            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.UserType, Constants.TenantId);
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.UserType, Constants.TenantId, expiresOn: authResult.ExpiresOn);
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             var authResult = await provider.GetAuthResultAsync(Constants.KeyVaultResourceId, string.Empty).ConfigureAwait(false);
 
-            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.UserType, Constants.TenantId);
+            Validator.ValidateToken(authResult.AccessToken, provider.PrincipalUsed, Constants.UserType, Constants.TenantId, expiresOn: authResult.ExpiresOn);
         }
 
         /// <summary>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AccessToken.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AccessToken.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Azure.Services.AppAuthentication
             }
         }
 
+        public static DateTimeOffset UnixTimeEpoch => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
         private static byte[] DecodeBytes(string arg)
         {
             string s = arg;
@@ -104,7 +106,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         public bool IsAboutToExpire()
         {
             // Current time represented in seconds since 1/1/1970
-            double currentTime = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0)).TotalSeconds;
+            double currentTime = (DateTime.UtcNow - UnixTimeEpoch).TotalSeconds;
             
             // If the expiration time is greater than current time by more than 5 minutes, it is not about to expire
             if (ExpiryTime > currentTime + 5 * 60)

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AccessToken.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AccessToken.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             }
         }
 
-        public static DateTimeOffset UnixTimeEpoch => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        internal static DateTimeOffset UnixTimeEpoch => new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
         private static byte[] DecodeBytes(string arg)
         {

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AppAuthenticationResult.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AppAuthenticationResult.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Services.AppAuthentication
+{
+    /// <summary>
+    /// Contains access token and other results from a token request call
+    /// </summary>
+    public class AppAuthenticationResult
+    {
+        /// <summary>
+        /// The access token returned from the token request
+        /// </summary>
+        [DataMember]
+        public string AccessToken { get; private set; }
+
+        /// <summary>
+        /// When the token is valid to
+        /// </summary>
+        [DataMember]
+        public DateTimeOffset ExpiresOn { get; private set; }
+
+        /// <summary>
+        /// The resource the token request is authorized for
+        /// </summary>
+        [DataMember]
+        public string Resource { get; private set; }
+
+        /// <summary>
+        /// The type of access token returned
+        /// </summary>
+        [DataMember]
+        public string TokenType { get; private set; }
+
+        /// <summary>
+        /// Return true when access token is near expiration
+        /// </summary>
+        /// <returns></returns>
+        public bool IsNearExpiry()
+        {
+            // If the expiration time is within the next 5 minutes, the token is about to expire
+            return ExpiresOn < DateTimeOffset.Now.AddMinutes(5);
+        }
+
+        internal static AppAuthenticationResult Create(TokenResponse response, TokenResponse.DateFormat dateFormat)
+        {
+            if (response == null)
+            {
+                throw new ArgumentNullException(nameof(response));
+            }
+
+            string expiresOnString = response.ExpiresOn ?? response.ExpiresOn2;
+            DateTimeOffset expiresOn = DateTimeOffset.MinValue;
+
+            switch (dateFormat)
+            {
+                case TokenResponse.DateFormat.DateTimeString:
+                    expiresOn = DateTimeOffset.Parse(expiresOnString);
+                    break;
+                case TokenResponse.DateFormat.Unix:
+                    double seconds = double.Parse(expiresOnString);
+                    expiresOn = AppAuthentication.AccessToken.UnixTimeEpoch.AddSeconds(seconds);
+                    break;
+            }
+
+            var result = new AppAuthenticationResult()
+            {
+                AccessToken = response.AccessToken ?? response.AccessToken2,
+                ExpiresOn = expiresOn,
+                Resource = response.Resource,
+                TokenType = response.TokenType ?? response.TokenType2
+            };
+
+            return result;
+        }
+
+        internal static AppAuthenticationResult Create(AuthenticationResult authResult)
+        {
+            if (authResult == null)
+            {
+                throw new ArgumentNullException(nameof(authResult));
+            }
+
+            var result = new AppAuthenticationResult()
+            {
+                AccessToken = authResult.AccessToken,
+                ExpiresOn = authResult.ExpiresOn
+            };
+
+            return result;
+        }
+
+        // for unit testing
+        internal static AppAuthenticationResult Create(string accessToken)
+        {
+            if (string.IsNullOrEmpty(accessToken))
+            {
+                throw new ArgumentNullException(nameof(accessToken));
+            }
+
+            var tokenObj = AppAuthentication.AccessToken.Parse(accessToken);
+
+            var result = new AppAuthenticationResult()
+            {
+                AccessToken = accessToken,
+                ExpiresOn = AppAuthentication.AccessToken.UnixTimeEpoch.AddSeconds(tokenObj.ExpiryTime)
+            };
+
+            return result;
+        }
+    }
+}

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AppAuthenticationResult.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AppAuthenticationResult.cs
@@ -1,10 +1,6 @@
 ﻿using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.Serialization;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Microsoft.Azure.Services.AppAuthentication
 {
@@ -20,19 +16,19 @@ namespace Microsoft.Azure.Services.AppAuthentication
         public string AccessToken { get; private set; }
 
         /// <summary>
-        /// When the token is valid to
+        /// The time when the access token expires
         /// </summary>
         [DataMember]
         public DateTimeOffset ExpiresOn { get; private set; }
 
         /// <summary>
-        /// The resource the token request is authorized for
+        /// The Resource URI of the receiving web service
         /// </summary>
         [DataMember]
         public string Resource { get; private set; }
 
         /// <summary>
-        /// The type of access token returned
+        /// Indicates the token type value
         /// </summary>
         [DataMember]
         public string TokenType { get; private set; }
@@ -41,10 +37,10 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// Return true when access token is near expiration
         /// </summary>
         /// <returns></returns>
-        public bool IsNearExpiry()
+        internal bool IsNearExpiry()
         {
             // If the expiration time is within the next 5 minutes, the token is about to expire
-            return ExpiresOn < DateTimeOffset.Now.AddMinutes(5);
+            return ExpiresOn < DateTimeOffset.UtcNow.AddMinutes(5);
         }
 
         internal static AppAuthenticationResult Create(TokenResponse response, TokenResponse.DateFormat dateFormat)
@@ -95,7 +91,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             return result;
         }
 
-        // for unit testing
+        // For unit testing
         internal static AppAuthenticationResult Create(string accessToken)
         {
             if (string.IsNullOrEmpty(accessToken))
@@ -105,7 +101,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
             var tokenObj = AppAuthentication.AccessToken.Parse(accessToken);
 
-            var result = new AppAuthenticationResult()
+            var result = new AppAuthenticationResult
             {
                 AccessToken = accessToken,
                 ExpiresOn = AppAuthentication.AccessToken.UnixTimeEpoch.AddSeconds(tokenObj.ExpiryTime)

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
@@ -44,7 +44,11 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// KeyVaultClient keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
         /// </code>
         /// </example>
-        public TokenCallback KeyVaultTokenCallback => GetAccessTokenAsyncImpl;
+        public TokenCallback KeyVaultTokenCallback => async (a, r, s) => 
+        {
+            var authResult = await GetAuthResultAsyncImpl(a, r, s).ConfigureAwait(false);
+            return authResult.AccessToken;
+        };
 
         /// <summary>
         /// The principal used to acquire token. This will be of type "User" for local development scenarios, and "App" when client credentials flow is used. 
@@ -123,19 +127,19 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <param name="resource"></param>
         /// <param name="scope"></param>
         /// <returns></returns>
-        private async Task<string> GetAccessTokenAsyncImpl(string authority, string resource, string scope)
+        private async Task<AppAuthenticationResult> GetAuthResultAsyncImpl(string authority, string resource, string scope)
         {
             // Check if the token is present in cache, for the given connection string, authority, and resource
             // This is an in-memory global cache, that will be used across instances of this class. 
             string cacheKey = $"ConnectionString:{_connectionString};Authority:{authority};Resource:{resource}";
 
-            Tuple<AccessToken, Principal> tokenResult = AccessTokenCache.Get(cacheKey);
+            Tuple<AppAuthenticationResult, Principal> cachedAuthResult = AppAuthResultCache.Get(cacheKey);
 
-            if (tokenResult != null)
+            if (cachedAuthResult != null)
             {
-                _principalUsed = tokenResult.Item2;
+                _principalUsed = cachedAuthResult.Item2;
 
-                return tokenResult.Item1.ToString();
+                return cachedAuthResult.Item1;
             }
 
             // If not in cache, lock. One of multiple threads that reach here will be allowed to get the token.
@@ -147,14 +151,14 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
             try
             {
-                // Check again if the token is in the cache now, the first thread may have got it.
-                tokenResult = AccessTokenCache.Get(cacheKey);
+                // Check again if the token is in the cache now, the first thread may have gotten it.
+                cachedAuthResult = AppAuthResultCache.Get(cacheKey);
 
-                if (tokenResult != null)
+                if (cachedAuthResult != null)
                 {
-                    _principalUsed = tokenResult.Item2;
+                    _principalUsed = cachedAuthResult.Item2;
 
-                    return tokenResult.Item1.ToString();
+                    return cachedAuthResult.Item1;
                 }
 
                 // If the token was not in cache, try to get it
@@ -166,7 +170,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     try
                     {
                         // Get the token, add to the cache, and return the token.
-                        string token = await tokenProvider.GetTokenAsync(authority, resource,
+                        var authResult = await tokenProvider.GetAuthResultAsync(authority, resource,
                                 string.Empty)
                             .ConfigureAwait(false);
 
@@ -176,10 +180,10 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
                         _principalUsed = tokenProvider.PrincipalUsed;
 
-                        AccessTokenCache.AddOrUpdate(cacheKey,
-                            new Tuple<AccessToken, Principal>(AccessToken.Parse(token), tokenProvider.PrincipalUsed));
+                        AppAuthResultCache.AddOrUpdate(cacheKey,
+                            new Tuple<AppAuthenticationResult, Principal>(authResult, tokenProvider.PrincipalUsed));
 
-                        return token;
+                        return authResult;
                     }
                     catch (AzureServiceTokenProviderException exp)
                     {
@@ -238,6 +242,27 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <exception cref="AzureServiceTokenProviderException">Thrown if access token cannot be acquired.</exception>
         public async Task<string> GetAccessTokenAsync(string resource, string tenantId = default(string))
         {
+            var authResult = await GetAuthenticationResultAsync(resource, tenantId).ConfigureAwait(false);
+
+            return authResult.AccessToken;
+        }
+
+        /// <summary>
+        /// Gets an authentication result which contains an access token to access the given Azure resource. 
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var azureServiceTokenProvider = new AzureServiceTokenProvider();
+        /// var authResult = await azureServiceTokenProvider.GetAuthResultAsync("https://management.azure.com/").ConfigureAwait(false);
+        /// </code>
+        /// </example>
+        /// <param name="resource">Resource to access. e.g. https://management.azure.com/.</param>
+        /// <param name="tenantId">If not specified, default tenant is used. Managed Service Identity REST protocols do not accept tenantId, so this can only be used with certificate and client secret based authentication.</param>
+        /// <returns>Access token</returns>
+        /// <exception cref="ArgumentNullException">Thrown if resource is null or empty.</exception>
+        /// <exception cref="AzureServiceTokenProviderException">Thrown if access token cannot be acquired.</exception>
+        public async Task<AppAuthenticationResult> GetAuthenticationResultAsync(string resource, string tenantId = default(string))
+        {
             if (string.IsNullOrWhiteSpace(resource))
             {
                 throw new ArgumentNullException(nameof(resource));
@@ -245,7 +270,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
             string authority = string.IsNullOrEmpty(tenantId) ? string.Empty : $"{_azureAdInstance}{tenantId}";
 
-            return await GetAccessTokenAsyncImpl(authority, resource, string.Empty).ConfigureAwait(false);
+            return await GetAuthResultAsyncImpl(authority, resource, string.Empty).ConfigureAwait(false);
         }
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProvider.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// KeyVaultClient keyVaultClient = new KeyVaultClient(new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
         /// </code>
         /// </example>
-        public TokenCallback KeyVaultTokenCallback => async (a, r, s) => 
-        {
-            var authResult = await GetAuthResultAsyncImpl(a, r, s).ConfigureAwait(false);
+        public TokenCallback KeyVaultTokenCallback => async (authority, resource, scope) => 
+        {   
+            var authResult = await GetAuthResultAsyncImpl(authority, resource, scope).ConfigureAwait(false);
             return authResult.AccessToken;
         };
 
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <returns></returns>
         private async Task<AppAuthenticationResult> GetAuthResultAsyncImpl(string authority, string resource, string scope)
         {
-            // Check if the token is present in cache, for the given connection string, authority, and resource
+            // Check if the auth result is present in cache, for the given connection string, authority, and resource
             // This is an in-memory global cache, that will be used across instances of this class. 
             string cacheKey = $"ConnectionString:{_connectionString};Authority:{authority};Resource:{resource}";
 
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
             try
             {
-                // Check again if the token is in the cache now, the first thread may have gotten it.
+                // Check again if the auth result is in the cache now, the first thread may have gotten it.
                 cachedAuthResult = AppAuthResultCache.Get(cacheKey);
 
                 if (cachedAuthResult != null)
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     return cachedAuthResult.Item1;
                 }
 
-                // If the token was not in cache, try to get it
+                // If the auth result was not in cache, try to get it
                 List<NonInteractiveAzureServiceTokenProviderBase> tokenProviders = GetTokenProviders();
                 
                 // Try to get the token using the selected providers
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 {
                     try
                     {
-                        // Get the token, add to the cache, and return the token.
+                        // Get the auth result, add to the cache, and return the auth result.
                         var authResult = await tokenProvider.GetAuthResultAsync(authority, resource,
                                 string.Empty)
                             .ConfigureAwait(false);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderException.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderException.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
         internal const string CertificateNotFound = "Specified certificate was not found. ";
 
-        internal const string MissingResource = "Resouce must be specified.";
-        
+        internal const string MissingResource = "Resource must be specified.";
+
 
         /// <summary>
         /// Creates an instance of AzureServiceTokenProviderException. 

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderException.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderException.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
         internal const string VisualStudioUsed = "Tried to get token using Visual Studio.";
 
-        internal const string CertificateNotFound = "Specified certificate was not found. ";
+        internal const string LocalCertificateNotFound = "Specified certificate was not found.";
+
+        internal const string KeyVaultCertificateRetrievalError = "Specified Key Vault certificate was unable to be retrieved.";
 
         internal const string MissingResource = "Resource must be specified.";
 

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Cache/AppAuthResultCache.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Cache/AppAuthResultCache.cs
@@ -7,14 +7,14 @@ using System.Collections.Concurrent;
 namespace Microsoft.Azure.Services.AppAuthentication
 {
     /// <summary>
-    /// Cache for access tokens. 
+    /// Cache for app authentication results 
     /// </summary>
     internal class AppAuthResultCache
     {
         private static readonly ConcurrentDictionary<string, Tuple<AppAuthenticationResult, Principal>> CacheDictionary = new ConcurrentDictionary<string, Tuple<AppAuthenticationResult, Principal>>();
 
         /// <summary>
-        /// Gets the token from the cache. If it is present, and not about to expire, it is returned. 
+        /// Gets the app authentication result from the cache. If it is present, and token is not about to expire, it is returned.
         /// </summary>
         /// <param name="cacheKey"></param>
         /// <returns></returns>
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         }
 
         /// <summary>
-        /// Tuple of access token and principal are added to the cache after the token is aquired. 
+        /// Tuple of app authentication result and principal are added to the cache after the token is acquired.
         /// </summary>
         /// <param name="cacheKey"></param>
         /// <param name="resultTuple"></param>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Cache/AppAuthResultCache.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Cache/AppAuthResultCache.cs
@@ -9,24 +9,24 @@ namespace Microsoft.Azure.Services.AppAuthentication
     /// <summary>
     /// Cache for access tokens. 
     /// </summary>
-    internal class AccessTokenCache
+    internal class AppAuthResultCache
     {
-        private static readonly ConcurrentDictionary<string, Tuple<AccessToken, Principal>> CacheDictionary = new ConcurrentDictionary<string, Tuple<AccessToken, Principal>>();
+        private static readonly ConcurrentDictionary<string, Tuple<AppAuthenticationResult, Principal>> CacheDictionary = new ConcurrentDictionary<string, Tuple<AppAuthenticationResult, Principal>>();
 
         /// <summary>
         /// Gets the token from the cache. If it is present, and not about to expire, it is returned. 
         /// </summary>
         /// <param name="cacheKey"></param>
         /// <returns></returns>
-        public static Tuple<AccessToken, Principal> Get(string cacheKey)
+        public static Tuple<AppAuthenticationResult, Principal> Get(string cacheKey)
         {
-            Tuple<AccessToken, Principal> tokenTuple;
+            Tuple<AppAuthenticationResult, Principal> resultTuple;
 
-            if (CacheDictionary.TryGetValue(cacheKey, out tokenTuple))
+            if (CacheDictionary.TryGetValue(cacheKey, out resultTuple))
             {
-                if (tokenTuple?.Item1 != null && !tokenTuple.Item1.IsAboutToExpire())
+                if (resultTuple?.Item1 != null && !resultTuple.Item1.IsNearExpiry())
                 {
-                    return tokenTuple;
+                    return resultTuple;
                 }
             }
 
@@ -37,10 +37,10 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// Tuple of access token and principal are added to the cache after the token is aquired. 
         /// </summary>
         /// <param name="cacheKey"></param>
-        /// <param name="tokenTuple"></param>
-        public static void AddOrUpdate(string cacheKey, Tuple<AccessToken, Principal> tokenTuple)
+        /// <param name="resultTuple"></param>
+        public static void AddOrUpdate(string cacheKey, Tuple<AppAuthenticationResult, Principal> resultTuple)
         {
-            CacheDictionary.AddOrUpdate(cacheKey, tokenTuple, (s, tuple) => tokenTuple);
+            CacheDictionary.AddOrUpdate(cacheKey, resultTuple, (s, tuple) => resultTuple);
         }
 
         /// <summary>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/AdalAuthenticationContext.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/AdalAuthenticationContext.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
     internal class AdalAuthenticationContext : IAuthenticationContext
     {
         /// <summary>
-        /// Used to get token for Integrated Windows Authentication scenario. 
+        /// Used to get authentication result for Integrated Windows Authentication scenario. 
         /// </summary>
         /// <param name="authority"></param>
         /// <param name="resource"></param>
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         }
 
         /// <summary>
-        /// Used to get token for Integrated Windows Authentication scenario, where the token may already be in ADAL cache. 
+        /// Used to get authentication result for Integrated Windows Authentication scenario, where the token may already be in ADAL cache. 
         /// </summary>
         /// <param name="authority"></param>
         /// <param name="resource"></param>
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         }
 
         /// <summary>
-        /// Used to get token for client credentials flow using a client secret. 
+        /// Used to get authentication result for client credentials flow using a client secret. 
         /// </summary>
         /// <param name="authority"></param>
         /// <param name="resource"></param>
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         }
 
         /// <summary>
-        /// Used to get token for client credentials flow using a client certificate. 
+        /// Used to get authentication for client credentials flow using a client certificate. 
         /// </summary>
         /// <param name="authority"></param>
         /// <param name="resource"></param>
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         public async Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, IClientAssertionCertificate clientCertificate)
         {
             AuthenticationContext authenticationContext = new AuthenticationContext(authority);
-            var authResult = await authenticationContext.AcquireTokenAsync(resource, clientCertificate).ConfigureAwait(false);
+            var authResult = await authenticationContext.AcquireTokenAsync(resource, clientCertificate, true).ConfigureAwait(false);
             return AppAuthenticationResult.Create(authResult);
         }
     }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/AdalAuthenticationContext.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/AdalAuthenticationContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
@@ -19,11 +20,11 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <param name="clientId"></param>
         /// <param name="userCredential"></param>
         /// <returns></returns>
-        public async Task<string> AcquireTokenAsync(string authority, string resource, string clientId, UserCredential userCredential)
+        public async Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, string clientId, UserCredential userCredential)
         {
             AuthenticationContext authenticationContext = new AuthenticationContext(authority);
-            var result = await authenticationContext.AcquireTokenAsync(resource, clientId, userCredential).ConfigureAwait(false);
-            return result.AccessToken;
+            var authResult = await authenticationContext.AcquireTokenAsync(resource, clientId, userCredential).ConfigureAwait(false);
+            return AppAuthenticationResult.Create(authResult);
         }
 
         /// <summary>
@@ -33,11 +34,11 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <param name="resource"></param>
         /// <param name="clientId"></param>
         /// <returns></returns>
-        public async Task<string> AcquireTokenSilentAsync(string authority, string resource, string clientId)
+        public async Task<AppAuthenticationResult> AcquireTokenSilentAsync(string authority, string resource, string clientId)
         {
             AuthenticationContext authenticationContext = new AuthenticationContext(authority);
-            var result = await authenticationContext.AcquireTokenSilentAsync(resource, clientId).ConfigureAwait(false);
-            return result.AccessToken;
+            var authResult = await authenticationContext.AcquireTokenSilentAsync(resource, clientId).ConfigureAwait(false);
+            return AppAuthenticationResult.Create(authResult);
         }
 
         /// <summary>
@@ -47,11 +48,11 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <param name="resource"></param>
         /// <param name="clientCredential"></param>
         /// <returns></returns>
-        public async Task<string> AcquireTokenAsync(string authority, string resource, ClientCredential clientCredential)
+        public async Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, ClientCredential clientCredential)
         {
             AuthenticationContext authenticationContext = new AuthenticationContext(authority);
             var authResult = await authenticationContext.AcquireTokenAsync(resource, clientCredential).ConfigureAwait(false);
-            return authResult.AccessToken;
+            return AppAuthenticationResult.Create(authResult);
         }
 
         /// <summary>
@@ -61,11 +62,11 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <param name="resource"></param>
         /// <param name="clientCertificate"></param>
         /// <returns></returns>
-        public async Task<string> AcquireTokenAsync(string authority, string resource, IClientAssertionCertificate clientCertificate)
+        public async Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, IClientAssertionCertificate clientCertificate)
         {
             AuthenticationContext authenticationContext = new AuthenticationContext(authority);
-            var result = await authenticationContext.AcquireTokenAsync(resource, clientCertificate).ConfigureAwait(false);
-            return result.AccessToken;
+            var authResult = await authenticationContext.AcquireTokenAsync(resource, clientCertificate).ConfigureAwait(false);
+            return AppAuthenticationResult.Create(authResult);
         }
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/IAuthenticationContext.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/IAuthenticationContext.cs
@@ -11,9 +11,9 @@ namespace Microsoft.Azure.Services.AppAuthentication
     /// </summary>
     interface IAuthenticationContext
     {
-        Task<string> AcquireTokenSilentAsync(string authority, string resource, string clientId);
-        Task<string> AcquireTokenAsync(string authority, string resource, string clientId, UserCredential userCredential);
-        Task<string> AcquireTokenAsync(string authority, string resource, ClientCredential clientCredential);
-        Task<string> AcquireTokenAsync(string authority, string resource, IClientAssertionCertificate clientCertificate);
+        Task<AppAuthenticationResult> AcquireTokenSilentAsync(string authority, string resource, string clientId);
+        Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, string clientId, UserCredential userCredential);
+        Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, ClientCredential clientCredential);
+        Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, IClientAssertionCertificate clientCertificate);
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/HttpBearerChallenge.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/HttpBearerChallenge.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Azure.Services.AppAuthentication
+{
+    /// <summary>
+    /// Helper class that handles HTTP Bearer challenges
+    /// </summary>
+    internal class HttpBearerChallenge
+    {
+        private const string AuthorizationParameter = "authorization";
+        private const string AuthorizationUriParameter = "authorization_uri";
+        private const string ResourceParameter = "resource";
+        private const string ScopeParameter = "scope";
+        private const string Bearer = "Bearer";
+
+        public string AuthorizationServer { get; private set; }
+        public string Resource { get; private set; }
+        public string Scope { get; private set; }
+
+        /// <summary>
+        /// Parses an HTTP Bearer challenge from Key Vault
+        /// </summary>
+        /// <param name="challenge">The value of the WWW-Authenticate header to parse</param>
+        /// <returns></returns>
+        internal static HttpBearerChallenge Parse(string challenge)
+        {
+            if (!ValidateChallenge(challenge))
+                return null;
+
+            var parameters = GetChallengeParameters(challenge);
+
+            string authorization = null;
+            string resource = null;
+            string scope = null;
+
+            if (parameters.ContainsKey(AuthorizationParameter))
+                authorization = parameters[AuthorizationParameter];
+            else if (parameters.ContainsKey(AuthorizationUriParameter))
+                authorization = parameters[AuthorizationUriParameter];
+
+            if (parameters.ContainsKey(ResourceParameter))
+                resource = parameters[ResourceParameter];
+
+            if (parameters.ContainsKey(ScopeParameter))
+                scope = parameters[ScopeParameter];
+
+            // scope is not a required parameter
+            if (authorization == null || resource == null)
+                return null;
+
+            return new HttpBearerChallenge(authorization, resource, scope);
+        }
+
+        private static bool ValidateChallenge(string challenge)
+        {
+            if (string.IsNullOrEmpty(challenge))
+                return false;
+
+            if (!challenge.Trim().StartsWith(Bearer + " "))
+                return false;
+
+            return true;
+        }
+
+        private static Dictionary<string, string> GetChallengeParameters(string challenge)
+        {
+            // first, trim the challenge's Bearer prefix
+            challenge = challenge.Trim().Substring(Bearer.Length + 1);
+
+            // then parse the key-value pairs into a dictionary
+            Dictionary<string, string> parameters = new Dictionary<string, string>();
+            string[] keyValuePairs = challenge.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+            if (keyValuePairs != null && keyValuePairs.Length > 0)
+            {
+                for (int i = 0; i < keyValuePairs.Length; i++)
+                {
+                    string[] keyValuePair = keyValuePairs[i].Split('=');
+
+                    if (keyValuePair.Length == 2)
+                    {
+                        string key = keyValuePair[0].Trim().Trim('"');
+                        string value = keyValuePair[1].Trim().Trim('"');
+
+                        if (!string.IsNullOrEmpty(key))
+                        {
+                            parameters[key] = value;
+                        }
+                    }
+                }
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
+        /// Create instance of HTTP Bearer Challenge
+        /// </summary>
+        /// <param name="authorization"></param>
+        /// <param name="resource"></param>
+        private HttpBearerChallenge(string authorization, string resource, string scope)
+        {
+            AuthorizationServer = authorization;
+            Resource = resource;
+            Scope = scope;
+        }
+    }
+}

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/KeyVaultClient.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/KeyVaultClient.cs
@@ -1,0 +1,192 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Services.AppAuthentication
+{
+    internal class KeyVaultClient
+    {
+        // These members allow for unit testing
+        private readonly HttpClient _httpClient;
+        private NonInteractiveAzureServiceTokenProviderBase _tokenProvider;
+
+        // Key Vault constants and well-known values
+        private const string KeyVaultRestApiVersion = "2016-10-01";
+        private const string AzureKeyVaultDnsSuffix = "vault.azure.net";
+        private const string ChinaKeyVaultDnsSuffix = "vault.azure.cn";
+        private const string USGovernmentKeyVaultDnsSuffix = "vault.usgovcloudapi.net";
+        private const string GermanKeyVaultDnsSuffix = "vault.microsoftazure.de";
+        private readonly List<string> WellKnownKeyVaultDnsSuffixes = new List<string>()
+        {
+            AzureKeyVaultDnsSuffix,
+            ChinaKeyVaultDnsSuffix,
+            USGovernmentKeyVaultDnsSuffix,
+            GermanKeyVaultDnsSuffix
+        };
+
+        // Error messages
+        internal const string BearerChallengeMissingOrInvalidError = "A bearer challenge was not returned or is invalid.";
+        internal const string EndpointNotAvailableError = "Unable to connect to the Key Vault endpoint. Please check that the secret identifier is correct.";
+        internal const string KeyVaultAccessTokenRetrievalError = "Unable to get a Key Vault access token to acquire certificate.";
+        internal const string KeyVaultResponseError = "Key Vault returned an error.";
+        internal const string SecretBundleInvalidContentTypeError = "Specified secret identifier does not contain private key data. Please check you are providing the secret identifier for the Key Vault client certificate.";
+        internal const string SecretIdentifierInvalidHostError = "Specified secret identifier has an unrecognized hostname.";
+        internal const string SecretIdentifierInvalidSchemeError = "Specified identifier must use HTTPS.";
+        internal const string SecretIdentifierInvalidTypeError = "Specified identifier is not a secret identifier.";
+        internal const string SecretIdentifierInvalidUriError = "Specified secret identifier is not a valid URI.";
+        internal const string TokenProviderErrorsFormat = "Tried the following {0} methods to get a Key Vault access token, but none of them worked.";
+
+        public KeyVaultClient(HttpClient httpClient = null, NonInteractiveAzureServiceTokenProviderBase tokenProvider = null)
+        {
+            _httpClient = httpClient ?? new HttpClient();
+            _tokenProvider = tokenProvider;
+        }
+
+        public async Task<X509Certificate2> GetCertificateAsync(string secretIdentifier)
+        {
+            try
+            {
+                ValidateSecretIdentifier(secretIdentifier);
+
+                string accessToken = await GetKeyVaultAccessToken(secretIdentifier).ConfigureAwait(false);
+
+                var requestUrl = $"{secretIdentifier}?api-version={KeyVaultRestApiVersion}";
+
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+                request.Headers.Add("Accept", "application/json");
+                request.Headers.Add("Authorization", $"Bearer {accessToken}");
+
+                HttpResponseMessage response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+
+                if (!response.IsSuccessStatusCode)
+                {
+                    string exceptionText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    throw new Exception($"{KeyVaultResponseError} KeyVault ResponseCode: {response.StatusCode}, Message: {exceptionText}");
+                }
+
+                string jsonResponse = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                // Validate that the JSON secret bundle returned contains private key data
+                SecretBundle secretBundle = SecretBundle.Parse(jsonResponse);
+                if (secretBundle.ContentType != "application/x-pkcs12")
+                {
+                    throw new Exception(SecretBundleInvalidContentTypeError);
+                }
+
+                byte[] rawCertBytes = Convert.FromBase64String(secretBundle.Value);
+
+                X509Certificate2 certificate = new X509Certificate2(rawCertBytes);
+                return certificate;
+            }
+            catch (KeyVaultAccessTokenRetrievalException exp)
+            {
+                throw new Exception($"{KeyVaultAccessTokenRetrievalError} {exp.Message}");
+            }
+            catch (HttpRequestException)
+            {
+                throw new Exception(EndpointNotAvailableError);
+            }
+        }
+
+        private void ValidateSecretIdentifier(string secretIdentifier)
+        {
+            // Ensure secret identifier is a valid URI
+            Uri secretUri;
+            if (!Uri.TryCreate(secretIdentifier, UriKind.Absolute, out secretUri))
+                throw new Exception(SecretIdentifierInvalidUriError);
+
+            // Ensure secret URI is using HTTPS scheme
+            if (!secretUri.Scheme.Equals("https", StringComparison.OrdinalIgnoreCase))
+                throw new Exception(SecretIdentifierInvalidSchemeError);
+
+            // Ensure secret URI host ends in well-known Key Vault DNS suffix
+            if (!WellKnownKeyVaultDnsSuffixes.Any(dnsSuffix => secretUri.Host.EndsWith(dnsSuffix, StringComparison.OrdinalIgnoreCase)))
+                throw new Exception(SecretIdentifierInvalidHostError);
+
+            // Ensure secret URI is actually a secret identifier (and not key or certificate identifier)
+            if (!secretUri.LocalPath.StartsWith("/secrets/", StringComparison.OrdinalIgnoreCase))
+                throw new Exception(SecretIdentifierInvalidTypeError);
+        }
+
+        private class KeyVaultAccessTokenRetrievalException : Exception
+        {
+            internal KeyVaultAccessTokenRetrievalException(string message) :
+                base(message)
+            {
+            }
+        }
+        private async Task<string> GetKeyVaultAccessToken(string secretUrl)
+        {
+            // Send an anonymous request to Key Vault endpoint to get an OAuth2 HTTP Bearer challenge
+            HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, secretUrl);
+            HttpResponseMessage response = await _httpClient.SendAsync(request).ConfigureAwait(false);
+
+            // Parse challenge to get authorization server and resource identifier for Key Vault
+            var authenticateHeader = response.Headers.WwwAuthenticate.FirstOrDefault()?.ToString();
+            var challenge = HttpBearerChallenge.Parse(authenticateHeader); 
+            if (challenge == null)
+            {
+                 throw new KeyVaultAccessTokenRetrievalException(BearerChallengeMissingOrInvalidError);
+            }
+
+            var tokenProviders = GetTokenProviders(challenge.AuthorizationServer);
+            List<Exception> exceptions = new List<Exception>();
+
+            // Use values parsed from the bearer challenge to request an access token for Key Vault
+            foreach (var tokenProvider in tokenProviders)
+            {
+                try
+                {
+                    var authResult = await tokenProvider.GetAuthResultAsync(challenge.AuthorizationServer,
+                        challenge.Resource, challenge.Scope).ConfigureAwait(false);
+
+                    return authResult.AccessToken;
+                }
+                catch (AzureServiceTokenProviderException exp)
+                {
+                    exceptions.Add(exp);
+                }
+            }
+
+            // Compile token provider exceptions and rethrow if token request was not successful
+            string message = string.Format(TokenProviderErrorsFormat, exceptions.Count) + Environment.NewLine;
+            foreach (var exception in exceptions)
+            {
+                message += $"{exception.Message}{Environment.NewLine}";
+            }
+
+            throw new KeyVaultAccessTokenRetrievalException(message);
+        }
+
+        private List<NonInteractiveAzureServiceTokenProviderBase> GetTokenProviders(string authority)
+        {
+            List<NonInteractiveAzureServiceTokenProviderBase> tokenProviders = null;
+
+            // use default user token providers if token provider not specified (e.g. by unit test)
+            if (_tokenProvider == null)
+            {
+                string azureAdInstance = UriHelper.GetAzureAdInstanceByAuthority(authority);
+                tokenProviders = new List<NonInteractiveAzureServiceTokenProviderBase>
+                {
+                    new VisualStudioAccessTokenProvider(new ProcessManager()),
+                    new AzureCliAccessTokenProvider(new ProcessManager()),
+#if FullNetFx
+                    new WindowsAuthenticationAzureServiceTokenProvider(new AdalAuthenticationContext(), azureAdInstance)
+#endif
+                };
+            }
+            else
+            {
+                tokenProviders = new List<NonInteractiveAzureServiceTokenProviderBase>() { _tokenProvider };
+            }
+
+            return tokenProviders;
+        }
+    }
+}

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/SecretBundle.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/SecretBundle.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Microsoft.Azure.Services.AppAuthentication
+{
+    /// <summary>
+    /// Used to hold the deserialized secret bundle from Key Vault. 
+    /// </summary>
+    [DataContract]
+    internal class SecretBundle
+    {
+        private string _rawJson;
+
+        // These fields are assigned to by JSON deserialization
+        [DataMember(Name = "contentType", IsRequired = false)]
+        public string ContentType { get; private set; }
+
+        [DataMember(Name = "value", IsRequired = false)]
+        public string Value { get; private set; }
+
+        public static SecretBundle Parse(string rawJsonString)
+        {
+            if (string.IsNullOrEmpty(rawJsonString))
+            {
+                throw new ArgumentNullException(nameof(rawJsonString));
+            }
+
+            try
+            {
+                var secretBundle = JsonHelper.Deserialize<SecretBundle>(
+                    Encoding.UTF8.GetBytes(rawJsonString));
+
+                secretBundle._rawJson = rawJsonString;
+
+                return secretBundle;
+            }
+            catch (Exception exp)
+            {
+                throw new Exception($"Unable to parse JSON secret bundle from Key Vault. Exception: {exp.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Return the secret bundle as-is
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return _rawJson;
+        }
+    }
+}

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Helpers/UriHelper.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Helpers/UriHelper.cs
@@ -5,13 +5,43 @@ namespace Microsoft.Azure.Services.AppAuthentication
     internal class UriHelper
     {
         /// <summary>
+        /// Given an Azure AD authority URL, returns the instance URL from it
+        /// </summary>
+        /// <param name="authority">Azure AD authority e.g. https://login.microsoftonline.com/tenantID</param>
+        /// <returns>Instance URL if the authority is valid, else null</returns>
+        internal static string GetAzureAdInstanceByAuthority(string authority)
+        {
+            if (!string.IsNullOrWhiteSpace(authority))
+            {
+                Uri authorityUri;
+                if (Uri.TryCreate(authority, UriKind.Absolute, out authorityUri))
+                {
+                    if (authorityUri.Scheme != "https")
+                    {
+                        return null;
+                    }
+
+                    string path = authorityUri.AbsolutePath.Substring(1);
+                    if (string.IsNullOrWhiteSpace(path))
+                    {
+                        return null;
+                    }
+
+                    return $"https://{authorityUri.Host}/";
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
         /// Given an Azure AD authority URL, returns the tenant from it
         /// </summary>
         /// <param name="authority">Azure AD authority e.g. https://login.microsoftonline.com/tenantID</param>
         /// <returns>Tenant if the authority is valid and has tenant information, else null</returns>
         internal static string GetTenantByAuthority(string authority)
         {
-            if (!string.IsNullOrEmpty(authority))
+            if (!string.IsNullOrWhiteSpace(authority))
             {
                 Uri authorityUri;
 

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -28,7 +28,7 @@
 	</PropertyGroup>
     <ItemGroup>
 		<Reference Include="System.Net.Http" />
-        <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.14.2" />
+        <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.4" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
         <PackageReference Include="System.Diagnostics.Process">

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -22,13 +22,8 @@
         <Content Include="build\*.targets" PackagePath="build\" />
     </ItemGroup>
     <PropertyGroup>
-        <TargetFrameworks>netstandard1.4;net452;net472</TargetFrameworks>
+        <TargetFrameworks>netstandard1.4;net452</TargetFrameworks>
     </PropertyGroup>
-	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
-		<DefineConstants>net472;FullNetFx</DefineConstants>		
-		<OutputPath>bin\$(Configuration)\</OutputPath>
-		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
-	</PropertyGroup>
     <ItemGroup>
 		<Reference Include="System.Net.Http" />
         <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.4" />

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -12,6 +12,9 @@
 			Adding new .NET 4.7.2 targeted package
 			Adding new method GetAuthResultAsync to AzureServiceTokenProvider
 			Adding new class SqlAzureAppAuthProvider that implements new SqlAuthenticationProvider (only in .NET 4.7.2 targeted package)
+			Adding support for user-assigned managed identities
+			Adding support for simplified Azure AD certificate roll-over (subject name and issuer authentication)
+			Adding new connection string option to specify Key Vault secret identifier for service principal certificate credential
 		]]>
 	</PackageReleaseNotes>
     </PropertyGroup>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -2,15 +2,16 @@
     <PropertyGroup>
         <PackageId>Microsoft.Azure.Services.AppAuthentication</PackageId>
         <Description>Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.</Description>
-        <Version>1.0.3</Version>
+        <Version>1.2.0-preview</Version>
         <AssemblyName>Microsoft.Azure.Services.AppAuthentication</AssemblyName>
         <PackageTags>Azure Authentication AppAuthentication</PackageTags>
 	<PackageReleaseNotes>
 		<![CDATA[
 			Documentation can be found at https://go.microsoft.com/fwlink/p/?linkid=862452.
 			
-			MsiAccessTokenProvider updated to use IDMS endpoint for authentication
-			Bug fix: Serializable tag was missing on AzureServicesTokenProviderException
+			Adding new .NET 4.7.2 targeted package
+			Adding new method GetAuthResultAsync to AzureServiceTokenProvider
+			Adding new class SqlAzureAppAuthProvider that implements new SqlAuthenticationProvider (only in .NET 4.7.2 targeted package)
 		]]>
 	</PackageReleaseNotes>
     </PropertyGroup>
@@ -18,13 +19,16 @@
         <Content Include="build\*.targets" PackagePath="build\" />
     </ItemGroup>
     <PropertyGroup>
-        <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
+        <TargetFrameworks>netstandard1.4;net452;net472</TargetFrameworks>
     </PropertyGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
+		<DefineConstants>net472;FullNetFx</DefineConstants>		
+		<OutputPath>bin\$(Configuration)\</OutputPath>
+		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+	</PropertyGroup>
     <ItemGroup>
+		<Reference Include="System.Net.Http" />
         <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.14.2" />
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="System.Net.Http" />
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
         <PackageReference Include="System.Diagnostics.Process">

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.CompilerServices;
 [assembly: AssemblyTitle("Microsoft.Azure.Services.AppAuthentication")]
 [assembly: AssemblyDescription("Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.")]
 
-[assembly: AssemblyVersion("1.0.3.0")]
-[assembly: AssemblyFileVersion("1.0.3.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/SqlAppAuthenticationParameters.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/SqlAppAuthenticationParameters.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#if net472
+using System.Data.SqlClient;
+
+namespace Microsoft.Azure.Services.AppAuthentication
+{
+    /// <summary>
+    /// Shim class that allows setting custom parameter values for unit testing. 
+    /// </summary>
+    public class SqlAppAuthenticationParameters
+    {
+        public SqlAppAuthenticationParameters(SqlAuthenticationParameters parameters)
+        {
+            Authority = parameters.Authority;
+            Resource = parameters.Resource;
+        }
+
+        public SqlAppAuthenticationParameters(string authority, string resource)
+        {
+            Authority = authority;
+            Resource = resource;
+        }
+        
+        public string Authority { get; }
+        public string Resource { get; }
+    }
+}
+#endif

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/SqlAppAuthenticationProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/SqlAppAuthenticationProvider.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+#if net472
+using System;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.Services.AppAuthentication
+{
+    /// <summary>
+    /// An implementation of SqlAuthenticationProvider that implements Active Directory Interactive SQL authentication.
+    /// </summary>
+    public class SqlAppAuthenticationProvider : SqlAuthenticationProvider
+    {
+        /// <summary>
+        /// Acquires an access token for SQL using AzureServiceTokenProvider with the given SQL authentication parameters.
+        /// </summary>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
+        public override async Task<SqlAuthenticationToken> AcquireTokenAsync(SqlAuthenticationParameters parameters)
+        {
+            var appAuthParameters = new SqlAppAuthenticationParameters(parameters);
+            return await AcquireTokenAsync(appAuthParameters);
+        }
+
+        /// <summary>
+        /// Acquires an access token for SQL using AzureServiceTokenProvider with the given SQL authentication parameters.
+        /// </summary>
+        /// <param name="parameters">The parameters needed in order to obtain a SQL access token</param>
+        /// <returns></returns>
+        public async Task<SqlAuthenticationToken> AcquireTokenAsync(SqlAppAuthenticationParameters parameters)
+        {
+            string azureAdInstance = UriHelper.GetAzureAdInstanceByAuthority(parameters.Authority);
+            string tenantId = UriHelper.GetTenantByAuthority(parameters.Authority);
+
+            if (string.IsNullOrEmpty(azureAdInstance))
+            {
+                throw new ArgumentException("The Azure AD instance could not be parsed from the authority provided in SqlAuthenticationParameters");
+            }
+
+            if (string.IsNullOrEmpty(parameters.Resource))
+            {
+                throw new ArgumentException("A resource must be specified in SqlAuthenticationParameters");
+            }
+
+            AzureServiceTokenProvider tokenProvider = new AzureServiceTokenProvider(azureAdInstance: azureAdInstance);
+
+            var authResult = await tokenProvider.GetAuthenticationResultAsync(parameters.Resource, tenantId).ConfigureAwait(false);
+
+            return new SqlAuthenticationToken(authResult.AccessToken, authResult.ExpiresOn);
+        }
+
+        /// <summary>
+        /// Implements virtual method in SqlAuthenticationProvider. Only Active Directory Interactive Authentication is supported.
+        /// </summary>
+        /// <param name="authenticationMethod">The SQL authentication method to check whether supported</param>
+        /// <returns></returns>
+        public override bool IsSupported(SqlAuthenticationMethod authenticationMethod)
+        {
+            return authenticationMethod == SqlAuthenticationMethod.ActiveDirectoryInteractive;
+        }
+    }
+}
+#endif

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/AzureCliAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/AzureCliAccessTokenProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             return startInfo;
         }
 
-        public override async Task<string> GetTokenAsync(string resource, string authority)
+        public override async Task<AppAuthenticationResult> GetAuthResultAsync(string resource, string authority)
         {
             try
             {
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     PrincipalUsed.TenantId = token.TenantId;
                 }
 
-                return accessToken;
+                return AppAuthenticationResult.Create(tokenResponse, TokenResponse.DateFormat.DateTimeString);
             }
             catch (Exception exp)
             {

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientCertificateAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientCertificateAccessTokenProvider.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <param name="resource">Resource to access.</param>
         /// <param name="authority">Authority where resource is.</param>
         /// <returns></returns>
-        public override async Task<string> GetTokenAsync(string resource, string authority)
+        public override async Task<AppAuthenticationResult> GetAuthResultAsync(string resource, string authority)
         {
             // If authority is not specified, create it using azureAdInstance and tenant Id. Tenant ID comes from the connection string. 
             if (string.IsNullOrWhiteSpace(authority))
@@ -130,8 +130,10 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     {
                         ClientAssertionCertificate certCred = new ClientAssertionCertificate(_clientId, cert);
 
-                        string accessToken =
+                        var authResult =
                             await _authenticationContext.AcquireTokenAsync(authority, resource, certCred).ConfigureAwait(false);
+
+                        var accessToken = authResult?.AccessToken;
 
                         if (accessToken != null)
                         {
@@ -139,7 +141,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                             PrincipalUsed.IsAuthenticated = true;
                             PrincipalUsed.TenantId = AccessToken.Parse(accessToken).TenantId;
 
-                            return accessToken;
+                            return authResult;
                         }
                     }
                     catch (Exception exp)

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientCertificateAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientCertificateAccessTokenProvider.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Azure.Services.AppAuthentication
         // AppId of the application.
         private readonly string _clientId;
 
-        // Certificate subject or thumbprint
-        private readonly string _certificateSubjectNameOrThumbprint;
+        // Certificate identifier: subject, thumbprint, or Key Vault secret identifier
+        private readonly string _certificateIdentifier;
 
-        // Flag which tells if subject or thumbprint is being used
-        private readonly bool _isThumbprint;
+        // Enum which tells if subject, thumbprint, or Key Vault secret identifier is being used as identifier
+        private readonly CertificateIdentifierType _certificateIdentifierType;
 
         private readonly string _tenantId;
 
@@ -30,58 +30,74 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
         private readonly IAuthenticationContext _authenticationContext;
 
+        private readonly KeyVaultClient _keyVaultClient;
+
         // Store where certificate is deployed. 
         private readonly StoreLocation _storeLocation;
+
+        internal enum CertificateIdentifierType
+        {
+            SubjectName,
+            Thumbprint,
+            KeyVaultSecretIdentifier
+        };
 
         /// <summary>
         /// Creates instance of ClientCertificateAzureServiceTokenProvider class.
         /// </summary>
         /// <param name="clientId"></param>
-        /// <param name="certificateSubjectNameOrThumbprint"></param>
-        /// <param name="isThumbprint"></param>
+        /// <param name="certificateIdentifier"></param>
+        /// <param name="certificateIdentifierType"></param>
         /// <param name="storeLocation"></param>
         /// <param name="azureAdInstance"></param>
         /// <param name="authenticationContext"></param>
         /// <param name="tenantId"></param>
         internal ClientCertificateAzureServiceTokenProvider(string clientId,
-            string certificateSubjectNameOrThumbprint, bool isThumbprint,
-            string storeLocation, string tenantId, string azureAdInstance, IAuthenticationContext authenticationContext)
+            string certificateIdentifier, CertificateIdentifierType certificateIdentifierType,
+            string storeLocation, string tenantId, string azureAdInstance,
+            IAuthenticationContext authenticationContext = null, KeyVaultClient keyVaultClient = null)
         {
             if (string.IsNullOrWhiteSpace(clientId))
             {
                 throw new ArgumentNullException(nameof(clientId));
             }
 
-            if (string.IsNullOrWhiteSpace(storeLocation))
+            if (string.IsNullOrWhiteSpace(certificateIdentifier))
             {
-                throw new ArgumentNullException(nameof(storeLocation));
+                throw new ArgumentNullException(nameof(certificateIdentifier));
             }
 
-            if (string.IsNullOrWhiteSpace(certificateSubjectNameOrThumbprint))
+            // require storeLocation if using subject name or thumbprint identifier
+            if (certificateIdentifierType == CertificateIdentifierType.SubjectName
+                || certificateIdentifierType == CertificateIdentifierType.Thumbprint)
             {
-                throw new ArgumentNullException(nameof(certificateSubjectNameOrThumbprint));
+                if (string.IsNullOrWhiteSpace(storeLocation))
+                {
+                    throw new ArgumentNullException(nameof(storeLocation));
+                }
+
+                // Parse store location specified in connection string. 
+                StoreLocation location;
+                if (Enum.TryParse(storeLocation, true, out location))
+                {
+                    _storeLocation = location;
+                }
+                else
+                {
+                    throw new ArgumentException(
+                        $"StoreLocation {storeLocation} is not valid. Valid values are CurrentUser and LocalMachine.");
+                }
             }
 
             _clientId = clientId;
 
-            _isThumbprint = isThumbprint;
+            _certificateIdentifierType = certificateIdentifierType;
             _tenantId = tenantId;
             _azureAdInstance = azureAdInstance;
-            _authenticationContext = authenticationContext;
+            _authenticationContext = authenticationContext ?? new AdalAuthenticationContext();
+            _keyVaultClient = keyVaultClient ?? new KeyVaultClient();
 
-            _certificateSubjectNameOrThumbprint = certificateSubjectNameOrThumbprint;
-
-            // Parse store location specified in connection string. 
-            StoreLocation location;
-            if (Enum.TryParse(storeLocation, true, out location))
-            {
-                _storeLocation = location;
-            }
-            else
-            {
-                throw new ArgumentException(
-                    $"StoreLocation {storeLocation} is not valid. Valid values are CurrentUser and LocalMachine.");
-            }
+            _certificateIdentifier = certificateIdentifier;
 
             PrincipalUsed = new Principal
             {
@@ -99,20 +115,41 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <returns></returns>
         public override async Task<AppAuthenticationResult> GetAuthResultAsync(string resource, string authority)
         {
-            // If authority is not specified, create it using azureAdInstance and tenant Id. Tenant ID comes from the connection string. 
+            // If authority is not specified, create it using azureAdInstance and tenantId. Tenant ID comes from the connection string. 
             if (string.IsNullOrWhiteSpace(authority))
             {
                 authority = $"{_azureAdInstance}{_tenantId}";
             }
 
-            // Get certificates for the given thumbprint or subject name. 
-            var certs = CertificateHelper.GetCertificates(_certificateSubjectNameOrThumbprint, _isThumbprint,
-                _storeLocation);
-
-            if (certs == null || certs.Count == 0)
+            List<X509Certificate2> certs = null;
+            switch (_certificateIdentifierType)
             {
-                throw new AzureServiceTokenProviderException(ConnectionString, resource, authority,
-                    AzureServiceTokenProviderException.CertificateNotFound);
+                case CertificateIdentifierType.KeyVaultSecretIdentifier:
+                    // Get certificate for the given Key Vault secret identifier
+                    try
+                    {
+                        var keyVaultCert = await _keyVaultClient.GetCertificateAsync(_certificateIdentifier);
+                        certs = new List<X509Certificate2>() { keyVaultCert };
+                    }
+                    catch (Exception exp)
+                    {
+                        throw new AzureServiceTokenProviderException(ConnectionString, resource, authority,
+                            $"{AzureServiceTokenProviderException.KeyVaultCertificateRetrievalError} {exp.Message}");
+                    }
+                    break;
+                case CertificateIdentifierType.SubjectName:
+                case CertificateIdentifierType.Thumbprint:
+                    // Get certificates for the given thumbprint or subject name. 
+                    bool isThumbprint = _certificateIdentifierType == CertificateIdentifierType.Thumbprint;
+                    certs = CertificateHelper.GetCertificates(_certificateIdentifier, isThumbprint,
+                        _storeLocation);
+
+                    if (certs == null || certs.Count == 0)
+                    {
+                        throw new AzureServiceTokenProviderException(ConnectionString, resource, authority,
+                            AzureServiceTokenProviderException.LocalCertificateNotFound);
+                    }
+                    break;
             }
 
             // If multiple certs were found, use in order of most recently created.

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientSecretAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientSecretAccessTokenProvider.cs
@@ -18,8 +18,8 @@ namespace Microsoft.Azure.Services.AppAuthentication
         private readonly string _azureAdInstance;
         private readonly IAuthenticationContext _authenticationContext;
 
-        internal ClientSecretAccessTokenProvider(string clientId,
-            string clientSecret, string tenantId, string azureAdInstance, IAuthenticationContext authenticationContext)
+        internal ClientSecretAccessTokenProvider(string clientId, string clientSecret,
+            string tenantId, string azureAdInstance, IAuthenticationContext authenticationContext = null)
         {
             if (string.IsNullOrWhiteSpace(clientId))
             {
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             _clientSecret = clientSecret;
             _tenantId = tenantId;
             _azureAdInstance = azureAdInstance;
-            _authenticationContext = authenticationContext;
+            _authenticationContext = authenticationContext ?? new AdalAuthenticationContext();
 
             PrincipalUsed = new Principal
             {

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientSecretAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/ClientSecretAccessTokenProvider.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             };
         }
 
-        public override async Task<string> GetTokenAsync(string resource, string authority)
+        public override async Task<AppAuthenticationResult> GetAuthResultAsync(string resource, string authority)
         {
             string errorMessage = string.Empty;
 
@@ -58,14 +58,16 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
                 ClientCredential clientCredential = new ClientCredential(_clientId, _clientSecret);
 
-                var result = await _authenticationContext.AcquireTokenAsync(authority, resource, clientCredential).ConfigureAwait(false);
+                var authResult = await _authenticationContext.AcquireTokenAsync(authority, resource, clientCredential).ConfigureAwait(false);
 
-                if (result != null)
+                var accessToken = authResult?.AccessToken;
+
+                if (accessToken != null)
                 {
                     PrincipalUsed.IsAuthenticated = true;
-                    PrincipalUsed.TenantId = AccessToken.Parse(result).TenantId;
+                    PrincipalUsed.TenantId = AccessToken.Parse(accessToken).TenantId;
 
-                    return result;
+                    return authResult;
                 }
             }
             catch (Exception ex)

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -91,7 +91,11 @@ namespace Microsoft.Azure.Services.AppAuthentication
                         PrincipalUsed.TenantId = token.TenantId;
                     }
 
-                    return AppAuthenticationResult.Create(tokenResponse, TokenResponse.DateFormat.Unix);
+                    TokenResponse.DateFormat expectedDateFormat = isAppServicesMsiAvailable
+                        ? TokenResponse.DateFormat.DateTimeString
+                        : TokenResponse.DateFormat.Unix;
+
+                    return AppAuthenticationResult.Create(tokenResponse, expectedDateFormat);
                 }
 
                 string exceptionText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -16,18 +16,23 @@ namespace Microsoft.Azure.Services.AppAuthentication
         // This is for unit testing
         private readonly HttpClient _httpClient;
 
+        // This client ID can be specified in the constructor to specify a specific managed identity to use (e.g. user-assigned identity)
+        private readonly string _managedIdentityClientId;
+
         // HttpClient is intended to be instantiated once and re-used throughout the life of an application. 
         private static readonly HttpClient DefaultHttpClient = new HttpClient();
 
         // Azure Instance Metadata Service (IDMS) endpoint
         private const string AzureVmIdmsEndpoint = "http://169.254.169.254/metadata/identity/oauth2/token";
 
-        internal MsiAccessTokenProvider()
+        internal MsiAccessTokenProvider(string managedIdentityClientId = default(string))
         {
+            _managedIdentityClientId = managedIdentityClientId;
+
             PrincipalUsed = new Principal { Type = "App" };
         }
 
-        internal MsiAccessTokenProvider(HttpClient httpClient) : this()
+        internal MsiAccessTokenProvider(HttpClient httpClient, string managedIdentityClientId = null) : this(managedIdentityClientId)
         {
             _httpClient = httpClient;
         }
@@ -41,10 +46,15 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 string msiSecret = Environment.GetEnvironmentVariable("MSI_SECRET");
                 var isAppServicesMsiAvailable = !string.IsNullOrWhiteSpace(msiEndpoint) && !string.IsNullOrWhiteSpace(msiSecret);
 
+                // If managed identity is specified, include client_id parameter in request
+                string clientIdParameter = _managedIdentityClientId != default(string)
+                    ? $"&client_id={_managedIdentityClientId}"
+                    : string.Empty;
+
                 // Craft request as per the MSI protocol
                 var requestUrl = isAppServicesMsiAvailable
-                    ? $"{msiEndpoint}?resource={resource}&api-version=2017-09-01"
-                    : $"{AzureVmIdmsEndpoint}?resource={resource}&api-version=2018-02-01";
+                    ? $"{msiEndpoint}?resource={resource}&api-version=2017-09-01" // TODO: include support for App Service user-assigned ID preemptively?
+                    : $"{AzureVmIdmsEndpoint}?resource={resource}{clientIdParameter}&api-version=2018-02-01";
 
                 // Use the httpClient specified in the constructor. If it was not specified in the constructor, use the default httpclient. 
                 HttpClient httpClient = _httpClient ?? DefaultHttpClient;

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             _httpClient = httpClient;
         }
 
-        public override async Task<string> GetTokenAsync(string resource, string authority)
+        public override async Task<AppAuthenticationResult> GetAuthResultAsync(string resource, string authority)
         {
             try
             {
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                         PrincipalUsed.TenantId = token.TenantId;
                     }
 
-                    return tokenResponse.AccessToken;
+                    return AppAuthenticationResult.Create(tokenResponse, TokenResponse.DateFormat.Unix);
                 }
 
                 string exceptionText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
 
                 // Craft request as per the MSI protocol
                 var requestUrl = isAppServicesMsiAvailable
-                    ? $"{msiEndpoint}?resource={resource}&api-version=2017-09-01" // TODO: include support for App Service user-assigned ID preemptively?
+                    ? $"{msiEndpoint}?resource={resource}&api-version=2017-09-01"
                     : $"{AzureVmIdmsEndpoint}?resource={resource}{clientIdParameter}&api-version=2018-02-01";
 
                 // Use the httpClient specified in the constructor. If it was not specified in the constructor, use the default httpclient. 

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/NonInteractiveAccessTokenProviderBase.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/NonInteractiveAccessTokenProviderBase.cs
@@ -13,9 +13,9 @@ namespace Microsoft.Azure.Services.AppAuthentication
         public string ConnectionString;
         public Principal PrincipalUsed;
 
-        public abstract Task<string> GetTokenAsync(string resource, string authority);
+        public abstract Task<AppAuthenticationResult> GetAuthResultAsync(string resource, string authority);
 
-        internal async Task<string> GetTokenAsync(string authority, string resource, string scope)
+        internal async Task<AppAuthenticationResult> GetAuthResultAsync(string authority, string resource, string scope)
         {
             if (string.IsNullOrWhiteSpace(resource))
             {
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     AzureServiceTokenProviderException.MissingResource);
             }
 
-            return await GetTokenAsync(resource, authority).ConfigureAwait(false);
+            return await GetAuthResultAsync(resource, authority).ConfigureAwait(false);
         }
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/VisualStudioAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/VisualStudioAccessTokenProvider.cs
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
             return processStartInfos;
         }
 
-        public override async Task<string> GetTokenAsync(string resource, string authority)
+        public override async Task<AppAuthenticationResult> GetAuthResultAsync(string resource, string authority)
         {
             try
             {
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                             PrincipalUsed.TenantId = token.TenantId;
                         }
 
-                        return tokenResponse.AccessToken;
+                        return AppAuthenticationResult.Create(tokenResponse, TokenResponse.DateFormat.DateTimeString);
 
                     }
                     catch (Exception exp)

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenResponse.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenResponse.cs
@@ -15,7 +15,13 @@ namespace Microsoft.Azure.Services.AppAuthentication
     {
         private const string TokenResponseFormatExceptionMessage = "Token response is not in the expected format.";
 
-        // Managed Service Identity returns access_token
+        internal enum DateFormat
+        {
+            Unix,
+            DateTimeString
+        };
+
+        // VS token service and MSI endpoint return access_token
         [DataMember(Name = "access_token", IsRequired = false)]
         public string AccessToken { get; private set; }
 
@@ -23,9 +29,29 @@ namespace Microsoft.Azure.Services.AppAuthentication
         [DataMember(Name = "accessToken", IsRequired = false)]
         public string AccessToken2 { get; private set; }
 
+        // VS token service and MSI endpoint return expires_on
+        [DataMember(Name = "expires_on", IsRequired = false)]
+        public string ExpiresOn { get; private set; }
+
+        // Azure CLI returns expiresOn
+        [DataMember(Name = "expiresOn", IsRequired = false)]
+        public string ExpiresOn2 { get; private set; }
+
         [DataMember(Name = "error_description", IsRequired = false)]
         public string ErrorDescription { get; private set; }
-        
+
+        // VS token service returns resource
+        [DataMember(Name = "resource", IsRequired = false)]
+        public string Resource { get; private set; }
+
+        // VS token service and MSI endpoint return token_type
+        [DataMember(Name = "token_type", IsRequired = false)]
+        public string TokenType { get; private set; }
+
+        // Azure CLI returns tokenType
+        [DataMember(Name = "tokenType", IsRequired = false)]
+        public string TokenType2 { get; private set; }
+
         /// <summary>
         /// Parse token response returned from OAuth provider.
         /// While more fields are returned, we only need the access token. 

--- a/src/SdkCommon/AppAuthentication/README.md
+++ b/src/SdkCommon/AppAuthentication/README.md
@@ -44,8 +44,9 @@ Before running these test cases, ensure that you
 1. Have Azure CLI 2.0 installed. 
 2. Have logged into Azure CLI using **az login**
 3. Set an environment variable named **AppAuthenticationTestCertUrl** to a certificate in Azure Key Vault e.g. https://myvault.vault.azure.net/secrets/cert1
+4. Set an environment variable named **AppAuthenticationTestSqlDbEndpoint** to an Azure SQL database endpoint e.g. mydatabase.database.windows.net
    
-   Integration test cases use AzureServiceTokenProvider itself to get a token for Graph API (using Azure CLI), to create Azure AD applications and service principals, and then test those flows. 
+   Integration test cases use AzureServiceTokenProvider itself to get a token for Graph API (using Azure CLI), to create Azure AD applications and service principals, and then test those flows. Additionally, the integration test cases also use SqlAzureAppAuthProvider to get a token for SQL Azure and connect to the test database.
    
 On Windows, open a command prompt, navigate to the integration test folder, and run **dotnet test**. This will run tests for both .NET 4.5.2 and .NET Standard 1.4. 
 


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
Adding the following new functionality to the AppAuthentication library:
- Adding new .NET 4.7.2 targeted package
- Adding new method GetAuthResultAsync to AzureServiceTokenProvider
- Adding new class SqlAzureAppAuthProvider that implements new SqlAuthenticationProvider (only in .NET 4.7.2 targeted package)
- Adding support for user-assigned managed identities
- Adding support for simplified Azure AD certificate roll-over (subject name and issuer authentication)
- Adding new connection string option to specify Key Vault secret identifier for service principal certificate credential

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
