### PR TITLE
Adding support for user-assigned identities for App Services

### DIFF
--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/EndtoEndPositiveTests.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/EndtoEndPositiveTests.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.IntegrationTests
                     connectionString = $"RunAs=App;AppId={app.AppId};TenantId={_tenantId};{thumbprintOrSubjectName};CertificateStoreLocation={Constants.CurrentUserStore};";
                     break;
                 case CertIdentifierType.KeyVaultCertificateSecretIdentifier:
-                    connectionString = $"RunAs=App;AppId={app.AppId};TenantId={_tenantId};CertificateKeyVaultCertificateSecretIdentifier={testCertUrl};";
+                    connectionString = $"RunAs=App;AppId={app.AppId};TenantId={_tenantId};KeyVaultSecretIdentifier={testCertUrl};";
                     break;
             }
             

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/Microsoft.Azure.Services.AppAuthentication.IntegrationTests.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.IntegrationTests/Microsoft.Azure.Services.AppAuthentication.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+        <TargetFrameworks>net472;net452;netcoreapp2.0</TargetFrameworks>
     </PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
 		<DefineConstants>net472;FullNetFx</DefineConstants>		

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Constants.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Constants.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.TestCommon
         public static readonly string AzureCliConnectionStringNoRunAs = "DeveloperTool=AzureCLI";
         public static readonly string ActiveDirectoryIntegratedConnectionString = "RunAs=CurrentUser;";
         public static readonly string ManagedServiceIdentityConnectionString = "RunAs=App;";
-        public static readonly string ManagedUserAssignedIdentityConnectionString = $"RunAs=App;AppId={TestUserAssignedManagedIdentityId};TenantId={TenantId}";
+        public static readonly string ManagedUserAssignedIdentityConnectionString = $"RunAs=App;AppId={TestUserAssignedManagedIdentityId}";
         public static readonly string CertificateConnStringThumbprintLocalMachine = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateThumbprint=123;CertificateStoreLocation=LocalMachine";
         public static readonly string CertificateConnStringThumbprintInvalidLocation = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateThumbprint=123;CertificateStoreLocation=InvalidLocation";
         public static readonly string AppConnStringNoLocationOrAppKey = $"RunAs=App;AppId={TestAppId};TenantId={TenantId};CertificateThumbprint=123;";

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Microsoft.Azure.Services.AppAuthentication.TestCommon.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.TestCommon/Microsoft.Azure.Services.AppAuthentication.TestCommon.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>     
+        <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>     
     </PropertyGroup>
     <ItemGroup>
         <ProjectReference Include="..\Azure.Services.AppAuthentication\Microsoft.Azure.Services.AppAuthentication.csproj" />

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Microsoft.Azure.Services.AppAuthentication.Unit.Tests.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Microsoft.Azure.Services.AppAuthentication.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 <Import Project="$([MSBuild]::GetPathOfFileAbove('test.props'))" />
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.0;net452</TargetFrameworks>
+        <TargetFrameworks>net472;net452;netcoreapp2.0</TargetFrameworks>
     </PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'net472'">
 		<DefineConstants>net472;FullNetFx</DefineConstants>		

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockMsi.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/Mocks/MockMsi.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         {
             MsiAppServicesUnauthorized,
             MsiAppServicesSuccess,
+            MsiUserAssignedIdentityAppServicesSuccess,
             MsiAppServicesFailure,
             MsiAzureVmSuccess,
             MsiUserAssignedIdentityAzureVmSuccess,
@@ -104,10 +105,19 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
                     };
                     break;
 
