### PR TITLE
[ADLA] - Catalog - Add stream path to USqlTableFragment

### DIFF
--- a/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/SessionRecords/DataLakeAnalytics.Tests.CatalogOperationTests/GetCatalogItemsTest.json
+++ b/src/SDKs/DataLake.Analytics/DataLakeAnalytics.Tests/SessionRecords/DataLakeAnalytics.Tests.CatalogOperationTests/GetCatalogItemsTest.json
@@ -7,58 +7,57 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "4a56fe55-cf00-42ec-a4d0-24956a268afa"
+          "0fde2665-5dac-49d4-a759-7b76e1c01ea3"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics\",\r\n  \"namespace\": \"Microsoft.DataLakeAnalytics\",\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"accounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/dataLakeStoreAccounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts/containers\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts/containers/listSasTokens\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationresults\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/capability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
         ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:12 GMT"
-        ],
         "Pragma": [
           "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Vary": [
-          "Accept-Encoding"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1199"
         ],
         "x-ms-request-id": [
-          "57fc9a46-e294-4429-af1e-5d248ea9a6c9"
+          "0d349490-afba-4dba-92ed-37aa8735de9d"
         ],
         "x-ms-correlation-request-id": [
-          "57fc9a46-e294-4429-af1e-5d248ea9a6c9"
+          "0d349490-afba-4dba-92ed-37aa8735de9d"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062412Z:57fc9a46-e294-4429-af1e-5d248ea9a6c9"
+          "WESTUS2:20190306T064354Z:0d349490-afba-4dba-92ed-37aa8735de9d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:54 GMT"
+        ],
+        "Content-Length": [
+          "1627"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics\",\r\n  \"namespace\": \"Microsoft.DataLakeAnalytics\",\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"accounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/dataLakeStoreAccounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts/containers\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts/containers/listSasTokens\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationresults\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/capability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "StatusCode": 200
     },
     {
@@ -68,55 +67,57 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "cf5277e4-cd93-4099-9f3d-8114413869c6"
+          "7620d4b5-aabc-4d3c-9e7e-d1917ad3d9d9"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics\",\r\n  \"namespace\": \"Microsoft.DataLakeAnalytics\",\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"accounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/dataLakeStoreAccounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts/containers\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts/containers/listSasTokens\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationresults\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/capability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:12 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14999"
+          "11999"
         ],
         "x-ms-request-id": [
-          "fa9f919b-c139-4e26-9b8d-43f429558f27"
+          "6566292a-5c3b-4228-85b5-4d6de693341d"
         ],
         "x-ms-correlation-request-id": [
-          "fa9f919b-c139-4e26-9b8d-43f429558f27"
+          "6566292a-5c3b-4228-85b5-4d6de693341d"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062412Z:fa9f919b-c139-4e26-9b8d-43f429558f27"
+          "WESTUS2:20190306T064354Z:6566292a-5c3b-4228-85b5-4d6de693341d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:54 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Content-Length": [
+          "1627"
         ]
       },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics\",\r\n  \"namespace\": \"Microsoft.DataLakeAnalytics\",\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"accounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove\"\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/dataLakeStoreAccounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts/containers\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/storageAccounts/containers/listSasTokens\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationresults\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/capability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "StatusCode": 200
     },
     {
@@ -126,58 +127,57 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f5c38324-d68f-400a-bde1-8f6e7a80528e"
+          "ea6a0424-e887-4653-b697-3ff8862ddaa5"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.Storage\",\r\n  \"namespace\": \"Microsoft.Storage\",\r\n  \"authorizations\": [\r\n    {\r\n      \"applicationId\": \"a6aa9161-5291-40bb-8c5c-923b567bee3b\",\r\n      \"roleDefinitionId\": \"070ab87f-0efc-4423-b18b-756f3bdb0236\"\r\n    },\r\n    {\r\n      \"applicationId\": \"e406a681-f3d4-42a8-90b6-c2b029497af1\"\r\n    }\r\n  ],\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"storageAccounts\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity\"\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/asyncoperations\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/listAccountSas\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/listServiceSas\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/blobServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/tableServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/queueServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/fileServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-07-01\",\r\n        \"2016-01-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/usages\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/deleteVirtualNetworkOrSubnets\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-07-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"usages\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/services\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"West US\",\r\n        \"East US 2 (Stage)\",\r\n        \"West Europe\",\r\n        \"North Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"East US 2\",\r\n        \"Central US\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"Brazil South\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2014-04-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/services/metricDefinitions\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"West US\",\r\n        \"East US 2 (Stage)\",\r\n        \"West Europe\",\r\n        \"North Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"East US 2\",\r\n        \"Central US\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"Brazil South\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2014-04-01\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
         ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:13 GMT"
-        ],
         "Pragma": [
           "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Vary": [
-          "Accept-Encoding"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1198"
         ],
         "x-ms-request-id": [
-          "300208c6-5b0a-4639-a712-e0f8655c7938"
+          "09595630-ea7b-4bbb-b8f8-843c4c920772"
         ],
         "x-ms-correlation-request-id": [
-          "300208c6-5b0a-4639-a712-e0f8655c7938"
+          "09595630-ea7b-4bbb-b8f8-843c4c920772"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062413Z:300208c6-5b0a-4639-a712-e0f8655c7938"
+          "WESTUS2:20190306T064355Z:09595630-ea7b-4bbb-b8f8-843c4c920772"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:55 GMT"
+        ],
+        "Content-Length": [
+          "9952"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.Storage\",\r\n  \"namespace\": \"Microsoft.Storage\",\r\n  \"authorizations\": [\r\n    {\r\n      \"applicationId\": \"a6aa9161-5291-40bb-8c5c-923b567bee3b\",\r\n      \"roleDefinitionId\": \"070ab87f-0efc-4423-b18b-756f3bdb0236\"\r\n    },\r\n    {\r\n      \"applicationId\": \"e406a681-f3d4-42a8-90b6-c2b029497af1\"\r\n    }\r\n  ],\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"storageAccounts\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity\"\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/asyncoperations\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/listAccountSas\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/listServiceSas\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/blobServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/tableServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/queueServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/fileServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-07-01\",\r\n        \"2016-01-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/usages\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/deleteVirtualNetworkOrSubnets\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-07-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"usages\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/services\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"West US\",\r\n        \"East US 2 (Stage)\",\r\n        \"West Europe\",\r\n        \"North Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"East US 2\",\r\n        \"Central US\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"Brazil South\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2014-04-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/services/metricDefinitions\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"West US\",\r\n        \"East US 2 (Stage)\",\r\n        \"West Europe\",\r\n        \"North Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"East US 2\",\r\n        \"Central US\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"Brazil South\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2014-04-01\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "StatusCode": 200
     },
     {
@@ -187,55 +187,57 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "48a815fd-4add-4f44-bbe3-e032d967c9a7"
+          "f88acabf-f1bb-4247-9a89-7f15a6e0be88"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.Storage\",\r\n  \"namespace\": \"Microsoft.Storage\",\r\n  \"authorizations\": [\r\n    {\r\n      \"applicationId\": \"a6aa9161-5291-40bb-8c5c-923b567bee3b\",\r\n      \"roleDefinitionId\": \"070ab87f-0efc-4423-b18b-756f3bdb0236\"\r\n    },\r\n    {\r\n      \"applicationId\": \"e406a681-f3d4-42a8-90b6-c2b029497af1\"\r\n    }\r\n  ],\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"storageAccounts\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity\"\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/asyncoperations\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/listAccountSas\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/listServiceSas\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/blobServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/tableServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/queueServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/fileServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-07-01\",\r\n        \"2016-01-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/usages\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/deleteVirtualNetworkOrSubnets\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-07-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"usages\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/services\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"West US\",\r\n        \"East US 2 (Stage)\",\r\n        \"West Europe\",\r\n        \"North Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"East US 2\",\r\n        \"Central US\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"Brazil South\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2014-04-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/services/metricDefinitions\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"West US\",\r\n        \"East US 2 (Stage)\",\r\n        \"West Europe\",\r\n        \"North Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"East US 2\",\r\n        \"Central US\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"Brazil South\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2014-04-01\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:13 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14998"
+          "11998"
         ],
         "x-ms-request-id": [
-          "00aefb73-c19e-4cb1-917c-cc63d1db8f20"
+          "21a0d2a8-26cf-469e-af8b-3358a22a7645"
         ],
         "x-ms-correlation-request-id": [
-          "00aefb73-c19e-4cb1-917c-cc63d1db8f20"
+          "21a0d2a8-26cf-469e-af8b-3358a22a7645"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062413Z:00aefb73-c19e-4cb1-917c-cc63d1db8f20"
+          "WESTUS2:20190306T064355Z:21a0d2a8-26cf-469e-af8b-3358a22a7645"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:55 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Content-Length": [
+          "9952"
         ]
       },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.Storage\",\r\n  \"namespace\": \"Microsoft.Storage\",\r\n  \"authorizations\": [\r\n    {\r\n      \"applicationId\": \"a6aa9161-5291-40bb-8c5c-923b567bee3b\",\r\n      \"roleDefinitionId\": \"070ab87f-0efc-4423-b18b-756f3bdb0236\"\r\n    },\r\n    {\r\n      \"applicationId\": \"e406a681-f3d4-42a8-90b6-c2b029497af1\"\r\n    }\r\n  ],\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"storageAccounts\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity\"\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/asyncoperations\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/listAccountSas\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/listServiceSas\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/blobServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/tableServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/queueServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/fileServices\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-07-01\",\r\n        \"2016-01-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/usages\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/deleteVirtualNetworkOrSubnets\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"East US 2\",\r\n        \"West US\",\r\n        \"West Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"Central US\",\r\n        \"North Europe\",\r\n        \"Brazil South\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-07-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"usages\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2018-11-01\",\r\n        \"2018-07-01\",\r\n        \"2018-03-01-preview\",\r\n        \"2018-02-01\",\r\n        \"2017-10-01\",\r\n        \"2017-06-01\",\r\n        \"2016-12-01\",\r\n        \"2016-05-01\",\r\n        \"2016-01-01\",\r\n        \"2015-06-15\",\r\n        \"2015-05-01-preview\"\r\n      ],\r\n      \"apiProfiles\": [\r\n        {\r\n          \"profileVersion\": \"2017-03-09-profile\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-03-01-hybrid\",\r\n          \"apiVersion\": \"2016-01-01\"\r\n        },\r\n        {\r\n          \"profileVersion\": \"2018-06-01-profile\",\r\n          \"apiVersion\": \"2017-10-01\"\r\n        }\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/services\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"West US\",\r\n        \"East US 2 (Stage)\",\r\n        \"West Europe\",\r\n        \"North Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"East US 2\",\r\n        \"Central US\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"Brazil South\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2014-04-01\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"storageAccounts/services/metricDefinitions\",\r\n      \"locations\": [\r\n        \"East US\",\r\n        \"West US\",\r\n        \"East US 2 (Stage)\",\r\n        \"West Europe\",\r\n        \"North Europe\",\r\n        \"East Asia\",\r\n        \"Southeast Asia\",\r\n        \"Japan East\",\r\n        \"Japan West\",\r\n        \"North Central US\",\r\n        \"South Central US\",\r\n        \"East US 2\",\r\n        \"Central US\",\r\n        \"Australia East\",\r\n        \"Australia Southeast\",\r\n        \"Brazil South\",\r\n        \"South India\",\r\n        \"Central India\",\r\n        \"West India\",\r\n        \"Canada East\",\r\n        \"Canada Central\",\r\n        \"West US 2\",\r\n        \"West Central US\",\r\n        \"UK South\",\r\n        \"UK West\",\r\n        \"Korea Central\",\r\n        \"Korea South\",\r\n        \"France Central\",\r\n        \"South Africa North\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2014-04-01\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "StatusCode": 200
     },
     {
@@ -245,58 +247,57 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "34c1f485-674e-46d4-b83d-21dd4f4a629d"
+          "cc27c0e0-781d-4252-a8ab-17d5c735098f"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore\",\r\n  \"namespace\": \"Microsoft.DataLakeStore\",\r\n  \"authorization\": {\r\n    \"applicationId\": \"e9f49c6b-5ce5-44c8-925d-015017e9f7ad\",\r\n    \"roleDefinitionId\": \"17eb9cca-f08a-4499-b2d3-852d175f614f\"\r\n  },\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"accounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity\"\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/firewallRules\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationresults\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/capability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
         ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:14 GMT"
-        ],
         "Pragma": [
           "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Vary": [
-          "Accept-Encoding"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1197"
         ],
         "x-ms-request-id": [
-          "1f6a53b2-8a2d-47a4-b1f0-38600b879bdd"
+          "e82ca913-32e6-43c6-bc8c-e1a8ee8f1391"
         ],
         "x-ms-correlation-request-id": [
-          "1f6a53b2-8a2d-47a4-b1f0-38600b879bdd"
+          "e82ca913-32e6-43c6-bc8c-e1a8ee8f1391"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062414Z:1f6a53b2-8a2d-47a4-b1f0-38600b879bdd"
+          "WESTUS2:20190306T064356Z:e82ca913-32e6-43c6-bc8c-e1a8ee8f1391"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:56 GMT"
+        ],
+        "Content-Length": [
+          "1569"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore\",\r\n  \"namespace\": \"Microsoft.DataLakeStore\",\r\n  \"authorization\": {\r\n    \"applicationId\": \"e9f49c6b-5ce5-44c8-925d-015017e9f7ad\",\r\n    \"roleDefinitionId\": \"17eb9cca-f08a-4499-b2d3-852d175f614f\"\r\n  },\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"accounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity\"\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/firewallRules\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/eventGridFilters\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\",\r\n        \"West Central US\",\r\n        \"West US 2\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationresults\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/capability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/deleteVirtualNetworkOrSubnets\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "StatusCode": 200
     },
     {
@@ -306,78 +307,45 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "264c91bb-197d-4bb5-8698-21053125fb50"
+          "97145eef-80bb-403d-8ab6-046a560a271c"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore\",\r\n  \"namespace\": \"Microsoft.DataLakeStore\",\r\n  \"authorization\": {\r\n    \"applicationId\": \"e9f49c6b-5ce5-44c8-925d-015017e9f7ad\",\r\n    \"roleDefinitionId\": \"17eb9cca-f08a-4499-b2d3-852d175f614f\"\r\n  },\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"accounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity\"\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/firewallRules\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationresults\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/capability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:14 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
+          "11997"
         ],
         "x-ms-request-id": [
-          "24d93bd4-78b2-4586-9270-7a303fae6b05"
+          "b8795fc8-870d-42aa-813f-2dd10ba81782"
         ],
         "x-ms-correlation-request-id": [
-          "24d93bd4-78b2-4586-9270-7a303fae6b05"
+          "b8795fc8-870d-42aa-813f-2dd10ba81782"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062414Z:24d93bd4-78b2-4586-9270-7a303fae6b05"
+          "WESTUS2:20190306T064356Z:b8795fc8-870d-42aa-813f-2dd10ba81782"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba11838?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlZ3JvdXBzL3JnYWJhMTE4Mzg/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "70a56cd8-ccee-4a9a-9719-afcc9886f895"
         ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResourceGroupNotFound\",\r\n    \"message\": \"Resource group 'rgaba11838' could not be found.\"\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "102"
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:56 GMT"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -385,11 +353,35 @@
         "Expires": [
           "-1"
         ],
+        "Content-Length": [
+          "1569"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore\",\r\n  \"namespace\": \"Microsoft.DataLakeStore\",\r\n  \"authorization\": {\r\n    \"applicationId\": \"e9f49c6b-5ce5-44c8-925d-015017e9f7ad\",\r\n    \"roleDefinitionId\": \"17eb9cca-f08a-4499-b2d3-852d175f614f\"\r\n  },\r\n  \"resourceTypes\": [\r\n    {\r\n      \"resourceType\": \"accounts\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ],\r\n      \"capabilities\": \"CrossResourceGroupResourceMove, CrossSubscriptionResourceMove, SystemAssignedResourceIdentity\"\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/firewallRules\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"accounts/eventGridFilters\",\r\n      \"locations\": [\r\n        \"East US 2\",\r\n        \"North Europe\",\r\n        \"Central US\",\r\n        \"West Europe\",\r\n        \"West Central US\",\r\n        \"West US 2\"\r\n      ],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/operationresults\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/checkNameAvailability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/capability\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"locations/deleteVirtualNetworkOrSubnets\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    },\r\n    {\r\n      \"resourceType\": \"operations\",\r\n      \"locations\": [],\r\n      \"apiVersions\": [\r\n        \"2016-11-01\",\r\n        \"2015-10-01-preview\"\r\n      ]\r\n    }\r\n  ],\r\n  \"registrationState\": \"Registered\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba13966?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlZ3JvdXBzL3JnYWJhMTM5NjY/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "035cdbc8-2ed6-4ad9-b7ea-fbe1de65b715"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:14 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -398,111 +390,85 @@
           "gateway"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
+          "11996"
         ],
         "x-ms-request-id": [
-          "b31f6461-c01c-416f-8f52-165b581c232f"
+          "b3cfd6b3-ecd1-4274-a10f-63962317734f"
         ],
         "x-ms-correlation-request-id": [
-          "b31f6461-c01c-416f-8f52-165b581c232f"
+          "b3cfd6b3-ecd1-4274-a10f-63962317734f"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062414Z:b31f6461-c01c-416f-8f52-165b581c232f"
+          "WESTUS2:20190306T064356Z:b3cfd6b3-ecd1-4274-a10f-63962317734f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:56 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Content-Length": [
+          "102"
         ]
       },
+      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResourceGroupNotFound\",\r\n    \"message\": \"Resource group 'rgaba13966' could not be found.\"\r\n  }\r\n}",
       "StatusCode": 404
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba11838?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlZ3JvdXBzL3JnYWJhMTE4Mzg/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba13966?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlZ3JvdXBzL3JnYWJhMTM5NjY/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "b9ada783-b21d-4923-ba2d-a65819944996"
+          "500bbc15-d79d-4605-83fd-789eeec8e93c"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838\",\r\n  \"name\": \"rgaba11838\",\r\n  \"location\": \"westeurope\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:16 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
+          "11995"
         ],
         "x-ms-request-id": [
-          "d12ab30a-c6df-4403-903e-09e98c9fcfb4"
+          "86eafa83-8f27-4c07-8f17-cd7a79b4931f"
         ],
         "x-ms-correlation-request-id": [
-          "d12ab30a-c6df-4403-903e-09e98c9fcfb4"
+          "86eafa83-8f27-4c07-8f17-cd7a79b4931f"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062417Z:d12ab30a-c6df-4403-903e-09e98c9fcfb4"
+          "WESTUS2:20190306T064358Z:86eafa83-8f27-4c07-8f17-cd7a79b4931f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba11838?api-version=2017-05-10",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlZ3JvdXBzL3JnYWJhMTE4Mzg/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
-      "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"West Europe\"\r\n}",
-      "RequestHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
         ],
-        "Content-Length": [
-          "33"
-        ],
-        "x-ms-client-request-id": [
-          "234785c4-b2c4-49d3-b548-c8b4a48a50c8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838\",\r\n  \"name\": \"rgaba11838\",\r\n  \"location\": \"westeurope\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "177"
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:58 GMT"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -510,69 +476,101 @@
         "Expires": [
           "-1"
         ],
+        "Content-Length": [
+          "174"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966\",\r\n  \"name\": \"rgaba13966\",\r\n  \"location\": \"eastus2\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba13966?api-version=2017-05-10",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlZ3JvdXBzL3JnYWJhMTM5NjY/YXBpLXZlcnNpb249MjAxNy0wNS0xMA==",
+      "RequestMethod": "PUT",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "763a9f60-1a16-44f6-90a5-1d4686295efb"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.ResourceManager.ResourceManagementClient/1.6.0.0"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Content-Length": [
+          "31"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:16 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-ratelimit-remaining-subscription-writes": [
-          "1196"
+          "1199"
         ],
         "x-ms-request-id": [
-          "2c9ca91f-cd1e-43c7-b1af-0c0a8734d84d"
+          "da105f51-19ba-49eb-b724-006a3482eb25"
         ],
         "x-ms-correlation-request-id": [
-          "2c9ca91f-cd1e-43c7-b1af-0c0a8734d84d"
+          "da105f51-19ba-49eb-b724-006a3482eb25"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062417Z:2c9ca91f-cd1e-43c7-b1af-0c0a8734d84d"
+          "WESTUS2:20190306T064358Z:da105f51-19ba-49eb-b724-006a3482eb25"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
-        ]
-      },
-      "StatusCode": 201
-    },
-    {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNDYwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "c15c8c0d-e713-4947-b21c-d4eec938418c"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:57 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResourceNotFound\",\r\n    \"message\": \"The Resource 'Microsoft.DataLakeStore/accounts/testdatalake11460' under resource group 'rgaba11838' was not found.\"\r\n  }\r\n}",
-      "ResponseHeaders": {
         "Content-Length": [
-          "164"
+          "174"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966\",\r\n  \"name\": \"rgaba13966\",\r\n  \"location\": \"eastus2\",\r\n  \"properties\": {\r\n    \"provisioningState\": \"Succeeded\"\r\n  }\r\n}",
+      "StatusCode": 201
+    },
+    {
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNjUwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "98043206-c584-4cf7-b0ef-0720f62cfe55"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:17 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -581,68 +579,67 @@
           "gateway"
         ],
         "x-ms-request-id": [
-          "72599393-062b-49dc-950a-160c073060a2"
+          "05826c81-be8a-4272-a876-e39e3de13b5d"
         ],
         "x-ms-correlation-request-id": [
-          "72599393-062b-49dc-950a-160c073060a2"
+          "05826c81-be8a-4272-a876-e39e3de13b5d"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062418Z:72599393-062b-49dc-950a-160c073060a2"
+          "WESTUS2:20190306T064358Z:05826c81-be8a-4272-a876-e39e3de13b5d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:43:58 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
+        ],
+        "Content-Length": [
+          "164"
         ]
       },
+      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResourceNotFound\",\r\n    \"message\": \"The Resource 'Microsoft.DataLakeStore/accounts/testdatalake11650' under resource group 'rgaba13966' was not found.\"\r\n  }\r\n}",
       "StatusCode": 404
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNDYwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNjUwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake11460.azuredatalakestore.net\",\r\n    \"accountId\": \"e8c6896a-c9cf-4b84-afaa-ce56d1a06457\",\r\n    \"creationTime\": \"2018-06-06T06:24:24.4700168Z\",\r\n    \"lastModifiedTime\": \"2018-06-06T06:24:24.4700168Z\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460\",\r\n  \"name\": \"testdatalake11460\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:55 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "938d8df1-fb10-4b4e-9262-b609be62aa29"
+          "178d7f23-f4de-4faf-a844-75c03ce157ff"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
+          "11995"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -651,138 +648,67 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "6ad6fce1-c431-44e9-8717-0c135285b141"
+          "eab36ca2-81b4-4082-a34e-4b64706f4325"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062456Z:6ad6fce1-c431-44e9-8717-0c135285b141"
+          "WESTUS2:20190306T064432Z:eab36ca2-81b4-4082-a34e-4b64706f4325"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNDYwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "e35be435-e30b-4b70-b99b-e94008d0d43b"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:31 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake11460.azuredatalakestore.net\",\r\n    \"accountId\": \"e8c6896a-c9cf-4b84-afaa-ce56d1a06457\",\r\n    \"creationTime\": \"2018-06-06T06:24:24.4700168Z\",\r\n    \"lastModifiedTime\": \"2018-06-06T06:24:24.4700168Z\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460\",\r\n  \"name\": \"testdatalake11460\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
-      "ResponseHeaders": {
+        "Content-Length": [
+          "879"
+        ],
         "Content-Type": [
           "application/json"
         ],
         "Expires": [
           "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:56 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "bce336a4-fe5b-486d-86b0-4f7ca09239d2"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14994"
-        ],
-        "X-AspNet-Version": [
-          "4.0.30319"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ],
-        "x-ms-correlation-request-id": [
-          "0d7f6979-a864-49a7-a24b-44d33005de0d"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062457Z:0d7f6979-a864-49a7-a24b-44d33005de0d"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake11650.azuredatalakestore.net\",\r\n    \"accountId\": \"62499214-f9bb-48d8-a795-00a702deeeea\",\r\n    \"creationTime\": \"2019-03-06T06:44:01.8561171Z\",\r\n    \"lastModifiedTime\": \"2019-03-06T06:44:01.8561171Z\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650\",\r\n  \"name\": \"testdatalake11650\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNDYwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNjUwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "41837a9a-a051-4360-bbcd-54004236af01"
+          "4278a2da-5d7c-4c45-85f4-5074cfb8f305"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake11460.azuredatalakestore.net\",\r\n    \"accountId\": \"e8c6896a-c9cf-4b84-afaa-ce56d1a06457\",\r\n    \"creationTime\": \"2018-06-06T06:24:24.4700168Z\",\r\n    \"lastModifiedTime\": \"2018-06-06T06:24:24.4700168Z\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460\",\r\n  \"name\": \"testdatalake11460\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:25:35 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "3e43e5b8-6f42-47cf-a7ed-b3401a95ec87"
+          "d70c75e0-64df-4ce7-8ecf-8809c95a0327"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14987"
+          "11994"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -791,74 +717,142 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "1ba4a391-ef21-4976-9343-07f84eebfef7"
+          "52adee07-8bb7-4a02-947a-cb3e27d61462"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062536Z:1ba4a391-ef21-4976-9343-07f84eebfef7"
+          "WESTUS2:20190306T064433Z:52adee07-8bb7-4a02-947a-cb3e27d61462"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:32 GMT"
+        ],
+        "Content-Length": [
+          "879"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake11650.azuredatalakestore.net\",\r\n    \"accountId\": \"62499214-f9bb-48d8-a795-00a702deeeea\",\r\n    \"creationTime\": \"2019-03-06T06:44:01.8561171Z\",\r\n    \"lastModifiedTime\": \"2019-03-06T06:44:01.8561171Z\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650\",\r\n  \"name\": \"testdatalake11650\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNDYwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNjUwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "16d6047d-b9df-421b-ad93-a8ed5347e7ee"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "26d2833f-271a-4418-bd22-52df45fc72c3"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11987"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-correlation-request-id": [
+          "30d2f9f0-845e-4b4f-a416-5c118486e7f3"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20190306T064507Z:30d2f9f0-845e-4b4f-a416-5c118486e7f3"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:06 GMT"
+        ],
+        "Content-Length": [
+          "879"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake11650.azuredatalakestore.net\",\r\n    \"accountId\": \"62499214-f9bb-48d8-a795-00a702deeeea\",\r\n    \"creationTime\": \"2019-03-06T06:44:01.8561171Z\",\r\n    \"lastModifiedTime\": \"2019-03-06T06:44:01.8561171Z\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650\",\r\n  \"name\": \"testdatalake11650\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTExNjUwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"West Europe\"\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "e5b2671a-b26b-404e-9996-7d53d9495be8"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "33"
-        ],
-        "x-ms-client-request-id": [
-          "f0e01fd5-4848-4cae-9571-756dcb252f83"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+          "31"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"provisioningState\": \"Creating\",\r\n    \"state\": null,\r\n    \"endpoint\": null,\r\n    \"accountId\": \"e8c6896a-c9cf-4b84-afaa-ce56d1a06457\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460\",\r\n  \"name\": \"testdatalake11460\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "366"
-        ],
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:21 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake11460/operationresults/0?api-version=2016-11-01"
+          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650/operationresults/0?api-version=2016-11-01"
         ],
         "Retry-After": [
           "10"
         ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/westeurope/operationResults/e8c6896a-c9cf-4b84-afaa-ce56d1a064570?api-version=2016-11-01&expanded=true"
+          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/eastus2/operationResults/62499214-f9bb-48d8-a795-00a702deeeea0?api-version=2016-11-01&expanded=true"
         ],
         "x-ms-request-id": [
-          "4c5e49a7-c52d-4866-9bbf-088e2c9bd688"
+          "63f5497d-bd77-4865-ad94-99b813e975d6"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -866,6 +860,9 @@
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1199"
         ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
         "X-AspNet-Version": [
           "4.0.30319"
         ],
@@ -873,62 +870,61 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "47686709-5d37-4cf9-b0f6-dbb6fd7b1d4a"
+          "9780641a-13bf-4a73-b002-173e4cc55594"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062422Z:47686709-5d37-4cf9-b0f6-dbb6fd7b1d4a"
+          "WESTUS2:20190306T064400Z:9780641a-13bf-4a73-b002-173e4cc55594"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:00 GMT"
+        ],
+        "Content-Length": [
+          "363"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"provisioningState\": \"Creating\",\r\n    \"state\": null,\r\n    \"endpoint\": null,\r\n    \"accountId\": \"62499214-f9bb-48d8-a795-00a702deeeea\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake11650\",\r\n  \"name\": \"testdatalake11650\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/westeurope/operationResults/e8c6896a-c9cf-4b84-afaa-ce56d1a064570?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvd2VzdGV1cm9wZS9vcGVyYXRpb25SZXN1bHRzL2U4YzY4OTZhLWM5Y2YtNGI4NC1hZmFhLWNlNTZkMWEwNjQ1NzA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/eastus2/operationResults/62499214-f9bb-48d8-a795-00a702deeeea0?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvZWFzdHVzMi9vcGVyYXRpb25SZXN1bHRzLzYyNDk5MjE0LWY5YmItNDhkOC1hNzk1LTAwYTcwMmRlZWVlYTA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:33 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "c1987714-de0c-4425-acf3-b7ad460a1b89"
+          "7d336e16-56d3-4e53-b611-fa1c8ebeec88"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14998"
+          "11998"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -937,62 +933,61 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "42b12036-26ae-4af7-8ba3-bc35acd5a2fa"
+          "88e4ea08-999a-4830-9b32-cd5d0d1b57eb"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062433Z:42b12036-26ae-4af7-8ba3-bc35acd5a2fa"
+          "WESTUS2:20190306T064411Z:88e4ea08-999a-4830-9b32-cd5d0d1b57eb"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/westeurope/operationResults/e8c6896a-c9cf-4b84-afaa-ce56d1a064570?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvd2VzdGV1cm9wZS9vcGVyYXRpb25SZXN1bHRzL2U4YzY4OTZhLWM5Y2YtNGI4NC1hZmFhLWNlNTZkMWEwNjQ1NzA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
-      "ResponseHeaders": {
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:10 GMT"
+        ],
+        "Content-Length": [
+          "23"
+        ],
         "Content-Type": [
           "application/json"
         ],
         "Expires": [
           "-1"
-        ],
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/eastus2/operationResults/62499214-f9bb-48d8-a795-00a702deeeea0?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvZWFzdHVzMi9vcGVyYXRpb25SZXN1bHRzLzYyNDk5MjE0LWY5YmItNDhkOC1hNzk1LTAwYTcwMmRlZWVlYTA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:44 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "7d7eb596-c0f4-477f-b1ee-0849e296c5bd"
+          "a14e9213-a7d7-4c6f-9037-c6e6fab47869"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
+          "11997"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1001,114 +996,115 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "6ed3add9-e7ef-412e-b2e3-372a129c97ef"
+          "f8ba6222-c798-4b50-8eb1-ea2e4a338464"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062444Z:6ed3add9-e7ef-412e-b2e3-372a129c97ef"
+          "WESTUS2:20190306T064421Z:f8ba6222-c798-4b50-8eb1-ea2e4a338464"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:20 GMT"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/westeurope/operationResults/e8c6896a-c9cf-4b84-afaa-ce56d1a064570?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvd2VzdGV1cm9wZS9vcGVyYXRpb25SZXN1bHRzL2U4YzY4OTZhLWM5Y2YtNGI4NC1hZmFhLWNlNTZkMWEwNjQ1NzA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/eastus2/operationResults/62499214-f9bb-48d8-a795-00a702deeeea0?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvZWFzdHVzMi9vcGVyYXRpb25SZXN1bHRzLzYyNDk5MjE0LWY5YmItNDhkOC1hNzk1LTAwYTcwMmRlZWVlYTA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "b428aac6-a060-4627-822c-8f593f2510bd"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11996"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-correlation-request-id": [
+          "0ae337bb-5d1e-46a5-87e7-ff491eb5bf77"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20190306T064432Z:0ae337bb-5d1e-46a5-87e7-ff491eb5bf77"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:31 GMT"
+        ],
+        "Content-Length": [
+          "22"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
       "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:54 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "1ba2ff6e-79dc-4f08-9e5e-813ad2b5cfce"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
-        ],
-        "X-AspNet-Version": [
-          "4.0.30319"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ],
-        "x-ms-correlation-request-id": [
-          "d234be12-887d-4508-8b9f-7dff681ae2b6"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062455Z:d234be12-887d-4508-8b9f-7dff681ae2b6"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake22036?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTIyMDM2P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake28525?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTI4NTI1P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "e0ab4643-db30-424f-a7ca-d99a8377239c"
+          "33bfdf41-8435-4bbc-af21-dd2a6a4e294a"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResourceNotFound\",\r\n    \"message\": \"The Resource 'Microsoft.DataLakeStore/accounts/testdatalake22036' under resource group 'rgaba11838' was not found.\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "164"
-        ],
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:57 GMT"
         ],
         "Pragma": [
           "no-cache"
@@ -1117,68 +1113,67 @@
           "gateway"
         ],
         "x-ms-request-id": [
-          "f95290c2-2628-414a-8b73-e08390fbd8a9"
+          "0d1b9722-54d0-4708-a11e-8464cb391a65"
         ],
         "x-ms-correlation-request-id": [
-          "f95290c2-2628-414a-8b73-e08390fbd8a9"
+          "0d1b9722-54d0-4708-a11e-8464cb391a65"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062457Z:f95290c2-2628-414a-8b73-e08390fbd8a9"
+          "WESTUS2:20190306T064433Z:0d1b9722-54d0-4708-a11e-8464cb391a65"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
         ],
         "X-Content-Type-Options": [
           "nosniff"
-        ]
-      },
-      "StatusCode": 404
-    },
-    {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake22036?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTIyMDM2P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake22036.azuredatalakestore.net\",\r\n    \"accountId\": \"ad3e3996-5f9e-498c-b6ea-6c9110f571dd\",\r\n    \"creationTime\": \"2018-06-06T06:25:01.6316767Z\",\r\n    \"lastModifiedTime\": \"2018-06-06T06:25:01.6316767Z\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake22036\",\r\n  \"name\": \"testdatalake22036\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
-      "ResponseHeaders": {
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:32 GMT"
+        ],
         "Content-Type": [
-          "application/json"
+          "application/json; charset=utf-8"
         ],
         "Expires": [
           "-1"
         ],
+        "Content-Length": [
+          "164"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"error\": {\r\n    \"code\": \"ResourceNotFound\",\r\n    \"message\": \"The Resource 'Microsoft.DataLakeStore/accounts/testdatalake28525' under resource group 'rgaba13966' was not found.\"\r\n  }\r\n}",
+      "StatusCode": 404
+    },
+    {
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake28525?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTI4NTI1P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:25:33 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "42a00f13-d786-4a89-a13f-186a0595eb3b"
+          "84aff85d-b1fe-40a4-8b34-afe2a155e4b3"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14989"
+          "11989"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1187,68 +1182,67 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "3a1e7fdb-bcea-480d-b713-0539acf68bc6"
+          "61e6f518-bebe-42e5-886c-9c13dfd9d934"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062534Z:3a1e7fdb-bcea-480d-b713-0539acf68bc6"
+          "WESTUS2:20190306T064506Z:61e6f518-bebe-42e5-886c-9c13dfd9d934"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:05 GMT"
+        ],
+        "Content-Length": [
+          "879"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake28525.azuredatalakestore.net\",\r\n    \"accountId\": \"02bf0566-5c04-4538-b7cd-55f69c771057\",\r\n    \"creationTime\": \"2019-03-06T06:44:35.0994735Z\",\r\n    \"lastModifiedTime\": \"2019-03-06T06:44:35.0994735Z\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake28525\",\r\n  \"name\": \"testdatalake28525\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake22036?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTIyMDM2P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake28525?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTI4NTI1P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "f21831c5-dc4f-4352-931f-d7a0aec025be"
+          "698b9662-9801-4d1e-8894-14e858e16c6d"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake22036.azuredatalakestore.net\",\r\n    \"accountId\": \"ad3e3996-5f9e-498c-b6ea-6c9110f571dd\",\r\n    \"creationTime\": \"2018-06-06T06:25:01.6316767Z\",\r\n    \"lastModifiedTime\": \"2018-06-06T06:25:01.6316767Z\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake22036\",\r\n  \"name\": \"testdatalake22036\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:25:34 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "23e071d6-0cfb-4b5f-ac15-5e4fb2af257c"
+          "43cad18b-2c87-4a47-9d87-0880f3cd867f"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14988"
+          "11988"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1257,74 +1251,73 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "545ce9a8-09dd-46ea-9e18-e6d61282064a"
+          "bc69c1be-e2fe-4126-a4df-9498c17a85f2"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062535Z:545ce9a8-09dd-46ea-9e18-e6d61282064a"
+          "WESTUS2:20190306T064506Z:bc69c1be-e2fe-4126-a4df-9498c17a85f2"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:06 GMT"
+        ],
+        "Content-Length": [
+          "879"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallAllowDataLakeAnalytics\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"trustedIdProviderState\": \"Disabled\",\r\n    \"trustedIdProviders\": [],\r\n    \"encryptionState\": \"Enabled\",\r\n    \"encryptionConfig\": {\r\n      \"type\": \"ServiceManaged\"\r\n    },\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"dataLakePerformanceTierState\": \"Disabled\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testdatalake28525.azuredatalakestore.net\",\r\n    \"accountId\": \"02bf0566-5c04-4538-b7cd-55f69c771057\",\r\n    \"creationTime\": \"2019-03-06T06:44:35.0994735Z\",\r\n    \"lastModifiedTime\": \"2019-03-06T06:44:35.0994735Z\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake28525\",\r\n  \"name\": \"testdatalake28525\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake22036?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTIyMDM2P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake28525?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZVN0b3JlL2FjY291bnRzL3Rlc3RkYXRhbGFrZTI4NTI1P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"West Europe\"\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\"\r\n}",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "39b216a5-9b7a-4e03-957c-24632ba482c1"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "33"
-        ],
-        "x-ms-client-request-id": [
-          "e07fe8db-2daf-4e00-8a8b-2d203dae83fb"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+          "31"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"provisioningState\": \"Creating\",\r\n    \"state\": null,\r\n    \"endpoint\": null,\r\n    \"accountId\": \"ad3e3996-5f9e-498c-b6ea-6c9110f571dd\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake22036\",\r\n  \"name\": \"testdatalake22036\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "366"
-        ],
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:24:59 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba11838/providers/Microsoft.DataLakeStore/accounts/testdatalake22036/operationresults/0?api-version=2016-11-01"
+          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake28525/operationresults/0?api-version=2016-11-01"
         ],
         "Retry-After": [
           "10"
         ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/westeurope/operationResults/ad3e3996-5f9e-498c-b6ea-6c9110f571dd0?api-version=2016-11-01&expanded=true"
+          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/eastus2/operationResults/02bf0566-5c04-4538-b7cd-55f69c7710570?api-version=2016-11-01&expanded=true"
         ],
         "x-ms-request-id": [
-          "54a0b1bb-bf13-4440-8887-40d6415c2895"
+          "eb27382f-8618-4751-a08c-80d2cb88f7c8"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1332,6 +1325,9 @@
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1198"
         ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
         "X-AspNet-Version": [
           "4.0.30319"
         ],
@@ -1339,62 +1335,61 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "fab81c25-61f4-4114-b330-6d9cc28ae2f9"
+          "bed9c5ea-f414-4b0d-ae35-f6c7f0d72d01"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062500Z:fab81c25-61f4-4114-b330-6d9cc28ae2f9"
+          "WESTUS2:20190306T064434Z:bed9c5ea-f414-4b0d-ae35-f6c7f0d72d01"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:34 GMT"
+        ],
+        "Content-Length": [
+          "363"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"provisioningState\": \"Creating\",\r\n    \"state\": null,\r\n    \"endpoint\": null,\r\n    \"accountId\": \"02bf0566-5c04-4538-b7cd-55f69c771057\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeStore/accounts/testdatalake28525\",\r\n  \"name\": \"testdatalake28525\",\r\n  \"type\": \"Microsoft.DataLakeStore/accounts\"\r\n}",
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/westeurope/operationResults/ad3e3996-5f9e-498c-b6ea-6c9110f571dd0?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvd2VzdGV1cm9wZS9vcGVyYXRpb25SZXN1bHRzL2FkM2UzOTk2LTVmOWUtNDk4Yy1iNmVhLTZjOTExMGY1NzFkZDA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/eastus2/operationResults/02bf0566-5c04-4538-b7cd-55f69c7710570?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvZWFzdHVzMi9vcGVyYXRpb25SZXN1bHRzLzAyYmYwNTY2LTVjMDQtNDUzOC1iN2NkLTU1ZjY5Yzc3MTA1NzA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:25:11 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "746c25d0-9b42-4cf0-9782-39def5fed2c9"
+          "457a6f22-ab76-4794-8c79-bda25f1f682a"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14992"
+          "11992"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1403,62 +1398,61 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "846d4abb-d6ff-414d-98f9-53e94045d848"
+          "516cb652-6175-400b-bb0c-89f12153224d"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062511Z:846d4abb-d6ff-414d-98f9-53e94045d848"
+          "WESTUS2:20190306T064444Z:516cb652-6175-400b-bb0c-89f12153224d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/westeurope/operationResults/ad3e3996-5f9e-498c-b6ea-6c9110f571dd0?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvd2VzdGV1cm9wZS9vcGVyYXRpb25SZXN1bHRzL2FkM2UzOTk2LTVmOWUtNDk4Yy1iNmVhLTZjOTExMGY1NzFkZDA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
-      "ResponseHeaders": {
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:44 GMT"
+        ],
+        "Content-Length": [
+          "23"
+        ],
         "Content-Type": [
           "application/json"
         ],
         "Expires": [
           "-1"
-        ],
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/eastus2/operationResults/02bf0566-5c04-4538-b7cd-55f69c7710570?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvZWFzdHVzMi9vcGVyYXRpb25SZXN1bHRzLzAyYmYwNTY2LTVjMDQtNDUzOC1iN2NkLTU1ZjY5Yzc3MTA1NzA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:25:21 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "56cda0eb-f7af-4fad-8a68-90e06895f1be"
+          "4ee70058-70c9-4542-8979-56148380ee58"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14991"
+          "11991"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1467,138 +1461,136 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "fd42acda-6bc9-4777-a16b-cbf8d9cab09a"
+          "82362e79-55d8-450a-9ff2-e6d1df7971c1"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062522Z:fd42acda-6bc9-4777-a16b-cbf8d9cab09a"
+          "WESTUS2:20190306T064455Z:82362e79-55d8-450a-9ff2-e6d1df7971c1"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:44:55 GMT"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/westeurope/operationResults/ad3e3996-5f9e-498c-b6ea-6c9110f571dd0?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvd2VzdGV1cm9wZS9vcGVyYXRpb25SZXN1bHRzL2FkM2UzOTk2LTVmOWUtNDk4Yy1iNmVhLTZjOTExMGY1NzFkZDA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeStore/locations/eastus2/operationResults/02bf0566-5c04-4538-b7cd-55f69c7710570?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VTdG9yZS9sb2NhdGlvbnMvZWFzdHVzMi9vcGVyYXRpb25SZXN1bHRzLzAyYmYwNTY2LTVjMDQtNDUzOC1iN2NkLTU1ZjY5Yzc3MTA1NzA/YXBpLXZlcnNpb249MjAxNi0xMS0wMSZleHBhbmRlZD10cnVl",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
           "Microsoft.Azure.Management.DataLake.Store.DataLakeStoreAccountManagementClient/2.2.0.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "b381b720-a478-4110-86fe-554f9a3c9ac8"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11990"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-correlation-request-id": [
+          "446b0c20-ccc6-4ab9-9115-e2f7995c6866"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20190306T064505Z:446b0c20-ccc6-4ab9-9115-e2f7995c6866"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:05 GMT"
+        ],
+        "Content-Length": [
+          "22"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
       "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:25:32 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "d11767b8-b52f-4b4d-a2b9-ffbdd6fe3584"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14990"
-        ],
-        "X-AspNet-Version": [
-          "4.0.30319"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ],
-        "x-ms-correlation-request-id": [
-          "124ee9f9-d23c-48ba-b163-e2a1676dc516"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062533Z:124ee9f9-d23c-48ba-b163-e2a1676dc516"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeAnalytics/accounts/testaba25339?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZUFuYWx5dGljcy9hY2NvdW50cy90ZXN0YWJhMjUzMzk/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeAnalytics/accounts/testaba28877?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZUFuYWx5dGljcy9hY2NvdW50cy90ZXN0YWJhMjg4Nzc/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"location\": \"West Europe\",\r\n  \"properties\": {\r\n    \"defaultDataLakeStoreAccount\": \"testdatalake11460\",\r\n    \"dataLakeStoreAccounts\": [\r\n      {\r\n        \"name\": \"testdatalake11460\",\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"location\": \"East US 2\",\r\n  \"properties\": {\r\n    \"defaultDataLakeStoreAccount\": \"testdatalake11650\",\r\n    \"dataLakeStoreAccounts\": [\r\n      {\r\n        \"name\": \"testdatalake11650\",\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        }\r\n      }\r\n    ]\r\n  }\r\n}",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "87f18930-0b7b-4cf9-8cdb-d5970bd8cf92"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.3.0"
+        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "292"
-        ],
-        "x-ms-client-request-id": [
-          "1034eefd-e7b0-4129-9378-59fb82a79482"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.0.0"
+          "290"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"defaultDataLakeStoreAccount\": \"testdatalake11460\",\r\n    \"dataLakeStoreAccounts\": [\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"testdatalake11460\"\r\n      }\r\n    ],\r\n    \"provisioningState\": \"Creating\",\r\n    \"state\": null,\r\n    \"endpoint\": null,\r\n    \"accountId\": \"a793b12e-bcef-4a48-91c8-7bd9a07ae175\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeAnalytics/accounts/testaba25339\",\r\n  \"name\": \"testaba25339\",\r\n  \"type\": \"Microsoft.DataLakeAnalytics/accounts\"\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "518"
-        ],
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:25:40 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
         "Location": [
-          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba11838/providers/Microsoft.DataLakeAnalytics/accounts/testaba25339/operationresults/0?api-version=2016-11-01"
+          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourcegroups/rgaba13966/providers/Microsoft.DataLakeAnalytics/accounts/testaba28877/operationresults/0?api-version=2016-11-01"
         ],
         "Retry-After": [
           "10"
         ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
         "Azure-AsyncOperation": [
-          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics/locations/westeurope/operationResults/a793b12e-bcef-4a48-91c8-7bd9a07ae1750?api-version=2016-11-01&expanded=true"
+          "https://management.azure.com/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics/locations/eastus2/operationResults/2f5148c5-940c-4142-a76b-b0d479a225180?api-version=2016-11-01&expanded=true"
         ],
         "x-ms-request-id": [
-          "6474c9ba-f093-4d0f-84fd-ebc2a0938dea"
+          "cd3f8a94-65a2-42f1-9fa3-30bad1c2acbd"
         ],
         "X-Content-Type-Options": [
           "nosniff"
@@ -1606,6 +1598,9 @@
         "x-ms-ratelimit-remaining-subscription-writes": [
           "1199"
         ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
         "X-AspNet-Version": [
           "4.0.30319"
         ],
@@ -1613,62 +1608,61 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "9e8e1415-1adc-4972-9440-163366844e47"
+          "feaa6b49-e6d9-4360-8626-a27097a73abd"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062540Z:9e8e1415-1adc-4972-9440-163366844e47"
+          "WESTUS2:20190306T064509Z:feaa6b49-e6d9-4360-8626-a27097a73abd"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:08 GMT"
+        ],
+        "Content-Length": [
+          "515"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"defaultDataLakeStoreAccount\": \"testdatalake11650\",\r\n    \"dataLakeStoreAccounts\": [\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"testdatalake11650\"\r\n      }\r\n    ],\r\n    \"provisioningState\": \"Creating\",\r\n    \"state\": null,\r\n    \"endpoint\": null,\r\n    \"accountId\": \"2f5148c5-940c-4142-a76b-b0d479a22518\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeAnalytics/accounts/testaba28877\",\r\n  \"name\": \"testaba28877\",\r\n  \"type\": \"Microsoft.DataLakeAnalytics/accounts\"\r\n}",
       "StatusCode": 201
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics/locations/westeurope/operationResults/a793b12e-bcef-4a48-91c8-7bd9a07ae1750?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VBbmFseXRpY3MvbG9jYXRpb25zL3dlc3RldXJvcGUvb3BlcmF0aW9uUmVzdWx0cy9hNzkzYjEyZS1iY2VmLTRhNDgtOTFjOC03YmQ5YTA3YWUxNzUwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDEmZXhwYW5kZWQ9dHJ1ZQ==",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics/locations/eastus2/operationResults/2f5148c5-940c-4142-a76b-b0d479a225180?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VBbmFseXRpY3MvbG9jYXRpb25zL2Vhc3R1czIvb3BlcmF0aW9uUmVzdWx0cy8yZjUxNDhjNS05NDBjLTQxNDItYTc2Yi1iMGQ0NzlhMjI1MTgwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDEmZXhwYW5kZWQ9dHJ1ZQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:25:51 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "5a12c539-a5b1-418a-a73f-10b7e69b0d77"
+          "b779a9f0-1c0a-4fc0-a06d-f02b7ca9704d"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14999"
+          "11999"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1677,62 +1671,61 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "4edcd23f-0777-46d7-9b1a-cc67e4fa9c7e"
+          "2d822f82-f22b-4a68-9d5d-6d021d5b97c0"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062551Z:4edcd23f-0777-46d7-9b1a-cc67e4fa9c7e"
+          "WESTUS2:20190306T064519Z:2d822f82-f22b-4a68-9d5d-6d021d5b97c0"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics/locations/westeurope/operationResults/a793b12e-bcef-4a48-91c8-7bd9a07ae1750?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VBbmFseXRpY3MvbG9jYXRpb25zL3dlc3RldXJvcGUvb3BlcmF0aW9uUmVzdWx0cy9hNzkzYjEyZS1iY2VmLTRhNDgtOTFjOC03YmQ5YTA3YWUxNzUwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDEmZXhwYW5kZWQ9dHJ1ZQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
-      "ResponseHeaders": {
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:19 GMT"
+        ],
+        "Content-Length": [
+          "23"
+        ],
         "Content-Type": [
           "application/json"
         ],
         "Expires": [
           "-1"
-        ],
+        ]
+      },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics/locations/eastus2/operationResults/2f5148c5-940c-4142-a76b-b0d479a225180?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VBbmFseXRpY3MvbG9jYXRpb25zL2Vhc3R1czIvb3BlcmF0aW9uUmVzdWx0cy8yZjUxNDhjNS05NDBjLTQxNDItYTc2Yi1iMGQ0NzlhMjI1MTgwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDEmZXhwYW5kZWQ9dHJ1ZQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:26:01 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "7328c0e7-99e6-4a40-8cbc-4dfd0eed07c7"
+          "61b94b63-9fa3-4724-97ae-9294c6bdbc55"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14998"
+          "11998"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1741,126 +1734,124 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "f8832edc-9fc7-4e9b-bff0-d2811b929a98"
+          "c386e77c-23ad-4cbb-bfb5-59d83121457f"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062602Z:f8832edc-9fc7-4e9b-bff0-d2811b929a98"
+          "WESTUS2:20190306T064530Z:c386e77c-23ad-4cbb-bfb5-59d83121457f"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:30 GMT"
+        ],
+        "Content-Length": [
+          "23"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"status\": \"InProgress\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics/locations/westeurope/operationResults/a793b12e-bcef-4a48-91c8-7bd9a07ae1750?api-version=2016-11-01&expanded=true",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VBbmFseXRpY3MvbG9jYXRpb25zL3dlc3RldXJvcGUvb3BlcmF0aW9uUmVzdWx0cy9hNzkzYjEyZS1iY2VmLTRhNDgtOTFjOC03YmQ5YTA3YWUxNzUwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDEmZXhwYW5kZWQ9dHJ1ZQ==",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/providers/Microsoft.DataLakeAnalytics/locations/eastus2/operationResults/2f5148c5-940c-4142-a76b-b0d479a225180?api-version=2016-11-01&expanded=true",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Byb3ZpZGVycy9NaWNyb3NvZnQuRGF0YUxha2VBbmFseXRpY3MvbG9jYXRpb25zL2Vhc3R1czIvb3BlcmF0aW9uUmVzdWx0cy8yZjUxNDhjNS05NDBjLTQxNDItYTc2Yi1iMGQ0NzlhMjI1MTgwP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDEmZXhwYW5kZWQ9dHJ1ZQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-cache"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "e9d59f39-3fd0-419c-a47a-37799012f4bd"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "x-ms-ratelimit-remaining-subscription-reads": [
+          "11997"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
+        ],
+        "X-AspNet-Version": [
+          "4.0.30319"
+        ],
+        "X-Powered-By": [
+          "ASP.NET"
+        ],
+        "x-ms-correlation-request-id": [
+          "3a21a83f-aa6d-4cd7-b374-07765b595bac"
+        ],
+        "x-ms-routing-request-id": [
+          "WESTUS2:20190306T064540Z:3a21a83f-aa6d-4cd7-b374-07765b595bac"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:40 GMT"
+        ],
+        "Content-Length": [
+          "22"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
       "ResponseBody": "{\r\n  \"status\": \"Succeeded\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:26:12 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
-        "x-ms-request-id": [
-          "2629a43a-c6af-42a2-9a5a-e10473b9226e"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "x-ms-ratelimit-remaining-subscription-reads": [
-          "14997"
-        ],
-        "X-AspNet-Version": [
-          "4.0.30319"
-        ],
-        "X-Powered-By": [
-          "ASP.NET"
-        ],
-        "x-ms-correlation-request-id": [
-          "c7fd21c2-fa4e-45f5-addb-10882ea43d39"
-        ],
-        "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062613Z:c7fd21c2-fa4e-45f5-addb-10882ea43d39"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=31536000; includeSubDomains"
-        ]
-      },
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeAnalytics/accounts/testaba25339?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZUFuYWx5dGljcy9hY2NvdW50cy90ZXN0YWJhMjUzMzk/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeAnalytics/accounts/testaba28877?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZUFuYWx5dGljcy9hY2NvdW50cy90ZXN0YWJhMjg4Nzc/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"debugDataAccessLevel\": \"All\",\r\n    \"defaultDataLakeStoreAccount\": \"testdatalake11460\",\r\n    \"dataLakeStoreAccounts\": [\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"testdatalake11460\"\r\n      }\r\n    ],\r\n    \"publicDataLakeStoreAccounts\": [],\r\n    \"storageAccounts\": [],\r\n    \"maxDegreeOfParallelism\": 32,\r\n    \"maxJobCount\": 20,\r\n    \"systemMaxDegreeOfParallelism\": 100,\r\n    \"systemMaxJobCount\": 20,\r\n    \"maxDegreeOfParallelismPerJob\": 32,\r\n    \"minPriorityPerJob\": 1,\r\n    \"computePolicies\": [],\r\n    \"queryStoreRetention\": 30,\r\n    \"hiveMetastores\": [],\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testaba25339.azuredatalakeanalytics.net\",\r\n    \"accountId\": \"a793b12e-bcef-4a48-91c8-7bd9a07ae175\",\r\n    \"creationTime\": \"2018-06-06T06:25:41.5380204Z\",\r\n    \"lastModifiedTime\": \"2018-06-06T06:25:41.5380204Z\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeAnalytics/accounts/testaba25339\",\r\n  \"name\": \"testaba25339\",\r\n  \"type\": \"Microsoft.DataLakeAnalytics/accounts\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:26:13 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "021ab339-43a7-4278-82e9-65156e797d58"
+          "d37c5647-f16c-4736-a64a-2ebbd3471aa6"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14996"
+          "11996"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1869,68 +1860,67 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "7b6cecc2-8670-4b13-81ef-c5c6a6107694"
+          "4adf6d7a-d880-48c4-936b-9956d864f4e8"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062614Z:7b6cecc2-8670-4b13-81ef-c5c6a6107694"
+          "WESTUS2:20190306T064541Z:4adf6d7a-d880-48c4-936b-9956d864f4e8"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:40 GMT"
+        ],
+        "Content-Length": [
+          "1271"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"debugDataAccessLevel\": \"All\",\r\n    \"defaultDataLakeStoreAccount\": \"testdatalake11650\",\r\n    \"dataLakeStoreAccounts\": [\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"testdatalake11650\"\r\n      }\r\n    ],\r\n    \"publicDataLakeStoreAccounts\": [\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"adltrainingsampledata\"\r\n      },\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"ghinsights\"\r\n      }\r\n    ],\r\n    \"storageAccounts\": [],\r\n    \"maxDegreeOfParallelism\": 32,\r\n    \"maxJobCount\": 20,\r\n    \"systemMaxDegreeOfParallelism\": 100,\r\n    \"systemMaxJobCount\": 20,\r\n    \"maxDegreeOfParallelismPerJob\": 32,\r\n    \"minPriorityPerJob\": 1,\r\n    \"computePolicies\": [],\r\n    \"queryStoreRetention\": 30,\r\n    \"hiveMetastores\": [],\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testaba28877.azuredatalakeanalytics.net\",\r\n    \"accountId\": \"2f5148c5-940c-4142-a76b-b0d479a22518\",\r\n    \"creationTime\": \"2019-03-06T06:45:10.9122105Z\",\r\n    \"lastModifiedTime\": \"2019-03-06T06:45:10.9122105Z\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeAnalytics/accounts/testaba28877\",\r\n  \"name\": \"testaba28877\",\r\n  \"type\": \"Microsoft.DataLakeAnalytics/accounts\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeAnalytics/accounts/testaba25339?api-version=2016-11-01",
-      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTE4MzgvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZUFuYWx5dGljcy9hY2NvdW50cy90ZXN0YWJhMjUzMzk/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestUri": "/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeAnalytics/accounts/testaba28877?api-version=2016-11-01",
+      "EncodedRequestUri": "L3N1YnNjcmlwdGlvbnMvMDQzMTlkNmQtNGE2Ni00NzAxLWJiMmYtZTdkYmJkOWFlNGRiL3Jlc291cmNlR3JvdXBzL3JnYWJhMTM5NjYvcHJvdmlkZXJzL01pY3Jvc29mdC5EYXRhTGFrZUFuYWx5dGljcy9hY2NvdW50cy90ZXN0YWJhMjg4Nzc/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "71e1bbcc-5d3d-4dbe-8c04-5b39200461b4"
+          "bc11633a-69dd-4b88-b87a-606e2e845487"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsAccountManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"debugDataAccessLevel\": \"All\",\r\n    \"defaultDataLakeStoreAccount\": \"testdatalake11460\",\r\n    \"dataLakeStoreAccounts\": [\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"testdatalake11460\"\r\n      }\r\n    ],\r\n    \"publicDataLakeStoreAccounts\": [],\r\n    \"storageAccounts\": [],\r\n    \"maxDegreeOfParallelism\": 32,\r\n    \"maxJobCount\": 20,\r\n    \"systemMaxDegreeOfParallelism\": 100,\r\n    \"systemMaxJobCount\": 20,\r\n    \"maxDegreeOfParallelismPerJob\": 32,\r\n    \"minPriorityPerJob\": 1,\r\n    \"computePolicies\": [],\r\n    \"queryStoreRetention\": 30,\r\n    \"hiveMetastores\": [],\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testaba25339.azuredatalakeanalytics.net\",\r\n    \"accountId\": \"a793b12e-bcef-4a48-91c8-7bd9a07ae175\",\r\n    \"creationTime\": \"2018-06-06T06:25:41.5380204Z\",\r\n    \"lastModifiedTime\": \"2018-06-06T06:25:41.5380204Z\"\r\n  },\r\n  \"location\": \"westeurope\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba11838/providers/Microsoft.DataLakeAnalytics/accounts/testaba25339\",\r\n  \"name\": \"testaba25339\",\r\n  \"type\": \"Microsoft.DataLakeAnalytics/accounts\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-cache"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:26:14 GMT"
         ],
         "Pragma": [
           "no-cache"
         ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "Server": [
-          "Microsoft-IIS/8.5"
-        ],
-        "Vary": [
-          "Accept-Encoding"
-        ],
         "x-ms-request-id": [
-          "30ae0aa5-6d5e-4176-8483-7e621e096007"
+          "fcd70e93-e44e-4e58-9897-661e692980c1"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "x-ms-ratelimit-remaining-subscription-reads": [
-          "14995"
+          "11995"
+        ],
+        "Server": [
+          "Microsoft-IIS/10.0"
         ],
         "X-AspNet-Version": [
           "4.0.30319"
@@ -1939,711 +1929,754 @@
           "ASP.NET"
         ],
         "x-ms-correlation-request-id": [
-          "9a00b651-b57e-4725-b871-628e25160395"
+          "9ad4b165-9169-4ee2-896c-4eae1aadac6d"
         ],
         "x-ms-routing-request-id": [
-          "WESTUS2:20180606T062615Z:9a00b651-b57e-4725-b871-628e25160395"
+          "WESTUS2:20190306T064541Z:9ad4b165-9169-4ee2-896c-4eae1aadac6d"
         ],
         "Strict-Transport-Security": [
           "max-age=31536000; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:45:41 GMT"
+        ],
+        "Content-Length": [
+          "1271"
+        ],
+        "Content-Type": [
+          "application/json"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"properties\": {\r\n    \"firewallState\": \"Disabled\",\r\n    \"firewallAllowAzureIps\": \"Disabled\",\r\n    \"firewallRules\": [],\r\n    \"virtualNetworkRules\": [],\r\n    \"debugDataAccessLevel\": \"All\",\r\n    \"defaultDataLakeStoreAccount\": \"testdatalake11650\",\r\n    \"dataLakeStoreAccounts\": [\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"testdatalake11650\"\r\n      }\r\n    ],\r\n    \"publicDataLakeStoreAccounts\": [\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"adltrainingsampledata\"\r\n      },\r\n      {\r\n        \"properties\": {\r\n          \"suffix\": \"azuredatalakestore.net\"\r\n        },\r\n        \"name\": \"ghinsights\"\r\n      }\r\n    ],\r\n    \"storageAccounts\": [],\r\n    \"maxDegreeOfParallelism\": 32,\r\n    \"maxJobCount\": 20,\r\n    \"systemMaxDegreeOfParallelism\": 100,\r\n    \"systemMaxJobCount\": 20,\r\n    \"maxDegreeOfParallelismPerJob\": 32,\r\n    \"minPriorityPerJob\": 1,\r\n    \"computePolicies\": [],\r\n    \"queryStoreRetention\": 30,\r\n    \"hiveMetastores\": [],\r\n    \"currentTier\": \"Consumption\",\r\n    \"newTier\": \"Consumption\",\r\n    \"provisioningState\": \"Succeeded\",\r\n    \"state\": \"Active\",\r\n    \"endpoint\": \"testaba28877.azuredatalakeanalytics.net\",\r\n    \"accountId\": \"2f5148c5-940c-4142-a76b-b0d479a22518\",\r\n    \"creationTime\": \"2019-03-06T06:45:10.9122105Z\",\r\n    \"lastModifiedTime\": \"2019-03-06T06:45:10.9122105Z\"\r\n  },\r\n  \"location\": \"eastus2\",\r\n  \"id\": \"/subscriptions/04319d6d-4a66-4701-bb2f-e7dbbd9ae4db/resourceGroups/rgaba13966/providers/Microsoft.DataLakeAnalytics/accounts/testaba28877\",\r\n  \"name\": \"testaba28877\",\r\n  \"type\": \"Microsoft.DataLakeAnalytics/accounts\"\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "PUT",
-      "RequestBody": "{\r\n  \"name\": \"testjob16268\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"type\": \"USql\",\r\n  \"properties\": {\r\n    \"type\": \"USql\",\r\n    \"script\": \"\\r\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\r\\n//Create Table\\r\\nCREATE TABLE testdb15955.dbo.testtbl18883\\r\\n(\\r\\n        //Define schema of table\\r\\n        UserId          int, \\r\\n        Start           DateTime, \\r\\n        Region          string, \\r\\n        Query           string, \\r\\n        Duration        int, \\r\\n        Urls            string, \\r\\n        ClickedUrls     string,\\r\\n    INDEX idx1 //Name of index\\r\\n    CLUSTERED (Region ASC) //Column to cluster by\\r\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\r\\n);\\r\\n\\r\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\r\\n\\r\\nINSERT INTO testdb15955.dbo.testtbl18883\\r\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\r\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\r\\nVALUES\\r\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\r\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\r\\n\\r\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\r\\n\\r\\n//create table weblogs on space-delimited website log data\\r\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\r\\nRETURNS @result TABLE\\r\\n(\\r\\n    s_date DateTime,\\r\\n    s_time string,\\r\\n    s_sitename string,\\r\\n    cs_method string, \\r\\n    cs_uristem string,\\r\\n    cs_uriquery string,\\r\\n    s_port int,\\r\\n    cs_username string, \\r\\n    c_ip string,\\r\\n    cs_useragent string,\\r\\n    cs_cookie string,\\r\\n    cs_referer string, \\r\\n    cs_host string,\\r\\n    sc_status int,\\r\\n    sc_substatus int,\\r\\n    sc_win32status int, \\r\\n    sc_bytes int,\\r\\n    cs_bytes int,\\r\\n    s_timetaken int\\r\\n)\\r\\nAS\\r\\nBEGIN\\r\\n\\r\\n    @result = EXTRACT\\r\\n        s_date DateTime,\\r\\n        s_time string,\\r\\n        s_sitename string,\\r\\n        cs_method string,\\r\\n        cs_uristem string,\\r\\n        cs_uriquery string,\\r\\n        s_port int,\\r\\n        cs_username string,\\r\\n        c_ip string,\\r\\n        cs_useragent string,\\r\\n        cs_cookie string,\\r\\n        cs_referer string,\\r\\n        cs_host string,\\r\\n        sc_status int,\\r\\n        sc_substatus int,\\r\\n        sc_win32status int,\\r\\n        sc_bytes int,\\r\\n        cs_bytes int,\\r\\n        s_timetaken int\\r\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\r\\n    USING Extractors.Text(delimiter:' ');\\r\\n\\r\\nRETURN;\\r\\nEND;\\r\\nCREATE VIEW testdb15955.dbo.testview12416 \\r\\nAS \\r\\n    SELECT * FROM \\r\\n    (\\r\\n        VALUES(1,2),(2,4)\\r\\n    ) \\r\\nAS \\r\\nT(a, b);\\r\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\r\\nAS BEGIN\\r\\n  CREATE VIEW testdb15955.dbo.testview12416 \\r\\n  AS \\r\\n    SELECT * FROM \\r\\n    (\\r\\n        VALUES(1,2),(2,4)\\r\\n    ) \\r\\n  AS \\r\\n  T(a, b);\\r\\nEND;\"\r\n  }\r\n}",
+      "RequestBody": "{\r\n  \"name\": \"testjob14137\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"type\": \"USql\",\r\n  \"properties\": {\r\n    \"type\": \"USql\",\r\n    \"script\": \"\\r\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\r\\n//Create Table\\r\\nCREATE TABLE testdb17950.dbo.testtbl16049\\r\\n(\\r\\n        //Define schema of table\\r\\n        UserId          int, \\r\\n        Start           DateTime, \\r\\n        Region          string, \\r\\n        Query           string, \\r\\n        Duration        int, \\r\\n        Urls            string, \\r\\n        ClickedUrls     string,\\r\\n    INDEX idx1 //Name of index\\r\\n    CLUSTERED (Region ASC) //Column to cluster by\\r\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\r\\n);\\r\\n\\r\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\r\\n\\r\\nINSERT INTO testdb17950.dbo.testtbl16049\\r\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\r\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\r\\nVALUES\\r\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\r\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\r\\n\\r\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\r\\n\\r\\n//create table weblogs on space-delimited website log data\\r\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\r\\nRETURNS @result TABLE\\r\\n(\\r\\n    s_date DateTime,\\r\\n    s_time string,\\r\\n    s_sitename string,\\r\\n    cs_method string, \\r\\n    cs_uristem string,\\r\\n    cs_uriquery string,\\r\\n    s_port int,\\r\\n    cs_username string, \\r\\n    c_ip string,\\r\\n    cs_useragent string,\\r\\n    cs_cookie string,\\r\\n    cs_referer string, \\r\\n    cs_host string,\\r\\n    sc_status int,\\r\\n    sc_substatus int,\\r\\n    sc_win32status int, \\r\\n    sc_bytes int,\\r\\n    cs_bytes int,\\r\\n    s_timetaken int\\r\\n)\\r\\nAS\\r\\nBEGIN\\r\\n\\r\\n    @result = EXTRACT\\r\\n        s_date DateTime,\\r\\n        s_time string,\\r\\n        s_sitename string,\\r\\n        cs_method string,\\r\\n        cs_uristem string,\\r\\n        cs_uriquery string,\\r\\n        s_port int,\\r\\n        cs_username string,\\r\\n        c_ip string,\\r\\n        cs_useragent string,\\r\\n        cs_cookie string,\\r\\n        cs_referer string,\\r\\n        cs_host string,\\r\\n        sc_status int,\\r\\n        sc_substatus int,\\r\\n        sc_win32status int,\\r\\n        sc_bytes int,\\r\\n        cs_bytes int,\\r\\n        s_timetaken int\\r\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\r\\n    USING Extractors.Text(delimiter:' ');\\r\\n\\r\\nRETURN;\\r\\nEND;\\r\\nCREATE VIEW testdb17950.dbo.testview1993 \\r\\nAS \\r\\n    SELECT * FROM \\r\\n    (\\r\\n        VALUES(1,2),(2,4)\\r\\n    ) \\r\\nAS \\r\\nT(a, b);\\r\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\r\\nAS BEGIN\\r\\n  CREATE VIEW testdb17950.dbo.testview1993 \\r\\n  AS \\r\\n    SELECT * FROM \\r\\n    (\\r\\n        VALUES(1,2),(2,4)\\r\\n    ) \\r\\n  AS \\r\\n  T(a, b);\\r\\nEND;\"\r\n  }\r\n}",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "87f966f4-eda8-4120-9189-b49f5f208446"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
+        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
-          "2948"
-        ],
-        "x-ms-client-request-id": [
-          "fc845506-edb4-4c74-bd80-4c27e9f546e7"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "2946"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT0S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00Z\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:16 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "9de2d44a-86fc-4833-ae42-a1f9327c9277"
+          "66265add-61ed-4643-b673-7eb62bdcbca9"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:50:42 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT0S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00Z\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "de8cfed9-b8d6-4c20-992e-095ecbf62779"
+          "a60cb401-e818-40b8-984e-c004ed08e815"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT0.3831048S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:17 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "49f70b75-2262-4741-b051-15bd60d1e552"
+          "a3426bda-e345-4ebf-8bff-51ec30e02023"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:50:42 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT0.2878547S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "a253fc5d-1166-400a-a210-4007382665e0"
+          "264060de-f76b-47e6-8aa4-0bcf31046d1f"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT5.7737557S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:22 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "398f8365-7b87-4345-80d0-f8778b37ab52"
+          "f1c205c5-ae0a-4b07-b082-01cc00a0d57a"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:50:48 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT5.6941841S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "88a7cc0a-2ce6-4526-a072-2bf976dba21b"
+          "af8796e4-99c9-41d6-9f2d-c447d63221f9"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT11.0238355S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:28 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "3e5f2330-6161-47bc-9c2e-dced8601a808"
+          "fbec9653-6fc5-4fff-be8a-6c1fef89c628"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:50:53 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT10.8661445S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "9f240a34-41ef-4b36-a4ab-ca6981a4ee50"
+          "bc8d5d4d-3f58-49af-9d6a-fc5e0811aa0f"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT16.3207558S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:34 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "146cce4f-ce29-4afd-ac55-a5cd052cc6ac"
+          "2248562b-aff6-4ab8-94f8-8ea4ad549dd1"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:50:58 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"state\": \"Compiling\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"default\",\r\n    \"rootProcessNodeId\": \"00000000-0000-0000-0000-000000000000\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT16.3262678S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "476bc929-2924-4fb9-8f6e-ec2fb178a080"
+          "163e00ff-23f3-4ebb-8d9c-cc3fcd79a0da"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"state\": \"Starting\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:39 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "5bc92e0b-c089-4bf9-baf9-7a6ee71b4aab"
+          "e555757d-e601-4667-aa0a-e750994bf5f8"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:03 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"state\": \"Starting\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT0S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "08e3fcf7-afa9-4a0c-a3e9-8175b7e70230"
+          "6cf69d36-0957-46b7-98f3-5d411027939d"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT0.1801375S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:44 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "e5f2b870-5b5b-4a5d-a70e-ae697a319c64"
+          "fe43b47b-07a0-4a11-9503-26e214460458"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:09 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT1.429104S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "cfff05c5-495c-4fb4-a84f-fbf1fc83d79a"
+          "9c0a5355-19fc-48a4-9352-f85e6a06a722"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT5.4614651S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:49 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "82e19d6a-37d2-4236-acb8-01e41404b65e"
+          "efad8560-89b0-4b48-8dc1-ed4a169c404e"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:14 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT6.6635444S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "6f222bd9-f031-49c5-b931-18dedcb42e57"
+          "c24bbf6c-c642-4119-b11a-5ffa1b1a26f8"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT10.7427773S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:28:54 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "df6a4122-ec24-4105-b292-e1049679e073"
+          "2d4e6a20-867d-44b5-af8c-bd5e47a37d7b"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:20 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT11.8824842S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "01718c1a-5974-4ee1-98a8-27e5e782cc0c"
+          "d75862c9-265b-4066-a9bd-6a022e1f0b16"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT16.2428624S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:01 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "4029971b-0353-4f57-a04f-93468eecd435"
+          "5770ba59-a2ce-4972-9f2d-6c65242972df"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:25 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT17.101241S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "98eb2b3f-4fb7-4245-ba18-5688614bff5d"
+          "75faf69a-961d-4b72-8761-679795477f19"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT21.5243358S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:05 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "9c88af12-63a9-4674-9326-3a4537d00fef"
+          "2fc54293-ca60-4af7-8108-0577df68d92f"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:30 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT22.3669327S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "d07d7d75-ab60-4646-9c7f-eb12e22137c6"
+          "a92e008f-4b42-4b43-96cd-5947c7fea982"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT26.7744098S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:11 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "1267c543-4787-451b-80f7-31bf1363c820"
+          "edc282cf-6740-4988-8b24-bdf42f700782"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:35 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT27.5857474S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "e928b24c-4525-4bbe-b3b9-89ed7e575124"
+          "4f4842df-443e-4280-aaa2-b601868b1bdf"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT32.0557101S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:16 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "70746fd4-bd77-446e-ab53-d6e9cb57b42f"
+          "26318057-9c33-48b0-b0ff-cf841ac819cd"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:40 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT32.8045955S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "4351d204-a49d-42c5-aa15-958e35b6ddfe"
+          "93895b93-4f3b-4cbd-b7b9-4d2dd9b5229e"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT37.3214109S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:21 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "d0a2ed22-c844-4d68-976b-2b224c0e1479"
+          "7d562b9c-ac97-4118-b4b3-c69881eb109f"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:46 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"state\": \"Running\",\r\n  \"result\": \"None\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT38.0078176S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/jobs/ed042635-a48d-456a-aa2e-8d20f5d14a69?api-version=2017-09-01-preview",
-      "EncodedRequestUri": "L2pvYnMvZWQwNDI2MzUtYTQ4ZC00NTZhLWFhMmUtOGQyMGY1ZDE0YTY5P2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
+      "RequestUri": "/jobs/9e535708-aa04-4ccc-9971-58f519f826b1?api-version=2017-09-01-preview",
+      "EncodedRequestUri": "L2pvYnMvOWU1MzU3MDgtYWEwNC00Y2NjLTk5NzEtNThmNTE5ZjgyNmIxP2FwaS12ZXJzaW9uPTIwMTctMDktMDEtcHJldmlldw==",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "752f78f4-a202-4290-8847-aea0e2098b28"
+          "025b3b20-5d7b-44e8-9c43-d318024cb93a"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsJobManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"jobId\": \"ed042635-a48d-456a-aa2e-8d20f5d14a69\",\r\n  \"name\": \"testjob16268\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n  \"startTime\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n  \"endTime\": \"2018-06-05T23:29:24.2642261-07:00\",\r\n  \"state\": \"Ended\",\r\n  \"result\": \"Succeeded\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.4358263-07:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:17.795184-07:00\",\r\n      \"details\": \"Compilation:ee28de24-61c9-4b22-9e2b-9e58cb6f1409;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4827995-07:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:d73d9f5c-b257-41b4-92b0-92350ac8cf7f\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2018-06-05T23:28:37.4984385-07:00\",\r\n      \"details\": \"runtimeVersion:release_20180315_adl_991096\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2018-06-05T23:28:44.7015573-07:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    },\r\n    {\r\n      \"newState\": \"Ended\",\r\n      \"timeStamp\": \"2018-06-05T23:29:24.2642261-07:00\",\r\n      \"details\": \"result:Succeeded\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"PartitionLastRows.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/PartitionLastRows.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20180315_adl_991096\",\r\n    \"rootProcessNodeId\": \"d73d9f5c-b257-41b4-92b0-92350ac8cf7f\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb15955; CREATE DATABASE testdb15955; \\n//Create Table\\nCREATE TABLE testdb15955.dbo.testtbl18883\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb15955.dbo.testtbl18883 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb15955.dbo.testtbl18883\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb15955.dbo.testtvf13272;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11460.azuredatalakestore.net/system/jobservice/jobs/Usql/2018/06/06/06/28/ed042635-a48d-456a-aa2e-8d20f5d14a69/algebra.xml\",\r\n    \"yarnApplicationId\": 360022,\r\n    \"yarnApplicationTimeStamp\": 1525971422029,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT19.6876155S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.015639S\",\r\n    \"totalRunningTime\": \"PT39.5626688S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; charset=utf-8"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:26 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "b526553e-553d-4e23-972e-f2614b6e53f8"
+          "b8d85fae-31e9-49e7-a130-74f7987ff0e6"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:51 GMT"
+        ],
+        "Content-Type": [
+          "application/json; charset=utf-8"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"jobId\": \"9e535708-aa04-4ccc-9971-58f519f826b1\",\r\n  \"name\": \"testjob14137\",\r\n  \"type\": \"USql\",\r\n  \"submitter\": \"AdlSdkTestApp01@SPI\",\r\n  \"degreeOfParallelism\": 2,\r\n  \"priority\": 1000,\r\n  \"submitTime\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n  \"startTime\": \"2019-03-05T22:51:00.769-08:00\",\r\n  \"endTime\": \"2019-03-05T22:51:44.644-08:00\",\r\n  \"state\": \"Ended\",\r\n  \"result\": \"Succeeded\",\r\n  \"stateAuditRecords\": [\r\n    {\r\n      \"newState\": \"New\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.4309355-08:00\",\r\n      \"details\": \"userName:;submitMachine:N/A\"\r\n    },\r\n    {\r\n      \"newState\": \"Compiling\",\r\n      \"timeStamp\": \"2019-03-05T22:50:42.9465685-08:00\",\r\n      \"details\": \"Compilation:c4584516-d271-42ab-b6e1-af023b81fce2;Status:Dispatched\"\r\n    },\r\n    {\r\n      \"newState\": \"Queued\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.6964245-08:00\"\r\n    },\r\n    {\r\n      \"newState\": \"Scheduling\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.7120569-08:00\",\r\n      \"details\": \"Detail:Dispatching job to cluster.;rootProcessId:0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\"\r\n    },\r\n    {\r\n      \"newState\": \"Starting\",\r\n      \"timeStamp\": \"2019-03-05T22:51:00.727676-08:00\",\r\n      \"details\": \"runtimeVersion:release_20181022_adl_2398995\"\r\n    },\r\n    {\r\n      \"newState\": \"Running\",\r\n      \"timeStamp\": \"2019-03-05T22:51:08.6651119-08:00\",\r\n      \"details\": \"runAttempt:1\"\r\n    },\r\n    {\r\n      \"newState\": \"Ended\",\r\n      \"timeStamp\": \"2019-03-05T22:51:46.9460412-08:00\",\r\n      \"details\": \"result:Succeeded\"\r\n    }\r\n  ],\r\n  \"properties\": {\r\n    \"owner\": \"AdlSdkTestApp01@SPI\",\r\n    \"resources\": [\r\n      {\r\n        \"name\": \"query.abr\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/query.abr\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"ScopeVertexDef.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/ScopeVertexDef.xml\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"diagnosticsjson\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/diagnosticsjson\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOptions__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOptions__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenResources__.zip\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenResources__.zip\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SystemInternalInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SystemInternalInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.cppresources\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.cppresources\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeDiagnosisInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeDiagnosisInfo__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenCompileOutput__.txt\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenCompileOutput__.txt\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.pdb\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.pdb\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll.cpp\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGen__.dll.cs\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGen__.dll.cs\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeCodeGenEngine__.dll\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeCodeGenEngine__.dll\",\r\n        \"type\": \"VertexResource\"\r\n      },\r\n      {\r\n        \"name\": \"__SStreamInfo__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__SStreamInfo__.xml\",\r\n        \"type\": \"JobManagerResource\"\r\n      },\r\n      {\r\n        \"name\": \"Profile\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/profile\",\r\n        \"type\": \"StatisticsResource\"\r\n      },\r\n      {\r\n        \"name\": \"__ScopeRuntimeStatistics__.xml\",\r\n        \"resourcePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/__ScopeRuntimeStatistics__.xml\",\r\n        \"type\": \"StatisticsResource\"\r\n      }\r\n    ],\r\n    \"runtimeVersion\": \"release_20181022_adl_2398995\",\r\n    \"rootProcessNodeId\": \"0e6b9f74-4ce9-4806-982f-0ad3fd1f4836\",\r\n    \"script\": \"\\nDROP DATABASE IF EXISTS testdb17950; CREATE DATABASE testdb17950; \\n//Create Table\\nCREATE TABLE testdb17950.dbo.testtbl16049\\n(\\n        //Define schema of table\\n        UserId          int, \\n        Start           DateTime, \\n        Region          string, \\n        Query           string, \\n        Duration        int, \\n        Urls            string, \\n        ClickedUrls     string,\\n    INDEX idx1 //Name of index\\n    CLUSTERED (Region ASC) //Column to cluster by\\n    PARTITIONED BY (UserId) HASH (Region) //Column to partition by\\n);\\n\\nALTER TABLE testdb17950.dbo.testtbl16049 ADD IF NOT EXISTS PARTITION (1);\\n\\nINSERT INTO testdb17950.dbo.testtbl16049\\n(UserId, Start, Region, Query, Duration, Urls, ClickedUrls)\\nON INTEGRITY VIOLATION MOVE TO PARTITION (1)\\nVALUES\\n(1, new DateTime(2018, 04, 25), \\\"US\\\", @\\\"fake query\\\", 34, \\\"http://url1.fake.com\\\", \\\"http://clickedUrl1.fake.com\\\"),\\n(1, new DateTime(2018, 04, 26), \\\"EN\\\", @\\\"fake query\\\", 23, \\\"http://url2.fake.com\\\", \\\"http://clickedUrl2.fake.com\\\");\\n\\nDROP FUNCTION IF EXISTS testdb17950.dbo.testtvf11076;\\n\\n//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\\nCREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\\nCREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n    \"algebraFilePath\": \"adl://testdatalake11650.azuredatalakestore.net/system/jobservice/jobs/Usql/2019/03/06/06/50/9e535708-aa04-4ccc-9971-58f519f826b1/algebra.xml\",\r\n    \"yarnApplicationId\": 1717515,\r\n    \"yarnApplicationTimeStamp\": 1551369016070,\r\n    \"compileMode\": \"Semantic\",\r\n    \"errorSource\": \"Unknown\",\r\n    \"totalCompilationTime\": \"PT17.749856S\",\r\n    \"totalPausedTime\": \"PT0S\",\r\n    \"totalQueuedTime\": \"PT0.0156324S\",\r\n    \"totalRunningTime\": \"PT38.2809293S\",\r\n    \"expirationTimeUtc\": \"0001-01-01T00:00:00\",\r\n    \"type\": \"USql\"\r\n  }\r\n}",
       "StatusCode": 200
     },
     {
@@ -2653,35 +2686,27 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "9369263f-55c3-414e-9a35-f120a25daab7"
+          "292e7862-d204-4cbf-ba59-de317a7df76d"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#databases\",\r\n  \"value\": [\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"version\": \"d6f03f6a-6a41-49b8-a920-d583074e91bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"version\": \"fe8e4ce0-f62e-4136-978b-9d82c5e0a3df\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:33 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "44177cdb-c904-4f82-9cbf-8293431651e9"
+          "702a3554-9210-4b35-a6b2-413ccd9765d9"
         ],
         "OData-Version": [
           "4.0"
@@ -2691,46 +2716,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTU/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "39dc7211-68fc-486b-96dd-ac97c2fb7e25"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:52 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#databases/$entity\",\r\n  \"computeAccountName\": \"testaba25339\",\r\n  \"databaseName\": \"testdb15955\",\r\n  \"version\": \"fe8e4ce0-f62e-4136-978b-9d82c5e0a3df\"\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#databases\",\r\n  \"value\": [\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"version\": \"8ee975c2-6df6-495f-890b-508e1d84236e\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"version\": \"b6a8e93b-5f10-4e39-9483-443c0f634b45\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTA/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "7429a08e-5d10-4783-8f81-0c043677ceb4"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:34 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "5d11ffb0-a1d7-4403-9055-5ff5fd87c218"
+          "c5db2f21-0cbf-4d92-93d4-f69776aa8a97"
         ],
         "OData-Version": [
           "4.0"
@@ -2740,46 +2767,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tables?basic=false&api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGVzP2Jhc2ljPWZhbHNlJmFwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "ae7b1382-2fc0-4893-a33c-2d5dbd0a54e1"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:52 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tables\",\r\n  \"value\": [\r\n    {\r\n      \"tableName\": \"testtbl18883\",\r\n      \"columnList\": [\r\n        {\r\n          \"name\": \"UserId\",\r\n          \"type\": \"System.Int32\"\r\n        },\r\n        {\r\n          \"name\": \"Start\",\r\n          \"type\": \"System.DateTime\"\r\n        },\r\n        {\r\n          \"name\": \"Region\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"Query\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"Duration\",\r\n          \"type\": \"System.Int32\"\r\n        },\r\n        {\r\n          \"name\": \"Urls\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"ClickedUrls\",\r\n          \"type\": \"System.String\"\r\n        }\r\n      ],\r\n      \"indexList\": [\r\n        {\r\n          \"name\": \"idx1\",\r\n          \"indexKeys\": [\r\n            {\r\n              \"name\": \"Region\",\r\n              \"descending\": false\r\n            }\r\n          ],\r\n          \"columns\": [\r\n            \"Region\",\r\n            \"UserId\"\r\n          ],\r\n          \"distributionInfo\": {\r\n            \"type\": 2,\r\n            \"keys\": [\r\n              {\r\n                \"name\": \"Region\",\r\n                \"descending\": false\r\n              }\r\n            ],\r\n            \"count\": 0,\r\n            \"dynamicCount\": 0\r\n          },\r\n          \"partitionFunction\": \"b5dd347e-6566-46a3-b8b6-3bde309af459\",\r\n          \"partitionKeyList\": [\r\n            \"UserId\"\r\n          ],\r\n          \"isColumnstore\": false,\r\n          \"indexId\": 1,\r\n          \"isUnique\": false\r\n        }\r\n      ],\r\n      \"partitionKeyList\": [],\r\n      \"externalTable\": null,\r\n      \"distributionInfo\": null,\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2018-06-06T06:29:10.203-07:00\",\r\n      \"updateTime\": \"2018-06-06T06:29:10.203-07:00\",\r\n      \"version\": \"24e00f0d-0e96-40e3-bcfb-8ccde132e19a\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#databases/$entity\",\r\n  \"computeAccountName\": \"testaba28877\",\r\n  \"databaseName\": \"testdb17950\",\r\n  \"version\": \"b6a8e93b-5f10-4e39-9483-443c0f634b45\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tables?basic=false&api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGVzP2Jhc2ljPWZhbHNlJmFwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "d03722e8-0a2c-4497-b11b-8ac1bdc0a89d"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:34 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "066da680-fe8e-4021-920c-6044db16c615"
+          "393474f6-49bd-4e0e-8c73-d73fff3840bb"
         ],
         "OData-Version": [
           "4.0"
@@ -2789,46 +2818,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tables?basic=true&api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGVzP2Jhc2ljPXRydWUmYXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "a2c282c9-db8e-4d86-b892-e1370abc6a71"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:52 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tables\",\r\n  \"value\": [\r\n    {\r\n      \"tableName\": \"testtbl18883\",\r\n      \"columnList\": [],\r\n      \"indexList\": [],\r\n      \"partitionKeyList\": [],\r\n      \"externalTable\": null,\r\n      \"distributionInfo\": null,\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": null,\r\n      \"updateTime\": null,\r\n      \"version\": \"24e00f0d-0e96-40e3-bcfb-8ccde132e19a\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tables\",\r\n  \"value\": [\r\n    {\r\n      \"tableName\": \"testtbl16049\",\r\n      \"columnList\": [\r\n        {\r\n          \"name\": \"UserId\",\r\n          \"type\": \"System.Int32\"\r\n        },\r\n        {\r\n          \"name\": \"Start\",\r\n          \"type\": \"System.DateTime\"\r\n        },\r\n        {\r\n          \"name\": \"Region\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"Query\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"Duration\",\r\n          \"type\": \"System.Int32\"\r\n        },\r\n        {\r\n          \"name\": \"Urls\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"ClickedUrls\",\r\n          \"type\": \"System.String\"\r\n        }\r\n      ],\r\n      \"indexList\": [\r\n        {\r\n          \"name\": \"idx1\",\r\n          \"indexKeys\": [\r\n            {\r\n              \"name\": \"Region\",\r\n              \"descending\": false\r\n            }\r\n          ],\r\n          \"columns\": [\r\n            \"Region\",\r\n            \"UserId\"\r\n          ],\r\n          \"distributionInfo\": {\r\n            \"type\": 2,\r\n            \"keys\": [\r\n              {\r\n                \"name\": \"Region\",\r\n                \"descending\": false\r\n              }\r\n            ],\r\n            \"count\": 0,\r\n            \"dynamicCount\": 0\r\n          },\r\n          \"partitionFunction\": \"8123450d-0850-4cf9-ab98-2b38e95136fb\",\r\n          \"partitionKeyList\": [\r\n            \"UserId\"\r\n          ],\r\n          \"isColumnstore\": false,\r\n          \"indexId\": 1,\r\n          \"isUnique\": false\r\n        }\r\n      ],\r\n      \"partitionKeyList\": [],\r\n      \"externalTable\": null,\r\n      \"distributionInfo\": null,\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2019-03-06T06:51:32.457-08:00\",\r\n      \"updateTime\": \"2019-03-06T06:51:32.457-08:00\",\r\n      \"version\": \"5d982878-c959-4ff8-a374-176d2c2cee22\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tables?basic=true&api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGVzP2Jhc2ljPXRydWUmYXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "7ac776d7-34c5-4f64-893e-fb677d0a8644"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:34 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "2b6aaafe-0c4b-4adf-a177-fc16404b349e"
+          "33286372-ec78-4878-b155-41f3be3cac3d"
         ],
         "OData-Version": [
           "4.0"
@@ -2838,46 +2869,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/tables?basic=false&api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvdGFibGVzP2Jhc2ljPWZhbHNlJmFwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "5ac8645c-1af3-47ee-ba74-09f06a7c7cce"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:53 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tables\",\r\n  \"value\": [\r\n    {\r\n      \"tableName\": \"testtbl18883\",\r\n      \"columnList\": [\r\n        {\r\n          \"name\": \"UserId\",\r\n          \"type\": \"System.Int32\"\r\n        },\r\n        {\r\n          \"name\": \"Start\",\r\n          \"type\": \"System.DateTime\"\r\n        },\r\n        {\r\n          \"name\": \"Region\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"Query\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"Duration\",\r\n          \"type\": \"System.Int32\"\r\n        },\r\n        {\r\n          \"name\": \"Urls\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"ClickedUrls\",\r\n          \"type\": \"System.String\"\r\n        }\r\n      ],\r\n      \"indexList\": [\r\n        {\r\n          \"name\": \"idx1\",\r\n          \"indexKeys\": [\r\n            {\r\n              \"name\": \"Region\",\r\n              \"descending\": false\r\n            }\r\n          ],\r\n          \"columns\": [\r\n            \"Region\",\r\n            \"UserId\"\r\n          ],\r\n          \"distributionInfo\": {\r\n            \"type\": 2,\r\n            \"keys\": [\r\n              {\r\n                \"name\": \"Region\",\r\n                \"descending\": false\r\n              }\r\n            ],\r\n            \"count\": 0,\r\n            \"dynamicCount\": 0\r\n          },\r\n          \"partitionFunction\": \"b5dd347e-6566-46a3-b8b6-3bde309af459\",\r\n          \"partitionKeyList\": [\r\n            \"UserId\"\r\n          ],\r\n          \"isColumnstore\": false,\r\n          \"indexId\": 1,\r\n          \"isUnique\": false\r\n        }\r\n      ],\r\n      \"partitionKeyList\": [],\r\n      \"externalTable\": null,\r\n      \"distributionInfo\": null,\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2018-06-06T06:29:10.203-07:00\",\r\n      \"updateTime\": \"2018-06-06T06:29:10.203-07:00\",\r\n      \"version\": \"24e00f0d-0e96-40e3-bcfb-8ccde132e19a\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tables\",\r\n  \"value\": [\r\n    {\r\n      \"tableName\": \"testtbl16049\",\r\n      \"columnList\": [],\r\n      \"indexList\": [],\r\n      \"partitionKeyList\": [],\r\n      \"externalTable\": null,\r\n      \"distributionInfo\": null,\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": null,\r\n      \"updateTime\": null,\r\n      \"version\": \"5d982878-c959-4ff8-a374-176d2c2cee22\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/tables?basic=false&api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvdGFibGVzP2Jhc2ljPWZhbHNlJmFwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "fd7ad34f-7cbe-4210-a695-1fe699bf4668"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:35 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "df46348e-e577-4da6-9e69-8b8c07387583"
+          "ac11f5a6-fbf7-40bb-a707-3f1690a353db"
         ],
         "OData-Version": [
           "4.0"
@@ -2887,46 +2920,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/tables?basic=true&api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvdGFibGVzP2Jhc2ljPXRydWUmYXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "401bcf2f-801c-460e-a145-0ee91564f531"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:53 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tables\",\r\n  \"value\": [\r\n    {\r\n      \"tableName\": \"testtbl18883\",\r\n      \"columnList\": [],\r\n      \"indexList\": [],\r\n      \"partitionKeyList\": [],\r\n      \"externalTable\": null,\r\n      \"distributionInfo\": null,\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": null,\r\n      \"updateTime\": null,\r\n      \"version\": \"24e00f0d-0e96-40e3-bcfb-8ccde132e19a\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tables\",\r\n  \"value\": [\r\n    {\r\n      \"tableName\": \"testtbl16049\",\r\n      \"columnList\": [\r\n        {\r\n          \"name\": \"UserId\",\r\n          \"type\": \"System.Int32\"\r\n        },\r\n        {\r\n          \"name\": \"Start\",\r\n          \"type\": \"System.DateTime\"\r\n        },\r\n        {\r\n          \"name\": \"Region\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"Query\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"Duration\",\r\n          \"type\": \"System.Int32\"\r\n        },\r\n        {\r\n          \"name\": \"Urls\",\r\n          \"type\": \"System.String\"\r\n        },\r\n        {\r\n          \"name\": \"ClickedUrls\",\r\n          \"type\": \"System.String\"\r\n        }\r\n      ],\r\n      \"indexList\": [\r\n        {\r\n          \"name\": \"idx1\",\r\n          \"indexKeys\": [\r\n            {\r\n              \"name\": \"Region\",\r\n              \"descending\": false\r\n            }\r\n          ],\r\n          \"columns\": [\r\n            \"Region\",\r\n            \"UserId\"\r\n          ],\r\n          \"distributionInfo\": {\r\n            \"type\": 2,\r\n            \"keys\": [\r\n              {\r\n                \"name\": \"Region\",\r\n                \"descending\": false\r\n              }\r\n            ],\r\n            \"count\": 0,\r\n            \"dynamicCount\": 0\r\n          },\r\n          \"partitionFunction\": \"8123450d-0850-4cf9-ab98-2b38e95136fb\",\r\n          \"partitionKeyList\": [\r\n            \"UserId\"\r\n          ],\r\n          \"isColumnstore\": false,\r\n          \"indexId\": 1,\r\n          \"isUnique\": false\r\n        }\r\n      ],\r\n      \"partitionKeyList\": [],\r\n      \"externalTable\": null,\r\n      \"distributionInfo\": null,\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2019-03-06T06:51:32.457-08:00\",\r\n      \"updateTime\": \"2019-03-06T06:51:32.457-08:00\",\r\n      \"version\": \"5d982878-c959-4ff8-a374-176d2c2cee22\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/tables?basic=true&api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvdGFibGVzP2Jhc2ljPXRydWUmYXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "4af038fc-d2c0-4d3f-8808-dee484f2321d"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:35 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "026a0d79-0bcb-4d5a-950e-8b32b39d1e28"
+          "750ec6cb-e856-489b-8fba-e1a4165ac8d3"
         ],
         "OData-Version": [
           "4.0"
@@ -2936,31 +2971,57 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:53 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tables\",\r\n  \"value\": [\r\n    {\r\n      \"tableName\": \"testtbl16049\",\r\n      \"columnList\": [],\r\n      \"indexList\": [],\r\n      \"partitionKeyList\": [],\r\n      \"externalTable\": null,\r\n      \"distributionInfo\": null,\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": null,\r\n      \"updateTime\": null,\r\n      \"version\": \"5d982878-c959-4ff8-a374-176d2c2cee22\"\r\n    }\r\n  ]\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tables/testtbl18883/previewrows?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxODg4My9wcmV2aWV3cm93cz9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tables/testtbl16049/previewrows?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxNjA0OS9wcmV2aWV3cm93cz9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "c73a389f-810b-44e4-a1cf-faa6869b82c4"
+          "c75c141f-918a-4e46-816b-ed6593d14e71"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"rowCount\": 2,\r\n  \"totalRowCount\": 2,\r\n  \"columnCount\": 7,\r\n  \"totalColumnCount\": 7,\r\n  \"schema\": [\r\n    {\r\n      \"name\": \"UserId\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Start\",\r\n      \"type\": \"System.DateTime\"\r\n    },\r\n    {\r\n      \"name\": \"Region\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Query\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Duration\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Urls\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"ClickedUrls\",\r\n      \"type\": \"System.String\"\r\n    }\r\n  ],\r\n  \"rows\": [\r\n    [\r\n      \"1\",\r\n      \"4/26/2018 12:00:00 AM\",\r\n      \"EN\",\r\n      \"fake query\",\r\n      \"23\",\r\n      \"http://url2.fake.com\",\r\n      \"http://clickedUrl2.fake.com\"\r\n    ],\r\n    [\r\n      \"1\",\r\n      \"4/25/2018 12:00:00 AM\",\r\n      \"US\",\r\n      \"fake query\",\r\n      \"34\",\r\n      \"http://url1.fake.com\",\r\n      \"http://clickedUrl1.fake.com\"\r\n    ]\r\n  ],\r\n  \"truncated\": false\r\n}",
       "ResponseHeaders": {
-        "Content-Length": [
-          "679"
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0"
+        ],
+        "Pragma": [
+          "no-cache"
+        ],
+        "x-ms-request-id": [
+          "97fe2396-83ba-4dd2-9522-2b501acfb13e"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:54 GMT"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -2968,538 +3029,560 @@
         "Expires": [
           "-1"
         ],
+        "Content-Length": [
+          "623"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"rowCount\": 2,\r\n  \"totalRowCount\": 2,\r\n  \"columnCount\": 7,\r\n  \"totalColumnCount\": 7,\r\n  \"schema\": [\r\n    {\r\n      \"name\": \"UserId\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Start\",\r\n      \"type\": \"System.DateTime\"\r\n    },\r\n    {\r\n      \"name\": \"Region\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Query\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Duration\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Urls\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"ClickedUrls\",\r\n      \"type\": \"System.String\"\r\n    }\r\n  ],\r\n  \"rows\": [\r\n    [\r\n      \"1\",\r\n      \"2018-04-26T07:00:00Z\",\r\n      \"EN\",\r\n      \"fake query\",\r\n      \"23\",\r\n      \"http://url2.fake.com\",\r\n      \"http://clickedUrl2.fake.com\"\r\n    ],\r\n    [\r\n      \"1\",\r\n      \"2018-04-25T07:00:00Z\",\r\n      \"US\",\r\n      \"fake query\",\r\n      \"34\",\r\n      \"http://url1.fake.com\",\r\n      \"http://clickedUrl1.fake.com\"\r\n    ]\r\n  ],\r\n  \"truncated\": false\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tables/testtbl16049?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxNjA0OT9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "26afa7ac-7235-4ecd-8bda-87d512b68c59"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
-          "no-store, no-cache, max-age=0"
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "4a43369b-3b4f-4052-b236-4b96e6635b19"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
         ],
         "Date": [
-          "Wed, 06 Jun 2018 06:29:37 GMT"
+          "Wed, 06 Mar 2019 06:51:54 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tables/$entity\",\r\n  \"tableName\": \"testtbl16049\",\r\n  \"columnList\": [\r\n    {\r\n      \"name\": \"UserId\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Start\",\r\n      \"type\": \"System.DateTime\"\r\n    },\r\n    {\r\n      \"name\": \"Region\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Query\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Duration\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Urls\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"ClickedUrls\",\r\n      \"type\": \"System.String\"\r\n    }\r\n  ],\r\n  \"indexList\": [\r\n    {\r\n      \"name\": \"idx1\",\r\n      \"indexKeys\": [\r\n        {\r\n          \"name\": \"Region\",\r\n          \"descending\": false\r\n        }\r\n      ],\r\n      \"columns\": [\r\n        \"Region\",\r\n        \"UserId\"\r\n      ],\r\n      \"distributionInfo\": {\r\n        \"type\": 2,\r\n        \"keys\": [\r\n          {\r\n            \"name\": \"Region\",\r\n            \"descending\": false\r\n          }\r\n        ],\r\n        \"count\": 0,\r\n        \"dynamicCount\": 0\r\n      },\r\n      \"partitionFunction\": \"8123450d-0850-4cf9-ab98-2b38e95136fb\",\r\n      \"partitionKeyList\": [\r\n        \"UserId\"\r\n      ],\r\n      \"isColumnstore\": false,\r\n      \"indexId\": 1,\r\n      \"isUnique\": false\r\n    }\r\n  ],\r\n  \"partitionKeyList\": [],\r\n  \"externalTable\": null,\r\n  \"distributionInfo\": null,\r\n  \"computeAccountName\": \"testaba28877\",\r\n  \"databaseName\": \"testdb17950\",\r\n  \"schemaName\": \"dbo\",\r\n  \"createTime\": \"2019-03-06T06:51:32.457-08:00\",\r\n  \"updateTime\": \"2019-03-06T06:51:32.457-08:00\",\r\n  \"version\": \"5d982878-c959-4ff8-a374-176d2c2cee22\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tablevaluedfunctions?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGV2YWx1ZWRmdW5jdGlvbnM/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "07d38d01-6e4e-41ba-8f4e-c6002611f641"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "68b7272b-19bb-49d2-a3f3-75c8aaf004f3"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:55 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tablevaluedfunctions\",\r\n  \"value\": [\r\n    {\r\n      \"tvfName\": \"testtvf11076\",\r\n      \"definition\": \"//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\",\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n      \"updateTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n      \"version\": \"8b2c9cfe-e6ed-412c-b924-29efe46c9b1f\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/tablevaluedfunctions?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvdGFibGV2YWx1ZWRmdW5jdGlvbnM/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "8b586074-e0e2-456a-817c-39e1e73e1061"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "25354f0d-499b-4501-8092-bb3aa35d9b70"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:55 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tablevaluedfunctions\",\r\n  \"value\": [\r\n    {\r\n      \"tvfName\": \"testtvf11076\",\r\n      \"definition\": \"//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\",\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n      \"updateTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n      \"version\": \"8b2c9cfe-e6ed-412c-b924-29efe46c9b1f\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tablevaluedfunctions/testtvf11076?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGV2YWx1ZWRmdW5jdGlvbnMvdGVzdHR2ZjExMDc2P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "03b9be46-8754-4924-a849-832a4dcd06b7"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "55cd08e0-caa3-4faf-816c-0bfee32bee50"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:55 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tablevaluedfunctions/$entity\",\r\n  \"tvfName\": \"testtvf11076\",\r\n  \"definition\": \"//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb17950.dbo.testtvf11076()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\",\r\n  \"computeAccountName\": \"testaba28877\",\r\n  \"databaseName\": \"testdb17950\",\r\n  \"schemaName\": \"dbo\",\r\n  \"createTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n  \"updateTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n  \"version\": \"8b2c9cfe-e6ed-412c-b924-29efe46c9b1f\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/views?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdmlld3M/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "61ee4fe1-5425-4078-8f2d-49cda235f66d"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "ffa53ace-8a05-4689-93f7-f1be00e7d4b2"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:55 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#views\",\r\n  \"value\": [\r\n    {\r\n      \"viewName\": \"testview1993\",\r\n      \"definition\": \"CREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\",\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n      \"updateTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n      \"version\": \"b12cd49d-93d5-4703-b7c2-138c9f298a55\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/views?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvdmlld3M/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "396859a4-4b88-43a8-8361-c0802c7c3cf9"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "c995c49f-68e4-4cd5-8bc7-3c574fc60f69"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:56 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#views\",\r\n  \"value\": [\r\n    {\r\n      \"viewName\": \"testview1993\",\r\n      \"definition\": \"CREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\",\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n      \"updateTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n      \"version\": \"b12cd49d-93d5-4703-b7c2-138c9f298a55\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/views/testview1993?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdmlld3MvdGVzdHZpZXcxOTkzP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "77fff474-7b7d-4681-94b9-a31d4d4f38d9"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "70f5a428-eacb-426b-96f6-1c16c5243809"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:56 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#views/$entity\",\r\n  \"viewName\": \"testview1993\",\r\n  \"definition\": \"CREATE VIEW testdb17950.dbo.testview1993 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\",\r\n  \"computeAccountName\": \"testaba28877\",\r\n  \"databaseName\": \"testdb17950\",\r\n  \"schemaName\": \"dbo\",\r\n  \"createTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n  \"updateTime\": \"2019-03-06T06:51:32.49-08:00\",\r\n  \"version\": \"b12cd49d-93d5-4703-b7c2-138c9f298a55\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/procedures?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vcHJvY2VkdXJlcz9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "d896e50f-d6b3-4053-a9a3-93645c5c3c19"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "dceb1685-a773-49b3-a750-608b690e6359"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:56 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#procedures\",\r\n  \"value\": [\r\n    {\r\n      \"procName\": \"testproc17628\",\r\n      \"definition\": \"CREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": null,\r\n      \"updateTime\": null,\r\n      \"version\": \"0b7faa95-cfe8-4499-ba99-827bfb3e6e1a\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/procedures/testproc17628?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vcHJvY2VkdXJlcy90ZXN0cHJvYzE3NjI4P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "767dd57c-f735-4960-86c0-ff037f4a48e2"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "b14647b2-dd11-4312-b519-d83297c46428"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:56 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#procedures/$entity\",\r\n  \"procName\": \"testproc17628\",\r\n  \"definition\": \"CREATE PROCEDURE testdb17950.dbo.testproc17628()\\nAS BEGIN\\n  CREATE VIEW testdb17950.dbo.testview1993 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n  \"computeAccountName\": \"testaba28877\",\r\n  \"databaseName\": \"testdb17950\",\r\n  \"schemaName\": \"dbo\",\r\n  \"createTime\": null,\r\n  \"updateTime\": null,\r\n  \"version\": \"0b7faa95-cfe8-4499-ba99-827bfb3e6e1a\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tables/testtbl16049/partitions?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxNjA0OS9wYXJ0aXRpb25zP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "e4a727c3-1366-4b86-97f8-e6b819ea08d9"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0, private"
+        ],
+        "Transfer-Encoding": [
+          "chunked"
+        ],
+        "x-ms-request-id": [
+          "b3175527-870b-45c8-bbbd-59be3b8a7722"
+        ],
+        "OData-Version": [
+          "4.0"
+        ],
+        "X-Content-Type-Options": [
+          "nosniff"
+        ],
+        "Strict-Transport-Security": [
+          "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:57 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#partitions\",\r\n  \"value\": [\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"testdb17950\",\r\n      \"schemaName\": \"dbo\",\r\n      \"partitionName\": \"testtbl16049_Partition_c6cfa6d3-3f77-4af8-aab9-b55ce943ff83\",\r\n      \"indexId\": 1,\r\n      \"label\": [\r\n        \"1\"\r\n      ],\r\n      \"createTime\": \"2019-03-06T06:51:32.473-08:00\",\r\n      \"parentName\": {\r\n        \"server\": \"2f5148c5-940c-4142-a76b-b0d479a22518\",\r\n        \"firstPart\": \"testdb17950\",\r\n        \"secondPart\": \"dbo\",\r\n        \"thirdPart\": \"testtbl16049\",\r\n        \"fourthPart\": null\r\n      },\r\n      \"version\": \"c0de57b9-0ad4-4be0-ac84-55888bfa1846\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tables/testtbl16049/partitions/testtbl16049_Partition_c6cfa6d3-3f77-4af8-aab9-b55ce943ff83/previewrows?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxNjA0OS9wYXJ0aXRpb25zL3Rlc3R0YmwxNjA0OV9QYXJ0aXRpb25fYzZjZmE2ZDMtM2Y3Ny00YWY4LWFhYjktYjU1Y2U5NDNmZjgzL3ByZXZpZXdyb3dzP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "b3974980-dafe-43cd-a4cf-ea3941e8a342"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
+        "Cache-Control": [
+          "no-store, no-cache, max-age=0"
         ],
         "Pragma": [
           "no-cache"
         ],
         "x-ms-request-id": [
-          "18294988-b5b7-4f95-b4f0-d03ab084c0ec"
+          "3a0e4b89-bfed-4190-9dfb-ad5592fe8d91"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tables/testtbl18883?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxODg4Mz9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "3df48e3c-6e90-4d08-b3bd-040b8bd141e8"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tables/$entity\",\r\n  \"tableName\": \"testtbl18883\",\r\n  \"columnList\": [\r\n    {\r\n      \"name\": \"UserId\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Start\",\r\n      \"type\": \"System.DateTime\"\r\n    },\r\n    {\r\n      \"name\": \"Region\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Query\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Duration\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Urls\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"ClickedUrls\",\r\n      \"type\": \"System.String\"\r\n    }\r\n  ],\r\n  \"indexList\": [\r\n    {\r\n      \"name\": \"idx1\",\r\n      \"indexKeys\": [\r\n        {\r\n          \"name\": \"Region\",\r\n          \"descending\": false\r\n        }\r\n      ],\r\n      \"columns\": [\r\n        \"Region\",\r\n        \"UserId\"\r\n      ],\r\n      \"distributionInfo\": {\r\n        \"type\": 2,\r\n        \"keys\": [\r\n          {\r\n            \"name\": \"Region\",\r\n            \"descending\": false\r\n          }\r\n        ],\r\n        \"count\": 0,\r\n        \"dynamicCount\": 0\r\n      },\r\n      \"partitionFunction\": \"b5dd347e-6566-46a3-b8b6-3bde309af459\",\r\n      \"partitionKeyList\": [\r\n        \"UserId\"\r\n      ],\r\n      \"isColumnstore\": false,\r\n      \"indexId\": 1,\r\n      \"isUnique\": false\r\n    }\r\n  ],\r\n  \"partitionKeyList\": [],\r\n  \"externalTable\": null,\r\n  \"distributionInfo\": null,\r\n  \"computeAccountName\": \"testaba25339\",\r\n  \"databaseName\": \"testdb15955\",\r\n  \"schemaName\": \"dbo\",\r\n  \"createTime\": \"2018-06-06T06:29:10.203-07:00\",\r\n  \"updateTime\": \"2018-06-06T06:29:10.203-07:00\",\r\n  \"version\": \"24e00f0d-0e96-40e3-bcfb-8ccde132e19a\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
         ],
         "Date": [
-          "Wed, 06 Jun 2018 06:29:38 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "e617d49a-e324-46e9-ad4b-23d7fbad8714"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tablevaluedfunctions?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGV2YWx1ZWRmdW5jdGlvbnM/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "e448413a-dcfe-4635-bd76-b017ccc19758"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tablevaluedfunctions\",\r\n  \"value\": [\r\n    {\r\n      \"tvfName\": \"testtvf13272\",\r\n      \"definition\": \"//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\",\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n      \"updateTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n      \"version\": \"62cf1679-54c5-4351-9465-df4f794d141b\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:38 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "4ff0261d-e3bb-4c55-b140-7b74eb535fb8"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/tablevaluedfunctions?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvdGFibGV2YWx1ZWRmdW5jdGlvbnM/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "e1f70a2c-ee68-47d9-bc8f-9911cc991f85"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tablevaluedfunctions\",\r\n  \"value\": [\r\n    {\r\n      \"tvfName\": \"testtvf13272\",\r\n      \"definition\": \"//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\",\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n      \"updateTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n      \"version\": \"62cf1679-54c5-4351-9465-df4f794d141b\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:38 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "eb492585-22ff-48ac-a7cd-c6fb37cb229d"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tablevaluedfunctions/testtvf13272?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGV2YWx1ZWRmdW5jdGlvbnMvdGVzdHR2ZjEzMjcyP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "941b219f-b23e-4c34-9d34-11b3dbd219f6"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tablevaluedfunctions/$entity\",\r\n  \"tvfName\": \"testtvf13272\",\r\n  \"definition\": \"//create table weblogs on space-delimited website log data\\nCREATE FUNCTION testdb15955.dbo.testtvf13272()\\nRETURNS @result TABLE\\n(\\n    s_date DateTime,\\n    s_time string,\\n    s_sitename string,\\n    cs_method string, \\n    cs_uristem string,\\n    cs_uriquery string,\\n    s_port int,\\n    cs_username string, \\n    c_ip string,\\n    cs_useragent string,\\n    cs_cookie string,\\n    cs_referer string, \\n    cs_host string,\\n    sc_status int,\\n    sc_substatus int,\\n    sc_win32status int, \\n    sc_bytes int,\\n    cs_bytes int,\\n    s_timetaken int\\n)\\nAS\\nBEGIN\\n\\n    @result = EXTRACT\\n        s_date DateTime,\\n        s_time string,\\n        s_sitename string,\\n        cs_method string,\\n        cs_uristem string,\\n        cs_uriquery string,\\n        s_port int,\\n        cs_username string,\\n        c_ip string,\\n        cs_useragent string,\\n        cs_cookie string,\\n        cs_referer string,\\n        cs_host string,\\n        sc_status int,\\n        sc_substatus int,\\n        sc_win32status int,\\n        sc_bytes int,\\n        cs_bytes int,\\n        s_timetaken int\\n    FROM @\\\"/Samples/Data/WebLog.log\\\"\\n    USING Extractors.Text(delimiter:' ');\\n\\nRETURN;\\nEND;\",\r\n  \"computeAccountName\": \"testaba25339\",\r\n  \"databaseName\": \"testdb15955\",\r\n  \"schemaName\": \"dbo\",\r\n  \"createTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n  \"updateTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n  \"version\": \"62cf1679-54c5-4351-9465-df4f794d141b\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:38 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "820cfddb-8e06-4d76-88f9-01e6e394bc68"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/views?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdmlld3M/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "e4428d9a-2a2c-4a5e-9dad-afb7ffaf001b"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#views\",\r\n  \"value\": [\r\n    {\r\n      \"viewName\": \"testview12416\",\r\n      \"definition\": \"CREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\",\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n      \"updateTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n      \"version\": \"dedc82ec-e557-4daf-937c-b02102a9b2c8\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:40 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "024f4d9d-00a9-43fd-bba0-e464479f4aec"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/views?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvdmlld3M/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "73ead5ec-5d37-4e2a-96e9-e1d8923bc321"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#views\",\r\n  \"value\": [\r\n    {\r\n      \"viewName\": \"testview12416\",\r\n      \"definition\": \"CREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\",\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n      \"updateTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n      \"version\": \"dedc82ec-e557-4daf-937c-b02102a9b2c8\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:40 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "0f4c576e-b6a5-4ec3-8911-713b051cde95"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/views/testview12416?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdmlld3MvdGVzdHZpZXcxMjQxNj9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "23652641-b4af-4806-892a-8dc474a64d06"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#views/$entity\",\r\n  \"viewName\": \"testview12416\",\r\n  \"definition\": \"CREATE VIEW testdb15955.dbo.testview12416 \\nAS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\nAS \\nT(a, b);\",\r\n  \"computeAccountName\": \"testaba25339\",\r\n  \"databaseName\": \"testdb15955\",\r\n  \"schemaName\": \"dbo\",\r\n  \"createTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n  \"updateTime\": \"2018-06-06T06:29:10.233-07:00\",\r\n  \"version\": \"dedc82ec-e557-4daf-937c-b02102a9b2c8\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:40 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "063c825d-c4dc-4ebf-a0cf-9727707cc766"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/procedures?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vcHJvY2VkdXJlcz9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "e12052c6-a914-4485-a164-b08162310547"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#procedures\",\r\n  \"value\": [\r\n    {\r\n      \"procName\": \"testproc19339\",\r\n      \"definition\": \"CREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"createTime\": null,\r\n      \"updateTime\": null,\r\n      \"version\": \"38ee03f8-54a3-4ad5-b0c3-321920fab09d\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:41 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "cf1de3b9-2680-4370-81ab-c42c408c25e3"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/procedures/testproc19339?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vcHJvY2VkdXJlcy90ZXN0cHJvYzE5MzM5P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "5a77e2c8-a825-46d0-82c3-40bee4e2b459"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#procedures/$entity\",\r\n  \"procName\": \"testproc19339\",\r\n  \"definition\": \"CREATE PROCEDURE testdb15955.dbo.testproc19339()\\nAS BEGIN\\n  CREATE VIEW testdb15955.dbo.testview12416 \\n  AS \\n    SELECT * FROM \\n    (\\n        VALUES(1,2),(2,4)\\n    ) \\n  AS \\n  T(a, b);\\nEND;\",\r\n  \"computeAccountName\": \"testaba25339\",\r\n  \"databaseName\": \"testdb15955\",\r\n  \"schemaName\": \"dbo\",\r\n  \"createTime\": null,\r\n  \"updateTime\": null,\r\n  \"version\": \"38ee03f8-54a3-4ad5-b0c3-321920fab09d\"\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:41 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "add1fdea-a712-48cf-a5c4-3d33e4ed73fd"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tables/testtbl18883/partitions?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxODg4My9wYXJ0aXRpb25zP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "add051b0-271f-4a78-8441-d8ae28298768"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#partitions\",\r\n  \"value\": [\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"testdb15955\",\r\n      \"schemaName\": \"dbo\",\r\n      \"partitionName\": \"testtbl18883_Partition_e6a9aaec-d140-4ca1-8867-6b58e209da29\",\r\n      \"indexId\": 1,\r\n      \"label\": [\r\n        \"1\"\r\n      ],\r\n      \"createTime\": \"2018-06-06T06:29:10.203-07:00\",\r\n      \"parentName\": {\r\n        \"server\": \"a793b12e-bcef-4a48-91c8-7bd9a07ae175\",\r\n        \"firstPart\": \"testdb15955\",\r\n        \"secondPart\": \"dbo\",\r\n        \"thirdPart\": \"testtbl18883\",\r\n        \"fourthPart\": null\r\n      },\r\n      \"version\": \"ef96f446-629d-41fe-9868-d90ab6d2bdd7\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:41 GMT"
-        ],
-        "Transfer-Encoding": [
-          "chunked"
-        ],
-        "x-ms-request-id": [
-          "c5bccd49-5cad-4455-a11e-c1e1ab96de77"
-        ],
-        "OData-Version": [
-          "4.0"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tables/testtbl18883/partitions/testtbl18883_Partition_e6a9aaec-d140-4ca1-8867-6b58e209da29/previewrows?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxODg4My9wYXJ0aXRpb25zL3Rlc3R0YmwxODg4M19QYXJ0aXRpb25fZTZhOWFhZWMtZDE0MC00Y2ExLTg4NjctNmI1OGUyMDlkYTI5L3ByZXZpZXdyb3dzP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "d13d227e-0fef-4ebb-a33c-458f8438c175"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"rowCount\": 2,\r\n  \"totalRowCount\": 2,\r\n  \"columnCount\": 7,\r\n  \"totalColumnCount\": 7,\r\n  \"schema\": [\r\n    {\r\n      \"columnName\": \"UserId\",\r\n      \"dataType\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"columnName\": \"Start\",\r\n      \"dataType\": \"System.DateTime\"\r\n    },\r\n    {\r\n      \"columnName\": \"Region\",\r\n      \"dataType\": \"System.String\"\r\n    },\r\n    {\r\n      \"columnName\": \"Query\",\r\n      \"dataType\": \"System.String\"\r\n    },\r\n    {\r\n      \"columnName\": \"Duration\",\r\n      \"dataType\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"columnName\": \"Urls\",\r\n      \"dataType\": \"System.String\"\r\n    },\r\n    {\r\n      \"columnName\": \"ClickedUrls\",\r\n      \"dataType\": \"System.String\"\r\n    }\r\n  ],\r\n  \"rows\": [\r\n    [\r\n      \"1\",\r\n      \"4/26/2018 12:00:00 AM\",\r\n      \"EN\",\r\n      \"fake query\",\r\n      \"23\",\r\n      \"http://url2.fake.com\",\r\n      \"http://clickedUrl2.fake.com\"\r\n    ],\r\n    [\r\n      \"1\",\r\n      \"4/25/2018 12:00:00 AM\",\r\n      \"US\",\r\n      \"fake query\",\r\n      \"34\",\r\n      \"http://url1.fake.com\",\r\n      \"http://clickedUrl1.fake.com\"\r\n    ]\r\n  ],\r\n  \"truncated\": false\r\n}",
-      "ResponseHeaders": {
-        "Content-Length": [
-          "679"
+          "Wed, 06 Mar 2019 06:51:57 GMT"
         ],
         "Content-Type": [
           "application/json; charset=utf-8"
@@ -3507,63 +3590,41 @@
         "Expires": [
           "-1"
         ],
-        "Cache-Control": [
-          "no-store, no-cache, max-age=0"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:42 GMT"
-        ],
-        "Pragma": [
-          "no-cache"
-        ],
-        "x-ms-request-id": [
-          "3d1af1c8-8324-4521-88c7-8942bbac6c0d"
-        ],
-        "X-Content-Type-Options": [
-          "nosniff"
-        ],
-        "Strict-Transport-Security": [
-          "max-age=15724800; includeSubDomains"
+        "Content-Length": [
+          "623"
         ]
       },
+      "ResponseBody": "{\r\n  \"rowCount\": 2,\r\n  \"totalRowCount\": 2,\r\n  \"columnCount\": 7,\r\n  \"totalColumnCount\": 7,\r\n  \"schema\": [\r\n    {\r\n      \"name\": \"UserId\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Start\",\r\n      \"type\": \"System.DateTime\"\r\n    },\r\n    {\r\n      \"name\": \"Region\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Query\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"Duration\",\r\n      \"type\": \"System.Int32\"\r\n    },\r\n    {\r\n      \"name\": \"Urls\",\r\n      \"type\": \"System.String\"\r\n    },\r\n    {\r\n      \"name\": \"ClickedUrls\",\r\n      \"type\": \"System.String\"\r\n    }\r\n  ],\r\n  \"rows\": [\r\n    [\r\n      \"1\",\r\n      \"2018-04-26T07:00:00Z\",\r\n      \"EN\",\r\n      \"fake query\",\r\n      \"23\",\r\n      \"http://url2.fake.com\",\r\n      \"http://clickedUrl2.fake.com\"\r\n    ],\r\n    [\r\n      \"1\",\r\n      \"2018-04-25T07:00:00Z\",\r\n      \"US\",\r\n      \"fake query\",\r\n      \"34\",\r\n      \"http://url1.fake.com\",\r\n      \"http://clickedUrl1.fake.com\"\r\n    ]\r\n  ],\r\n  \"truncated\": false\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tables/testtbl18883/partitions/testtbl18883_Partition_e6a9aaec-d140-4ca1-8867-6b58e209da29?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxODg4My9wYXJ0aXRpb25zL3Rlc3R0YmwxODg4M19QYXJ0aXRpb25fZTZhOWFhZWMtZDE0MC00Y2ExLTg4NjctNmI1OGUyMDlkYTI5P2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tables/testtbl16049/partitions/testtbl16049_Partition_c6cfa6d3-3f77-4af8-aab9-b55ce943ff83?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxNjA0OS9wYXJ0aXRpb25zL3Rlc3R0YmwxNjA0OV9QYXJ0aXRpb25fYzZjZmE2ZDMtM2Y3Ny00YWY4LWFhYjktYjU1Y2U5NDNmZjgzP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "GET",
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "9c07c2f2-3146-4f9e-8329-4fe6cabf77d7"
+          "73d79e05-421c-4c19-8668-02c6590bbf06"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#partitions/$entity\",\r\n  \"computeAccountName\": \"testaba25339\",\r\n  \"databaseName\": \"testdb15955\",\r\n  \"schemaName\": \"dbo\",\r\n  \"partitionName\": \"testtbl18883_Partition_e6a9aaec-d140-4ca1-8867-6b58e209da29\",\r\n  \"indexId\": 1,\r\n  \"label\": [\r\n    \"1\"\r\n  ],\r\n  \"createTime\": \"2018-06-06T06:29:10.203-07:00\",\r\n  \"parentName\": {\r\n    \"server\": \"a793b12e-bcef-4a48-91c8-7bd9a07ae175\",\r\n    \"firstPart\": \"testdb15955\",\r\n    \"secondPart\": \"dbo\",\r\n    \"thirdPart\": \"testtbl18883\",\r\n    \"fourthPart\": null\r\n  },\r\n  \"version\": \"ef96f446-629d-41fe-9868-d90ab6d2bdd7\"\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:42 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "d1e43860-d05c-4b2f-b5e9-68c46873795a"
+          "2dbbc162-775d-48b2-a7a1-c1b80f096ba0"
         ],
         "OData-Version": [
           "4.0"
@@ -3573,46 +3634,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/tables/testtbl18883/tablefragments?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxODg4My90YWJsZWZyYWdtZW50cz9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "68e5f96e-3ce1-4702-a975-dbb3a07ae83c"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:57 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#tablefragments\",\r\n  \"value\": [\r\n    {\r\n      \"parentId\": \"ef96f446-629d-41fe-9868-d90ab6d2bdd7\",\r\n      \"fragmentId\": \"8c3e664e-1c10-465c-a803-c79c9248d0c2\",\r\n      \"indexId\": 1,\r\n      \"size\": 34008,\r\n      \"rowCount\": 2,\r\n      \"createDate\": \"2018-06-06T06:28:25.997-07:00\",\r\n      \"streamPath\": null\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#partitions/$entity\",\r\n  \"computeAccountName\": \"testaba28877\",\r\n  \"databaseName\": \"testdb17950\",\r\n  \"schemaName\": \"dbo\",\r\n  \"partitionName\": \"testtbl16049_Partition_c6cfa6d3-3f77-4af8-aab9-b55ce943ff83\",\r\n  \"indexId\": 1,\r\n  \"label\": [\r\n    \"1\"\r\n  ],\r\n  \"createTime\": \"2019-03-06T06:51:32.473-08:00\",\r\n  \"parentName\": {\r\n    \"server\": \"2f5148c5-940c-4142-a76b-b0d479a22518\",\r\n    \"firstPart\": \"testdb17950\",\r\n    \"secondPart\": \"dbo\",\r\n    \"thirdPart\": \"testtbl16049\",\r\n    \"fourthPart\": null\r\n  },\r\n  \"version\": \"c0de57b9-0ad4-4be0-ac84-55888bfa1846\"\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/tables/testtbl16049/tablefragments?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdGFibGVzL3Rlc3R0YmwxNjA0OS90YWJsZWZyYWdtZW50cz9hcGktdmVyc2lvbj0yMDE2LTExLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "1b6ffc50-04a3-46aa-96f2-d1c1292706e8"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:43 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "09876a93-8d1f-41ec-bb31-7cb0f8c09487"
+          "1abcb291-2d35-4091-8de1-0beec1db654e"
         ],
         "OData-Version": [
           "4.0"
@@ -3622,46 +3685,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/types?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdHlwZXM/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "3df71174-9f1e-4a57-983e-5303e02df327"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:58 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#types\",\r\n  \"value\": [\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlArray\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Microsoft.Analytics.Types.Sql.SqlArray\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlArray\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": true,\r\n      \"version\": \"1137ad93-d19b-4d4e-b726-011f76d4d833\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlBinary\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlBinary\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlBinary\",\r\n      \"systemTypeId\": 165,\r\n      \"userTypeId\": 165,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"b05e4357-12c7-461f-9559-4c39cfae1338\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlBit\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlBit\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlBit\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"caeb6f59-f027-4348-a3ff-f064531e0ee8\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlByte\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlByte\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlByte\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f2583736-1f0e-4072-8a04-d83db5e08241\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDate\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDate\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDate\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"29f9721a-315b-498f-a304-762e0511226d\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDateTime\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDateTime\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDateTime\",\r\n      \"systemTypeId\": 61,\r\n      \"userTypeId\": 61,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"6879225d-44ff-4404-a0bd-05ee379c39db\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDecimal\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDecimal\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDecimal\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"d6d8f781-23bf-48a6-a462-8946bab23c36\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDouble\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDouble\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDouble\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"db1bc9a7-f5da-4d64-9baa-399c9f72d6e2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlGuid\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlGuid\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlGuid\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"ab6715ed-cfba-4b5a-92e9-f86520b8e711\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt16\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt16\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt16\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"4ee64682-cbd4-40cc-90e9-c5de1433bbed\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt32\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt32\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt32\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"9af787e7-9fc0-4819-80ac-0339ce031ab3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt64\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt64\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"44d67b27-8bd8-4072-81ca-2d32adfdb17c\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlMap\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Microsoft.Analytics.Types.Sql.SqlMap\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlMap\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": true,\r\n      \"version\": \"18cf5d12-3651-44fe-ad16-cf5068f0b112\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlMoney\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlMoney\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlMoney\",\r\n      \"systemTypeId\": 60,\r\n      \"userTypeId\": 60,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"861e13ee-e110-4dd2-b0df-f2eb9a6b5bd2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlSingle\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlSingle\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlSingle\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"7037d7f1-e3d4-416f-bf81-285b630a75e4\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlString\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlString\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlString\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"a15306f5-43f5-433b-b795-ce02ee911953\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlStruct\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Microsoft.Analytics.Types.Sql.SqlStruct\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlStruct\",\r\n      \"systemTypeId\": 243,\r\n      \"userTypeId\": 332,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": true,\r\n      \"version\": \"f89f413d-bd5f-440a-b069-8fc345643648\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Boolean\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"bool\",\r\n      \"fullCSharpName\": \"System.Boolean\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"c04b91b8-2b7e-45b3-ada9-db5ede901672\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Boolean?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"bool?\",\r\n      \"fullCSharpName\": \"System.Boolean?\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"42f3147a-ed9b-47ae-a8ad-aa2fbc51e0ad\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte\",\r\n      \"fullCSharpName\": \"System.Byte\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"6a048add-f003-4d73-8471-3b0be963d1ac\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte?\",\r\n      \"fullCSharpName\": \"System.Byte?\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"c2623267-2a86-444a-a773-89783eae5b30\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte[]\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte[]\",\r\n      \"fullCSharpName\": \"System.Byte[]\",\r\n      \"systemTypeId\": 165,\r\n      \"userTypeId\": 165,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"84506afa-d9ad-4bef-9e44-cd00f1f54ce3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Char\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"char\",\r\n      \"fullCSharpName\": \"System.Char\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"bb4bb082-4d9c-4ce4-aa1b-bfaea278ac92\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Char?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"char?\",\r\n      \"fullCSharpName\": \"System.Char?\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"748c6bfa-5a8e-43d4-823b-3b3be0d8b85a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.DateTime\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"DateTime\",\r\n      \"fullCSharpName\": \"System.DateTime\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"4e348b46-7218-4c30-b879-ceee5a59e7bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.DateTime?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"DateTime?\",\r\n      \"fullCSharpName\": \"System.DateTime?\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"eb486159-acfa-4499-9b1a-e0ecda5d52a2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Decimal\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"decimal\",\r\n      \"fullCSharpName\": \"System.Decimal\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f29ebb5f-17e8-4448-8aec-1a6702380e75\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Decimal?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"decimal?\",\r\n      \"fullCSharpName\": \"System.Decimal?\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"b78657ef-955b-4841-805e-bec1e9d11e37\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Double\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"double\",\r\n      \"fullCSharpName\": \"System.Double\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f3bbcc4e-d872-4bd1-8429-7082199016d3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Double?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"double?\",\r\n      \"fullCSharpName\": \"System.Double?\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"5832365f-70cb-47f9-92db-46cf7903dffc\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Guid\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Guid\",\r\n      \"fullCSharpName\": \"System.Guid\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"ccccbe73-770a-4bc8-905f-2eec41e79736\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Guid?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Guid?\",\r\n      \"fullCSharpName\": \"System.Guid?\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"db4c6514-17fa-4de1-ab25-a22817844593\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int16\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"short\",\r\n      \"fullCSharpName\": \"System.Int16\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"2cca4ae1-4272-4ca4-832e-5bc22c486299\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int16?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"short?\",\r\n      \"fullCSharpName\": \"System.Int16?\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"cef0bb72-9079-471b-855c-cfb87b1dc11f\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int32\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"int\",\r\n      \"fullCSharpName\": \"System.Int32\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"2a3f9560-1645-4e60-8ca5-9713f2ef8363\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int32?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"int?\",\r\n      \"fullCSharpName\": \"System.Int32?\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"29fedecb-21d0-4fa8-bf6b-2539bee71bcc\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int64\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"long\",\r\n      \"fullCSharpName\": \"System.Int64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"14c67089-ce4d-4770-8425-a0c41788c3cd\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int64?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"long?\",\r\n      \"fullCSharpName\": \"System.Int64?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"01b8cce9-d5e9-4f38-9f29-d5f3927d7407\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.SByte\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"sbyte\",\r\n      \"fullCSharpName\": \"System.SByte\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"899a07dd-662c-4cd2-8f98-6ec34d739355\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.SByte?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"sbyte?\",\r\n      \"fullCSharpName\": \"System.SByte?\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f76f7f1a-64d9-4c50-a38c-a6b2578f66d3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Single\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"float\",\r\n      \"fullCSharpName\": \"System.Single\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"04ae7374-f270-48ba-b429-c7e07bfcde61\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Single?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"float?\",\r\n      \"fullCSharpName\": \"System.Single?\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f8f90902-84a6-449f-96fe-6710accc0f7a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.String\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"string\",\r\n      \"fullCSharpName\": \"System.String\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"313664ea-0a0b-4016-8c25-a11052d885ad\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt16\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ushort\",\r\n      \"fullCSharpName\": \"System.UInt16\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"1ee295be-df81-4f21-a17c-31205884958b\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt16?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ushort?\",\r\n      \"fullCSharpName\": \"System.UInt16?\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"a3228a28-dc3d-42f1-81d7-86899822af91\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt32\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"uint\",\r\n      \"fullCSharpName\": \"System.UInt32\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"133275dc-ec4b-4662-86ee-f6d13b0e8b7e\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt32?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"uint?\",\r\n      \"fullCSharpName\": \"System.UInt32?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"7292a0b6-ff2d-4c02-b256-63993c2b270a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt64\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ulong\",\r\n      \"fullCSharpName\": \"System.UInt64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"e80c1a1c-99d9-418c-9f66-097c048095bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt64?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ulong?\",\r\n      \"fullCSharpName\": \"System.UInt64?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"48cbabb8-03fc-4f00-bad6-0641a7f562c7\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#tablefragments\",\r\n  \"value\": [\r\n    {\r\n      \"parentId\": \"c0de57b9-0ad4-4be0-ac84-55888bfa1846\",\r\n      \"fragmentId\": \"5b456c70-a734-4e8d-afbd-2d4a230789e7\",\r\n      \"indexId\": 1,\r\n      \"size\": 34008,\r\n      \"rowCount\": 2,\r\n      \"createDate\": \"2019-03-06T06:50:50.083-08:00\",\r\n      \"streamPath\": \"catalog/database/b6a8e93b-5f10-4e39-9483-443c0f634b45/schema/de8d0556-da29-43c8-84a9-7f85da845588/table/5d982878-c959-4ff8-a374-176d2c2cee22/5b456c70-a734-4e8d-afbd-2d4a230789e7.ss\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/types?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdHlwZXM/YXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "82d1e78b-091f-427f-9f19-1193c9700750"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:43 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "a7354158-e768-4662-ac6f-d25ca992ae22"
+          "0eb197f4-2025-4703-9d14-cd108e20df31"
         ],
         "OData-Version": [
           "4.0"
@@ -3671,46 +3736,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/schemas/dbo/types?$filter=isComplexType%20eq%20false&api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvc2NoZW1hcy9kYm8vdHlwZXM/JGZpbHRlcj1pc0NvbXBsZXhUeXBlJTIwZXElMjBmYWxzZSZhcGktdmVyc2lvbj0yMDE2LTExLTAx",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "866983ad-d687-4df6-aae7-d6ca536e336f"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:58 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#types\",\r\n  \"value\": [\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlBinary\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlBinary\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlBinary\",\r\n      \"systemTypeId\": 165,\r\n      \"userTypeId\": 165,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"b05e4357-12c7-461f-9559-4c39cfae1338\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlBit\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlBit\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlBit\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"caeb6f59-f027-4348-a3ff-f064531e0ee8\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlByte\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlByte\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlByte\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f2583736-1f0e-4072-8a04-d83db5e08241\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDate\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDate\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDate\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"29f9721a-315b-498f-a304-762e0511226d\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDateTime\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDateTime\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDateTime\",\r\n      \"systemTypeId\": 61,\r\n      \"userTypeId\": 61,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"6879225d-44ff-4404-a0bd-05ee379c39db\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDecimal\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDecimal\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDecimal\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"d6d8f781-23bf-48a6-a462-8946bab23c36\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDouble\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDouble\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDouble\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"db1bc9a7-f5da-4d64-9baa-399c9f72d6e2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlGuid\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlGuid\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlGuid\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"ab6715ed-cfba-4b5a-92e9-f86520b8e711\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt16\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt16\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt16\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"4ee64682-cbd4-40cc-90e9-c5de1433bbed\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt32\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt32\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt32\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"9af787e7-9fc0-4819-80ac-0339ce031ab3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt64\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt64\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"44d67b27-8bd8-4072-81ca-2d32adfdb17c\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlMoney\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlMoney\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlMoney\",\r\n      \"systemTypeId\": 60,\r\n      \"userTypeId\": 60,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"861e13ee-e110-4dd2-b0df-f2eb9a6b5bd2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlSingle\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlSingle\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlSingle\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"7037d7f1-e3d4-416f-bf81-285b630a75e4\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlString\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlString\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlString\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"a15306f5-43f5-433b-b795-ce02ee911953\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Boolean\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"bool\",\r\n      \"fullCSharpName\": \"System.Boolean\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"c04b91b8-2b7e-45b3-ada9-db5ede901672\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Boolean?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"bool?\",\r\n      \"fullCSharpName\": \"System.Boolean?\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"42f3147a-ed9b-47ae-a8ad-aa2fbc51e0ad\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte\",\r\n      \"fullCSharpName\": \"System.Byte\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"6a048add-f003-4d73-8471-3b0be963d1ac\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte?\",\r\n      \"fullCSharpName\": \"System.Byte?\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"c2623267-2a86-444a-a773-89783eae5b30\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte[]\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte[]\",\r\n      \"fullCSharpName\": \"System.Byte[]\",\r\n      \"systemTypeId\": 165,\r\n      \"userTypeId\": 165,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"84506afa-d9ad-4bef-9e44-cd00f1f54ce3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Char\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"char\",\r\n      \"fullCSharpName\": \"System.Char\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"bb4bb082-4d9c-4ce4-aa1b-bfaea278ac92\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Char?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"char?\",\r\n      \"fullCSharpName\": \"System.Char?\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"748c6bfa-5a8e-43d4-823b-3b3be0d8b85a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.DateTime\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"DateTime\",\r\n      \"fullCSharpName\": \"System.DateTime\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"4e348b46-7218-4c30-b879-ceee5a59e7bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.DateTime?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"DateTime?\",\r\n      \"fullCSharpName\": \"System.DateTime?\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"eb486159-acfa-4499-9b1a-e0ecda5d52a2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Decimal\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"decimal\",\r\n      \"fullCSharpName\": \"System.Decimal\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f29ebb5f-17e8-4448-8aec-1a6702380e75\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Decimal?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"decimal?\",\r\n      \"fullCSharpName\": \"System.Decimal?\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"b78657ef-955b-4841-805e-bec1e9d11e37\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Double\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"double\",\r\n      \"fullCSharpName\": \"System.Double\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f3bbcc4e-d872-4bd1-8429-7082199016d3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Double?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"double?\",\r\n      \"fullCSharpName\": \"System.Double?\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"5832365f-70cb-47f9-92db-46cf7903dffc\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Guid\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Guid\",\r\n      \"fullCSharpName\": \"System.Guid\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"ccccbe73-770a-4bc8-905f-2eec41e79736\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Guid?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Guid?\",\r\n      \"fullCSharpName\": \"System.Guid?\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"db4c6514-17fa-4de1-ab25-a22817844593\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int16\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"short\",\r\n      \"fullCSharpName\": \"System.Int16\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"2cca4ae1-4272-4ca4-832e-5bc22c486299\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int16?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"short?\",\r\n      \"fullCSharpName\": \"System.Int16?\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"cef0bb72-9079-471b-855c-cfb87b1dc11f\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int32\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"int\",\r\n      \"fullCSharpName\": \"System.Int32\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"2a3f9560-1645-4e60-8ca5-9713f2ef8363\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int32?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"int?\",\r\n      \"fullCSharpName\": \"System.Int32?\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"29fedecb-21d0-4fa8-bf6b-2539bee71bcc\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int64\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"long\",\r\n      \"fullCSharpName\": \"System.Int64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"14c67089-ce4d-4770-8425-a0c41788c3cd\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int64?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"long?\",\r\n      \"fullCSharpName\": \"System.Int64?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"01b8cce9-d5e9-4f38-9f29-d5f3927d7407\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.SByte\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"sbyte\",\r\n      \"fullCSharpName\": \"System.SByte\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"899a07dd-662c-4cd2-8f98-6ec34d739355\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.SByte?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"sbyte?\",\r\n      \"fullCSharpName\": \"System.SByte?\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f76f7f1a-64d9-4c50-a38c-a6b2578f66d3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Single\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"float\",\r\n      \"fullCSharpName\": \"System.Single\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"04ae7374-f270-48ba-b429-c7e07bfcde61\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Single?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"float?\",\r\n      \"fullCSharpName\": \"System.Single?\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f8f90902-84a6-449f-96fe-6710accc0f7a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.String\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"string\",\r\n      \"fullCSharpName\": \"System.String\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"313664ea-0a0b-4016-8c25-a11052d885ad\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt16\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ushort\",\r\n      \"fullCSharpName\": \"System.UInt16\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"1ee295be-df81-4f21-a17c-31205884958b\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt16?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ushort?\",\r\n      \"fullCSharpName\": \"System.UInt16?\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"a3228a28-dc3d-42f1-81d7-86899822af91\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt32\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"uint\",\r\n      \"fullCSharpName\": \"System.UInt32\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"133275dc-ec4b-4662-86ee-f6d13b0e8b7e\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt32?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"uint?\",\r\n      \"fullCSharpName\": \"System.UInt32?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"7292a0b6-ff2d-4c02-b256-63993c2b270a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt64\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ulong\",\r\n      \"fullCSharpName\": \"System.UInt64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"e80c1a1c-99d9-418c-9f66-097c048095bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba25339\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt64?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ulong?\",\r\n      \"fullCSharpName\": \"System.UInt64?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"48cbabb8-03fc-4f00-bad6-0641a7f562c7\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#types\",\r\n  \"value\": [\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlArray\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Microsoft.Analytics.Types.Sql.SqlArray\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlArray\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": true,\r\n      \"version\": \"1137ad93-d19b-4d4e-b726-011f76d4d833\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlBinary\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlBinary\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlBinary\",\r\n      \"systemTypeId\": 165,\r\n      \"userTypeId\": 165,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"b05e4357-12c7-461f-9559-4c39cfae1338\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlBit\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlBit\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlBit\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"caeb6f59-f027-4348-a3ff-f064531e0ee8\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlByte\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlByte\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlByte\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f2583736-1f0e-4072-8a04-d83db5e08241\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDate\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDate\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDate\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"29f9721a-315b-498f-a304-762e0511226d\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDateTime\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDateTime\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDateTime\",\r\n      \"systemTypeId\": 61,\r\n      \"userTypeId\": 61,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"6879225d-44ff-4404-a0bd-05ee379c39db\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDecimal\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDecimal\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDecimal\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"d6d8f781-23bf-48a6-a462-8946bab23c36\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDouble\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDouble\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDouble\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"db1bc9a7-f5da-4d64-9baa-399c9f72d6e2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlGuid\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlGuid\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlGuid\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"ab6715ed-cfba-4b5a-92e9-f86520b8e711\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt16\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt16\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt16\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"4ee64682-cbd4-40cc-90e9-c5de1433bbed\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt32\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt32\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt32\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"9af787e7-9fc0-4819-80ac-0339ce031ab3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt64\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt64\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"44d67b27-8bd8-4072-81ca-2d32adfdb17c\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlMap\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Microsoft.Analytics.Types.Sql.SqlMap\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlMap\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": true,\r\n      \"version\": \"18cf5d12-3651-44fe-ad16-cf5068f0b112\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlMoney\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlMoney\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlMoney\",\r\n      \"systemTypeId\": 60,\r\n      \"userTypeId\": 60,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"861e13ee-e110-4dd2-b0df-f2eb9a6b5bd2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlSingle\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlSingle\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlSingle\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"7037d7f1-e3d4-416f-bf81-285b630a75e4\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlString\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlString\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlString\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"a15306f5-43f5-433b-b795-ce02ee911953\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlStruct\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Microsoft.Analytics.Types.Sql.SqlStruct\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlStruct\",\r\n      \"systemTypeId\": 243,\r\n      \"userTypeId\": 332,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": true,\r\n      \"version\": \"f89f413d-bd5f-440a-b069-8fc345643648\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Boolean\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"bool\",\r\n      \"fullCSharpName\": \"System.Boolean\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"c04b91b8-2b7e-45b3-ada9-db5ede901672\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Boolean?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"bool?\",\r\n      \"fullCSharpName\": \"System.Boolean?\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"42f3147a-ed9b-47ae-a8ad-aa2fbc51e0ad\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte\",\r\n      \"fullCSharpName\": \"System.Byte\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"6a048add-f003-4d73-8471-3b0be963d1ac\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte?\",\r\n      \"fullCSharpName\": \"System.Byte?\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"c2623267-2a86-444a-a773-89783eae5b30\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte[]\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte[]\",\r\n      \"fullCSharpName\": \"System.Byte[]\",\r\n      \"systemTypeId\": 165,\r\n      \"userTypeId\": 165,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"84506afa-d9ad-4bef-9e44-cd00f1f54ce3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Char\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"char\",\r\n      \"fullCSharpName\": \"System.Char\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"bb4bb082-4d9c-4ce4-aa1b-bfaea278ac92\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Char?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"char?\",\r\n      \"fullCSharpName\": \"System.Char?\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"748c6bfa-5a8e-43d4-823b-3b3be0d8b85a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.DateTime\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"DateTime\",\r\n      \"fullCSharpName\": \"System.DateTime\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"4e348b46-7218-4c30-b879-ceee5a59e7bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.DateTime?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"DateTime?\",\r\n      \"fullCSharpName\": \"System.DateTime?\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"eb486159-acfa-4499-9b1a-e0ecda5d52a2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Decimal\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"decimal\",\r\n      \"fullCSharpName\": \"System.Decimal\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f29ebb5f-17e8-4448-8aec-1a6702380e75\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Decimal?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"decimal?\",\r\n      \"fullCSharpName\": \"System.Decimal?\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"b78657ef-955b-4841-805e-bec1e9d11e37\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Double\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"double\",\r\n      \"fullCSharpName\": \"System.Double\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f3bbcc4e-d872-4bd1-8429-7082199016d3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Double?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"double?\",\r\n      \"fullCSharpName\": \"System.Double?\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"5832365f-70cb-47f9-92db-46cf7903dffc\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Guid\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Guid\",\r\n      \"fullCSharpName\": \"System.Guid\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"ccccbe73-770a-4bc8-905f-2eec41e79736\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Guid?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Guid?\",\r\n      \"fullCSharpName\": \"System.Guid?\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"db4c6514-17fa-4de1-ab25-a22817844593\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int16\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"short\",\r\n      \"fullCSharpName\": \"System.Int16\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"2cca4ae1-4272-4ca4-832e-5bc22c486299\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int16?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"short?\",\r\n      \"fullCSharpName\": \"System.Int16?\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"cef0bb72-9079-471b-855c-cfb87b1dc11f\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int32\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"int\",\r\n      \"fullCSharpName\": \"System.Int32\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"2a3f9560-1645-4e60-8ca5-9713f2ef8363\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int32?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"int?\",\r\n      \"fullCSharpName\": \"System.Int32?\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"29fedecb-21d0-4fa8-bf6b-2539bee71bcc\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int64\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"long\",\r\n      \"fullCSharpName\": \"System.Int64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"14c67089-ce4d-4770-8425-a0c41788c3cd\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int64?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"long?\",\r\n      \"fullCSharpName\": \"System.Int64?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"01b8cce9-d5e9-4f38-9f29-d5f3927d7407\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.SByte\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"sbyte\",\r\n      \"fullCSharpName\": \"System.SByte\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"899a07dd-662c-4cd2-8f98-6ec34d739355\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.SByte?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"sbyte?\",\r\n      \"fullCSharpName\": \"System.SByte?\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f76f7f1a-64d9-4c50-a38c-a6b2578f66d3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Single\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"float\",\r\n      \"fullCSharpName\": \"System.Single\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"04ae7374-f270-48ba-b429-c7e07bfcde61\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Single?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"float?\",\r\n      \"fullCSharpName\": \"System.Single?\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f8f90902-84a6-449f-96fe-6710accc0f7a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.String\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"string\",\r\n      \"fullCSharpName\": \"System.String\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"313664ea-0a0b-4016-8c25-a11052d885ad\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt16\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ushort\",\r\n      \"fullCSharpName\": \"System.UInt16\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"1ee295be-df81-4f21-a17c-31205884958b\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt16?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ushort?\",\r\n      \"fullCSharpName\": \"System.UInt16?\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"a3228a28-dc3d-42f1-81d7-86899822af91\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt32\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"uint\",\r\n      \"fullCSharpName\": \"System.UInt32\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"133275dc-ec4b-4662-86ee-f6d13b0e8b7e\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt32?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"uint?\",\r\n      \"fullCSharpName\": \"System.UInt32?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"7292a0b6-ff2d-4c02-b256-63993c2b270a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt64\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ulong\",\r\n      \"fullCSharpName\": \"System.UInt64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"e80c1a1c-99d9-418c-9f66-097c048095bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt64?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ulong?\",\r\n      \"fullCSharpName\": \"System.UInt64?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"48cbabb8-03fc-4f00-bad6-0641a7f562c7\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/schemas/dbo/types?$filter=isComplexType%20eq%20false&api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvc2NoZW1hcy9kYm8vdHlwZXM/JGZpbHRlcj1pc0NvbXBsZXhUeXBlJTIwZXElMjBmYWxzZSZhcGktdmVyc2lvbj0yMDE2LTExLTAx",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "c9aead65-6b53-4cf5-b5dc-6c2d048f7525"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:43 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "d930ef70-d401-4f48-8fe3-a6f029797bb3"
+          "c11b8845-0aa0-43fb-a3f0-e741decc9dcc"
         ],
         "OData-Version": [
           "4.0"
@@ -3720,46 +3787,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/acl?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvYWNsP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "f09737a5-699f-44c1-bd3c-5b9a9d7cb4f5"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:58 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#types\",\r\n  \"value\": [\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlBinary\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlBinary\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlBinary\",\r\n      \"systemTypeId\": 165,\r\n      \"userTypeId\": 165,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"b05e4357-12c7-461f-9559-4c39cfae1338\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlBit\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlBit\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlBit\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"caeb6f59-f027-4348-a3ff-f064531e0ee8\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlByte\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlByte\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlByte\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f2583736-1f0e-4072-8a04-d83db5e08241\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDate\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDate\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDate\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"29f9721a-315b-498f-a304-762e0511226d\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDateTime\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDateTime\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDateTime\",\r\n      \"systemTypeId\": 61,\r\n      \"userTypeId\": 61,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"6879225d-44ff-4404-a0bd-05ee379c39db\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDecimal\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDecimal\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDecimal\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"d6d8f781-23bf-48a6-a462-8946bab23c36\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlDouble\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlDouble\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlDouble\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"db1bc9a7-f5da-4d64-9baa-399c9f72d6e2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlGuid\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlGuid\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlGuid\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"ab6715ed-cfba-4b5a-92e9-f86520b8e711\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt16\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt16\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt16\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"4ee64682-cbd4-40cc-90e9-c5de1433bbed\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt32\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt32\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt32\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"9af787e7-9fc0-4819-80ac-0339ce031ab3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlInt64\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlInt64\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlInt64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"44d67b27-8bd8-4072-81ca-2d32adfdb17c\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlMoney\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlMoney\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlMoney\",\r\n      \"systemTypeId\": 60,\r\n      \"userTypeId\": 60,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"861e13ee-e110-4dd2-b0df-f2eb9a6b5bd2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlSingle\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlSingle\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlSingle\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"7037d7f1-e3d4-416f-bf81-285b630a75e4\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"Microsoft.Analytics.Types.Sql.SqlString\",\r\n      \"typeFamily\": \"SQL\",\r\n      \"cSharpName\": \"SqlString\",\r\n      \"fullCSharpName\": \"Microsoft.Analytics.Types.Sql.SqlString\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"a15306f5-43f5-433b-b795-ce02ee911953\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Boolean\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"bool\",\r\n      \"fullCSharpName\": \"System.Boolean\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"c04b91b8-2b7e-45b3-ada9-db5ede901672\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Boolean?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"bool?\",\r\n      \"fullCSharpName\": \"System.Boolean?\",\r\n      \"systemTypeId\": 104,\r\n      \"userTypeId\": 104,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"42f3147a-ed9b-47ae-a8ad-aa2fbc51e0ad\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte\",\r\n      \"fullCSharpName\": \"System.Byte\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"6a048add-f003-4d73-8471-3b0be963d1ac\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte?\",\r\n      \"fullCSharpName\": \"System.Byte?\",\r\n      \"systemTypeId\": 48,\r\n      \"userTypeId\": 48,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"c2623267-2a86-444a-a773-89783eae5b30\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Byte[]\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"byte[]\",\r\n      \"fullCSharpName\": \"System.Byte[]\",\r\n      \"systemTypeId\": 165,\r\n      \"userTypeId\": 165,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"84506afa-d9ad-4bef-9e44-cd00f1f54ce3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Char\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"char\",\r\n      \"fullCSharpName\": \"System.Char\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"bb4bb082-4d9c-4ce4-aa1b-bfaea278ac92\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Char?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"char?\",\r\n      \"fullCSharpName\": \"System.Char?\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"748c6bfa-5a8e-43d4-823b-3b3be0d8b85a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.DateTime\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"DateTime\",\r\n      \"fullCSharpName\": \"System.DateTime\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"4e348b46-7218-4c30-b879-ceee5a59e7bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.DateTime?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"DateTime?\",\r\n      \"fullCSharpName\": \"System.DateTime?\",\r\n      \"systemTypeId\": 42,\r\n      \"userTypeId\": 42,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"eb486159-acfa-4499-9b1a-e0ecda5d52a2\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Decimal\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"decimal\",\r\n      \"fullCSharpName\": \"System.Decimal\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f29ebb5f-17e8-4448-8aec-1a6702380e75\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Decimal?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"decimal?\",\r\n      \"fullCSharpName\": \"System.Decimal?\",\r\n      \"systemTypeId\": 106,\r\n      \"userTypeId\": 106,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"b78657ef-955b-4841-805e-bec1e9d11e37\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Double\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"double\",\r\n      \"fullCSharpName\": \"System.Double\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f3bbcc4e-d872-4bd1-8429-7082199016d3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Double?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"double?\",\r\n      \"fullCSharpName\": \"System.Double?\",\r\n      \"systemTypeId\": 62,\r\n      \"userTypeId\": 62,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"5832365f-70cb-47f9-92db-46cf7903dffc\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Guid\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Guid\",\r\n      \"fullCSharpName\": \"System.Guid\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"ccccbe73-770a-4bc8-905f-2eec41e79736\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Guid?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"Guid?\",\r\n      \"fullCSharpName\": \"System.Guid?\",\r\n      \"systemTypeId\": 36,\r\n      \"userTypeId\": 36,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"db4c6514-17fa-4de1-ab25-a22817844593\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int16\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"short\",\r\n      \"fullCSharpName\": \"System.Int16\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"2cca4ae1-4272-4ca4-832e-5bc22c486299\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int16?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"short?\",\r\n      \"fullCSharpName\": \"System.Int16?\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"cef0bb72-9079-471b-855c-cfb87b1dc11f\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int32\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"int\",\r\n      \"fullCSharpName\": \"System.Int32\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"2a3f9560-1645-4e60-8ca5-9713f2ef8363\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int32?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"int?\",\r\n      \"fullCSharpName\": \"System.Int32?\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"29fedecb-21d0-4fa8-bf6b-2539bee71bcc\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int64\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"long\",\r\n      \"fullCSharpName\": \"System.Int64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"14c67089-ce4d-4770-8425-a0c41788c3cd\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Int64?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"long?\",\r\n      \"fullCSharpName\": \"System.Int64?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"01b8cce9-d5e9-4f38-9f29-d5f3927d7407\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.SByte\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"sbyte\",\r\n      \"fullCSharpName\": \"System.SByte\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"899a07dd-662c-4cd2-8f98-6ec34d739355\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.SByte?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"sbyte?\",\r\n      \"fullCSharpName\": \"System.SByte?\",\r\n      \"systemTypeId\": 52,\r\n      \"userTypeId\": 52,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f76f7f1a-64d9-4c50-a38c-a6b2578f66d3\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Single\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"float\",\r\n      \"fullCSharpName\": \"System.Single\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"04ae7374-f270-48ba-b429-c7e07bfcde61\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.Single?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"float?\",\r\n      \"fullCSharpName\": \"System.Single?\",\r\n      \"systemTypeId\": 59,\r\n      \"userTypeId\": 59,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"f8f90902-84a6-449f-96fe-6710accc0f7a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.String\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"string\",\r\n      \"fullCSharpName\": \"System.String\",\r\n      \"systemTypeId\": 231,\r\n      \"userTypeId\": 231,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"313664ea-0a0b-4016-8c25-a11052d885ad\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt16\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ushort\",\r\n      \"fullCSharpName\": \"System.UInt16\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"1ee295be-df81-4f21-a17c-31205884958b\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt16?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ushort?\",\r\n      \"fullCSharpName\": \"System.UInt16?\",\r\n      \"systemTypeId\": 56,\r\n      \"userTypeId\": 56,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"a3228a28-dc3d-42f1-81d7-86899822af91\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt32\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"uint\",\r\n      \"fullCSharpName\": \"System.UInt32\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"133275dc-ec4b-4662-86ee-f6d13b0e8b7e\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt32?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"uint?\",\r\n      \"fullCSharpName\": \"System.UInt32?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"7292a0b6-ff2d-4c02-b256-63993c2b270a\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt64\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ulong\",\r\n      \"fullCSharpName\": \"System.UInt64\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"e80c1a1c-99d9-418c-9f66-097c048095bb\"\r\n    },\r\n    {\r\n      \"computeAccountName\": \"testaba28877\",\r\n      \"databaseName\": \"master\",\r\n      \"schemaName\": \"sys\",\r\n      \"typeName\": \"System.UInt64?\",\r\n      \"typeFamily\": \"C#\",\r\n      \"cSharpName\": \"ulong?\",\r\n      \"fullCSharpName\": \"System.UInt64?\",\r\n      \"systemTypeId\": 127,\r\n      \"userTypeId\": 127,\r\n      \"schemaId\": 0,\r\n      \"principalId\": null,\r\n      \"isNullable\": false,\r\n      \"isUserDefined\": false,\r\n      \"isAssemblyType\": false,\r\n      \"isTableType\": false,\r\n      \"isComplexType\": false,\r\n      \"version\": \"48cbabb8-03fc-4f00-bad6-0641a7f562c7\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/acl?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvYWNsP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "14f22b42-aa03-4892-bc5d-fc04adb1f0bc"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:43 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "9fe711ab-7a47-4382-b9a3-cd3cca84f565"
+          "f28515d6-d3b9-48ce-a662-7adf69921c14"
         ],
         "OData-Version": [
           "4.0"
@@ -3769,46 +3838,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/acl?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvYWNsP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "3a5942f5-1fd8-45ee-adcc-444d7c7ab012"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:58 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    },\r\n    {\r\n      \"aceType\": \"User\",\r\n      \"principalId\": \"ea84f08c-ec2c-4ecc-b6e4-2599c15b05d9\",\r\n      \"permission\": \"Use\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/acl?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvYWNsP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "d3412844-c3d1-4930-80d8-ae118294bde0"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:45 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "6f74ada8-8457-4f86-9009-90f26add8cb4"
+          "ba099a92-3770-44c6-93c1-5180008c6371"
         ],
         "OData-Version": [
           "4.0"
@@ -3818,46 +3889,48 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
-        ]
-      },
-      "StatusCode": 200
-    },
-    {
-      "RequestUri": "/catalog/usql/databases/testdb15955/acl?api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvYWNsP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
-      "RequestMethod": "GET",
-      "RequestBody": "",
-      "RequestHeaders": {
-        "x-ms-client-request-id": [
-          "a1936190-e4b8-4856-b3b0-686fc50119b5"
         ],
-        "accept-language": [
-          "en-US"
+        "Date": [
+          "Wed, 06 Mar 2019 06:52:00 GMT"
         ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
-        ]
-      },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    }\r\n  ]\r\n}",
-      "ResponseHeaders": {
         "Content-Type": [
           "application/json; odata.metadata=minimal; odata.streaming=true"
         ],
         "Expires": [
           "-1"
+        ]
+      },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    },\r\n    {\r\n      \"aceType\": \"User\",\r\n      \"principalId\": \"d684e13d-8340-4fdf-8d96-8c98fd53db96\",\r\n      \"permission\": \"Use\"\r\n    }\r\n  ]\r\n}",
+      "StatusCode": 200
+    },
+    {
+      "RequestUri": "/catalog/usql/databases/testdb17950/acl?api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvYWNsP2FwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestMethod": "GET",
+      "RequestBody": "",
+      "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "38a4d70b-e2c0-47ee-959a-257d18269897"
         ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ]
+      },
+      "ResponseHeaders": {
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:46 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "8e5eba2c-e5e3-41e0-bbaa-b58510d97305"
+          "e24267d7-a210-4a12-99b1-31b83d3c54bf"
         ],
         "OData-Version": [
           "4.0"
@@ -3867,8 +3940,18 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:52:01 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    }\r\n  ]\r\n}",
       "StatusCode": 200
     },
     {
@@ -3878,35 +3961,27 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "14254c5c-cec1-4d7d-9cd1-0fcd4636224f"
+          "2de1d08c-09e9-40ef-9613-62d2049ac0e5"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:44 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "50d8a39c-2503-46d9-bfcc-14f7c6d6d2a2"
+          "1d1ca5af-231a-47b8-a511-f14510efe3ad"
         ],
         "OData-Version": [
           "4.0"
@@ -3916,8 +3991,18 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:51:59 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    }\r\n  ]\r\n}",
       "StatusCode": 200
     },
     {
@@ -3927,35 +4012,27 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "13a32dcd-697b-4502-97f3-6d02e27d4826"
+          "d2e993bd-89eb-4290-ae44-d051557a4dbb"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    },\r\n    {\r\n      \"aceType\": \"User\",\r\n      \"principalId\": \"ea84f08c-ec2c-4ecc-b6e4-2599c15b05d9\",\r\n      \"permission\": \"Use\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:46 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "5fe50e10-8e5b-4d8d-8dd8-714c863c3d1f"
+          "7b9c7a35-d243-4daf-96c8-423da320f65c"
         ],
         "OData-Version": [
           "4.0"
@@ -3965,8 +4042,18 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:52:02 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    },\r\n    {\r\n      \"aceType\": \"User\",\r\n      \"principalId\": \"d684e13d-8340-4fdf-8d96-8c98fd53db96\",\r\n      \"permission\": \"Use\"\r\n    }\r\n  ]\r\n}",
       "StatusCode": 200
     },
     {
@@ -3976,35 +4063,27 @@
       "RequestBody": "",
       "RequestHeaders": {
         "x-ms-client-request-id": [
-          "0c65a391-de7a-44c1-9f80-c39d6cfac245"
+          "059356c1-14cf-4eaf-b003-71e3138e1105"
         ],
-        "accept-language": [
+        "Accept-Language": [
           "en-US"
         ],
         "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
         ]
       },
-      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba25339.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    }\r\n  ]\r\n}",
       "ResponseHeaders": {
-        "Content-Type": [
-          "application/json; odata.metadata=minimal; odata.streaming=true"
-        ],
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:47 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "9d9e30c6-6700-40b9-aa70-8721c0f65edd"
+          "4e6c540a-8f7b-4ba4-8679-c03d85e46478"
         ],
         "OData-Version": [
           "4.0"
@@ -4014,233 +4093,251 @@
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:52:02 GMT"
+        ],
+        "Content-Type": [
+          "application/json; odata.metadata=minimal; odata.streaming=true"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "{\r\n  \"@odata.context\": \"https://testaba28877.azuredatalakeanalytics.net/sqlip/$metadata#acl\",\r\n  \"value\": [\r\n    {\r\n      \"aceType\": \"UserObj\",\r\n      \"principalId\": \"e994d55d-2464-4c73-b5e1-40e3c9894434\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"GroupObj\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"All\"\r\n    },\r\n    {\r\n      \"aceType\": \"Other\",\r\n      \"principalId\": \"00000000-0000-0000-0000-000000000000\",\r\n      \"permission\": \"None\"\r\n    }\r\n  ]\r\n}",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/catalog/usql/databases/testdb15955/acl?op=GRANTACE&api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvYWNsP29wPUdSQU5UQUNFJmFwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
+      "RequestUri": "/catalog/usql/databases/testdb17950/acl?op=GRANTACE&api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvYWNsP29wPUdSQU5UQUNFJmFwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"aceType\": \"User\",\r\n  \"principalId\": \"ea84f08c-ec2c-4ecc-b6e4-2599c15b05d9\",\r\n  \"permission\": \"Use\"\r\n}",
+      "RequestBody": "{\r\n  \"aceType\": \"User\",\r\n  \"principalId\": \"d684e13d-8340-4fdf-8d96-8c98fd53db96\",\r\n  \"permission\": \"Use\"\r\n}",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "fea79b79-6940-4d12-8a70-4d4fb3191126"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
           "107"
-        ],
-        "x-ms-client-request-id": [
-          "476649dc-6ec2-4578-9b74-a9b6b75b06b1"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
         ]
       },
