### PR TITLE
Adding Impression Pixel

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -60,3 +60,6 @@ These SDKs depend on Microsoft.Rest.ClientRuntime.Azure
 Please see at [Azure documentation](https://azure.microsoft.com/en-us/documentation/api/) for more details
 
 
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2FDocumentation%2FREADME.png)

--- a/README.md
+++ b/README.md
@@ -168,3 +168,6 @@ Much of the SDK code is generated from metadata specs about the REST APIs. Do no
   - File an issue describing the problem,
   - Refer to the the [AutoRest project](https://github.com/azure/autorest) to view and modify the generator, or
   - Add additional methods, properties, and overloads to the SDK by adding classes in the 'Customizations' folder of a project
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2FREADME.png)

--- a/sdk/Template/Azure.Template/README.md
+++ b/sdk/Template/Azure.Template/README.md
@@ -96,3 +96,5 @@ If the package or a related package supports it, include tips for logging or ena
 <!-- LINKS -->
 [style-guide-msft]: https://docs.microsoft.com/style-guide/capitalization
 [style-guide-cloud]: https://worldready.cloudapp.net/Styleguide/Read?id=2696&topicid=25357
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2FTemplate%2FAzure.Template%2FREADME.png)

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/Readme.md
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/Readme.md
@@ -14,3 +14,6 @@ Run:
     3. Double check your active subscription value by doing `az account show`
 5. From the output, get the first connection string and add it as `AZ_CONFIG_CONNECTION` environment variable's value.
 6. Make sure to restart VS or the environment where the tests are running.
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FAzure.ApplicationModel.Configuration%2Fdata-plane%2FAzure.Configuration.Tests%2FReadme.png)

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/README.md
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/README.md
@@ -48,3 +48,5 @@ This will enable the project to project references:
 ```
 set UseProjectReferenceToAzureBase=true
 ```
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FAzure.ApplicationModel.Configuration%2Fdata-plane%2FREADME.png)

--- a/src/SDKs/Azure.Base/data-plane/README.md
+++ b/src/SDKs/Azure.Base/data-plane/README.md
@@ -43,3 +43,6 @@ public async Task HelloWorld()
 # Other Samples
 
 Comming soon ...
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FAzure.Base%2Fdata-plane%2FREADME.png)