+                case MsiTestType.MsiUserAssignedIdentityAppServicesSuccess:
+                    responseMessage = new HttpResponseMessage
+                    {
+                        Content = new StringContent(TokenHelper.GetManagedIdentityAppServicesTokenResponse(),
+                            Encoding.UTF8,
+                            Constants.JsonContentType)
+                    };
+                    break;
+
                 case MsiTestType.MsiUserAssignedIdentityAzureVmSuccess:
                     responseMessage = new HttpResponseMessage
                     {
-                        Content = new StringContent(TokenHelper.GetManagedIdentityTokenResponse(),
+                        Content = new StringContent(TokenHelper.GetManagedIdentityAzureVmTokenResponse(),
                             Encoding.UTF8,
                             Constants.JsonContentType)
                     };

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication.Unit.Tests/TokenHelper.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             byte[] tokenAsBytes = Convert.FromBase64String(accessToken);
             string tokenAsString = Encoding.ASCII.GetString(tokenAsBytes);
-            tokenAsString = tokenAsString.Replace("[exp]", $"{(long) timeSpan.TotalSeconds + secondsFromCurrent}");
+            tokenAsString = tokenAsString.Replace("[exp]", $"{(long)timeSpan.TotalSeconds + secondsFromCurrent}");
             tokenAsBytes = Encoding.ASCII.GetBytes(tokenAsString);
             return Convert.ToBase64String(tokenAsBytes);
         }
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
 
             midPart = UpdateTokenTime(midPart, secondsFromCurrent);
 
-            return 
+            return
                 "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USIsImtpZCI6IlZXVkljMVdEMVRrc2JiMzAxc2FzTTVrT3E1USJ9" + "." + midPart + "." + "gGo1wCH2k8kqt6JUdjBMavZX9Sq2L_tKLvVDPUJv3NurZT5JGYyS7gJ11RMrVaxyG48dnlWat1vEBcB-YLOkpL-2gR_sSAoAStPuz8yXAFHxluw-WOqiWxlm2leENqwMmCrMYinm8ohkrScpfRFm6-4fzgczdhNi0vjkTHaycYnrPrH9cZHSL9Qyzt6MH6pEyGct4zmgASI1Vlrga5_x_x8xj-FscIRYorrvx61fThaor8M4FjzglNgum4j5yecn1pIcp75CK43xb7e4jdsfL2nl6wgn5mZj_59b_aKNa3_VA-NmZTlxjvjlL_AHdDkYPlku_B75-0EbfKN2IR5eLw";
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        ///  The response has claims as expected from Azure App Service MSI response
+        ///  The response has claims as expected from App Service MSI response
         /// </summary>
         /// <returns></returns>
         internal static string GetMsiAppServicesTokenResponse()
@@ -84,14 +84,25 @@ namespace Microsoft.Azure.Services.AppAuthentication.Unit.Tests
         }
 
         /// <summary>
-        ///  The response has claims as expected from MSI response with user-assigned managed identity
+        ///  The response has claims as expected from App Service MSI response with user-assigned managed identity
         /// </summary>
         /// <returns></returns>
