### PR TITLE
CognitiveServices.Vision.Face: add FaceClient constructor with "endpoint" parameter

### DIFF
--- a/src/SDKs/CognitiveServices/dataPlane/Vision/Face/Face.Tests/BaseTests.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/Face/Face.Tests/BaseTests.cs
@@ -16,12 +16,7 @@ namespace FaceSDK.Tests
 
         protected IFaceClient GetFaceClient(DelegatingHandler handler)
         {
-            IFaceClient client = new FaceClient(new ApiKeyServiceClientCredentials(FaceSubscriptionKey), handlers: handler)
-            {
-                Endpoint = "https://westus.api.cognitive.microsoft.com"
-            };
-
-            return client;
+            return new FaceClient(new ApiKeyServiceClientCredentials(FaceSubscriptionKey), endpoint: "https://westus.api.cognitive.microsoft.com", handlers: handler);
         }
     }
 }

--- a/src/SDKs/CognitiveServices/dataPlane/Vision/Face/Face/Customizations/FaceClient.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Vision/Face/Face/Customizations/FaceClient.cs
@@ -1,0 +1,30 @@
+namespace Microsoft.Azure.CognitiveServices.Vision.Face
+{
+    using Microsoft.Rest;
+    using System.Net.Http;
+
+    public partial class FaceClient 
+    {
+    
+        /// <summary>
+        /// Initializes a new instance of the FaceClient class.
+        /// </summary>
+        /// <param name='credentials'>
+        /// Required. Subscription credentials which uniquely identify client subscription.
+        /// </param>
+        /// <param name='endpoint'>
+        /// Required. Supported Cognitive Services endpoints (protocol and hostname, for example:
+        /// https://westus.api.cognitive.microsoft.com).
+        /// </param>
+        /// <param name='handlers'>
+        /// Optional. The delegating handlers to add to the http client pipeline.
+        /// </param>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        public FaceClient(ServiceClientCredentials credentials, string endpoint, params DelegatingHandler[] handlers) : this(credentials, handlers)        
+        {
+            Endpoint = endpoint;  
+        }
+    }
+}


### PR DESCRIPTION
## Description
This adds another constructor to [Microsoft.Azure.CognitiveServices.Vision.Face.FaceClient](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cognitiveservices.vision.face.faceclient?view=azure-dotnet#constructors), which accepts an `endpoint` parameter. 

Since the client can't work without an endpoint, it seems to me that this would be a sensible minor customization.

See for example [this](https://docs.microsoft.com/en-us/azure/cognitive-services/face/quickstarts/csharp-detect-sdk#create-and-use-the-face-client) code snippet in the quickstart, which could then be simplified to

```
FaceClient faceClient = new FaceClient(new ApiKeyServiceClientCredentials(subscriptionKey), faceEndpoint);
```

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ n/a ] Please add REST spec PR link to the SDK PR
- [X] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [X] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [X] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [ n/a ] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [ n/a ] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [ n/a ] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
