### PR TITLE
VM Matrix for Parallelization, moved CG support to job analyze

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -54,7 +54,7 @@ jobs:
         Windows:
           OSVmImage: 'vs2017-win2016'
         MacOs:
-          OSVmImage : 'macOS-10.13'
+          OSVmImage: 'macOS-10.13'
 
     pool:
       vmImage: '$(OSVmImage)'

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -50,14 +50,12 @@ jobs:
     strategy:
       matrix:
         Linux:
-          os.name: 'Linux'
-          os.vmImage: 'ubuntu-16.04'
+          OSVmImage: 'ubuntu-16.04'
         Windows:
-          os.name: 'Windows'
-          os.vmImage: 'vs2017-win2016'
+          OSVmImage: 'vs2017-win2016'
 
     pool:
-      vmImage: '$(os.vmImage)'
+      vmImage: '$(OSVmImage)'
 
     steps:
       - task: DotNetCoreInstaller@0

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -1,8 +1,11 @@
+# External variables:
+# ProjectFile - The project to build and test. This variable is defined in pipeline web ui because we want to be able to provide it at queue time and that isn't supported in yaml yet.
+
 trigger:
 - master
 
-# variables:
-# ProjectFile - The project to build and test. This variable is defined in pipeline web ui because we want to be able to provide it at queue time and that isn't supported in yaml yet.
+variables:
+  DotNetCoreVersion: '2.1.503'
 
 jobs:
   - job: 'Build_Packages'
@@ -12,9 +15,9 @@ jobs:
 
     steps:
       - task: DotNetCoreInstaller@0
-        displayName: 'Use .NET Core sdk 2.1.503'
+        displayName: 'Use .NET Core sdk $(DotNetCoreVersion)'
         inputs:
-          version: 2.1.503
+          version: '$(DotNetCoreVersion)'
 
       - task: DotNetCoreCLI@2
         displayName: 'Build and Package'
@@ -27,39 +30,40 @@ jobs:
         inputs:
           ArtifactName: packages
 
-  - job: 'Test_Windows'
+  - job: 'Analyze'
+
+    dependsOn:
+      'Build_Packages'
 
     pool:
       vmImage: 'vs2017-win2016'
 
     steps:
-      - task: DotNetCoreInstaller@0
-        displayName: 'Use .NET Core sdk 2.1.503'
-        inputs:
-          version: 2.1.503
-
-      - task: DotNetCoreCLI@2
-        displayName: 'Build & Test'
-        inputs:
-          command: test
-          projects: '$(ProjectFile)'
-
       - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
         displayName: 'Component Detection'
         # ComponentGovernance is currently unable to run on pull requests of public projects.  Running on
         # scheduled builds should be good enough.
-        condition: and(succeeded(), eq(variables['Build.Reason'], 'Schedule'))
+        condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
 
-  - job: 'Test_Linux'
+  - job: 'Test'
+
+    strategy:
+      matrix:
+        Linux:
+          os.name: 'Linux'
+          os.vmImage: 'ubuntu-16.04'
+        Windows:
+          os.name: 'Windows'
+          os.vmImage: 'vs2017-win2016'
 
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: '$(os.vmImage)'
 
     steps:
       - task: DotNetCoreInstaller@0
-        displayName: 'Use .NET Core sdk 2.1.503'
+        displayName: 'Use .NET Core sdk $(DotNetCoreVersion)'
         inputs:
-          version: 2.1.503
+          version: '$(DotNetCoreVersion)'
 
       - task: DotNetCoreCLI@2
         displayName: 'Build & Test'

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -8,7 +8,7 @@ variables:
   DotNetCoreVersion: '2.1.503'
 
 jobs:
-  - job: 'Build_Packages'
+  - job: 'Build'
 
     pool:
       vmImage: 'vs2017-win2016'
@@ -33,7 +33,7 @@ jobs:
   - job: 'Analyze'
 
     dependsOn:
-      'Build_Packages'
+      'Build'
 
     pool:
       vmImage: 'vs2017-win2016'
@@ -53,6 +53,8 @@ jobs:
           OSVmImage: 'ubuntu-16.04'
         Windows:
           OSVmImage: 'vs2017-win2016'
+        MacOs:
+          OSVmImage : 'macOS-10.13'
 
     pool:
       vmImage: '$(OSVmImage)'


### PR DESCRIPTION
## Description
- Added strategy matrix for VM Parallelization
- Moved CG support to job analyze
---
This checklist is used to make sure that common guidelines for a pull request are followed.
[x] Please add REST spec PR link to the SDK PR
[x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
[x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).**
### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
[x] Title of the pull request is clear and informative.
[x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).
### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
[x] Pull request includes test coverage for the included changes.
### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)
[x] If an SDK is being regenerated based on a new swagger spec, a link to the pull request containing these swagger spec changes has been included above.
[x] The generate.cmd file for the SDK has been updated with the version of AutoRest, as well as the commitid of your swagger spec or link to the swagger spec, used to generate the code.
[x] The `*.csproj` and `AssemblyInfo.cs` files have been updated with the new version of the SDK.