### PR TITLE
[Newtonsoft] Publish new version of Batch dataplane for preview branch

### DIFF
--- a/src/SDKs/Batch/DataPlane/Azure.Batch/AssemblyAttributes.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/AssemblyAttributes.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Client library for interacting with the Azure Batch service.")]
 
 [assembly: AssemblyVersion("9.0.0.0")]
-[assembly: AssemblyFileVersion("9.0.0.0")]
+[assembly: AssemblyFileVersion("9.0.1.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: CLSCompliant(false)]

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
@@ -10,7 +10,7 @@
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <PackageId>Microsoft.Azure.Batch</PackageId>
     <Description>This client library provides access to the Microsoft Azure Batch service.</Description>
-    <Version>9.0.0</Version>
+    <Version>9.0.1</Version>
     <DefineConstants>$(DefineConstants);CODESIGN</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Microsoft.Azure.Batch</AssemblyName>
@@ -28,7 +28,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageReleaseNotes>For detailed release notes, see: https://aka.ms/batch-net-dataplane-changelog</PackageReleaseNotes>
+    <PackageReleaseNotes>For detailed release notes, see: https://aka.ms/batch-net-dataplane-changelog. Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>http://aka.ms/batch</PackageProjectUrl>

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
@@ -28,7 +28,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageReleaseNotes>For detailed release notes, see: https://aka.ms/batch-net-dataplane-changelog.</PackageReleaseNotes>
+    <PackageReleaseNotes>For detailed release notes, see: https://aka.ms/batch-net-dataplane-changelog</PackageReleaseNotes>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>http://aka.ms/batch</PackageProjectUrl>

--- a/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch/Azure.Batch.csproj
@@ -28,7 +28,7 @@
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <PackageReleaseNotes>For detailed release notes, see: https://aka.ms/batch-net-dataplane-changelog. Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
+    <PackageReleaseNotes>For detailed release notes, see: https://aka.ms/batch-net-dataplane-changelog.</PackageReleaseNotes>
     <Authors>Microsoft</Authors>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageProjectUrl>http://aka.ms/batch</PackageProjectUrl>

--- a/src/SDKs/Batch/DataPlane/changelog.md
+++ b/src/SDKs/Batch/DataPlane/changelog.md
@@ -1,7 +1,7 @@
 # Microsoft.Azure.Batch release notes
 
 ## Changes in 9.0.1
-Taking dependency on 10.0.3 version of Newtonsoft nuget package.
+- Updating Newtonsoft.Json to 10.0.3
 
 ## Changes in 9.0.0
 ### Features

--- a/src/SDKs/Batch/DataPlane/changelog.md
+++ b/src/SDKs/Batch/DataPlane/changelog.md
@@ -1,5 +1,8 @@
 # Microsoft.Azure.Batch release notes
 
+## Changes in 9.0.1
+Taking dependency on 10.0.3 version of Newtonsoft nuget package.
+
 ## Changes in 9.0.0
 ### Features
 - Added the ability to see what version of the Azure Batch Node Agent is running on each of the VMs in a pool, via the new `NodeAgentInformation` property on `ComputeNode`.


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
