### PR TITLE
AzConfig sdk parity with latest service changes

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationLiveTests.cs
@@ -634,7 +634,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                     await service.UpdateAsync(testSettingUpdate);
                 });
                 var response = e.Response;
-                Assert.AreEqual(403, response.Status);
+                Assert.AreEqual(409, response.Status);
                 response.Dispose();
                 
                 // Test Unlock

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
@@ -48,7 +48,7 @@ namespace Azure.ApplicationModel.Configuration
         [KnownException(typeof(HttpRequestException), Message = "The request failed due to an underlying issue such as network connectivity, DNS failure, or timeout.")]
         [HttpError(typeof(ResponseFailedException), 412, Message = "matching item is already in the store")]
         [HttpError(typeof(ResponseFailedException), 429, Message = "too many requests")]
-        [UsageErrors(typeof(ResponseFailedException), 401, 403, 408, 500, 502, 503, 504)]
+        [UsageErrors(typeof(ResponseFailedException), 401, 409, 408, 500, 502, 503, 504)]
         public async Task<Response<ConfigurationSetting>> AddAsync(ConfigurationSetting setting, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (setting == null) throw new ArgumentNullException(nameof(setting));
@@ -109,7 +109,7 @@ namespace Azure.ApplicationModel.Configuration
                 if (response.Status == 200) {
                     return await CreateResponse(response, cancellation);
                 }
-                if (response.Status == 403) throw new ResponseFailedException(response, "the item is locked");
+                if (response.Status == 409) throw new ResponseFailedException(response, "the item is locked");
                 else throw new ResponseFailedException(response);
             }
         }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient_private.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient_private.cs
@@ -26,7 +26,7 @@ namespace Azure.ApplicationModel.Configuration
         const string RevisionsRoute = "/revisions/";
         const string KeyQueryFilter = "key";
         const string LabelQueryFilter = "label";
-        const string FieldsQueryFilter = "fields";
+        const string FieldsQueryFilter = "$select";
         const string IfMatchName = "If-Match";
         const string IfNoneMatch = "If-None-Match";
 


### PR DESCRIPTION
Recently, the service roll out changes that broke the sdk live test. This change brings us to parity with their changes.
- Error code changes
- Select instead of fields.

Issues:
- https://github.com/Azure/azure-sdk-for-net-lab/issues/101
- https://github.com/Azure/azure-sdk-for-net-lab/issues/121

I tested the changes in the playground subscription, using a build that is sill connected to the labs repo and that contains the exact same changes => https://dev.azure.com/azure-sdk/playground/_build/results?buildId=4514&_a=summary
This until we have live test enabled again in this repo. See PR https://github.com/Azure/azure-sdk-for-net/pull/5239 for more details.