### PR TITLE
[NO MERGE] Added AsyncEnumerable-based ConfigurationClient.GetAll

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <LangVersion>7.2</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationMockTests.cs
@@ -215,9 +215,18 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var query = new BatchRequestOptions();
 
+            // if the consumer has C# 8.0
             int keyIndex = 0;
             await foreach (var value in service.GetAllAsync(query, default)) {
                 Assert.AreEqual("key" + keyIndex.ToString(), value.Key);
+                keyIndex++;
+            }
+
+            // if the consumer does not have C# 8.0
+            keyIndex = 0;
+            var enumerator = service.GetAllAsync(query, default);
+            while(await enumerator.MoveNextAsync()) {
+                Assert.AreEqual("key" + keyIndex.ToString(), enumerator.Current.Key);
                 keyIndex++;
             }
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationMockTests.cs
@@ -205,6 +205,26 @@ namespace Azure.ApplicationModel.Configuration.Tests
         }
 
         [Test]
+        public async Task GetAll()
+        {
+            var transport = new GetBatchMockTransport(5);
+            transport.Batches.Add((0, 4));
+            transport.Batches.Add((4, 1));
+
+            var (service, pool) = CreateTestService(transport);
+
+            var query = new BatchRequestOptions();
+
+            int keyIndex = 0;
+            await foreach (var value in service.GetAllAsync(query, default)) {
+                Assert.AreEqual("key" + keyIndex.ToString(), value.Key);
+                keyIndex++;
+            }
+
+            Assert.AreEqual(0, pool.CurrentlyRented);
+        }
+
+        [Test]
         public void ConfiguringTheClient()
         {
             var options = new PipelineOptions();

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/MockHttpClientTransport.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/MockHttpClientTransport.cs
@@ -154,6 +154,8 @@ namespace Azure.ApplicationModel.Configuration.Test
         }
         protected override void WriteResponseCore(HttpResponseMessage response)
         {
+            if (_currentBathIndex >= Batches.Count) _currentBathIndex = 0;
+
             var batch = Batches[_currentBathIndex++];
             var bathItems = new MockBatch();
             int itemIndex = batch.index;

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
@@ -14,13 +14,14 @@
     <RequiredTargetFrameworks>net461;netstandard2.0</RequiredTargetFrameworks>
     
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <NoWarn>3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
     <PackageReference Include="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview.19073.11">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
@@ -14,7 +14,7 @@
     <RequiredTargetFrameworks>net461;netstandard2.0</RequiredTargetFrameworks>
     
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>7.3</LangVersion>
     <NoWarn>3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
@@ -330,8 +330,6 @@ namespace Azure.ApplicationModel.Configuration
 
             public ConfigurationSetting Current => _current;
 
-            public ValueTask DisposeAsync() => default;
-
             public Enumerator GetAsyncEnumerator(CancellationToken cancellationToken = default) => this;
         }
     }


### PR DESCRIPTION
This is just an illustration, thus NO MERGE.

This PR illustrates how we can use C#8's async enumerable / foreach support to expose service call operations that return large number of items through batch operations.

Here are some caveats with the approach:
1. It somewhat hides service calls.
2. In .NET Core 3.0, there is a support for async yield return. Since we want the SDKs to work on .NET Framework and older versions of .NET Core, the async enumerators need to be implemented manually, i.e. without using yield return.
3. We cannot expose IAsyncEnumerable<T> as it exists in .NET Core 3.0 only. Instead the solution relies on duck typing (pattern) to be able to foreach the nested Enumerator class.
4. I need to think what to do with errors, quotas, access to headers, etc. in MoveNext. 
5. I am not sure what to do with the cancellation token passed to GetAsyncEnumerator. The token is passed by the compiler when the foreach statement used WithCancellation. But then, I would need to create a new instance in GetAsyncEnumerator, which I was trying to avoid (for various reasons). I will think about it more.

```c#
await foreach (var result in GetAllAsync(batchOptions).WithCancellation(token)) { ...}
```

Lastly, the build fails in the lab as I don't think it can pull C#8.0. It does build and run fine on my lacal machine with VS2019 Preview 3 installed. cc: @weshaggard 

UPDATE: changed the code such that it now does not require C#8.0, but if the caller has C#8.0, they can use nicer syntax.

UPDATE: added the ability to enumerate batches. I think we should consider changing our GetBatch APIs to it, i.e.  hide the GetBatch API. 