### PR TITLE
Adding support for .NET 461 and .NET Standard 2.0

### DIFF
--- a/src/SDKs/Graph.RBAC/Graph.RBAC/Microsoft.Azure.Graph.RBAC.csproj
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC/Microsoft.Azure.Graph.RBAC.csproj
@@ -5,13 +5,13 @@
   
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Graph.RBAC</PackageId>
-    <VersionPrefix>3.5.0-preview</VersionPrefix>
+    <VersionPrefix>3.5.1-preview</VersionPrefix>
     <Description>Microsoft.Azure.Graph.RBAC</Description>
     <AssemblyName>Microsoft.Azure.Graph.RBAC</AssemblyName>
     <PackageTags>Microsoft AutoRest Management REST;netcore451511</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
-          Updating SDK -> moving to 3.5.0, with current Swagger changes (new features and fields such as customKeyIdentifier and principalType).
+          Supporting additional target frameworks ( .NET 461 and .NET Standard 2.0)
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/SDKs/Graph.RBAC/Graph.RBAC/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Graph.RBAC/Graph.RBAC/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription("Provides Microsoft Azure Graph RBAC access.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.5.0.0")]
+[assembly: AssemblyFileVersion("3.5.1.0")]
 
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]


### PR DESCRIPTION
- Republishing Graph.Rbac to publish symbols for VS dependency.
- Adding support for .NET 461 and .NET Standard 2.0