-      "ResponseBody": "",
       "ResponseHeaders": {
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:44 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "f4720150-8c26-483f-8ebc-6accdfd34fd2"
+          "a97098a7-2e1a-433c-9351-472670b52f95"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:52:00 GMT"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "",
       "StatusCode": 200
     },
     {
-      "RequestUri": "/catalog/usql/databases/testdb15955/acl?op=REVOKEACE&api-version=2016-11-01",
-      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTU5NTUvYWNsP29wPVJFVk9LRUFDRSZhcGktdmVyc2lvbj0yMDE2LTExLTAx",
+      "RequestUri": "/catalog/usql/databases/testdb17950/acl?op=REVOKEACE&api-version=2016-11-01",
+      "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9kYXRhYmFzZXMvdGVzdGRiMTc5NTAvYWNsP29wPVJFVk9LRUFDRSZhcGktdmVyc2lvbj0yMDE2LTExLTAx",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"aceType\": \"User\",\r\n  \"principalId\": \"ea84f08c-ec2c-4ecc-b6e4-2599c15b05d9\"\r\n}",
+      "RequestBody": "{\r\n  \"aceType\": \"User\",\r\n  \"principalId\": \"d684e13d-8340-4fdf-8d96-8c98fd53db96\"\r\n}",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "1b62cedd-a56f-48d9-91b0-2bbd73bf9e15"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
           "83"
-        ],
-        "x-ms-client-request-id": [
-          "86951ff5-d5ab-4831-abb0-95d011988f38"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
         ]
       },
