### PR TITLE
HttpPipelineOptions Simplification

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/ConfigurationMockTests.cs
@@ -8,7 +8,6 @@ using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Base.Testing;
-using Azure.Base;
 using Azure.Base.Http;
 using System.Buffers;
 using Azure.Base.Http.Pipeline;
@@ -35,10 +34,9 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
         private static (ConfigurationClient service, TestPool<byte> pool) CreateTestService(MockHttpClientTransport transport)
         {
-            var options = new HttpPipeline.Options();
+            HttpPipelineOptions options = ConfigurationClient.CreateDefaultPipelineOptions();
             var testPool = new TestPool<byte>();
-            options.Pool = testPool;
-
+            options.AddService(testPool, typeof(ArrayPool<byte>));
             options.Transport = transport;
 
             var service = new ConfigurationClient(connectionString, options);
@@ -207,9 +205,10 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void ConfiguringTheClient()
         {
-            var options = new HttpPipeline.Options();
+            HttpPipelineOptions options = ConfigurationClient.CreateDefaultPipelineOptions();
+
             options.ApplicationId = "test_application";
-            options.Pool = ArrayPool<byte>.Create(1024 * 1024 * 4, maxArraysPerBucket: 4);
+            options.AddService(ArrayPool<byte>.Create(1024 * 1024 * 4, maxArraysPerBucket: 4));
             options.Transport = new GetMockTransport(s_testSetting.Key, default, s_testSetting);
             options.RetryPolicy = RetryPolicy.CreateFixed(5, TimeSpan.FromMilliseconds(100), 404);
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample6_ConfiguringRetries.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample6_ConfiguringRetries.cs
@@ -16,8 +16,9 @@ namespace Azure.ApplicationModel.Configuration.Samples
         [Test]
         public async Task ConfiguringRetries()
         {
+            HttpPipelineOptions options = ConfigurationClient.CreateDefaultPipelineOptions();
+
             // specify retry policy options
-            var options = new HttpPipeline.Options();
             options.RetryPolicy = RetryPolicy.CreateFixed(
                 maxRetries: 10,
                 delay: TimeSpan.FromSeconds(1),

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample7_ConfiguringPipeline.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration.Tests/samples/Sample7_ConfiguringPipeline.cs
@@ -20,7 +20,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
         public async Task ConfiguringPipeline()
         {
             // this instance will hold pipeline creation options
-            var options = new HttpPipeline.Options();
+            HttpPipelineOptions options = ConfigurationClient.CreateDefaultPipelineOptions();
 
             // specify custon HttpClient
             options.Transport = new HttpClientTransport(s_client);
@@ -39,10 +39,10 @@ namespace Azure.ApplicationModel.Configuration.Samples
             );
 
             // add a policy (custom behavior) that executes once per client call
-            options.PerCallPolicies = new HttpPipelinePolicy[] { new AddHeaderPolicy() };
+            options.AddPerCallPolicy(new AddHeaderPolicy());
 
             // add a policy that executes once per retry
-            options.PerRetryPolicies = new HttpPipelinePolicy[] { new CustomLogPolicy() };
+            options.AddPerRetryPolicy(new CustomLogPolicy());
 
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
             // pass the policy options to the client

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient.cs
@@ -18,7 +18,9 @@ namespace Azure.ApplicationModel.Configuration
         const string ComponentVersion = "1.0.0";
 
         static readonly HttpPipelinePolicy s_defaultRetryPolicy = RetryPolicy.CreateFixed(3, TimeSpan.Zero,
+            //429, // Too Many Requests TODO (pri 2): this needs to throttle based on x-ms-retry-after 
             500, // Internal Server Error 
+            503, // Service Unavailable
             504  // Gateway Timeout
         );
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient_private.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.Configuration/ConfigurationClient_private.cs
@@ -31,7 +31,7 @@ namespace Azure.ApplicationModel.Configuration
         const string IfNoneMatch = "If-None-Match";
 
         static readonly HttpHeader MediaTypeKeyValueApplicationHeader = new HttpHeader(
-            HttpHeader.Constants.Accept,
+            HttpHeader.Names.Accept,
             Encoding.ASCII.GetBytes("application/vnd.microsoft.appconfig.kv+json")
         );
 

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/Testing/Mocks.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/Testing/Mocks.cs
@@ -60,8 +60,8 @@ namespace Azure.Base.Testing
         public MockTransport(params int[] statusCodes)
             => _statusCodes = statusCodes;
 
-        public override HttpMessage CreateMessage(HttpPipeline.Options options, CancellationToken cancellation)
-            => new Message(ref options, cancellation);
+        public override HttpMessage CreateMessage(IServiceProvider services, CancellationToken cancellation)
+            => new Message(cancellation);
 
         public override Task ProcessAsync(HttpMessage message)
         {
@@ -85,7 +85,7 @@ namespace Azure.Base.Testing
 
             public override HttpVerb Method => throw new NotImplementedException();
 
-            public Message(ref HttpPipeline.Options options, CancellationToken cancellation)
+            public Message(CancellationToken cancellation)
                 : base(cancellation)
             { }
 

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/samples/Sample1_HelloWorld.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/samples/Sample1_HelloWorld.cs
@@ -3,10 +3,10 @@
 // license information.
 
 using Azure.Base.Http;
+using Azure.Base.Http.Pipeline;
 using NUnit.Framework;
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Base.Samples
@@ -17,14 +17,12 @@ namespace Azure.Base.Samples
         [Test]
         public async Task HelloWorld()
         {
-            var cancellation = new CancellationTokenSource();
-            var options = new HttpPipeline.Options();
-            HttpPipeline pipeline = HttpPipeline.Create(options, sdkName: "test", sdkVersion: "1.0");
+            var pipeline = new HttpPipeline(new HttpClientTransport());
 
-            using (HttpMessage message = pipeline.CreateMessage(options, cancellation: default)) {
-                var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/src/SDKs/Azure.Base/data-plane/Azure.Base.sln");
+            using (HttpMessage message = pipeline.CreateMessage(cancellation: default)) {
+
+                var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/src/SDKs/Azure.Base/data-plane/README.md");
                 message.SetRequestLine(HttpVerb.Get, uri);
-
                 message.AddHeader("Host", uri.Host);
 
                 await pipeline.SendMessageAsync(message).ConfigureAwait(false);

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/HttpHeader.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/HttpHeader.cs
@@ -117,7 +117,7 @@ namespace Azure.Base.Http
         public bool Equals(HttpHeader other)
             => _utf8.AsSpan().SequenceEqual(other._utf8);
 
-        public static class Constants
+        public static class Names
         {
             static readonly byte[] s_host = Encoding.ASCII.GetBytes("Host");
             public static ReadOnlySpan<byte> Host => s_host;
@@ -131,12 +131,6 @@ namespace Azure.Base.Http
             static readonly byte[] s_contentType = Encoding.ASCII.GetBytes("Content-Type");
             public static ReadOnlySpan<byte> ContentType => s_contentType;
 
-            static readonly byte[] s_applicationJson = Encoding.ASCII.GetBytes("application/json");
-            public static ReadOnlySpan<byte> ApplicationJson => s_applicationJson;
-
-            static readonly byte[] s_applicationOctetStream = Encoding.ASCII.GetBytes("application/octet-stream");
-            public static ReadOnlySpan<byte> ApplicationOctetStream => s_applicationOctetStream;
-
             static readonly byte[] s_userAgent = Encoding.ASCII.GetBytes("User-Agent");
             public static ReadOnlySpan<byte> UserAgent => s_userAgent;
 
@@ -147,16 +141,19 @@ namespace Azure.Base.Http
 
         public static class Common
         {
-            public static readonly HttpHeader JsonContentType = new HttpHeader(Constants.ContentType, Constants.ApplicationJson);
-            public static readonly HttpHeader OctetStreamContentType = new HttpHeader(Constants.ContentType, Constants.ApplicationOctetStream);
+            static readonly byte[] s_applicationJson = Encoding.ASCII.GetBytes("application/json");
+            static readonly byte[] s_applicationOctetStream = Encoding.ASCII.GetBytes("application/octet-stream");
+
+            public static readonly HttpHeader JsonContentType = new HttpHeader(Names.ContentType, s_applicationJson);
+            public static readonly HttpHeader OctetStreamContentType = new HttpHeader(Names.ContentType, s_applicationOctetStream);
 
             static readonly string PlatfromInformation = $"({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})";
 
-            public static HttpHeader CreateUserAgent(string sdkName, string sdkVersion, string applicationId = default)
+            public static HttpHeader CreateUserAgent(string componentName, string componentVersion, string applicationId = default)
             {
                 byte[] utf8 = null;
-                if (applicationId == default) utf8 = Encoding.ASCII.GetBytes($"User-Agent:{sdkName}/{sdkVersion} {PlatfromInformation}\r\n");
-                else utf8 = Encoding.ASCII.GetBytes($"User-Agent:{applicationId} {sdkName}/{sdkVersion} {PlatfromInformation}\r\n");
+                if (applicationId == default) utf8 = Encoding.ASCII.GetBytes($"User-Agent:{componentName}/{componentVersion} {PlatfromInformation}\r\n");
+                else utf8 = Encoding.ASCII.GetBytes($"User-Agent:{applicationId} {componentName}/{componentVersion} {PlatfromInformation}\r\n");
                 return new HttpHeader(utf8);
             }
 
@@ -168,10 +165,10 @@ namespace Azure.Base.Http
 
             public static HttpHeader CreateHost(ReadOnlySpan<byte> hostName)
             {
-                var buffer = new byte[Constants.Host.Length + hostName.Length + 3];
-                Constants.Host.CopyTo(buffer);
-                buffer[Constants.Host.Length] = (byte)':';
-                hostName.CopyTo(buffer.AsSpan(Constants.Host.Length + 1));
+                var buffer = new byte[Names.Host.Length + hostName.Length + 3];
+                Names.Host.CopyTo(buffer);
+                buffer[Names.Host.Length] = (byte)':';
+                hostName.CopyTo(buffer.AsSpan(Names.Host.Length + 1));
                 buffer[buffer.Length - 1] = (byte)'\n';
                 buffer[buffer.Length - 2] = (byte)'\r';
                 return new HttpHeader(buffer);

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/HttpPipelineOptions.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/HttpPipelineOptions.cs
@@ -3,77 +3,138 @@
 
 using Azure.Base.Http.Pipeline;
 using System;
-using System.Buffers;
+using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
-using System.Threading.Tasks;
 
 namespace Azure.Base.Http
 {
-    public partial struct HttpPipeline
+    public class HttpPipelineOptions
     {
-        public class Options
-        {
-            static readonly HttpPipelinePolicy s_default = new Default();
+        ServiceContainer _container = new ServiceContainer();
 
-            HttpPipelineTransport _transport;
+        HttpPipelineTransport _transport;
+        List<HttpPipelinePolicy> _perCallPolicies;
+        List<HttpPipelinePolicy> _perRetryPolicies;
 
-            public ArrayPool<byte> Pool { get; set; } = ArrayPool<byte>.Shared;
-
-            public HttpPipelineTransport Transport {
-                get => _transport;
-                set {
-                    if (value == null) throw new ArgumentNullException(nameof(value));
-                    _transport = value;
-                }
+        public HttpPipelineTransport Transport {
+            get => _transport;
+            set {
+                if (value == null) throw new ArgumentNullException(nameof(value));
+                _transport = value;
             }
-
-            public HttpPipelinePolicy TelemetryPolicy { get; set; } = s_default;
-
-            public HttpPipelinePolicy LoggingPolicy { get; set; } = s_default;
-
-            public HttpPipelinePolicy RetryPolicy { get; set; } = s_default;
-
-            public HttpPipelinePolicy[] PerCallPolicies = Array.Empty<HttpPipelinePolicy>();
-
-            public HttpPipelinePolicy[] PerRetryPolicies = Array.Empty<HttpPipelinePolicy>();
-
-            public string ApplicationId { get; set; }
-
-            public int PolicyCount {
-                get {
-                    int numberOfPolicies = 3 + PerCallPolicies.Length + PerRetryPolicies.Length;
-                    if (LoggingPolicy == null) numberOfPolicies--;
-                    if (TelemetryPolicy == null) numberOfPolicies--;
-                    if (RetryPolicy == null) numberOfPolicies--;
-                    return numberOfPolicies;
-                }
-            }
-
-            internal static bool IsDefault(HttpPipelinePolicy policy)
-             => policy == s_default;
-
-            // TODO (pri 3): I am not happy with the design that needs a sentinel policy. 
-            sealed class Default : HttpPipelinePolicy
-            {
-                public override async Task ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
-                {
-                    Debug.Fail("default policy should be removed");
-                    await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
-                }
-            }
-
-            #region nobody wants to see these
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public override bool Equals(object obj) => base.Equals(obj);
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public override int GetHashCode() => base.GetHashCode();
-
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public override string ToString() => base.ToString();
-            #endregion
         }
+
+        public HttpPipelinePolicy LoggingPolicy { get; set; }
+
+        public HttpPipelinePolicy RetryPolicy { get; set; }
+
+        public bool DisableTelemetry { get; set; } = false;
+
+        public string ApplicationId { get; set; }
+
+        public HttpPipelineOptions( HttpPipelineTransport transport)
+            => _transport = transport;
+
+        public HttpPipelineOptions() : this( HttpClientTransport.Shared)
+        { }
+
+        public void AddPerCallPolicy(HttpPipelinePolicy policy)
+        {
+            if (policy == null) throw new ArgumentNullException(nameof(policy));
+
+            if (_perCallPolicies == null) _perCallPolicies = new List<HttpPipelinePolicy>();
+            _perCallPolicies.Add(policy);
+        }
+
+        public void AddPerRetryPolicy(HttpPipelinePolicy policy)
+        {
+            if (policy == null) throw new ArgumentNullException(nameof(policy));
+
+            if (_perRetryPolicies == null) _perRetryPolicies = new List<HttpPipelinePolicy>();
+            _perRetryPolicies.Add(policy);
+        }
+
+        public void AddService(object service, Type type = null)
+        {
+            if (service == null) throw new ArgumentNullException(nameof(service));
+
+            if (_container == null) _container = new ServiceContainer();
+            _container.Add(service, type != null ? type : service.GetType());
+        }
+
+        int PolicyCount {
+            get {
+                int numberOfPolicies = 1; // HttpPipelineTransport
+                if (DisableTelemetry == false) numberOfPolicies++; // AddHeadersPolicy
+
+                if (LoggingPolicy != null) numberOfPolicies++;
+                if (RetryPolicy != null) numberOfPolicies++;
+
+                if (_perCallPolicies != null) numberOfPolicies += _perCallPolicies.Count;
+                if (_perRetryPolicies != null) numberOfPolicies += _perRetryPolicies.Count;
+
+                return numberOfPolicies;
+            }
+        }
+
+        public HttpPipeline Build(string componentName, string componentVersion)
+        {
+            HttpPipelinePolicy[] policies = new HttpPipelinePolicy[PolicyCount];
+            int index = 0;
+
+            if (DisableTelemetry == false) {
+                var addHeadersPolicy = new AddHeadersPolicy();
+                policies[index++] = addHeadersPolicy;
+
+                var ua = HttpHeader.Common.CreateUserAgent(componentName, componentVersion, ApplicationId);
+                addHeadersPolicy.AddHeader(ua);
+            }
+            if (_perCallPolicies != null) {
+                foreach (var policy in _perCallPolicies) {
+                    policies[index++] = policy;
+                }
+            }
+            if (RetryPolicy != null) {
+                policies[index++] = RetryPolicy;
+            }
+            if (_perRetryPolicies != null) {
+                foreach (var policy in _perRetryPolicies) {
+                    policies[index++] = policy;
+                }
+            }
+            if (LoggingPolicy != null) {
+                policies[index++] = LoggingPolicy;
+            }
+            policies[index++] = _transport;
+
+            var pipeline = new HttpPipeline(policies, _container);
+            return pipeline;
+        }
+
+        #region nobody wants to see these
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override bool Equals(object obj) => base.Equals(obj);
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override int GetHashCode() => base.GetHashCode();
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public override string ToString() => base.ToString();
+        #endregion
+
+        class ServiceContainer : IServiceProvider
+        {
+            Dictionary<Type, object> _services = new Dictionary<Type, object>();
+
+            public object GetService(Type serviceType)
+            {
+                _services.TryGetValue(serviceType, out var service);
+                return service;
+            }
+
+            internal void Add(object service, Type type)
+                => _services.Add(type, service);
+        }      
     }
 }
 

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/HttpClientTransport.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/HttpClientTransport.cs
@@ -22,7 +22,9 @@ namespace Azure.Base.Http.Pipeline
         public HttpClientTransport(HttpClient client = null)
             => _client = client == null ? s_defaultClient : client;
 
-        public sealed override HttpMessage CreateMessage(HttpPipeline.Options options, CancellationToken cancellation)
+        public readonly static HttpClientTransport Shared = new HttpClientTransport();
+
+        public sealed override HttpMessage CreateMessage(IServiceProvider services, CancellationToken cancellation)
             => new Message(cancellation);
 
         public sealed override async Task ProcessAsync(HttpMessage message)
@@ -55,6 +57,7 @@ namespace Azure.Base.Http.Pipeline
             {
                 _requestMessage.Method = ToHttpClientMethod(method);
                 _requestMessage.RequestUri = uri;
+                _requestMessage.Version = new Version(1, 1);
             }
 
             public override HttpVerb Method => ToPipelineMethod(_requestMessage.Method);

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/HttpPipelinePolicy.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/HttpPipelinePolicy.cs
@@ -12,13 +12,14 @@ namespace Azure.Base.Http.Pipeline
     {
         public abstract Task ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline);
 
+        protected HttpPipelineEventSource Log = HttpPipelineEventSource.Singleton;
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected internal static async Task ProcessNextAsync(ReadOnlyMemory<HttpPipelinePolicy> pipeline, HttpMessage message)
+        protected static async Task ProcessNextAsync(ReadOnlyMemory<HttpPipelinePolicy> pipeline, HttpMessage message)
         {
+            if (pipeline.IsEmpty) throw new InvalidOperationException("last policy in the pipeline must be a transport"); 
             var next = pipeline.Span[0];
             await next.ProcessAsync(message, pipeline.Slice(1)).ConfigureAwait(false);
         }
-
-        protected HttpPipelineEventSource Log = HttpPipelineEventSource.Singleton;
     }
 }

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/HttpPipelineTransport.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/HttpPipelineTransport.cs
@@ -11,7 +11,7 @@ namespace Azure.Base.Http.Pipeline
     {
         public abstract Task ProcessAsync(HttpMessage message);
 
-        public abstract HttpMessage CreateMessage(HttpPipeline.Options options, CancellationToken cancellation);
+        public abstract HttpMessage CreateMessage(IServiceProvider services, CancellationToken cancellation);
 
         public sealed override async Task ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> next)
         {

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/LoggingPolicy.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/LoggingPolicy.cs
@@ -15,7 +15,8 @@ namespace Azure.Base.Http.Pipeline
 
         int[] _excludeErrors = Array.Empty<int>();
 
-        // TODO (pri 3): should this be a true singleton?
+        public readonly static LoggingPolicy Shared = new LoggingPolicy();
+
         public LoggingPolicy(params int[] excludeErrors)
             => _excludeErrors = excludeErrors;
 

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/TelemetryPolicy.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/TelemetryPolicy.cs
@@ -2,20 +2,21 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace Azure.Base.Http.Pipeline
 {
-    public class TelemetryPolicy : HttpPipelinePolicy
+    public class AddHeadersPolicy : HttpPipelinePolicy
     {
-        HttpHeader _uaHeader;
+        List<HttpHeader> _headersToAdd = new List<HttpHeader>();
 
-        public TelemetryPolicy(HttpHeader userAgentHeader)
-            => _uaHeader = userAgentHeader;
+        public void AddHeader(HttpHeader header)
+            => _headersToAdd.Add(header);
 
         public override async Task ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            message.AddHeader(_uaHeader);
+            foreach (var header in _headersToAdd) message.AddHeader(header);
             await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
         }
     }


### PR DESCRIPTION
This PR changes HttpPipelineOptions  such that:
1. There is not need for sentinel Default policy anymore. Actual default policies are set by the client in CreateDefaultPipelineOptions, then the options object is passed to the user to be modified, and then pipeline is constructed. If the user sets a policy option (e.g. logging policy) to null, the policy would not be added to the pipeline when it is created. Before, the sentinel was used to distinguish between "use default policy" and "remove the policy".
2. TelemetryPolicy is just a special instance of "add header policy" (and so I renamed it as such).
3. I moved UserAgentHeader creation to Build method. This way pipeline or options don't need to know anything about user agent headers. The only place that knows about it is the HttpPipelineOptions.Build method.
4. Added support for IServiceProvider. This will be used to integrate ASP.NET DI engine into the pipeline. Also, it allowed me to remove specific property for passing array pool to the pipeline. Now the pool is passed through the service provider. This feature is somehow experimental.
