### PR TITLE
Use package references or project references

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <!-- Project references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToBase)'=='true'">
+  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'=='true'">
     <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
   </ItemGroup>
 
@@ -34,7 +34,7 @@
   <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
     <Compile Include="..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Testing\TestPool.cs" Link="TestPool.cs" />
   <!-- Package references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
+  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'==''">
     
     <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
     <PackageReference Include="System.Text.Primitives" Version="0.1.0-preview1-180216-4" />

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
@@ -15,4 +16,19 @@
     <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
     <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Azure.Base.Tests.csproj" />
   </ItemGroup>
+
+
+  <!-- Project references -->
+  <ItemGroup Condition="'$(UseProjectReferenceToBase)'=='true'">
+    <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
+  </ItemGroup>
+  
+  <!-- Package references -->
+  <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
+    <Compile Include="..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Testing\TestPool.cs" Link="TestPool.cs" />
+    
+    <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
+    <PackageReference Include="System.Text.Primitives" Version="0.1.0-preview1-180216-4" />
+  </ItemGroup>
+
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -13,8 +13,15 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Azure.Configuration\Azure.Configuration.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Testing\TestPool.cs" Link="TestPool.cs" />
+  </ItemGroup>
+
+  <!-- Project references -->
+  <ItemGroup Condition="'$(UseProjectReferenceToBase)'=='true'">
     <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
-    <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Azure.Base.Tests.csproj" />
   </ItemGroup>
 
 
@@ -26,6 +33,8 @@
   <!-- Package references -->
   <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
     <Compile Include="..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Testing\TestPool.cs" Link="TestPool.cs" />
+  <!-- Package references -->
+  <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
     
     <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
     <PackageReference Include="System.Text.Primitives" Version="0.1.0-preview1-180216-4" />

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -5,7 +5,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
+    <PackageReference Include="System.Text.Primitives" Version="0.1.0-preview1-180216-4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Azure.Configuration\Azure.Configuration.csproj" />
@@ -34,10 +35,9 @@
   <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
     <Compile Include="..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Testing\TestPool.cs" Link="TestPool.cs" />
   <!-- Package references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'==''">
+  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'!='true'">
     
     <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
-    <PackageReference Include="System.Text.Primitives" Version="0.1.0-preview1-180216-4" />
   </ItemGroup>
 
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
-    <PackageReference Include="System.Text.Primitives" Version="0.1.0-preview1-180216-4" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Azure.Configuration\Azure.Configuration.csproj" />
@@ -24,20 +23,9 @@
   <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'=='true'">
     <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
   </ItemGroup>
-
-
-  <!-- Project references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToBase)'=='true'">
-    <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
-  </ItemGroup>
   
   <!-- Package references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
-    <Compile Include="..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Testing\TestPool.cs" Link="TestPool.cs" />
-  <!-- Package references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'!='true'">
-    
+  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'==''">
     <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
   </ItemGroup>
-
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -25,6 +25,6 @@
   
   <!-- Package references -->
   <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'==''">
-    <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
+    <PackageReference Include="Azure.Base" Version="1.0.0-preview.2" />
   </ItemGroup>
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
@@ -37,6 +37,13 @@
   </ItemGroup>
   <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
     <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
+  <!-- Project references -->
+  <ItemGroup Condition="'$(UseProjectReferenceToBase)'=='true'">
+    <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
   </ItemGroup>
 
+  <!-- Package references -->
+  <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
+    <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
+  </ItemGroup>
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
@@ -29,14 +29,6 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
-    <ProjectReference Include="..\..\..\Azure.Core\data-plane\Azure.Core\Azure.Core.csproj" />
-  <ItemGroup Condition="'$(UseProjectReferenceToBase)'=='true'">
-    <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
-    <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
   <!-- Project references -->
   <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'=='true'">
     <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
@@ -44,6 +36,6 @@
 
   <!-- Package references -->
   <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'!='true'">
-    <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
+    <PackageReference Include="Azure.Base" Version="1.0.0-preview.2" />
   </ItemGroup>
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
@@ -31,6 +31,12 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
+    <ProjectReference Include="..\..\..\Azure.Core\data-plane\Azure.Core\Azure.Core.csproj" />
+  <ItemGroup Condition="'$(UseProjectReferenceToBase)'=='true'">
+    <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
+    <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
   </ItemGroup>
 
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
@@ -38,12 +38,12 @@
   <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
     <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
   <!-- Project references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToBase)'=='true'">
+  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'=='true'">
     <ProjectReference Include="..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.csproj" />
   </ItemGroup>
 
   <!-- Package references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToBase)'==''">
+  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'==''">
     <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
   </ItemGroup>
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
@@ -43,7 +43,7 @@
   </ItemGroup>
 
   <!-- Package references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'==''">
+  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'!='true'">
     <PackageReference Include="Azure.Base" Version="1.0.0-preview.1" />
   </ItemGroup>
 </Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
-using Azure.Base.Diagnostics;
+using Azure.Base;
 using Azure.Base.Http;
 using System;
 using System.Net.Http;

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
@@ -2,7 +2,8 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
-using Azure.Base;
+using Azure;
+using Azure.Base.Diagnostics;
 using Azure.Base.Http;
 using System;
 using System.Net.Http;

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/README.md
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/README.md
@@ -39,3 +39,12 @@ public async Task HelloWorld()
 1. [How to access diagnostic logs](https://github.com/Azure/azure-sdk-for-net/tree/master/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample4_Logging.cs)
 2. [How to configure retry policy](https://github.com/Azure/azure-sdk-for-net/tree/master/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample6_ConfiguringRetries.cs)
 3. [How to configure service requests](https://github.com/Azure/azure-sdk-for-net/tree/master/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample7_ConfiguringPipeline.cs)
+
+
+# Contributing
+If the changes you are working on span both Azure.Base and Azure.Configuration then you can set this environment variable before launching Visual Studio. That will use Project To Project references between Azure.Configuration and Azure.Base instead of package references.
+
+This will enable the project to project references:
+```
+set UseProjectReferenceToAzureBase=true
+```


### PR DESCRIPTION
This commit makes it such that we reference Azure.Base package from AzConfig SDK to allow it to be published.

In order to make it easier for the developer to make changes to both the pipeline as well as the AzConfig SDK the following have been done:
 - Introduce a variable `UseProjectReferenceToBase` that controls whether the references are based on package or projects
 - Link the `TestPool.cs` file during compilation of the tests -- this removes the dependency to `Azure.Base.Tests` project
 - Directly import the `System.Text.Primitives` package since it is not transitively added to the project after removing the reference to `Azure.Base.Tests` project

/cc @weshaggard @KrzysztofCwalina @maririos 

PS: This build will fail CI since we don't have the Azure.Base package published yet on NuGet.org.