-      "ResponseBody": "",
       "ResponseHeaders": {
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:45 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "272aed12-bfc6-4e33-8e16-fc5745935ba5"
+          "7c61a33d-eb1c-4b28-ab75-b49926921eee"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:52:01 GMT"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "",
       "StatusCode": 200
     },
     {
       "RequestUri": "/catalog/usql/acl?op=GRANTACE&api-version=2016-11-01",
       "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9hY2w/b3A9R1JBTlRBQ0UmYXBpLXZlcnNpb249MjAxNi0xMS0wMQ==",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"aceType\": \"User\",\r\n  \"principalId\": \"ea84f08c-ec2c-4ecc-b6e4-2599c15b05d9\",\r\n  \"permission\": \"Use\"\r\n}",
+      "RequestBody": "{\r\n  \"aceType\": \"User\",\r\n  \"principalId\": \"d684e13d-8340-4fdf-8d96-8c98fd53db96\",\r\n  \"permission\": \"Use\"\r\n}",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "615a554e-181d-4d82-b69b-f0706f7d2311"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
           "107"
-        ],
-        "x-ms-client-request-id": [
-          "e830b734-5a53-4412-857a-83f4f5ec9010"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
         ]
       },
-      "ResponseBody": "",
       "ResponseHeaders": {
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:46 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "5f4baed2-6e65-4f9b-871d-80ac44ba821f"
+          "1352b61e-09c3-47ee-b4cb-c42bd47df69f"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:52:01 GMT"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "",
       "StatusCode": 200
     },
     {
       "RequestUri": "/catalog/usql/acl?op=REVOKEACE&api-version=2016-11-01",
       "EncodedRequestUri": "L2NhdGFsb2cvdXNxbC9hY2w/b3A9UkVWT0tFQUNFJmFwaS12ZXJzaW9uPTIwMTYtMTEtMDE=",
       "RequestMethod": "POST",
-      "RequestBody": "{\r\n  \"aceType\": \"User\",\r\n  \"principalId\": \"ea84f08c-ec2c-4ecc-b6e4-2599c15b05d9\"\r\n}",
+      "RequestBody": "{\r\n  \"aceType\": \"User\",\r\n  \"principalId\": \"d684e13d-8340-4fdf-8d96-8c98fd53db96\"\r\n}",
       "RequestHeaders": {
+        "x-ms-client-request-id": [
+          "6dc85115-1a56-497b-9e4b-e22d324ec938"
+        ],
+        "Accept-Language": [
+          "en-US"
+        ],
+        "User-Agent": [
+          "FxVersion/4.6.26628.05",
+          "OSName/Windows",
+          "OSVersion/Microsoft.Windows.10.0.14393.",
+          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.3.0"
+        ],
         "Content-Type": [
           "application/json; charset=utf-8"
         ],
         "Content-Length": [
           "83"
-        ],
-        "x-ms-client-request-id": [
-          "63d37299-4f28-4cd2-bc12-8178009e2382"
-        ],
-        "accept-language": [
-          "en-US"
-        ],
-        "User-Agent": [
-          "FxVersion/4.6.25211.01",
-          "Microsoft.Azure.Management.DataLake.Analytics.DataLakeAnalyticsCatalogManagementClient/3.5.0.0"
         ]
       },
-      "ResponseBody": "",
       "ResponseHeaders": {
-        "Expires": [
-          "-1"
-        ],
         "Cache-Control": [
           "no-store, no-cache, max-age=0, private"
-        ],
-        "Date": [
-          "Wed, 06 Jun 2018 06:29:46 GMT"
         ],
         "Transfer-Encoding": [
           "chunked"
         ],
         "x-ms-request-id": [
-          "8c1437c3-91c9-4cdb-88fe-d0be30432862"
+          "bfc04515-9336-48fd-b13c-c170d1c241c5"
         ],
         "X-Content-Type-Options": [
           "nosniff"
         ],
         "Strict-Transport-Security": [
           "max-age=15724800; includeSubDomains"
+        ],
+        "Date": [
+          "Wed, 06 Mar 2019 06:52:02 GMT"
+        ],
+        "Expires": [
+          "-1"
         ]
       },
+      "ResponseBody": "",
       "StatusCode": 200
     }
   ],
   "Names": {
     ".ctor": [
-      "rgaba11838",
-      "testaba15650",
-      "testaba25339",
-      "teststorage14571",
-      "testdatalake11460",
-      "testdatalake22036",
-      "testazureblob19535",
-      "testdb15955",
-      "testtbl18883",
-      "testtvf13272",
-      "testproc19339",
-      "testview12416",
-      "testcred14768",
-      "testsecret19287",
-      "testsecretpwd13650"
+      "rgaba13966",
+      "testaba14883",
+      "testaba28877",
+      "teststorage12624",
+      "testdatalake11650",
+      "testdatalake28525",
+      "testazureblob17389",
+      "testdb17950",
+      "testtbl16049",
+      "testtvf11076",
+      "testproc17628",
+      "testview1993",
+      "testcred18145",
+      "testsecret15791",
+      "testsecretpwd1818"
     ],
     "CreateCatalog": [
-      "ed042635-a48d-456a-aa2e-8d20f5d14a69"
+      "9e535708-aa04-4ccc-9971-58f519f826b1"
     ],
     "RunJobToCompletion": [
-      "testjob16268"
+      "testjob14137"
     ],
     "GetCatalogItemsTest": [
-      "ea84f08c-ec2c-4ecc-b6e4-2599c15b05d9"
+      "d684e13d-8340-4fdf-8d96-8c98fd53db96"
     ]
   },
   "Variables": {

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Customizations/DataLakeAnalyticsCustomizationHelper.cs
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Customizations/DataLakeAnalyticsCustomizationHelper.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Management.DataLake.Analytics
         /// This constant is used as the default package version to place in the user agent.
         /// It should mirror the package version in the project.json file.
         /// </summary>
-        internal const string PackageVersion = "3.5.0-preview";
+        internal const string PackageVersion = "3.5.3-preview";
 
         internal const string DefaultAdlaDnsSuffix = "azuredatalakeanalytics.net";
 

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/Diagnostics.cs
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/Diagnostics.cs
@@ -33,10 +33,10 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         /// <param name="severity">The severity of the error. Possible values
         /// include: 'Warning', 'Error', 'Info', 'SevereWarning', 'Deprecated',
         /// 'UserWarning'</param>
-        /// <param name="lineNumber">The line number the error occured
+        /// <param name="lineNumber">The line number the error occurred
         /// on.</param>
         /// <param name="columnNumber">The column where the error
-        /// occured.</param>
+        /// occurred.</param>
         /// <param name="start">The starting index of the error.</param>
         /// <param name="end">The ending index of the error.</param>
         public Diagnostics(string message = default(string), SeverityTypes? severity = default(SeverityTypes?), int? lineNumber = default(int?), int? columnNumber = default(int?), int? start = default(int?), int? end = default(int?))
@@ -69,13 +69,13 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         public SeverityTypes? Severity { get; private set; }
 
         /// <summary>
-        /// Gets the line number the error occured on.
+        /// Gets the line number the error occurred on.
         /// </summary>
         [JsonProperty(PropertyName = "lineNumber")]
         public int? LineNumber { get; private set; }
 
         /// <summary>
-        /// Gets the column where the error occured.
+        /// Gets the column where the error occurred.
         /// </summary>
         [JsonProperty(PropertyName = "columnNumber")]
         public int? ColumnNumber { get; private set; }

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/JobErrorDetails.cs
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/JobErrorDetails.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         /// <param name="description">The error message description.</param>
         /// <param name="details">The details of the error message.</param>
         /// <param name="lineNumber">The specific line number in the job where
-        /// the error occured.</param>
+        /// the error occurred.</param>
         /// <param name="startOffset">The start offset in the job where the
         /// error was found</param>
         /// <param name="endOffset">The end offset in the job where the error
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         public string Details { get; private set; }
 
         /// <summary>
-        /// Gets the specific line number in the job where the error occured.
+        /// Gets the specific line number in the job where the error occurred.
         /// </summary>
         [JsonProperty(PropertyName = "lineNumber")]
         public int? LineNumber { get; private set; }

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/JobStatisticsVertexStage.cs
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/JobStatisticsVertexStage.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         /// bytes.</param>
         /// <param name="duplicateDiscardCount">The number of duplicates that
         /// were discarded.</param>
-        /// <param name="failedCount">The number of failures that occured in
+        /// <param name="failedCount">The number of failures that occurred in
         /// this stage.</param>
         /// <param name="maxVertexDataRead">The maximum amount of data read in
         /// a single vertex, in bytes.</param>
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         public int? DuplicateDiscardCount { get; private set; }
 
         /// <summary>
-        /// Gets the number of failures that occured in this stage.
+        /// Gets the number of failures that occurred in this stage.
         /// </summary>
         [JsonProperty(PropertyName = "failedCount")]
         public int? FailedCount { get; private set; }

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/USqlIndex.cs
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/USqlIndex.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         /// index</param>
         /// <param name="partitionFunction">partition function ID for the
         /// index.</param>
-        /// <param name="partitionKeyList">the list of partion keys in the
+        /// <param name="partitionKeyList">the list of partition keys in the
         /// index</param>
         /// <param name="streamNames">the list of full paths to the streams
         /// that contain this index in the DataLake account.</param>
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         public System.Guid? PartitionFunction { get; set; }
 
         /// <summary>
-        /// Gets or sets the list of partion keys in the index
+        /// Gets or sets the list of partition keys in the index
         /// </summary>
         [JsonProperty(PropertyName = "partitionKeyList")]
         public IList<string> PartitionKeyList { get; set; }

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/USqlTableFragment.cs
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/Models/USqlTableFragment.cs
@@ -40,7 +40,9 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         /// fragment.</param>
         /// <param name="createDate">the creation time of the table
         /// fragment.</param>
-        public USqlTableFragment(System.Guid? parentId = default(System.Guid?), System.Guid? fragmentId = default(System.Guid?), int? indexId = default(int?), long? size = default(long?), long? rowCount = default(long?), System.DateTimeOffset? createDate = default(System.DateTimeOffset?))
+        /// <param name="streamPath">the relative path for the table fragment
+        /// location.</param>
+        public USqlTableFragment(System.Guid? parentId = default(System.Guid?), System.Guid? fragmentId = default(System.Guid?), int? indexId = default(int?), long? size = default(long?), long? rowCount = default(long?), System.DateTimeOffset? createDate = default(System.DateTimeOffset?), string streamPath = default(string))
         {
             ParentId = parentId;
             FragmentId = fragmentId;
@@ -48,6 +50,7 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
             Size = size;
             RowCount = rowCount;
             CreateDate = createDate;
+            StreamPath = streamPath;
             CustomInit();
         }
 
@@ -93,6 +96,12 @@ namespace Microsoft.Azure.Management.DataLake.Analytics.Models
         /// </summary>
         [JsonProperty(PropertyName = "createDate")]
         public System.DateTimeOffset? CreateDate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the relative path for the table fragment location.
+        /// </summary>
+        [JsonProperty(PropertyName = "streamPath")]
+        public string StreamPath { get; set; }
 
     }
 }

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/SdkInfo_DataLakeAnalyticsAccountManagementClient.cs
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Generated/SdkInfo_DataLakeAnalyticsAccountManagementClient.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Azure.Management.DataLake.Analytics
       // BEGIN: Code Generation Metadata Section
       public static readonly String AutoRestVersion = "latest";
       public static readonly String AutoRestBootStrapperVersion = "autorest@2.0.4283";