-        internal static string GetManagedIdentityTokenResponse()
+        internal static string GetManagedIdentityAppServicesTokenResponse()
         {
             return
-                "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6IjdfWnVmMXR2a3dMeFlhSFMzcTZsVWpVWUlHdyIsImtpZCI6IjdfWnVmMXR2a3dMeFlhSFMzcTZsVWpVWUlHdyJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNTM2MDkxMTk1LCJuYmYiOjE1MzYwOTExOTUsImV4cCI6MTUzNjEyMDI5NSwiYWlvIjoiNDJCZ1lJaW8zK3N1cE1XOVcrZWd4UGZNK3pFbUFBPT0iLCJhcHBpZCI6Ijk0MjM0M2IxLTRhZjItNDkwYy1iNmQ5LTkyNTBiOGYyODA4YyIsImFwcGlkYWNyIjoiMiIsImVfZXhwIjoyODgwMDAsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJvaWQiOiJiMzllNTZiZS1jZThiLTQyYjAtYjY3ZS0xYWI5YmU4ODUxZmQiLCJzdWIiOiJiMzllNTZiZS1jZThiLTQyYjAtYjY3ZS0xYWI5YmU4ODUxZmQiLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1dGkiOiJtcVk3QnJfOENVS3hnd1JteW11RkFBIiwidmVyIjoiMS4wIiwieG1zX21pcmlkIjoiL3N1YnNjcmlwdGlvbnMvYmRkNzg5ZjMtZDlkMS00YmVhLWFjMTQtMzBhMzllZDY2ZDMzL3Jlc291cmNlZ3JvdXBzL3Rlc3RiZWQvcHJvdmlkZXJzL01pY3Jvc29mdC5NYW5hZ2VkSWRlbnRpdHkvdXNlckFzc2lnbmVkSWRlbnRpdGllcy9UZXN0QmVkTWFuYWdlZElkZW50aXR5In0.ic31ZbWlTJ72DLGDmwbuPQJi1Lw_pw7UdBUauXD9MpDznSts2j3GXpa9mldiEeTeUAKtygt2ncnjStUaIlxfh94wxT37V5NElEwE2yVjY1mD1yRkTN9MIB8QQijkzNgzKms6y-zWn0i7oLCV6fdOZInrSLB9zd_X4AJI4LAGLvpzzt7cemNYRtNH4OJa3tTQP6vxh5wLY_gVlfSnOe1zX2RCXcOX3SC4YgOdo-L0n9w4iMV4HrQo6sfN5F5Rtaqi4MlwsuNuMiPZO0S8B73Qy3SFMQD3P2j_u47c5TI-PBa69ORqIEtbdg9FUIjY1_dBKgruJCXSm9tA0WvX-P0u5A\",\"client_id\":\"942343b1-4af2-490c-b6d9-9250b8f2808c\",\"expires_in\":\"28799\",\"expires_on\":\"1536120295\",\"ext_expires_in\":\"288000\",\"not_before\":\"1536091195\",\"resource\":\"https://vault.azure.net/\",\"token_type\":\"Bearer\"}";
+                "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ii1zeE1KTUxDSURXTVRQdlp5SjZ0eC1DRHh3MCIsImtpZCI6Ii1zeE1KTUxDSURXTVRQdlp5SjZ0eC1DRHh3MCJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNTUwMjc3NjYwLCJuYmYiOjE1NTAyNzc2NjAsImV4cCI6MTU1MDMwNjc2MCwiYWlvIjoiNDJKZ1lPaWZHRnlZUFgrSnRsbXQvdTFucjdjMkFBQT0iLCJhcHBpZCI6Ijk0MjM0M2IxLTRhZjItNDkwYy1iNmQ5LTkyNTBiOGYyODA4YyIsImFwcGlkYWNyIjoiMiIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJvaWQiOiJiMzllNTZiZS1jZThiLTQyYjAtYjY3ZS0xYWI5YmU4ODUxZmQiLCJzdWIiOiJiMzllNTZiZS1jZThiLTQyYjAtYjY3ZS0xYWI5YmU4ODUxZmQiLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1dGkiOiJUVW9za19PbGkwNlMzZGh6TXVsOEFBIiwidmVyIjoiMS4wIiwieG1zX21pcmlkIjoiL3N1YnNjcmlwdGlvbnMvYmRkNzg5ZjMtZDlkMS00YmVhLWFjMTQtMzBhMzllZDY2ZDMzL3Jlc291cmNlZ3JvdXBzL3Rlc3RiZWQvcHJvdmlkZXJzL01pY3Jvc29mdC5NYW5hZ2VkSWRlbnRpdHkvdXNlckFzc2lnbmVkSWRlbnRpdGllcy9UZXN0QmVkTWFuYWdlZElkZW50aXR5In0.l1E07vTtwSCFasXuFMw1QQXzZutZxFYRjtJhO0L5jyni6L9FO8B2azuIb6ot2KoS5TY-jcvJiLuX-e1Nxu4GlrVAMBukRKjxsyHhYQJ9vppVu7vPFG9EY-GCcamsgkoh6ItbYhDD6sRBqUjTGG2I7lvKNhLg2g92KZiwDhXVtfDPwWLMrnZKmuwOOBwU5UZ61poAmZvw5NO5a8pvXqJ1s5koKo8aPjnCdkJ5WA2SvLbGM_VMo5O6WgLgB4UTC_LnNvsp5nzie2W6Z-VnM_Ar3w1KMeP6_xJZAyEVsxQIgIF3hy12iekpvViwXXUzvthjpeoFobvn65l6NX7fIrNZNQ\",\"expires_on\":\"2/16/2019 8:46:00 AM +00:00\",\"resource\":\"https://vault.azure.net/\",\"token_type\":\"Bearer\"}";
         }
