### PR TITLE
Bump the Azure.Base package version and bring back the change to not …

### DIFF
--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.csproj
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.csproj
@@ -2,12 +2,15 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.0.0-preview.1</Version>
+    <Version>1.0.0-preview.3</Version>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[
       ]]>
     </PackageReleaseNotes>
+
+   <!-- Make sure that we don't pull in additional dependencies during build or package -->	
+    <ImportDefaultReferences>false</ImportDefaultReferences>
 
     <!-- This is a workaorund until https://github.com/Azure/azure-sdk-for-net/issues/5214 is addressed -->
     <RequiredTargetFrameworks>net461;netstandard2.0</RequiredTargetFrameworks>


### PR DESCRIPTION
…import default references

/cc @KrzysztofCwalina 