### PR TITLE
Move the tests for Azure.Core to XUnit

### DIFF
--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Azure.Core.Tests.csproj
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Azure.Core.Tests.csproj
@@ -7,8 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.10.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Text.Primitives" Version="0.1.0-preview1-180216-4" />
   </ItemGroup>

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/HeadersTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/HeadersTests.cs
@@ -3,14 +3,14 @@
 using System.Text;
 using System.Text.RegularExpressions;
 using Azure.Core.Http;
-using NUnit.Framework;
+using Xunit;
 using static System.Buffers.Text.Encodings;
 
 namespace Azure.Core.Tests
 {
     public class HeadersTests
     {
-        [Test]
+        [Fact]
         public void Basics()
         {
             var utf16Name = "XnameX";
@@ -21,22 +21,22 @@ namespace Azure.Core.Tests
             byte[] utf8Value = Encoding.ASCII.GetBytes(utf16Value);
 
             var mixedHeader = new HttpHeader(utf8Name, utf16Value);
-            Assert.AreEqual(utf16Text, mixedHeader.ToString());
-            Assert.AreEqual(utf16Name, Utf8.ToString(mixedHeader.Name));
-            Assert.AreEqual(utf16Value, Utf8.ToString(mixedHeader.Value));
+            Assert.Equal(utf16Text, mixedHeader.ToString());
+            Assert.Equal(utf16Name, Utf8.ToString(mixedHeader.Name));
+            Assert.Equal(utf16Value, Utf8.ToString(mixedHeader.Value));
 
             var utf16Header = new HttpHeader(utf16Name, utf16Value);
-            Assert.AreEqual(utf16Text, utf16Header.ToString());
-            Assert.AreEqual(utf16Name, Utf8.ToString(utf16Header.Name));
-            Assert.AreEqual(utf16Value, Utf8.ToString(utf16Header.Value));
+            Assert.Equal(utf16Text, utf16Header.ToString());
+            Assert.Equal(utf16Name, Utf8.ToString(utf16Header.Name));
+            Assert.Equal(utf16Value, Utf8.ToString(utf16Header.Value));
 
             var utf8Header = new HttpHeader(utf8Name, utf8Value);
-            Assert.AreEqual(utf16Text, utf8Header.ToString());       
-            Assert.AreEqual(utf16Name, Utf8.ToString(utf8Header.Name));
-            Assert.AreEqual(utf16Value, Utf8.ToString(utf8Header.Value));
+            Assert.Equal(utf16Text, utf8Header.ToString());       
+            Assert.Equal(utf16Name, Utf8.ToString(utf8Header.Name));
+            Assert.Equal(utf16Value, Utf8.ToString(utf8Header.Value));
         }
 
-        [Test]
+        [Fact]
         public void UserAgentHeaderBasics()
         {
             var userAgent = HttpHeader.Common.CreateUserAgent("sdk_name", "sdk_version", "application_id").ToString();

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/HeadersTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/HeadersTests.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
+using Azure.Core.Http;
 using System.Text;
 using System.Text.RegularExpressions;
-using Azure.Core.Http;
 using Xunit;
 using static System.Buffers.Text.Encodings;
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/PipelineTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/PipelineTests.cs
@@ -4,9 +4,9 @@
 using Azure.Core.Http;
 using Azure.Core.Http.Pipeline;
 using Azure.Core.Testing;
-using NUnit.Framework;
 using System;
 using System.Diagnostics.Tracing;
+using Xunit;
 
 namespace Azure.Core.Tests
 {
@@ -15,7 +15,7 @@ namespace Azure.Core.Tests
     {
         string expected = @"ProcessingRequest : Get https://contoso.a.io/ # ErrorResponse : 500 # ProcessingResponse : Get https://contoso.a.io/ # ProcessingRequest : Get https://contoso.a.io/ # ProcessingResponse : Get https://contoso.a.io/";
 
-        [Test]
+        [Fact]
         public void Basics() {
 
             var options = new PipelineOptions();
@@ -32,9 +32,9 @@ namespace Azure.Core.Tests
                 message.SetRequestLine(PipelineMethod.Get, new Uri("https://contoso.a.io"));
                 pipeline.ProcessAsync(message).Wait();
 
-                Assert.AreEqual(1, message.Response.Status);
+                Assert.Equal(1, message.Response.Status);
                 var result = listener.ToString();
-                Assert.AreEqual(expected, result);
+                Assert.Equal(expected, result);
             }
         }
 


### PR DESCRIPTION
This will move from NUnit to XUnit for the tests we have for Azure.Core. This matches the standard for this repo.