-      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datalake-analytics/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=A:\\azure-sdk-for-net\\src\\SDKs";
+      public static readonly String AutoRestCmdExecuted = "cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datalake-analytics/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=D:\\code\\AzureSDK\\azure-sdk-for-net\\src\\SDKs";
       public static readonly String GithubForkName = "Azure";
       public static readonly String GithubBranchName = "master";
-      public static readonly String GithubCommidId = "bad3cbbc7f3bd4f2ff018ff936be010a8fd2c4bb";
+      public static readonly String GithubCommidId = "6a18208aed692f02215a2ea50736c0a8d5ac7329";
       public static readonly String CodeGenerationErrors = "";
       public static readonly String GithubRepoName = "azure-rest-api-specs";
       // END: Code Generation Metadata Section

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Microsoft.Azure.Management.DataLake.Analytics.csproj
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Microsoft.Azure.Management.DataLake.Analytics.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <PackageId>Microsoft.Azure.Management.DataLake.Analytics</PackageId>
     <Description>Provides Data Lake Analytics account, job and catalog management capabilities for Microsoft Azure.</Description>
-    <Version>3.5.2-preview</Version>
+    <Version>3.5.3-preview</Version>
     <AssemblyName>Microsoft.Azure.Management.DataLake.Analytics</AssemblyName>
     <PackageTags>Microsoft Azure Data Lake Analytics management;DataLakeAnalytics;Data Lake Analytics;</PackageTags>
     <PackageReleaseNotes>See https://aka.ms/adladotnetsdkchangelog for release notes.</PackageReleaseNotes>

