### PR TITLE
ResultTask<T>

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -46,7 +46,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
         private async Task<string> SetMultipleKeys(ConfigurationClient service, int expectedEvents)
         {
-            string key = string.Concat("key-", Guid.NewGuid().ToString("N")); ;
+            string value = string.Concat("key-", Guid.NewGuid().ToString("N")); ;
             
             /*
              * The configuration store contains a KV with the Key
@@ -57,19 +57,19 @@ namespace Azure.ApplicationModel.Configuration.Tests
             
             try
             {
-                var responseGet = await service.GetAsync(batchKey);
-                key = responseGet.Value;
+                ConfigurationSetting setting = await service.GetAsync(batchKey);
+                value = setting.Value;
             }
             catch
             {
                 for (int i = 0; i < expectedEvents; i++)
                 {
-                    await service.AddAsync(new ConfigurationSetting(key, "test_value", $"{i.ToString()}"));
+                    await service.AddAsync(new ConfigurationSetting(value, "test_value", $"{i.ToString()}"));
                 }
 
-                await service.SetAsync(new ConfigurationSetting(batchKey, key));
+                await service.SetAsync(new ConfigurationSetting(batchKey, value));
             }
-            return key;
+            return value;
         }
 
         [Test]
@@ -456,10 +456,9 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 await service.SetAsync(testSettingNoLabel);
                 // Test
                 ResponseTask<ConfigurationSetting> task = service.GetAsync(key: testSettingNoLabel.Key, options: default, CancellationToken.None);
-                await task;
-                Assert.True(task.Response.TryGetHeader("ETag", out string etagHeader));
+                ConfigurationSetting setting= await task;
 
-                ConfigurationSetting setting = task.Result;
+                Assert.True(task.Response.TryGetHeader("ETag", out string etagHeader));
                 Assert.AreEqual(testSettingNoLabel, setting);
             }
             finally

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -440,6 +440,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         }
 
+        async ResponseTask<ConfigurationSetting> Foo(ConfigurationClient client)
+        {
+            await Task.Delay(100);
+            return await ResponseTask.Await(client.GetAsync(""));
+        }
+
         [Test]
         public async Task Get()
         {

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -58,8 +58,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             try
             {
                 var responseGet = await service.GetAsync(batchKey);
-                key = responseGet.Result.Value;
-                responseGet.Dispose();
+                key = responseGet.Value;
             }
             catch
             {
@@ -456,13 +455,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
             {
                 await service.SetAsync(testSettingNoLabel);
                 // Test
-                Response<ConfigurationSetting> response = await service.GetAsync(key: testSettingNoLabel.Key, options: default, CancellationToken.None);
+                ResponseTask<ConfigurationSetting> task = service.GetAsync(key: testSettingNoLabel.Key, options: default, CancellationToken.None);
+                await task;
+                Assert.True(task.Response.TryGetHeader("ETag", out string etagHeader));
 
-                Assert.True(response.TryGetHeader("ETag", out string etagHeader));
-
-                ConfigurationSetting setting = response.Result;
+                ConfigurationSetting setting = task.Result;
                 Assert.AreEqual(testSettingNoLabel, setting);
-                response.Dispose();
             }
             finally
             {
@@ -504,13 +502,13 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 await service.SetAsync(s_testSetting);
 
                 // Test
-                Response<ConfigurationSetting> response = await service.GetAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
+                ResponseTask<ConfigurationSetting> task = service.GetAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
+                await task;
 
-                Assert.True(response.TryGetHeader("ETag", out string etagHeader));
+                Assert.True(task.Response.TryGetHeader("ETag", out string etagHeader));
 
-                ConfigurationSetting responseSetting = response.Result;
+                ConfigurationSetting responseSetting = task.Result;
                 Assert.AreEqual(s_testSetting, responseSetting);
-                response.Dispose();
             }
             finally
             {

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -71,6 +71,21 @@ namespace Azure.ApplicationModel.Configuration.Tests
         }
 
         [Test]
+        public async Task GetHeaders()
+        {
+            var transport = new GetMockTransport(s_testSetting.Key, default, s_testSetting);
+            var (service, pool) = CreateTestService(transport);
+
+            ResponseTask<ConfigurationSetting> task = service.GetAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
+            ConfigurationSetting setting = await task;
+            Response response = task.Response;
+            Assert.True(task.Response.TryGetHeader("Content-Length", out string len));
+            Assert.AreEqual("207", len);
+            Assert.AreEqual(s_testSetting, setting);
+            Assert.AreEqual(0, pool.CurrentlyRented);
+        }
+
+        [Test]
         public void GetNotFound()
         {
             var transport = new GetMockTransport(s_testSetting.Key, default, HttpStatusCode.NotFound);

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
@@ -226,7 +226,7 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<ConfigurationSetting>> GetAsync(string key, RequestOptions options = null, CancellationToken cancellation = default)
+        public async ResponseTask<ConfigurationSetting> GetAsync(string key, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentNullException($"{nameof(key)}");
 
@@ -247,7 +247,10 @@ namespace Azure.ApplicationModel.Configuration
 
                 var response = message.Response;
                 if (response.Status == 200) {
-                    return await CreateResponse(response, cancellation);
+                    var r = await CreateResponse(response, cancellation);
+                    var rt = new ResponseTask<ConfigurationSetting>(Task.FromResult(r.Result));
+                    rt.Response = response;
+                    return await rt;
                 }
                 else throw new RequestFailedException(response);
             }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
@@ -247,10 +247,8 @@ namespace Azure.ApplicationModel.Configuration
 
                 var response = message.Response;
                 if (response.Status == 200) {
-                    var r = await CreateResponse(response, cancellation);
-                    var rt = new ResponseTask<ConfigurationSetting>(Task.FromResult(r.Result));
-                    rt.Response = response;
-                    return await rt;
+                    var setting = await ConfigurationServiceSerializer.DeserializeSettingAsync(response.ContentStream, cancellation);
+                    return await ResponseTask.FromResult(setting, response);
                 }
                 else throw new RequestFailedException(response);
             }

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.csproj
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.csproj
@@ -25,5 +25,6 @@
     <PackageReference Include="System.Memory" Version="4.5.1" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.props
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.props
@@ -1,11 +1,6 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Project references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'=='true'">
+  <ItemGroup>
     <ProjectReference Include="$(MSBuildThisFileDirectory)Azure.Base.csproj" />
-  </ItemGroup>
-
-  <!-- Package references -->
-  <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'!='true'">
-    <PackageReference Include="Azure.Base" Version="1.0.0-preview.3" />
   </ItemGroup>
 </Project>

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/ResponseTask.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/ResponseTask.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Base.Threading;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Azure
+{
+    [AsyncMethodBuilder(typeof(AsyncResponseTaskMethodBuilder<>))]
+    public struct ResponseTask<T>
+    {
+        private readonly Task<T> _parent;
+        public ResponseTask(Task<T> parent)
+        {
+            _parent = parent;
+            Response = default;
+        }
+        public T Result => _parent.Result;
+        public Response Response { get; set; }
+        public TaskAwaiter<T> GetAwaiter() => _parent.GetAwaiter();
+        public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext) => _parent.ConfigureAwait(continueOnCapturedContext);
+
+        public static implicit operator Task<T>(ResponseTask<T> t) => t._parent;
+    }
+}
+
+namespace Azure.Base.Threading { 
+    public struct AsyncResponseTaskMethodBuilder<T>
+    {
+        private AsyncTaskMethodBuilder<T> _methodBuilder;
+
+        public static AsyncResponseTaskMethodBuilder<T> Create() => default;
+
+        public void Start<TStateMachine>(ref TStateMachine stateMachine) where TStateMachine : IAsyncStateMachine => _methodBuilder.Start(ref stateMachine);
+
+        public void SetStateMachine(IAsyncStateMachine stateMachine) => _methodBuilder.SetStateMachine(stateMachine);
+
+        public void SetResult(T result) => _methodBuilder.SetResult(result);
+
+        public void SetException(Exception exception) => _methodBuilder.SetException(exception);
+
+        public ResponseTask<T> Task => new ResponseTask<T>(_methodBuilder.Task);
+
+        public void AwaitOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : INotifyCompletion
+            where TStateMachine : IAsyncStateMachine => _methodBuilder.AwaitOnCompleted(ref awaiter, ref stateMachine);
+
+        public void AwaitUnsafeOnCompleted<TAwaiter, TStateMachine>(ref TAwaiter awaiter, ref TStateMachine stateMachine)
+            where TAwaiter : ICriticalNotifyCompletion
+            where TStateMachine : IAsyncStateMachine => _methodBuilder.AwaitUnsafeOnCompleted(ref awaiter, ref stateMachine);
+    }
+}

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/ResponseTask.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/ResponseTask.cs
@@ -12,17 +12,33 @@ namespace Azure
     public struct ResponseTask<T>
     {
         private readonly Task<T> _parent;
+
         public ResponseTask(Task<T> parent)
         {
             _parent = parent;
             Response = default;
         }
+
+        public ResponseTask(Task<T> parent, Response response)
+        {
+            _parent = parent;
+            Response = response;
+        }
+
         public T Result => _parent.Result;
         public Response Response { get; set; }
         public TaskAwaiter<T> GetAwaiter() => _parent.GetAwaiter();
         public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext) => _parent.ConfigureAwait(continueOnCapturedContext);
 
         public static implicit operator Task<T>(ResponseTask<T> t) => t._parent;
+
+
+    }
+
+    public struct ResponseTask
+    {
+        public static ResponseTask<T> FromResult<T>(T result, Response response)
+            => new ResponseTask<T>(Task.FromResult(result), response);
     }
 }
 

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/ResponseTask.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/ResponseTask.cs
@@ -9,30 +9,29 @@ using System.Threading.Tasks;
 namespace Azure
 {
     [AsyncMethodBuilder(typeof(AsyncResponseTaskMethodBuilder<>))]
-    public struct ResponseTask<T>
+    public readonly struct ResponseTask<T>
     {
         private readonly Task<T> _parent;
-
-        public ResponseTask(Task<T> parent)
-        {
-            _parent = parent;
-            Response = default;
-        }
+        private readonly Response _response;
 
         public ResponseTask(Task<T> parent, Response response)
         {
             _parent = parent;
-            Response = response;
+            _response = response;
         }
 
+        public ResponseTask(Task<T> parent) : this(parent, default) { }
+               
         public T Result => _parent.Result;
-        public Response Response { get; set; }
+
+        public Response Response => _response;
+
         public TaskAwaiter<T> GetAwaiter() => _parent.GetAwaiter();
-        public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext) => _parent.ConfigureAwait(continueOnCapturedContext);
+
+        public ConfiguredTaskAwaitable<T> ConfigureAwait(bool continueOnCapturedContext) 
+            => _parent.ConfigureAwait(continueOnCapturedContext);
 
         public static implicit operator Task<T>(ResponseTask<T> t) => t._parent;
-
-
     }
 
     public struct ResponseTask
@@ -43,6 +42,7 @@ namespace Azure
 }
 
 namespace Azure.Base.Threading { 
+
     public struct AsyncResponseTaskMethodBuilder<T>
     {
         private AsyncTaskMethodBuilder<T> _methodBuilder;


### PR DESCRIPTION
This shows a custom task that combines Result<T> and Task<T>. 

The signature of the new service method call looks like following:
https://github.com/Azure/azure-sdk-for-net/pull/5463/files#diff-dc8c034ca799f0adda89b03091e51a31R229

The calling code for getting the model is very nice:
https://github.com/Azure/azure-sdk-for-net/pull/5463/files#diff-52a87aaca27185907f80c568a0802eedR61

The calling code for getting the headers is a bit ugly but possible: 
https://github.com/Azure/azure-sdk-for-net/pull/5463/files#diff-ceba0fdb8b4f0470e5a6eb1f7fed2201R82

The calling code for returning this task is very bad:
https://github.com/Azure/azure-sdk-for-net/pull/5463/files#diff-dc8c034ca799f0adda89b03091e51a31R229

One additional, thing we could do to make headers consumption easier is to add WithResponse method to ResponseTask<T>. The method would convert ResponseTask<T> to ResponseFullTask<T> that would return a tuple of T and Response when awaited:
```c#
var (setting, response) = await service.GetAsync(...).WithResponse();
Assert.True(response.TryGetHeader("ETag", out string etagHeader));
```
The negative is that it adds more and more exotic task types.

Thanks to @stephentoub for helping me in creating this custom task.

UPDATE: yeah, this code is all super clunky. The response is being lost in many places. This will be very problematic.
