### PR TITLE
Updated SDKs for bot framework and ...

### DIFF
--- a/src/SDKs/BotService/Management.BotService/Customizations/BotProperties.cs
+++ b/src/SDKs/BotService/Management.BotService/Customizations/BotProperties.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Management.BotService.Models
         /// <summary>
         /// Gets or sets the app password of the bot
         /// </summary>
-        [JsonIgnore]
+        [JsonProperty(PropertyName = "msaAppPassword")]
         public string MsaAppPassword { get; set; }
     }
 }

--- a/src/SDKs/BotService/Management.BotService/Customizations/MsaAuthenticator.cs
+++ b/src/SDKs/BotService/Management.BotService/Customizations/MsaAuthenticator.cs
@@ -11,7 +11,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 namespace Microsoft.Azure.Management.BotService
 {
     /// <summary>
-    /// Obtains user level tokesn with the bot service first party app audience in order
+    /// Obtains user level tokens with the bot service first party app audience in order
     /// to provision Msa Apps, which are crucial for bots to work
     /// </summary>
     internal class MsaAuthenticator

--- a/src/SDKs/BotService/Management.BotService/Microsoft.Azure.Management.BotService.csproj
+++ b/src/SDKs/BotService/Management.BotService/Microsoft.Azure.Management.BotService.csproj
@@ -27,7 +27,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.4.1" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.17.0" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\BotServiceErrorMessages.Designer.cs">
@@ -49,6 +50,9 @@
     <None Update="Templates\webapp.template.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <!-- Please do not move/edit code below this line -->

--- a/src/SDKs/BotService/Management.BotService/Microsoft.Azure.Management.BotService.csproj
+++ b/src/SDKs/BotService/Management.BotService/Microsoft.Azure.Management.BotService.csproj
@@ -20,18 +20,14 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[2.28.3]" />
-    <PackageReference Update="Newtonsoft.Json" Version="6.0.8" /> 
-    <PackageReference Include="System.Net.Http"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[3.14.0]" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="[5.1.2]" />
-    <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />
-    <PackageReference Include="System.Net.Http" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
-    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.16.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\BotServiceErrorMessages.Designer.cs">

--- a/src/SDKs/BotService/Management.BotService/Microsoft.Azure.Management.BotService.csproj
+++ b/src/SDKs/BotService/Management.BotService/Microsoft.Azure.Management.BotService.csproj
@@ -20,15 +20,18 @@
   </PropertyGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[2.28.3]" />
+    <PackageReference Update="Newtonsoft.Json" Version="6.0.8" /> 
+    <PackageReference Include="System.Net.Http"/>
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.4' ">
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="[3.14.0]" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="[5.1.2]" />
+    <PackageReference Update="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Net.Http" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.6.0-preview" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager.Fluent" Version="1.17.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Resources\BotServiceErrorMessages.Designer.cs">
@@ -50,9 +53,6 @@
     <None Update="Templates\webapp.template.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Update="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <!-- Please do not move/edit code below this line -->


### PR DESCRIPTION
Changed the BotProperties class so you can pass msaAppPassword to rest API

<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] Please add REST spec PR link to the SDK PR
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [ ] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
