### PR TITLE
KeyVaultKeyResolver constructor has been updated to use IKeyVaultClie…

### DIFF
--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/KeyVaultKey.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/KeyVaultKey.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Azure.KeyVault
     /// </summary>
     internal class KeyVaultKey : IKey
     {
-        private readonly KeyVaultClient _client;
+        private readonly IKeyVaultClient _client;
         private          IKey           _implementation;
 
-        internal KeyVaultKey( KeyVaultClient client, KeyBundle keyBundle )
+        internal KeyVaultKey( IKeyVaultClient client, KeyBundle keyBundle )
         {
             switch ( keyBundle.Key.Kty )
             {

--- a/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/KeyVaultKeyResolver.cs
+++ b/src/SDKs/KeyVault/dataPlane/Microsoft.Azure.KeyVault.Extensions/KeyVaultKeyResolver.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.KeyVault
     /// </summary>
     public class KeyVaultKeyResolver : IKeyResolver
     {
-        private readonly KeyVaultClient _client;
+        private readonly IKeyVaultClient _client;
         private readonly string         _name;
 
         /// <summary>
@@ -34,13 +34,10 @@ namespace Microsoft.Azure.KeyVault
         /// Create a new Key Vault KeyResolver that uses the specified KeyVaultClient
         /// </summary>
         /// <param name="client">Key Vault client</param>
-        public KeyVaultKeyResolver( KeyVaultClient client )
+        public KeyVaultKeyResolver( IKeyVaultClient client )
         {
-            if ( client == null )
-                throw new ArgumentNullException( "client" );
-
-            _name   = null;
-            _client = client;
+            _name = null;
+            _client = client ?? throw new ArgumentNullException( "client" );
         }
 
         /// <summary>
@@ -61,7 +58,7 @@ namespace Microsoft.Azure.KeyVault
         /// </summary>
         /// <param name="vaultName">The URL for the Key Vault, e.g. https://myvault.vault.azure.net/ </param>
         /// <param name="client">Key Vault client</param>
-        public KeyVaultKeyResolver( string vaultName, KeyVaultClient client )
+        public KeyVaultKeyResolver( string vaultName, IKeyVaultClient client )
         {
             if ( string.IsNullOrWhiteSpace( vaultName ) )
                 throw new ArgumentNullException( "vaultName" );


### PR DESCRIPTION
…nt instead of KeyVaultClient

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