--- a/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Properties/AssemblyInfo.cs
+++ b/src/SDKs/DataLake.Analytics/Management.DataLake.Analytics/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides Microsoft Azure Data Lake Analytics management operations including account, catalog and job management.")]
 
 [assembly: AssemblyVersion("3.0.0.0")]
-[assembly: AssemblyFileVersion("3.5.2.0")]
+[assembly: AssemblyFileVersion("3.5.3.0")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Azure .NET SDK")]

--- a/src/SDKs/DataLake.Analytics/changelog.md
+++ b/src/SDKs/DataLake.Analytics/changelog.md
@@ -1,5 +1,11 @@
 ## Microsoft.Azure.Management.DataLake.Analytics release notes
 
+### Changes in 3.5.3-preview
+
+**Notes**
+
+- Added a property, StreamPath of type string to USqlTableFragment class
+
 ### Changes in 3.5.2-preview
 
 **Notes**

--- a/src/SDKs/_metadata/datalake-analytics_data-plane.txt
+++ b/src/SDKs/_metadata/datalake-analytics_data-plane.txt
@@ -3,12 +3,12 @@ AutoRest installed successfully.
 Commencing code generation
 Generating CSharp code
 Executing AutoRest command
-cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datalake-analytics/data-plane/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=A:\azure-sdk-for-net\src\SDKs
-2018-10-16 00:38:57 UTC
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datalake-analytics/data-plane/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=D:\code\AzureSDK\azure-sdk-for-net\src\SDKs
+2019-03-08 02:43:58 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      bad3cbbc7f3bd4f2ff018ff936be010a8fd2c4bb
+Commit:      6a18208aed692f02215a2ea50736c0a8d5ac7329
 AutoRest information
 Requested version: latest
 Bootstrapper version:    autorest@2.0.4283

--- a/src/SDKs/_metadata/datalake-analytics_resource-manager.txt
+++ b/src/SDKs/_metadata/datalake-analytics_resource-manager.txt
@@ -3,12 +3,12 @@ AutoRest installed successfully.
 Commencing code generation
 Generating CSharp code
 Executing AutoRest command
-cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datalake-analytics/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=A:\azure-sdk-for-net\src\SDKs
-2018-10-16 00:37:45 UTC
+cmd.exe /c autorest.cmd https://github.com/Azure/azure-rest-api-specs/blob/master/specification/datalake-analytics/resource-manager/readme.md --csharp --version=latest --reflect-api-versions --csharp-sdks-folder=D:\code\AzureSDK\azure-sdk-for-net\src\SDKs
+2019-03-08 02:42:16 UTC
 Azure-rest-api-specs repository information
 GitHub fork: Azure
 Branch:      master
-Commit:      bad3cbbc7f3bd4f2ff018ff936be010a8fd2c4bb
+Commit:      6a18208aed692f02215a2ea50736c0a8d5ac7329
 AutoRest information
 Requested version: latest
 Bootstrapper version:    autorest@2.0.4283


### PR DESCRIPTION
### Swagger PR Links
- [Azure/azure-rest-api-specs#4676: typo: Microsoft.DataLakeAnalytics](https://github.com/Azure/azure-rest-api-specs/pull/4676)
- [Azure/azure-rest-api-specs#5329: [ADLA] - Catalog - Add stream path to USqlTableFragment](https://github.com/Azure/azure-rest-api-specs/pull/5329)


### Note
- [Azure/azure-rest-api-specs#4676: typo: Microsoft.DataLakeAnalytics](https://github.com/Azure/azure-rest-api-specs/pull/4676)
    * partion -> partition
    * formatxii -> format
    * occured -> occurred
    * underying -> underlying
    * Double word "delete"
Asunc -> Async
- [Azure/azure-rest-api-specs#3013: [ADLA] - Support table preview](https://github.com/Azure/azure-rest-api-specs/pull/3013)
    - Added `StreamPath` of type string to `USqlTableFragment`