--- a/src/SDKs/Batch/DataPlane/README.md
+++ b/src/SDKs/Batch/DataPlane/README.md
@@ -46,3 +46,6 @@ There are a number of special flags which have meaning in the `BatchProperties.j
  
 Once `BatchProperties.json` is updated with your changes, mark the `ObjectModelCodeGenerator` as your startup project in Visual Studio and run it -- it will regenerate the contents of the `src\Generated` folder.
 
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FBatch%2FDataPlane%2FREADME.png)

--- a/src/SDKs/Batch/Support/FileConventions/README.md
+++ b/src/SDKs/Batch/Support/FileConventions/README.md
@@ -134,3 +134,6 @@ then its path within the container is "analysis-309/$TaskLog/analytics.log".
 The purpose behind this structure is to enable clients to readily locate
 outputs based on their kind - for example, "list the main outputs of the job"
 or "list the log files for task analysis-309".
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FBatch%2FSupport%2FFileConventions%2FREADME.png)

--- a/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Readme.md
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/TextAnalytics/TextAnalytics/Readme.md
@@ -15,3 +15,5 @@
 ## Build Instructions:
 
 To build this project, please follow the instructions [here](https://github.com/Azure/azure-sdk-for-net/blob/psSdkJson6/README.md).
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FCognitiveServices%2FdataPlane%2FLanguage%2FTextAnalytics%2FTextAnalytics%2FReadme.png)

--- a/src/SDKs/DataMigration/Management.DataMigration/README.md
+++ b/src/SDKs/DataMigration/Management.DataMigration/README.md
@@ -1,2 +1,4 @@
 # Swagger JSON
 This is a swagger JSON built by the [swagger-codegen](https://github.com/swagger-api/swagger-codegen) project.
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FDataMigration%2FManagement.DataMigration%2FREADME.png)

--- a/src/SDKs/KeyVault/data-plane/README.md
+++ b/src/SDKs/KeyVault/data-plane/README.md
@@ -79,3 +79,5 @@ Code samples for the Azure Key Vault SDK are available on [Azure Code Samples](h
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information 
 see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) 
 with any additional questions or comments.
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FKeyVault%2Fdata-plane%2FREADME.png)

--- a/src/SDKs/PostgreSQL/Management.PostgreSQL/README.md
+++ b/src/SDKs/PostgreSQL/Management.PostgreSQL/README.md
@@ -1,2 +1,4 @@
 # Swagger JSON
 This is a swagger JSON built by the [swagger-codegen](https://github.com/swagger-api/swagger-codegen) project.
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2FPostgreSQL%2FManagement.PostgreSQL%2FREADME.png)

--- a/src/SDKs/_metadata/readme.md
+++ b/src/SDKs/_metadata/readme.md
@@ -9,3 +9,6 @@ Historically, this information was only stored in `generate.cmd` files per servi
 
 The metadata file addresses these problems since it is auto-generated when generating the SDK. No matter whether the `generate.cmd` of an SDK uses the latest or a specific version of AutoRest or whether it uses a fork/branch of the specs repository: The metadata will contain the information necessary to reproduce these steps.
 The `generate.cmd` has to be updated only if the *strategy* of code generation changes, but not with every regeneration due to commit IDs.
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSDKs%2F_metadata%2Freadme.png)

--- a/src/SdkCommon/AppAuthentication/README.md
+++ b/src/SdkCommon/AppAuthentication/README.md
@@ -51,3 +51,5 @@ Before running these test cases, ensure that you
 On Windows, open a command prompt, navigate to the integration test folder, and run **dotnet test**. This will run tests for both .NET 4.5.2 and .NET Standard 1.4. 
 
 On Linux, open a command prompt, navigate to the integration test folder, and run **dotnet test -f netcoreapp1.1**. This will run tests for .NET Standard 1.4. 
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSdkCommon%2FAppAuthentication%2FREADME.png)

--- a/src/SdkCommon/ClientRuntime.Etw/README.md
+++ b/src/SdkCommon/ClientRuntime.Etw/README.md
@@ -9,3 +9,6 @@ Exposes AutoRest Generated Libraries events via ETW (Event Tracing for Windows).
 ServiceClientInterceptor.AddTracingInterceptor(new EtwTracingInterceptor());
 ```
 2. Use a tool such as [PerfView](http://www.microsoft.com/en-us/download/details.aspx?id=28567) to capture events under the ```Microsoft.Rest``` provider.
+
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSdkCommon%2FClientRuntime.Etw%2FREADME.png)

--- a/src/SdkCommon/ClientRuntime.Log4Net/README.md
+++ b/src/SdkCommon/ClientRuntime.Log4Net/README.md
@@ -40,3 +40,5 @@ Using Log4Net for AutoRest Generated Clients:
 	ServiceClientTracing.AddTracingInterceptor(new Log4NetTracingInterceptor());
 	ServiceClientTracing.IsEnabled = true;
 ```
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsrc%2FSdkCommon%2FClientRuntime.Log4Net%2FREADME.png)

--- a/tools/legacy/ScriptBackup/autogenForSwaggers/readme.md
+++ b/tools/legacy/ScriptBackup/autogenForSwaggers/readme.md
@@ -62,3 +62,5 @@ Optional `dotNet` properties:
 |`dotNet.ft`       |an AutoRest flattering parameter|`0`                                                 |`0`                                 |
 |`dotNet.commit`   |a specification commit id       |current commit id                                   |`undefined`                         |
 |`dotNet.autorest` |an AutoRest package             |current AutoRest                                    |`undefined`                         |
+
+![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions?path=azure-sdk-for-net%2F%2Ftools%2Flegacy%2FScriptBackup%2FautogenForSwaggers%2Freadme.md)


### PR DESCRIPTION
Peter and co want to be able to see distribution of viewership in the context of all this Track 2 work we're doing.

Adding an impression pixel is the only way currently that github can't curtail.

@Azure/azure-sdk-eng 