### PR TITLE
Update Batch supporting assemblies version and depedencies

### DIFF
--- a/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/AzureBatchFileConventions.csproj
+++ b/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/AzureBatchFileConventions.csproj
@@ -8,11 +8,11 @@ by task and job id and the type of output.
     </Description>
     <AssemblyTitle>Microsoft Azure Batch File Conventions</AssemblyTitle>
     <AssemblyName>Microsoft.Azure.Batch.Conventions.Files</AssemblyName>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <PackageTags>Microsoft, Azure, Batch, windowsazureofficial</PackageTags>
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
     <PackageReleaseNotes>
-Updated dependent libraries.
+Updated Microsoft.Azure.Batch dependency to 10.0.
     </PackageReleaseNotes>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -35,7 +35,7 @@ Updated dependent libraries.
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Batch" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Batch" Version="[10.0.0, 11.0.0)" />
     <PackageReference Include="WindowsAzure.Storage" Version="[8.1.1, 10.0.0)" />
   </ItemGroup>
 

--- a/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Src/AzureBatchFileConventions/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("A convention-based library for saving and retrieving Azure Batch task output files.")]
 
 [assembly: AssemblyVersion("3.0.0.0")] 
-[assembly: AssemblyFileVersion("3.2.0.0")]
+[assembly: AssemblyFileVersion("3.3.0.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright © Microsoft Corporation. All rights reserved.")]

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/Utilities/FakeBatchServiceClient.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.IntegrationTests/Utilities/FakeBatchServiceClient.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.IntegrationTests.Utilities
         public FakeBatchServiceClient(Func<HttpRequestMessage, HttpResponseMessage> impl)
             : base(new FakingHandler(impl))
         {
+            this.BatchUrl = "https://a.b.c.d.e.f.g";
         }
 
         public FakeBatchServiceClient(object responseBody)

--- a/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/Utilities/FakeBatchServiceClient.cs
+++ b/src/SDKs/Batch/Support/FileConventions/Tests/AzureBatchFileConventions.Tests/Utilities/FakeBatchServiceClient.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Batch.Conventions.Files.UnitTests.Utilities
         public FakeBatchServiceClient(Func<HttpRequestMessage, HttpResponseMessage> impl)
             : base(new FakingHandler(impl))
         {
+            this.BatchUrl = "https://a.b.c.d.e.f.g";
         }
 
         public FakeBatchServiceClient(object responseBody)

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/AssemblyAttributes.cs
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/AssemblyAttributes.cs
@@ -21,7 +21,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Client library for uploading resource files for tasks in the Azure Batch service.")]
 
 [assembly: AssemblyVersion("8.0.0.0")]
-[assembly: AssemblyFileVersion("8.1.0.0")]
+[assembly: AssemblyFileVersion("8.2.0.0")]
 [assembly: AssemblyCompany("Microsoft Corporation")]
 [assembly: AssemblyProduct("Microsoft Azure")]
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Corporation. All rights reserved.")]

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/Batch.FileStaging.csproj
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/Batch.FileStaging.csproj
@@ -8,7 +8,7 @@ Visit our home page for more detail - http://azure.microsoft.com/services/batch/
 For technical overview, see http://azure.microsoft.com/documentation/articles/batch-technical-overview/.
 
 API reference can be found at http://go.microsoft.com/fwlink/?LinkId=717949.</Description>
-    <Version>8.1.0</Version>
+    <Version>8.2.0</Version>
     <DefineConstants>$(DefineConstants);CODESIGN</DefineConstants>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AssemblyName>Microsoft.Azure.Batch.FileStaging</AssemblyName>
@@ -18,6 +18,9 @@ API reference can be found at http://go.microsoft.com/fwlink/?LinkId=717949.</De
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(LibraryToolsFolder)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
     <RestorePackagesPath>$(LibraryNugetPackageFolder)</RestorePackagesPath>
+    <PackageReleaseNotes>
+Updated Microsoft.Azure.Batch dependency to 10.0.
+    </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard1.4</TargetFrameworks>
@@ -34,7 +37,7 @@ API reference can be found at http://go.microsoft.com/fwlink/?LinkId=717949.</De
 
   <ItemGroup>
     <PackageReference Include="WindowsAzure.Storage" Version="[8.1.1, 10.0.0)" />
-    <PackageReference Include="Microsoft.Azure.Batch" Version="[9.0.0,10.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Batch" Version="[10.0.0, 11.0.0)" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System.Web" />

--- a/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/SequentialFileStaging.cs
+++ b/src/SDKs/Batch/Support/FileStaging/Batch.FileStaging/SequentialFileStaging.cs
@@ -432,7 +432,7 @@ namespace Microsoft.Azure.Batch.FileStaging
             string nodeFileName = stageThisFile.NodeFileName;
 
             // create a new ResourceFile and populate it.  This file is now staged!
-            stageThisFile.StagedFiles = new ResourceFile[] { new ResourceFile(blobSAS, nodeFileName) };
+            stageThisFile.StagedFiles = new ResourceFile[] { ResourceFile.FromUrl(blobSAS, nodeFileName) };
         }
 
 #endregion internal/private


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description
<!--
Please add an informative description that covers that changes made by the pull request.

If you are regenerating your SDK based off of a new swagger spec, please add the link to the corresponding swagger spec pull request that has been merged in the azure-rest-api-specs repository
-->

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [x] Please add REST spec PR link to the SDK PR
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [x] Pull request includes test coverage for the included changes.

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
- [x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
- [x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
- [x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.
