### PR TITLE
Reservations RP 2018-06-01 Preview: Add RedHat in reserved resource t…

### DIFF
--- a/src/SDKs/Reservations/Management.Reservations/Generated/Models/ReservationProperties.cs
+++ b/src/SDKs/Reservations/Management.Reservations/Generated/Models/ReservationProperties.cs
@@ -31,7 +31,8 @@ namespace Microsoft.Azure.Management.Reservations.Models
         /// Initializes a new instance of the ReservationProperties class.
         /// </summary>
         /// <param name="reservedResourceType">Possible values include:
-        /// 'VirtualMachines', 'SqlDatabases', 'SuseLinux', 'CosmosDb'</param>
+        /// 'VirtualMachines', 'SqlDatabases', 'SuseLinux', 'CosmosDb',
+        /// 'RedHat'</param>
         /// <param name="instanceFlexibility">Possible values include: 'On',
         /// 'Off', 'NotSupported'</param>
         /// <param name="displayName">Friendly name for user to easily identify
@@ -76,7 +77,7 @@ namespace Microsoft.Azure.Management.Reservations.Models
 
         /// <summary>
         /// Gets or sets possible values include: 'VirtualMachines',
-        /// 'SqlDatabases', 'SuseLinux', 'CosmosDb'
+        /// 'SqlDatabases', 'SuseLinux', 'CosmosDb', 'RedHat'
         /// </summary>
         [JsonProperty(PropertyName = "reservedResourceType")]
         public string ReservedResourceType { get; set; }

--- a/src/SDKs/Reservations/Management.Reservations/Generated/Models/ReservedResourceType.cs
+++ b/src/SDKs/Reservations/Management.Reservations/Generated/Models/ReservedResourceType.cs
@@ -20,5 +20,6 @@ namespace Microsoft.Azure.Management.Reservations.Models
         public const string SqlDatabases = "SqlDatabases";
         public const string SuseLinux = "SuseLinux";
         public const string CosmosDb = "CosmosDb";
+        public const string RedHat = "RedHat";
     }
 }

--- a/src/SDKs/Reservations/Management.Reservations/Generated/SdkInfo_AzureReservationAPI.cs
+++ b/src/SDKs/Reservations/Management.Reservations/Generated/SdkInfo_AzureReservationAPI.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Management.Reservations
       public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/reservations/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=D:\\AzureSDK\\azure-sdk-for-net\\src\\SDKs";
       public static readonly String GithubForkName = "Azure";
       public static readonly String GithubBranchName = "master";
-      public static readonly String GithubCommidId = "845d69ebfc099f69630e725b43f3167866d970c3";
+      public static readonly String GithubCommidId = "1f3cc4eada45a048c8287981f1e04d9850abf5a6";
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
       // END: Code Generation Metadata Section  }

--- a/src/SDKs/Reservations/Management.Reservations/Generated/SdkInfo_AzureReservationAPI.cs
+++ b/src/SDKs/Reservations/Management.Reservations/Generated/SdkInfo_AzureReservationAPI.cs
@@ -36,5 +36,5 @@ namespace Microsoft.Azure.Management.Reservations
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
       // END: Code Generation Metadata Section  
-	  }
+  }
 }

--- a/src/SDKs/Reservations/Management.Reservations/Generated/SdkInfo_AzureReservationAPI.cs
+++ b/src/SDKs/Reservations/Management.Reservations/Generated/SdkInfo_AzureReservationAPI.cs
@@ -32,9 +32,8 @@ namespace Microsoft.Azure.Management.Reservations
       public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/reservations/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=D:\\AzureSDK\\azure-sdk-for-net\\src\\SDKs";
       public static readonly String GithubForkName = "Azure";
       public static readonly String GithubBranchName = "master";
-      public static readonly String GithubCommidId = "42f4b3eb96f88ab5d477785cf7a29bde8e0a1b87";
+      public static readonly String GithubCommidId = "845d69ebfc099f69630e725b43f3167866d970c3";
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
-      // END: Code Generation Metadata Section  
-  }
+      // END: Code Generation Metadata Section  }
 }

