### PR TITLE
[KeyVault] updating package versions to republish and resign.

### DIFF
--- a/src/SDKs/KeyVault/Management/KeyVaultManagement.Tests/KeyVaultManagement.Tests.csproj
+++ b/src/SDKs/KeyVault/Management/KeyVaultManagement.Tests/KeyVaultManagement.Tests.csproj
@@ -3,17 +3,11 @@
   <PropertyGroup>
     <PackageId>KeyVaultManagement.Tests</PackageId>
     <Description>KeyVault.Tests Class Library</Description>
-    <VersionPrefix>2.1.1-alpha</VersionPrefix>
+    <Version>1.0.0</Version>
     <Authors>Microsoft Corporation</Authors>
     <AssemblyName>KeyVaultManagement.Tests</AssemblyName>    
   </PropertyGroup>
-
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
-
   <ItemGroup>
-    <!--<PackageReference Include="Microsoft.Azure.Management.KeyVault" Version="2.1.0-ForTest" />-->
     <ProjectReference Include="..\Management.KeyVault\Microsoft.Azure.Management.KeyVault.csproj" />
 
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.1.3-preview" />

--- a/src/SDKs/KeyVault/Management/Management.KeyVault/Microsoft.Azure.Management.KeyVault.csproj
+++ b/src/SDKs/KeyVault/Management/Management.KeyVault/Microsoft.Azure.Management.KeyVault.csproj
@@ -10,7 +10,11 @@
 		<AssemblyName>Microsoft.Azure.Management.KeyVault</AssemblyName>
 		<Version>2.4.3</Version>
 		<PackageTags>Microsoft Azure key vault management;Key Vault;</PackageTags>
-		<PackageReleaseNotes>Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
+		<PackageReleaseNotes>      
+			<![CDATA[
+				Republishing to sign package with correct hash.
+			]]>
+    	</PackageReleaseNotes>
 	</PropertyGroup>
 	<PropertyGroup>
 		<TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/KeyVault/Management/Management.KeyVault/Microsoft.Azure.Management.KeyVault.csproj
+++ b/src/SDKs/KeyVault/Management/Management.KeyVault/Microsoft.Azure.Management.KeyVault.csproj
@@ -8,7 +8,7 @@
 		<Description>Provides key vault management capabilities for Microsoft Azure.</Description>
 		<AssemblyTitle>Microsoft Azure Key Vault Management</AssemblyTitle>
 		<AssemblyName>Microsoft.Azure.Management.KeyVault</AssemblyName>
-		<Version>2.4.2</Version>
+		<Version>2.4.3</Version>
 		<PackageTags>Microsoft Azure key vault management;Key Vault;</PackageTags>
 		<PackageReleaseNotes>Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
 	</PropertyGroup>

