### PR TITLE
Support using MSI to fetch Key Vault access tokens

### DIFF
--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/KeyVaultClient.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/KeyVaultClient.cs
@@ -174,6 +174,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 string azureAdInstance = UriHelper.GetAzureAdInstanceByAuthority(authority);
                 tokenProviders = new List<NonInteractiveAzureServiceTokenProviderBase>
                 {
+                    new MsiAccessTokenProvider(),
                     new VisualStudioAccessTokenProvider(new ProcessManager()),
                     new AzureCliAccessTokenProvider(new ProcessManager()),
 #if FullNetFx


### PR DESCRIPTION
## Description
In situations requiring cross-tenant auth, it is currently not possible to use MSI to fetch an access token directly. In these scenarios, it would be helpful to be able to use a client certificate grant, but with the certificate stored in (and retrieved from) Key Vault.

Currently, this workflow is supported, but only for "development-like" environments (i.e. through the Visual Studio or Azure CLI token flows). This commit makes it possible for a service to use its managed identity to retrieve a Key Vault access token for client certificate grants.

_I'm very happy to take any and all feedback on this PR, for example I'm not sure if I need to update release notes/versions/etc. with this change. Please let me know!_

---

This checklist is used to make sure that common guidelines for a pull request are followed.
- [ ] ~~Please add REST spec PR link to the SDK PR~~ _[Not applicable?]_
- [x] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md).**
- [x] **The pull request does not introduce [breaking changes](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/Documentation/breaking-changes.md).** _[I do not believe this is a breaking change, as the `KeyVaultClient` will [fall through](https://github.com/Azure/azure-sdk-for-net/blob/e2cab23a59f309ba142f7ab119d3a42c93fb23ed/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/KeyVault/KeyVaultClient.cs#L142-L155) to the remaining token providers in non-MSI environments.]_

### [General Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#general-guidelines)
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/dev/documentation/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#testing-guidelines)
- [ ] Pull request includes test coverage for the included changes. _[The change is not currently tested, but neither is the existing list of token providers for `KeyVaultClient`. I'm happy to take advice on how this could be tested!]_

### [SDK Generation Guidelines](https://github.com/Azure/azure-sdk-for-net/blob/AutoRest/.github/CONTRIBUTING.md#sdk-generation-guidelines)

_[Removed as not applicable.]_
