### PR TITLE
Update new projects to remove duplicated properties

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -1,7 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
-    <LangVersion>7.2</LangVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/Azure.Configuration.csproj
@@ -10,15 +10,11 @@
       ]]>
     </PackageReleaseNotes>
 
-    <!-- This is a workaorund until https://github.com/Azure/azure-sdk-for-net/issues/5214 is addressed -->
-    <RequiredTargetFrameworks>net461;netstandard2.0</RequiredTargetFrameworks>
-    
     <!-- Make sure that we don't pull in additional dependencies during build or package -->
     <ImportDefaultReferences>false</ImportDefaultReferences>
 
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
-    <NoWarn>3021</NoWarn>
+    <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/Azure.Base.Tests.csproj
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/Azure.Base.Tests.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
     <ProjectGuid>{84491222-6C36-4FA7-BBAE-1FA804129151}</ProjectGuid>
-    <LangVersion>7.2</LangVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.csproj
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.csproj
@@ -16,7 +16,6 @@
     <ImportDefaultReferences>false</ImportDefaultReferences>
     
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 


### PR DESCRIPTION
The common properties/targets file now correctly detect and set
the LangVersion=latest and the RequiredTargetFrameworks to match
ns2.0/net461 for client libraries.

cc @AlexGhiondea 

Target frameworks get set here now https://github.com/Azure/azure-sdk-for-net/blob/master/eng/Directory.Build.Data.props#L20 and these libraries correctly get detected as Client Libraries because of https://github.com/Azure/azure-sdk-for-net/blob/master/Directory.Build.props#L6.

For test projects we also already set IsPackage=false at https://github.com/Azure/azure-sdk-for-net/blob/master/eng/Directory.Build.Data.targets#L19 so we can remove those from the projects. 