### PR TITLE
[Newtonsoft] Publish new version of GuestConfiguration for preview branch 

### DIFF
--- a/src/SDKs/GuestConfiguration/Management.GuestConfiguration/Microsoft.Azure.Management.GuestConfiguration.csproj
+++ b/src/SDKs/GuestConfiguration/Management.GuestConfiguration/Microsoft.Azure.Management.GuestConfiguration.csproj
@@ -6,11 +6,11 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.GuestConfiguration</PackageId>
     <Description>Provides Microsoft Azure Guest Configuration management operations including the ability to create, update and get guest configuration assignments, compliance statuses, guest configuration assignment reports.</Description>
-    <Version>0.9.0-preview</Version>
+    <Version>0.10.0-preview</Version>
     <AssemblyTitle>Microsoft Azure Guest Configuration Management Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Management.GuestConfiguration</AssemblyName>
     <PackageTags>GuestConfiguration; Guest Configuration; GuestConfiguration policy; GuestConfigurationPolicy</PackageTags>
-    <PackageReleaseNotes>First release of SDK for Microsoft Azure GuestConfiguration service.</PackageReleaseNotes>
+    <PackageReleaseNotes>For detailed release notes, see: https://aka.ms/batch-net-dataplane-changelog. Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SDKs/GuestConfiguration/Management.GuestConfiguration/Properties/AssemblyInfo.cs
+++ b/src/SDKs/GuestConfiguration/Management.GuestConfiguration/Properties/AssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Resources;
 [assembly: AssemblyTitle("Microsoft Azure GuestConfiguration Management Library")]
 [assembly: AssemblyDescription("Provides Microsoft Azure Guest Configuration management operations including the ability to create, update and get guest configuration assignments, compliance statuses, guest configuration assignment reports.")]
 
-[assembly: AssemblyVersion("0.9.0")]
-[assembly: AssemblyFileVersion("0.9.0")]
+[assembly: AssemblyVersion("0.10.0")]
+[assembly: AssemblyFileVersion("0.10.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
