### PR TITLE
Fixed error message when certificate does not contain private RSA key.

### DIFF
--- a/src/SdkCommon/Auth/Az.Auth/Az.Authentication/ClientAssertionCertificate.cs
+++ b/src/SdkCommon/Auth/Az.Auth/Az.Authentication/ClientAssertionCertificate.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Rest.Azure.Authentication
         {
             using (var key = certificate.GetRSAPrivateKey())
             {
+                if(key == null)
+                {
+                    throw new CryptographicException("No valid private RSA key found for X509Certificate2.");
+                }
+
                 return key.SignData(Encoding.UTF8.GetBytes(message), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             }
         }

--- a/src/SdkCommon/Auth/Az.Auth/Az.Authentication/Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj
+++ b/src/SdkCommon/Auth/Az.Auth/Az.Authentication/Microsoft.Rest.ClientRuntime.Azure.Authentication.csproj
@@ -5,11 +5,11 @@
     <Description>Provides ADAL based authentication for Azure management client libraries</Description>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure.Authentication</AssemblyName>
     <AssemblyTitle>Authentication for Azure Management Clients</AssemblyTitle>
-    <Version>2.3.6</Version>    
+    <Version>2.3.7</Version>    
     <PackageTags>Microsoft AutoRest ClientRuntime Authentication $(NugetCommonTags) $(NugetCommonProfileTags)</PackageTags>
 	<PackageReleaseNotes>
       <![CDATA[
-        1) SHA256 signed
+        1) Fixed null ref exception when RSA private key is not found in the provided X509Certificate2
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SdkCommon/Auth/Az.Auth/Az.Authentication/Properties/AssemblyInfo.cs
+++ b/src/SdkCommon/Auth/Az.Auth/Az.Authentication/Properties/AssemblyInfo.cs
@@ -10,7 +10,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTitle("Microsoft Rest Azure Client Runtime Authentication")]
 [assembly: AssemblyDescription("Client authentication infrastructure for Azure client libraries.")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.3.6.0")]
+[assembly: AssemblyFileVersion("2.3.7.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft Corporation")]


### PR DESCRIPTION
Fixes null ref message issue reported here https://github.com/Azure/azure-libraries-for-net/issues/553 