### PR TITLE
Fix batch changelog and test

### DIFF
--- a/src/SDKs/Batch/DataPlane/Azure.Batch.IntegrationTests/JobPrepReleaseIntegrationTests.cs
+++ b/src/SDKs/Batch/DataPlane/Azure.Batch.IntegrationTests/JobPrepReleaseIntegrationTests.cs
@@ -324,7 +324,7 @@
                                 JobPreparationTask prep = new JobPreparationTask("cmd /c JobPrep Task");
                                 unboundJob.JobPreparationTask = prep;
 
-                                ResourceFile[] badResFiles = { ResourceFile.FromUrl("https://127.0.0.1/foo/bar/baf", "bob.txt")};
+                                ResourceFile[] badResFiles = { ResourceFile.FromUrl("https://not.a.domain.invalid/file", "bob.txt")};
 
                                 prep.ResourceFiles = badResFiles;
 
@@ -416,8 +416,8 @@
                             {
                                 JobReleaseTask relTask = new JobReleaseTask("cmd /c echo Job Release Task");
                                 unboundJob.JobReleaseTask = relTask;
-                                
-                                ResourceFile[] badResFiles = { ResourceFile.FromUrl("https://127.0.0.1/foo/bar/baf", "bob.txt")};
+
+                                ResourceFile[] badResFiles = { ResourceFile.FromUrl("https://not.a.domain.invalid/file", "bob.txt")};
 
                                 relTask.ResourceFiles = badResFiles;
 

--- a/src/SDKs/Batch/DataPlane/changelog.md
+++ b/src/SDKs/Batch/DataPlane/changelog.md
@@ -14,11 +14,13 @@
     - `ResourceFile.FromStorageContainerUrl` creates a `ResourceFile` pointing to an Azure Blob Storage container.
     - `ResourceFile.FromAutoStorageContainer` creates a `ResourceFile` pointing to an Azure Blob Storage container in the Batch registered auto-storage account.
   - URLs provided to `ResourceFile` via the `ResourceFile.FromUrl` method can now be any HTTP URL. Previously, these had to be an Azure Blob Storage URL.
+  - The `BlobPrefix` property can be used to filter downloads from a storage container to only those matching the prefix.
 - **[Breaking]** Removed `OSDisk` property from `VirtualMachineConfiguration`. This property is no longer supported.
 - Pools which set the `DynamicVNetAssignmentScope` on `NetworkConfiguration` to be `DynamicVNetAssignmentScope.Job` can 
   now dynamically assign a Virtual Network to each node the job's tasks run on. The specific Virtual Network to join the nodes to is specified in 
   the new `JobNetworkConfiguration` property on `CloudJob` and `JobSpecification`. 
-  - **Note**: This feature is in public preview. It is disabled for all Batch accounts except for those 
+  - **Note**: This feature is in public preview. It is disabled for all Batch accounts except for those which have contacted us and requested to
+    be in the pilot.
 - The maximum lifetime of a task is now 180 days (previously it was 7).
 - Added support on Windows pools for creating users with a specific login mode (either `Batch` or `Interactive`) via `WindowsUserConfiguration.LoginMode`.
 - The default task retention time for all tasks is now 7 days, previously it was infinite.


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
