### PR TITLE
[Azure Search] new GA 5.0.3 with additional parsing mode for indexer

### DIFF
--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Microsoft.Azure.Search.Common.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Microsoft.Azure.Search.Common.csproj
@@ -6,7 +6,7 @@
     <Description>Common types needed by the Azure Search .NET libraries. This is not the package you are looking for; It is only meant to be used as a dependency.</Description>
     <AssemblyTitle>Microsoft Azure Search Common Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search.Common</AssemblyName>
-    <Version>5.0.2</Version>
+    <Version>5.0.3</Version>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Common/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.2.0")]
+[assembly: AssemblyFileVersion("5.0.3.0")]
 
 [assembly: AssemblyTitle("Microsoft Azure Search Common Library")]
 [assembly: AssemblyDescription("Common types needed by the Azure Search .NET libraries. This is not the assembly you are looking for; It is only meant to be used as a dependency.")]

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Microsoft.Azure.Search.Data.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Microsoft.Azure.Search.Data.csproj
@@ -6,7 +6,7 @@
     <Description>Use this package if you're developing a .NET application using Azure Search, and you only need to query or update documents in your indexes. If you also need to create or update indexes, synonym maps, or other service-level resources, use the Microsoft.Azure.Search package instead.</Description>
     <AssemblyTitle>Microsoft Azure Search Data Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search.Data</AssemblyName>
-    <Version>5.0.2</Version>
+    <Version>5.0.3</Version>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>	
   </PropertyGroup>
 
