### PR TITLE
Retry-After header was consumed in milliseconds

### DIFF
--- a/src/SdkCommon/ClientRuntime/ClientRuntime/RetryAfterDelegatingHandler.cs
+++ b/src/SdkCommon/ClientRuntime/ClientRuntime/RetryAfterDelegatingHandler.cs
@@ -3,6 +3,7 @@
 
 namespace Microsoft.Rest
 {
+    using System;
     using System.Globalization;
     using System.Linq;
     using System.Net;
@@ -58,7 +59,7 @@ namespace Microsoft.Rest
                             var retryAfter = int.Parse(retryValue, CultureInfo.InvariantCulture);
                             
                             // wait for that duration
-                            await Task.Delay(retryAfter,cancellationToken);
+                            await Task.Delay(TimeSpan.FromSeconds(retryAfter), cancellationToken);
 
                             // and try again
                             continue;


### PR DESCRIPTION
Retry-After header is returned as int representing seconds.
In the SDK it was handled as milliseconds which cause the SDK to retry x1000 faster 