### PR TITLE
Re-enable the version check for the HttpRequestMessage

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -69,6 +69,10 @@ jobs:
       - task: DotNetCoreCLI@2
         displayName: 'Build & Test (no live tests)'
         condition: eq(variables['System.TeamProject'], 'public')
+        env:
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+          DOTNET_CLI_TELEMETRY_OPTOUT: 1
+          DOTNET_MULTILEVEL_LOOKUP: 0
         inputs:
           command: test
           projects: '$(ProjectFile)'
@@ -78,6 +82,9 @@ jobs:
         displayName: 'Build & Test (with live tests)'
         condition: ne(variables['System.TeamProject'], 'public')
         env:
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+          DOTNET_CLI_TELEMETRY_OPTOUT: 1
+          DOTNET_MULTILEVEL_LOOKUP: 0
           AZ_CONFIG_CONNECTION: $(AzConfigConnectionString)
         inputs:
           command: test

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/MockHttpClientTransport.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/MockHttpClientTransport.cs
@@ -249,7 +249,7 @@ namespace Azure.ApplicationModel.Configuration.Test
         {
             Assert.AreEqual(_expectedMethod, request.Method);
             _expectedUri.Verify(request.RequestUri.ToString());
-            //Assert.AreEqual(new Version(2, 0), request.Version);
+            Assert.AreEqual(new Version(2, 0), request.Version);
         }
 
         void VerifyRequestContent(HttpRequestMessage request)


### PR DESCRIPTION
When porting the code for the AzConfg service we disabled a version check as that was causing tests to fail depending on what version of .NET you are running the code.

Re-enabling this check and making sure it works as expected.

Fixes #5253 
Fixes #5198