@@ -23,7 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Azure.Search.Common" Version="[5.0.2, 6.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Search.Common" Version="[5.0.3, 6.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.Search.Common\Microsoft.Azure.Search.Common.csproj" />

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Data/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.2.0")]
+[assembly: AssemblyFileVersion("5.0.3.0")]
 
 [assembly: AssemblyTitle("Microsoft Azure Search Data Library")]
 [assembly: AssemblyDescription("Use this assembly if you're developing a .NET application using Azure Search, and you only need to query or update documents in your indexes. If you also need to create or update indexes, synonym maps, or other service-level resources, use the Microsoft.Azure.Search assembly instead.")]

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/Models/IndexingParametersExtensions.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexers/Models/IndexingParametersExtensions.cs
@@ -94,6 +94,62 @@ namespace Microsoft.Azure.Search.Models
             Configure(parameters, ParsingModeKey, "json");
 
         /// <summary>
+        /// Tells the indexer to assume that all blobs contain JSON arrays, which it will then parse such that each JSON object in each array will
+        /// map to a single document in the Azure Search index.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-howto-index-json-blobs" /> for details.
+        /// </summary>
+        /// <param name="parameters">IndexingParameters to configure.</param>
+        /// <param name="documentRoot">
+        /// An optional JSON Pointer that tells the indexer how to find the JSON array if it's not the top-level JSON property of each blob. If this
+        /// parameter is null or empty, the indexer will assume that the JSON array can be found in the top-level JSON property of each blob.
+        /// Default is null.
+        /// </param>
+        /// <remarks>
+        /// This option only applies to indexers that index Azure Blob Storage.
+        /// </remarks>
+        /// <returns>The IndexingParameters instance.</returns>
+        public static IndexingParameters ParseJsonArrays(this IndexingParameters parameters, string documentRoot = null)
+        {
+            Configure(parameters, ParsingModeKey, "jsonArray");
+
+            if (!string.IsNullOrEmpty(documentRoot))
+            {
+                Configure(parameters, "documentRoot", documentRoot);
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
+        /// Tells the indexer to assume that all blobs are delimited text files. Currently only comma-separated value (CSV) text files are supported.
+        /// See <see href="https://docs.microsoft.com/azure/search/search-howto-index-csv-blobs" /> for details.
+        /// </summary>
+        /// <param name="parameters">IndexingParameters to configure.</param>
+        /// <param name="headers">
+        /// Specifies column headers that the indexer will use to map values to specific fields in the Azure Search index. If you don't specify any
+        /// headers, the indexer assumes that the first non-blank line of each blob contains comma-separated headers.
+        /// </param>
+        /// <remarks>
+        /// This option only applies to indexers that index Azure Blob Storage.
+        /// </remarks>
+        /// <returns>The IndexingParameters instance.</returns>
+        public static IndexingParameters ParseDelimitedTextFiles(this IndexingParameters parameters, params string[] headers)
+        {
+            Configure(parameters, ParsingModeKey, "delimitedText");
+
+            if (headers?.Length > 0)
+            {
+                Configure(parameters, "delimitedTextHeaders", headers.ToCommaSeparatedString());
+            }
+            else
+            {
+                Configure(parameters, "firstLineContainsHeaders", true);
+            }
+
+            return parameters;
+        }
+
+        /// <summary>
         /// Tells the indexer to assume that blobs should be parsed as text files in UTF-8 encoding.
         /// See <see href="https://docs.microsoft.com/azure/search/search-howto-indexing-azure-blob-storage#indexing-plain-text"/>
         /// </summary>

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Microsoft.Azure.Search.Service.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Microsoft.Azure.Search.Service.csproj
@@ -6,7 +6,7 @@
     <Description>Use this package if you're developing automation in .NET to manage Azure Search indexes, synonym maps, indexers, data sources, or other service-level resources. If you only need to query or update documents in your indexes, use the Microsoft.Azure.Search.Data package instead. If you need all the functionality of Azure Search, use the Microsoft.Azure.Search package instead.</Description>
     <AssemblyTitle>Microsoft Azure Search Service Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search.Service</AssemblyName>
-    <Version>5.0.2</Version>
+    <Version>5.0.3</Version>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" Version="7.2.0" />
-    <PackageReference Include="Microsoft.Azure.Search.Common" Version="[5.0.2, 6.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Search.Common" Version="[5.0.3, 6.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.Search.Common\Microsoft.Azure.Search.Common.csproj" />

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.2.0")]
+[assembly: AssemblyFileVersion("5.0.3.0")]
 
 [assembly: AssemblyTitle("Microsoft Azure Search Service Library")]
 [assembly: AssemblyDescription("Use this assembly if you're developing automation in .NET to manage Azure Search indexes, synonym maps, indexers, data sources, or other service-level resources. If you only need to query or update documents in your indexes, use the Microsoft.Azure.Search.Data assembly instead. If you need all the functionality of Azure Search, use the Microsoft.Azure.Search assembly instead.")]

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Microsoft.Azure.Search.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Microsoft.Azure.Search.csproj
@@ -6,16 +6,16 @@
     <Description>Makes it easy to develop a .NET application that uses Azure Search.</Description>
     <AssemblyTitle>Microsoft Azure Search Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search</AssemblyName>
-    <Version>5.0.2</Version>
-    <PackageReleaseNotes>This is the newest major version of the Azure Search .NET SDK, based on version 2017-11-11 of the Azure Search REST API. New in this GA version is support for synonyms. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade.</PackageReleaseNotes>
+    <Version>5.0.3</Version>
+    <PackageReleaseNotes>This is the newest major version of the Azure Search .NET SDK, based on version 2017-11-11 of the Azure Search REST API. New in this GA version is support for synonyms and additional parsing modes for indexer. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.Common.cs" Link="Properties\AssemblyInfo.Common.cs" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Search.Data" Version="[5.0.2, 6.0.0)" />
-    <PackageReference Include="Microsoft.Azure.Search.Service" Version="[5.0.2, 6.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Search.Data" Version="[5.0.3, 6.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Search.Service" Version="[5.0.3, 6.0.0)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.Search.Data\Microsoft.Azure.Search.Data.csproj" />

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Microsoft.Azure.Search.csproj
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Microsoft.Azure.Search.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>Microsoft Azure Search Library</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Search</AssemblyName>
     <Version>5.0.3</Version>
-    <PackageReleaseNotes>This is the newest major version of the Azure Search .NET SDK, based on version 2017-11-11 of the Azure Search REST API. New in this GA version is support for synonyms and additional parsing modes for indexer. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade.</PackageReleaseNotes>
+    <PackageReleaseNotes>This is the newest major version of the Azure Search .NET SDK, based on version 2017-11-11 of the Azure Search REST API. New in this GA version is support for synonyms and additional parsing modes for Blob indexers. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade.</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\AssemblyInfo.Common.cs" Link="Properties\AssemblyInfo.Common.cs" />

--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search/Properties/AssemblyInfo.cs
@@ -5,7 +5,7 @@
 using System.Reflection;
 
 [assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.2.0")]
+[assembly: AssemblyFileVersion("5.0.3.0")]
 
 [assembly: AssemblyTitle("Microsoft Azure Search Library")]
 [assembly: AssemblyDescription("Makes it easy to develop a .NET application that uses Azure Search.")]

--- a/src/SDKs/Search/DataPlane/Search.Tests/Tests/IndexingParametersTests.cs
+++ b/src/SDKs/Search/DataPlane/Search.Tests/Tests/IndexingParametersTests.cs
@@ -74,6 +74,50 @@ namespace Microsoft.Azure.Search.Tests
         }
 
         [Fact]
+        public void ParseJsonArraysWithNullDocumentRootSetCorrectly()
+        {
+            var parameters = new IndexingParameters().ParseJsonArrays();
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "jsonArray");
+        }
+
+        [Fact]
+        public void ParseJsonArraysWithEmptyDocumentRootSetCorrectly()
+        {
+            var parameters = new IndexingParameters().ParseJsonArrays(string.Empty);
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "jsonArray");
+        }
+
+        [Fact]
+        public void ParseJsonArraysWithDocumentRootSetCorrectly()
+        {
+            const int ExpectedCount = 2;
+
+            var parameters = new IndexingParameters().ParseJsonArrays("/my/path");
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "jsonArray", ExpectedCount);
+            AssertHasConfigItem(parameters, "documentRoot", "/my/path", ExpectedCount);
+        }
+
+        [Fact]
+        public void ParseDelimitedTextFilesWithInlineHeadersSetCorrectly()
+        {
+            const int ExpectedCount = 2;
+
+            var parameters = new IndexingParameters().ParseDelimitedTextFiles();
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "delimitedText", ExpectedCount);
+            AssertHasConfigItem(parameters, "firstLineContainsHeaders", true, ExpectedCount);
+        }
+
+        [Fact]
+        public void ParseDelimitedTextFilesWithGivenHeadersSetCorrectly()
+        {
+            const int ExpectedCount = 2;
+
+            var parameters = new IndexingParameters().ParseDelimitedTextFiles("id", "name", "address");
+            AssertHasConfigItem(parameters, ExpectedParsingModeKey, "delimitedText", ExpectedCount);
+            AssertHasConfigItem(parameters, "delimitedTextHeaders", "id,name,address", ExpectedCount);
+        }
+
+        [Fact]
         public void ParseTextSetCorrectly()
         {
             const int ExpectedCount = 2;


### PR DESCRIPTION
This PR adds two parsing modes for indexer, `jsonArray` and `delimitedText`. 

This GA release is free from the hanging bug from Client.Runtime 2.3.13

Bump up the version number from 5.0.2 to 5.0.3. 

FYI @Yahnoosh @mhko @jeji1101 @natinimni @brjohnstmsft 

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