--- a/src/SDKs/KeyVault/Management/Management.KeyVault/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/Management/Management.KeyVault/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides key vault management capabilities for Microsoft Azure.")]
 
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.4.2.0")]
+[assembly: AssemblyFileVersion("2.4.3.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.csproj
@@ -7,9 +7,9 @@
     <AssemblyName>Microsoft.Azure.KeyVault.Core</AssemblyName>
     <VersionPrefix>3.0.1</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault Core</PackageTags>
-    <PackageReleaseNotes>
+    <PackageReleaseNotes>      
       <![CDATA[
-        Moving version to 3.0 to align all Azure Key Vault SDK packages.
+        Republishing to sign package with correct hash.
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault Core Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Core</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Core</AssemblyName>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault Core</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Microsoft.Azure.KeyVault.Core.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault Core Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Core</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Core</AssemblyName>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <Version>3.0.1</Version>
     <PackageTags>Microsoft Azure Key Vault Core</PackageTags>
     <PackageReleaseNotes>      
       <![CDATA[

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Core/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault Core Class Library")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography.Tests/Microsoft.Azure.KeyVault.Cryptography.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography.Tests/Microsoft.Azure.KeyVault.Cryptography.Tests.csproj
@@ -5,27 +5,14 @@
     <Description>Microsoft Azure Key Vault Cryptography tests</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Cryptography tests</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Cryptography.Tests</AssemblyName>
-    <VersionPrefix>3.0.1</VersionPrefix>    
+    <Version>1.0.0</Version>    
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
-  <!--<ItemGroup>
-    <None Update="appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>-->
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.KeyVault.Core\Microsoft.Azure.KeyVault.Core.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.KeyVault.Cryptography\Microsoft.Azure.KeyVault.Cryptography.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.KeyVault.WebKey\Microsoft.Azure.KeyVault.WebKey.csproj" />
   </ItemGroup>
-
-  <!--<ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.1' ">
-    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />
-    <PackageReference Include="System.Security.Cryptography.Primitives" Version="4.3.0" />
-  </ItemGroup>-->
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.0" />

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography.Tests/Microsoft.Azure.KeyVault.Cryptography.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography.Tests/Microsoft.Azure.KeyVault.Cryptography.Tests.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault Cryptography tests</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Cryptography tests</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Cryptography.Tests</AssemblyName>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>    
+    <VersionPrefix>3.0.1</VersionPrefix>    
   </PropertyGroup>
   <!--<PropertyGroup>
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Microsoft.Azure.KeyVault.Cryptography.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Microsoft.Azure.KeyVault.Cryptography.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Azure.KeyVault.Cryptography</PackageId>
     <Description>Microsoft Azure Key Vault Cryptography Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Cryptography</AssemblyTitle>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault.Cryptography</AssemblyName>
     <PackageTags>Microsoft Azure Key Vault Cryptography</PackageTags>    
     <PackageReleaseNotes>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Microsoft.Azure.KeyVault.Cryptography.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Microsoft.Azure.KeyVault.Cryptography.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Azure.KeyVault.Cryptography</PackageId>
     <Description>Microsoft Azure Key Vault Cryptography Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Cryptography</AssemblyTitle>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <Version>3.0.1</Version>
     <AssemblyName>Microsoft.Azure.KeyVault.Cryptography</AssemblyName>
     <PackageTags>Microsoft Azure Key Vault Cryptography</PackageTags>    
     <PackageReleaseNotes>      

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Microsoft.Azure.KeyVault.Cryptography.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Microsoft.Azure.KeyVault.Cryptography.csproj
@@ -7,11 +7,9 @@
     <VersionPrefix>3.0.1</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault.Cryptography</AssemblyName>
     <PackageTags>Microsoft Azure Key Vault Cryptography</PackageTags>    
-    <PackageReleaseNotes>
+    <PackageReleaseNotes>      
       <![CDATA[
-        * Adding support for eliptical curve keys.
-          * supported curves: P-256, P-384, P-521, P256K
-          * supported algorithms: ES256, ES384, ES512, ES256K
+        Republishing to sign package with correct hash.
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Cryptography/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault Cryptography Class Library.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions.Tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions.Tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
@@ -3,12 +3,9 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.KeyVault.Extensions.Tests</PackageId>
     <Description>Microsoft Azure Key Vault Extensions tests</Description>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <Version>1.0.0</Version>
     <AssemblyName>Microsoft.Azure.KeyVault.Extensions.Tests</AssemblyName>    
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
   <ItemGroup>
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -29,11 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0-preview-20170106-08" />-->
-    <!--<PackageReference Include="xunit.runner.visualstudio" Version="2.2.0-beta5-build1225" />-->
-    <!--<PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="[1.3.5-preview, 2.0.0)" />-->
     <PackageReference Include="Moq" Version="4.9.0" />
-    <!--<PackageReference Include="xunit" Version="2.2.0-beta5-build3474" />-->
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.14.0" />
   </ItemGroup>
 

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions.Tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions.Tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.KeyVault.Extensions.Tests</PackageId>
     <Description>Microsoft Azure Key Vault Extensions tests</Description>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault.Extensions.Tests</AssemblyName>    
   </PropertyGroup>
   <!--<PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault Extensions Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Extensions</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Extensions</AssemblyName>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <Version>3.0.1</Version>
     <PackageReleaseNotes>      
       <![CDATA[
         Republishing to sign package with correct hash.

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault Extensions Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Extensions</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Extensions</AssemblyName>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>3.0.1</VersionPrefix>
     <PackageReleaseNotes>
       <![CDATA[
         Moving version to 3.0 to align all Azure Key Vault SDK packages.

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Microsoft.Azure.KeyVault.Extensions.csproj
@@ -6,9 +6,9 @@
     <AssemblyTitle>Microsoft Azure Key Vault Extensions</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.Extensions</AssemblyName>
     <VersionPrefix>3.0.1</VersionPrefix>
-    <PackageReleaseNotes>
+    <PackageReleaseNotes>      
       <![CDATA[
-        Moving version to 3.0 to align all Azure Key Vault SDK packages.
+        Republishing to sign package with correct hash.
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault Extensions Class Library")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.0.1")]
+[assembly: AssemblyFileVersion("3.0.1.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.TestFramework/Microsoft.Azure.KeyVault.TestFramework.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.TestFramework/Microsoft.Azure.KeyVault.TestFramework.csproj
@@ -4,12 +4,8 @@
     <Description>Microsoft Azure Key Vault Test Framework</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Test Framework</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.TestFramework</AssemblyName>    
-    <VersionPrefix>3.0.1</VersionPrefix>    
+    <Version>1.0.0</Version>    
   </PropertyGroup>
-  <!-- <PropertyGroup> -->
-    <!-- <TargetFrameworks>netcoreapp1.1</TargetFrameworks> -->
-  <!-- </PropertyGroup> -->
-
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.KeyVault\Microsoft.Azure.KeyVault.csproj" />
   </ItemGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.TestFramework/Microsoft.Azure.KeyVault.TestFramework.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.TestFramework/Microsoft.Azure.KeyVault.TestFramework.csproj
@@ -4,7 +4,7 @@
     <Description>Microsoft Azure Key Vault Test Framework</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Test Framework</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.TestFramework</AssemblyName>    
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>    
+    <VersionPrefix>3.0.1</VersionPrefix>    
   </PropertyGroup>
   <!-- <PropertyGroup> -->
     <!-- <TargetFrameworks>netcoreapp1.1</TargetFrameworks> -->

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Tests/Microsoft.Azure.KeyVault.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Tests/Microsoft.Azure.KeyVault.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.KeyVault.Tests</PackageId>
     <Description>Microsoft.Azure.KeyVault.Tests Class Library</Description>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault.Tests</AssemblyName>
   </PropertyGroup>
   <!--<PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Tests/Microsoft.Azure.KeyVault.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Tests/Microsoft.Azure.KeyVault.Tests.csproj
@@ -3,13 +3,9 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.KeyVault.Tests</PackageId>
     <Description>Microsoft.Azure.KeyVault.Tests Class Library</Description>
-    <VersionPrefix>3.0.2</VersionPrefix>
+    <Version>1.0.0</Version>
     <AssemblyName>Microsoft.Azure.KeyVault.Tests</AssemblyName>
   </PropertyGroup>
-  <!--<PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
-  </PropertyGroup>-->
-  
   <ItemGroup>  
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey.Tests/Microsoft.Azure.KeyVault.WebKey.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey.Tests/Microsoft.Azure.KeyVault.WebKey.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.KeyVault.WebKey.Tests</PackageId>
     <Description>Microsoft.Azure.KeyVault.WebKey.Tests Class Library</Description>
-    <VersionPrefix>3.0.0-alpha</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault.WebKey.Tests</AssemblyName>    
   </PropertyGroup>
   <PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey.Tests/Microsoft.Azure.KeyVault.WebKey.Tests.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey.Tests/Microsoft.Azure.KeyVault.WebKey.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.KeyVault.WebKey.Tests</PackageId>
     <Description>Microsoft.Azure.KeyVault.WebKey.Tests Class Library</Description>
-    <VersionPrefix>3.0.2</VersionPrefix>
+    <Version>1.0.0</Version>
     <AssemblyName>Microsoft.Azure.KeyVault.WebKey.Tests</AssemblyName>    
   </PropertyGroup>
   <PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
@@ -7,7 +7,11 @@
     <AssemblyName>Microsoft.Azure.KeyVault.WebKey</AssemblyName>
     <VersionPrefix>3.0.2</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault WebKey</PackageTags>
-    <PackageReleaseNotes>Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
+    <PackageReleaseNotes>      
+      <![CDATA[
+        Republishing to sign package with correct hash.
+      ]]>
+    </PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault WebKey Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault WebKey</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.WebKey</AssemblyName>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault WebKey</PackageTags>
     <PackageReleaseNotes>Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Microsoft.Azure.KeyVault.WebKey.csproj
@@ -5,7 +5,7 @@
     <Description>Microsoft Azure Key Vault WebKey Class Library</Description>
     <AssemblyTitle>Microsoft Azure Key Vault WebKey</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.KeyVault.WebKey</AssemblyName>
-    <VersionPrefix>3.0.2</VersionPrefix>
+    <Version>3.0.2</Version>
     <PackageTags>Microsoft Azure Key Vault WebKey</PackageTags>
     <PackageReleaseNotes>      
       <![CDATA[

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.WebKey/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Reflection;
 [assembly: AssemblyDescription("Microsoft Azure Key Vault WebKey Class Library.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.1.0")]
+[assembly: AssemblyFileVersion("3.0.2.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
@@ -7,7 +7,11 @@
     <VersionPrefix>3.0.2</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault</AssemblyName>
     <PackageTags>Microsoft Azure Key Vault;Key Vault;REST HTTP client;azureofficial;windowsazureofficial</PackageTags>
-    <PackageReleaseNotes>Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
+    <PackageReleaseNotes>      
+      <![CDATA[
+        Republishing to sign package with correct hash.
+      ]]>
+    </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Azure.KeyVault</PackageId>
     <Description>Azure Key Vault enables users to store and use cryptographic keys within the Microsoft Azure environment. Azure Key Vault supports multiple key types and algorithms and enables the use of Hardware Security Modules (HSM) for high value customer keys. In addition, Azure Key Vault allows users to securely store secrets in a Key Vault; secrets are limited size octet objects and Azure Key Vault applies no specific semantics to these objects. A Key Vault may contain a mix of keys and secrets at the same time, and access control for the two types of object is independently controlled. Users, subject to appropriate authorization, may: 1) Manage cryptographic keys using Create, Import, Update, Delete and other operations 2) Manage secrets using Get, Set, Delete and other operations 3) Use cryptographic keys with Sign/Verify, WrapKey/UnwrapKey and Encrypt/Decrypt operations. Operations against Key Vaults are authenticated and authorized using Azure Active Directory. Key Vault now supports certificates, a complex type that makes use of existing key and secret infrastructure for certificate operations. KV certificates also support notification and auto-renewal as well as other management features.</Description>
     <AssemblyTitle>Microsoft Azure Key Vault</AssemblyTitle>
-    <VersionPrefix>3.0.1</VersionPrefix>
+    <VersionPrefix>3.0.2</VersionPrefix>
     <AssemblyName>Microsoft.Azure.KeyVault</AssemblyName>
     <PackageTags>Microsoft Azure Key Vault;Key Vault;REST HTTP client;azureofficial;windowsazureofficial</PackageTags>
     <PackageReleaseNotes>Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Microsoft.Azure.KeyVault.csproj
@@ -4,7 +4,7 @@
     <PackageId>Microsoft.Azure.KeyVault</PackageId>
     <Description>Azure Key Vault enables users to store and use cryptographic keys within the Microsoft Azure environment. Azure Key Vault supports multiple key types and algorithms and enables the use of Hardware Security Modules (HSM) for high value customer keys. In addition, Azure Key Vault allows users to securely store secrets in a Key Vault; secrets are limited size octet objects and Azure Key Vault applies no specific semantics to these objects. A Key Vault may contain a mix of keys and secrets at the same time, and access control for the two types of object is independently controlled. Users, subject to appropriate authorization, may: 1) Manage cryptographic keys using Create, Import, Update, Delete and other operations 2) Manage secrets using Get, Set, Delete and other operations 3) Use cryptographic keys with Sign/Verify, WrapKey/UnwrapKey and Encrypt/Decrypt operations. Operations against Key Vaults are authenticated and authorized using Azure Active Directory. Key Vault now supports certificates, a complex type that makes use of existing key and secret infrastructure for certificate operations. KV certificates also support notification and auto-renewal as well as other management features.</Description>
     <AssemblyTitle>Microsoft Azure Key Vault</AssemblyTitle>
-    <VersionPrefix>3.0.2</VersionPrefix>
+    <Version>3.0.2</Version>
     <AssemblyName>Microsoft.Azure.KeyVault</AssemblyName>
     <PackageTags>Microsoft Azure Key Vault;Key Vault;REST HTTP client;azureofficial;windowsazureofficial</PackageTags>
     <PackageReleaseNotes>      

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Properties/AssemblyInfo.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Azure Key Vault enables users to store and use cryptographic keys within the Microsoft Azure environment. Azure Key Vault supports multiple key types and algorithms and enables the use of Hardware Security Modules (HSM) for high value customer keys. In addition, Azure Key Vault allows users to securely store secrets in a Key Vault; secrets are limited size octet objects and Azure Key Vault applies no specific semantics to these objects. A Key Vault may contain a mix of keys and secrets at the same time, and access control for the two types of object is independently controlled. Users, subject to appropriate authorization, may: 1) Manage cryptographic keys using Create, Import, Update, Delete and other operations 2) Manage secrets using Get, Set, Delete and other operations 3) Use cryptographic keys with Sign/Verify, WrapKey/UnwrapKey and Encrypt/Decrypt operations. Operations against Key Vaults are authenticated and authorized using Azure Active Directory.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.0.1.0")]
+[assembly: AssemblyFileVersion("3.0.2.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
