### PR TITLE
Enable live tests in non ci

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -1,5 +1,6 @@
 # External variables:
 # ProjectFile - The project to build and test. This variable is defined in pipeline web ui because we want to be able to provide it at queue time and that isn't supported in yaml yet.
+# AzConfigConnectionString - The connection string used for testing the AzConfig service. This is set in the pipeline web ui as it needs different values for public vs internal.
 
 trigger:
 - master
@@ -66,7 +67,18 @@ jobs:
           version: '$(DotNetCoreVersion)'
 
       - task: DotNetCoreCLI@2
-        displayName: 'Build & Test'
+        displayName: 'Build & Test (no live tests)'
+        condition: eq(variables['System.TeamProject'], 'public')
+        inputs:
+          command: test
+          projects: '$(ProjectFile)'
+          arguments: --filter TestCategory!=Live
+        
+      - task: DotNetCoreCLI@2
+        displayName: 'Build & Test (with live tests)'
+        condition: ne(variables['System.TeamProject'], 'public')
+        env:
+          AZ_CONFIG_CONNECTION: $(AzConfigConnectionString)
         inputs:
           command: test
           projects: '$(ProjectFile)'

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationLiveTests.cs
@@ -82,7 +82,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             return key;
         }
 
-        //[Test]
+        [Test]
         public async Task DeleteNotFound()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -95,7 +95,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             response.Dispose();
         }
 
-        //[Test]
+        [Test]
         public async Task Delete()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -119,7 +119,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task DeleteWithLabel()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -133,7 +133,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
         }
 
-        //[Test]
+        [Test]
         public async Task DeleteWithETag()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -154,7 +154,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             await service.DeleteAsync(key: s_testSetting.Key, options: options, CancellationToken.None);
         }
 
-        //[Test]
+        [Test]
         public async Task Set()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -177,7 +177,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task Add()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -200,7 +200,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task UpdateIfAny()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -234,7 +234,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task UpdateIfETag()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -264,7 +264,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task UpdateIfNoMatch()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -295,7 +295,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task UpdateWrongETag()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -329,7 +329,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task UpdateTags()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -369,7 +369,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task GetIfNoMatch()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -401,7 +401,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task Revisions()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -450,7 +450,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task Get()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -479,7 +479,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public void GetNotFound()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -496,7 +496,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             response.Dispose();
         }
 
-        //[Test]
+        [Test]
         public async Task GetWithLabel()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -528,7 +528,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task GetBatchPagination()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -555,7 +555,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         }
 
 
-        //[Test]
+        [Test]
         public async Task GetBatchWithFields()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -583,7 +583,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task GetWithNullLabel()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -607,7 +607,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task LockUnlock()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
@@ -649,7 +649,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
-        //[Test]
+        [Test]
         public async Task GetWithRequestId()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationWatcherTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationWatcherTests.cs
@@ -15,7 +15,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
     [Category("Live")]
     public class ConfigurationWatcherTests
     {
-        //[Test]
+        [Test]
         public async Task Helpers()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample1_HelloWorld.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample1_HelloWorld.cs
@@ -12,7 +12,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
     [Category("Live")]
     public partial class ConfigurationSamples
     {
-        //[Test]
+        [Test]
         public async Task HelloWorld()
         {
             // Retrieve the connection string from the configuration store. 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample4_Logging.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample4_Logging.cs
@@ -16,7 +16,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
     {
         // ConfigurationClient logs lots of useful information automatically to .NET's EventSource.
         // This sample illustrate how to control and access the log information.
-        //[Test]
+        [Test]
         public async Task Logging()
         {
             // Retrieve the connection string from the configuration store. 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample5_Watcher.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample5_Watcher.cs
@@ -11,7 +11,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
     [Category("Live")]
     public partial class ConfigurationSamples
     {
-        //[Test]
+        [Test]
         public async Task Watcher()
         {
             // Retrieve the connection string from the configuration store. 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample6_ConfiguringRetries.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample6_ConfiguringRetries.cs
@@ -13,7 +13,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
     [Category("Live")]
     public partial class ConfigurationSamples
     {
-        //[Test]
+        [Test]
         public async Task ConfiguringRetries()
         {
             // specify retry policy options

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample7_ConfiguringPipeline.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample7_ConfiguringPipeline.cs
@@ -16,7 +16,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
     {
         HttpClient s_client = new HttpClient();
 
-        //[Test]
+        [Test]
         public async Task ConfiguringPipeline()
         {
             // this instance will hold pipeline creation options


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

Enable the AzConfig tests against the live service. They should not run during CI.

/cc @maririos @mikeharder @weshaggard @bsiegel 