--- a/src/SDKs/Reservations/Management.Reservations/Generated/SdkInfo_AzureReservationAPI.cs
+++ b/src/SDKs/Reservations/Management.Reservations/Generated/SdkInfo_AzureReservationAPI.cs
@@ -35,5 +35,6 @@ namespace Microsoft.Azure.Management.Reservations
       public static readonly String GithubCommidId = "1f3cc4eada45a048c8287981f1e04d9850abf5a6";
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
-      // END: Code Generation Metadata Section  }
+      // END: Code Generation Metadata Section  
+	  }
 }

--- a/src/SDKs/Reservations/Management.Reservations/Microsoft.Azure.Management.Reservations.csproj
+++ b/src/SDKs/Reservations/Management.Reservations/Microsoft.Azure.Management.Reservations.csproj
@@ -7,7 +7,7 @@
 		<PackageId>Microsoft.Azure.Management.Reservations</PackageId>
 		<Description>Microsoft.Azure.Management.Reservations Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.Reservations</AssemblyName>
-		<Version>1.10.0-preview</Version>
+		<Version>1.9.2-preview</Version>
     <PackageTags>Reservations;</PackageTags>
 		<PackageReleaseNotes>
 			Taking dependency on 10.0.3 version of Newtonsoft nuget package.

--- a/src/SDKs/Reservations/Management.Reservations/Microsoft.Azure.Management.Reservations.csproj
+++ b/src/SDKs/Reservations/Management.Reservations/Microsoft.Azure.Management.Reservations.csproj
@@ -7,7 +7,7 @@
 		<PackageId>Microsoft.Azure.Management.Reservations</PackageId>
 		<Description>Microsoft.Azure.Management.Reservations Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.Reservations</AssemblyName>
-		<Version>1.9.2-preview</Version>
+		<Version>1.9.1-preview</Version>
     <PackageTags>Reservations;</PackageTags>
 		<PackageReleaseNotes>
 			Taking dependency on 10.0.3 version of Newtonsoft nuget package.

--- a/src/SDKs/Reservations/Management.Reservations/Microsoft.Azure.Management.Reservations.csproj
+++ b/src/SDKs/Reservations/Management.Reservations/Microsoft.Azure.Management.Reservations.csproj
@@ -7,7 +7,7 @@
 		<PackageId>Microsoft.Azure.Management.Reservations</PackageId>
 		<Description>Microsoft.Azure.Management.Reservations Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.Reservations</AssemblyName>
-		<Version>1.9.1-preview</Version>
+		<Version>1.10.0-preview</Version>
     <PackageTags>Reservations;</PackageTags>
 		<PackageReleaseNotes>
 			Taking dependency on 10.0.3 version of Newtonsoft nuget package.

--- a/src/SDKs/Reservations/Management.Reservations/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Reservations/Management.Reservations/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure Reserved Instance Resources.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.9.1.0")]
+[assembly: AssemblyFileVersion("1.10.0.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]

--- a/src/SDKs/Reservations/Management.Reservations/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Reservations/Management.Reservations/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure Reserved Instance Resources.")]
 
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.10.0.0")]
+[assembly: AssemblyFileVersion("1.9.2.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]

--- a/src/SDKs/Reservations/changelog.md
+++ b/src/SDKs/Reservations/changelog.md
@@ -1,6 +1,6 @@
 ## Microsoft.Azure.Management.Reservations release notes
 
-### Changes in 1.10.0-preview
+### Changes in 1.9.2-preview
 
 **Notes**
 

--- a/src/SDKs/Reservations/changelog.md
+++ b/src/SDKs/Reservations/changelog.md
@@ -1,5 +1,11 @@
 ## Microsoft.Azure.Management.Reservations release notes
 
+### Changes in 1.10.0-preview
+
+**Notes**
+
+* Add RedHat type in ReservedResourceType enum.
+
 ### Changes in 1.9.0-preview
 
 **Notes**


### PR DESCRIPTION
…ype enum

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

**LINK:** 
https://github.com/Azure/azure-rest-api-specs/pull/4370
---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