+
+        /// <summary>
+        ///  The response has claims as expected from Azure VM MSI response with user-assigned managed identity
+        /// </summary>
+        /// <returns></returns>
+        internal static string GetManagedIdentityAzureVmTokenResponse()
+        {
+            return
+                "{\"access_token\":\"eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ii1zeE1KTUxDSURXTVRQdlp5SjZ0eC1DRHh3MCIsImtpZCI6Ii1zeE1KTUxDSURXTVRQdlp5SjZ0eC1DRHh3MCJ9.eyJhdWQiOiJodHRwczovL3ZhdWx0LmF6dXJlLm5ldC8iLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC83MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDcvIiwiaWF0IjoxNTUwMjc4NDkwLCJuYmYiOjE1NTAyNzg0OTAsImV4cCI6MTU1MDMwNzU5MCwiYWlvIjoiNDJKZ1lBaU9YWmxSWXBlZitYcWZaZEFpTnMyN0FBPT0iLCJhcHBpZCI6Ijk0MjM0M2IxLTRhZjItNDkwYy1iNmQ5LTkyNTBiOGYyODA4YyIsImFwcGlkYWNyIjoiMiIsImlkcCI6Imh0dHBzOi8vc3RzLndpbmRvd3MubmV0LzcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0Ny8iLCJvaWQiOiJiMzllNTZiZS1jZThiLTQyYjAtYjY3ZS0xYWI5YmU4ODUxZmQiLCJzdWIiOiJiMzllNTZiZS1jZThiLTQyYjAtYjY3ZS0xYWI5YmU4ODUxZmQiLCJ0aWQiOiI3MmY5ODhiZi04NmYxLTQxYWYtOTFhYi0yZDdjZDAxMWRiNDciLCJ1dGkiOiJaUHZPY0tPUE4wYVZicm9lZmhNQUFBIiwidmVyIjoiMS4wIiwieG1zX21pcmlkIjoiL3N1YnNjcmlwdGlvbnMvYmRkNzg5ZjMtZDlkMS00YmVhLWFjMTQtMzBhMzllZDY2ZDMzL3Jlc291cmNlZ3JvdXBzL3Rlc3RiZWQvcHJvdmlkZXJzL01pY3Jvc29mdC5NYW5hZ2VkSWRlbnRpdHkvdXNlckFzc2lnbmVkSWRlbnRpdGllcy9UZXN0QmVkTWFuYWdlZElkZW50aXR5In0.TxlAPmz2_xAgIQUtrz0zP7Y2iid7tiQg3SEMOAMW6P69NngKBR8JZWMZ20K01rHarrxsb_7IaKwFpK4MHadv-ZNcjXeGgA_FdnxKkluNArjCAj-2n3wLeZVE3o8kbmrBCuosEwUCyH69wHINABmz3xLnO5c9OUQXjK7-Z73DfV1ZYWXXBE2HzQlNAyKbTcd4GQng22REahKFj4snuDTt_dvXg1s8pkrnqsz-fCHf1QHK6mk_ds-Y4uz40SyLlVJ_i4PxZtLZYcl-kS-ol0qEKdxYE6ghAVzuwF6DbX-2LAw2QY2mcMIOttyCw4r1V-lTVuTenrG2uOM7syBTJ-4y4A\",\"client_id\":\"942343b1-4af2-490c-b6d9-9250b8f2808c\",\"expires_in\":\"28800\",\"expires_on\":\"1550307590\",\"ext_expires_in\":\"28800\",\"not_before\":\"1550278490\",\"resource\":\"https://vault.azure.net/\",\"token_type\":\"Bearer\"}";
+        }
+
 
         /// <summary>
         ///  The response from MSI missing token

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderFactory.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/AzureServiceTokenProviderFactory.cs
@@ -77,13 +77,13 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 if (connectionSettings.ContainsKey(AppId))
                 {
                     ValidateAttribute(connectionSettings, AppId, connectionString);
-                    ValidateAttribute(connectionSettings, TenantId, connectionString);
 
                     if (connectionSettings.ContainsKey(CertificateStoreLocation))
                     {
                         ValidateAttributes(connectionSettings, new List<string> { CertificateSubjectName, CertificateThumbprint }, connectionString);
                         ValidateAttribute(connectionSettings, CertificateStoreLocation, connectionString);
                         ValidateStoreLocation(connectionSettings, connectionString);
+                        ValidateAttribute(connectionSettings, TenantId, connectionString);
 
                         azureServiceTokenProvider =
                             new ClientCertificateAzureServiceTokenProvider(
@@ -107,6 +107,8 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     }
                     else if (connectionSettings.ContainsKey(KeyVaultSecretIdentifier))
                     {
+                        ValidateAttribute(connectionSettings, TenantId, connectionString);
+
                         azureServiceTokenProvider =
                             new ClientCertificateAzureServiceTokenProvider(
                                 connectionSettings[AppId],
@@ -119,6 +121,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
                     else if (connectionSettings.ContainsKey(AppKey))
                     {
                         ValidateAttribute(connectionSettings, AppKey, connectionString);
+                        ValidateAttribute(connectionSettings, TenantId, connectionString);
 
                         azureServiceTokenProvider =
                             new ClientSecretAccessTokenProvider(

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -2,17 +2,15 @@
     <PropertyGroup>
         <PackageId>Microsoft.Azure.Services.AppAuthentication</PackageId>
         <Description>Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.</Description>
-        <Version>1.2.0-preview</Version>
+        <Version>1.2.0-preview2</Version>
         <AssemblyName>Microsoft.Azure.Services.AppAuthentication</AssemblyName>
         <PackageTags>Azure Authentication AppAuthentication</PackageTags>
 	<PackageReleaseNotes>
 		<![CDATA[
 			Documentation can be found at https://go.microsoft.com/fwlink/p/?linkid=862452.
 			
-			Adding new method GetAuthResultAsync to AzureServiceTokenProvider
-			Adding support for user-assigned managed identities
-			Adding support for simplified Azure AD certificate roll-over (subject name and issuer authentication)
-			Adding new connection string option to specify Key Vault secret identifier for service principal certificate credential
+			Adding support for user-assigned managed identities for App Services
+			Removing TenantId as a required connection string parameter for auth flows that use managed identities
 		]]>
 	</PackageReleaseNotes>
     </PropertyGroup>
@@ -20,29 +18,32 @@
         <Content Include="build\*.targets" PackagePath="build\" />
     </ItemGroup>
     <PropertyGroup>
-        <TargetFrameworks>net452;net461;netstandard1.4;netstandard2.0</TargetFrameworks>
+        <TargetFrameworks>net472;net452;net461;netstandard2.0;netstandard1.4</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>
         <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.4" />
     </ItemGroup>
 
+    <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
+        <Reference Include="System.Net.Http" />
+    </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
         <Reference Include="System.Net.Http" />
     </ItemGroup>
 
-    <ItemGroup Condition="'$(TargetFramework)' == 'net461'">
-        <Reference Include="System.Net.Http" />
-    </ItemGroup>
-    
-    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
-        <PackageReference Include="System.Diagnostics.Process">
-            <Version>4.3.0</Version>
-        </PackageReference>
-    </ItemGroup>
     <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
         <PackageReference Include="System.Diagnostics.Process">
             <Version>4.3.0</Version>
         </PackageReference>
     </ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
+        <PackageReference Include="System.Diagnostics.Process">
+            <Version>4.3.0</Version>
+        </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/TokenProviders/MsiAccessTokenProvider.cs
@@ -46,14 +46,15 @@ namespace Microsoft.Azure.Services.AppAuthentication
                 string msiSecret = Environment.GetEnvironmentVariable("MSI_SECRET");
                 var isAppServicesMsiAvailable = !string.IsNullOrWhiteSpace(msiEndpoint) && !string.IsNullOrWhiteSpace(msiSecret);
 
-                // If managed identity is specified, include client_id parameter in request
+                // If managed identity is specified, include client ID parameter in request
+                string clientIdParameterName = isAppServicesMsiAvailable ? "clientid" : "client_id";
                 string clientIdParameter = _managedIdentityClientId != default(string)
-                    ? $"&client_id={_managedIdentityClientId}"
+                    ? $"&{clientIdParameterName}={_managedIdentityClientId}"
                     : string.Empty;
 
                 // Craft request as per the MSI protocol
                 var requestUrl = isAppServicesMsiAvailable
-                    ? $"{msiEndpoint}?resource={resource}&api-version=2017-09-01"
+                    ? $"{msiEndpoint}?resource={resource}{clientIdParameter}&api-version=2017-09-01"
                     : $"{AzureVmIdmsEndpoint}?resource={resource}{clientIdParameter}&api-version=2018-02-01";
 
                 // Use the httpClient specified in the constructor. If it was not specified in the constructor, use the default httpclient. 


### PR DESCRIPTION
Adding support for user-assigned managed identities for App Services
Removing TenantId as a required connection string parameter for auth flows that use managed identities