### PR TITLE
Moved some types to Azure root namespace

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
-using Azure.Base;
+using Azure.Base.Diagnostics;
 using Azure.Base.Http;
 using System;
 using System.Net.Http;

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Attributes/HttpErrorAttribute.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Attributes/HttpErrorAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Azure.Base
+namespace Azure.Base.Diagnostics
 {
     /// <summary>
     /// Represents errors that the application might handle.

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Attributes/KnownExceptionAttribute.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Attributes/KnownExceptionAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Azure.Base
+namespace Azure.Base.Diagnostics
 {
     public class KnownExceptionAttribute : Attribute
     {

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Attributes/UsageErrorsAttribute.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Attributes/UsageErrorsAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Azure.Base
+namespace Azure.Base.Diagnostics
 {
     /// <summary>
     /// Represents errors resulting from misuse of the API. The application code should be changed/fixed.

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/ETag.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/ETag.cs
@@ -5,7 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Text;
 
-namespace Azure.Base
+namespace Azure
 {
     public readonly struct ETag : IEquatable<ETag>
     {
@@ -13,17 +13,27 @@ namespace Azure.Base
 
         public ETag(string etag) => _ascii = Encoding.ASCII.GetBytes(etag);
 
-        public bool Equals(ETag other) => _ascii.AsSpan().SequenceEqual(other._ascii);
+        public bool Equals(ETag other)
+        {
+            if(_ascii == null) {
+                if (other._ascii == null) return true;
+                return false;
+            }
+            if (other._ascii == null) return false;
+            
+            return _ascii.AsSpan().SequenceEqual(other._ascii);
+        }
 
         public static bool operator ==(ETag left, ETag rigth) => left.Equals(rigth);
 
         public static bool operator !=(ETag left, ETag rigth) => !left.Equals(rigth);
 
-        public override string ToString() => Encoding.ASCII.GetString(_ascii);
+        public override string ToString() => _ascii == null ? "<null>" : Encoding.ASCII.GetString(_ascii);
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override int GetHashCode()
         {
+            if (_ascii == null) return 0;
             int hash = 17;
             for (int i = 0; i < _ascii.Length; i+=2)
             {

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/ETagFilter.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/ETagFilter.cs
@@ -4,7 +4,7 @@
 using System;
 using System.ComponentModel;
 
-namespace Azure.Base
+namespace Azure
 {
     public struct ETagFilter : IEquatable<ETagFilter>
     {

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/FailedResponseException.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/FailedResponseException.cs
@@ -4,7 +4,7 @@
 using Azure.Base.Http;
 using System;
 
-namespace Azure.Base
+namespace Azure
 {
     public class ResponseFailedException : Exception
     {

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Net/UriExtensions.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Net/UriExtensions.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Azure.Base
+namespace Azure.Base.Http
 {
     public static class UriExtensions
     {

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Response.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Response.cs
@@ -8,7 +8,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Text;
 
-namespace Azure.Base
+namespace Azure
 {
     public readonly struct Response
     {

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/ResponseOfT.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/ResponseOfT.cs
@@ -5,7 +5,7 @@ using System;
 using System.ComponentModel;
 using System.Text;
 
-namespace Azure.Base
+namespace Azure
 {
     public struct Response<T> : IDisposable
     {


### PR DESCRIPTION
Also, made ETag APIs resilient to default ETag value (i.e. with null byte array field)