### PR TITLE
Change ETag type

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -138,7 +138,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             ConfigurationSetting settting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
             RequestOptions options = new RequestOptions()
             {
-                ETag = new ETagFilter() { IfMatch = new ETag(settting.ETag) },
+                ETag = new ETagFilter() { IfMatch = settting.ETag },
                 Label = settting.Label
             };
 
@@ -355,7 +355,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             {
                 RequestOptions options = new RequestOptions()
                 {
-                    ETag = new ETagFilter() { IfMatch = new ETag(responseGet.ETag) }
+                    ETag = new ETagFilter() { IfMatch = responseGet.ETag }
                 };
 
                 ConfigurationSetting responseSetting = await service.UpdateAsync(testSettingDiff, options, CancellationToken.None);
@@ -382,7 +382,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             {
                 RequestOptions options = new RequestOptions()
                 {
-                    ETag = new ETagFilter() { IfNoneMatch = new ETag(setting.ETag) }
+                    ETag = new ETagFilter() { IfNoneMatch = setting.ETag }
                 };
 
                 var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -488,7 +488,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 RequestOptions options = new RequestOptions()
                 {
                     Label = setting.Label,
-                    ETag = new ETagFilter() { IfNoneMatch = new ETag(setting.ETag) }
+                    ETag = new ETagFilter() { IfNoneMatch = setting.ETag }
                 };
 
                 var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -794,8 +794,8 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             //Etag tests
             var testSettingEtagDiff = testSettingsameCase.Clone();
-            testSettingsameCase.ETag = Guid.NewGuid().ToString();
-            testSettingEtagDiff.ETag = Guid.NewGuid().ToString();
+            testSettingsameCase.ETag = new ETag(Guid.NewGuid().ToString());
+            testSettingEtagDiff.ETag = new ETag(Guid.NewGuid().ToString());
             Assert.AreNotEqual(testSettingsameCase, testSettingEtagDiff);
 
             // Different tags
@@ -821,7 +821,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 ContentType = setting.ContentType,
                 LastModified = setting.LastModified,
                 Locked = setting.Locked,
-                ETag = null,
+                ETag = default,
                 Tags = tags
             };
         }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
@@ -24,10 +24,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/kv/{responseContent.Key}{GetExtraUriParameters(responseContent)}";
             _expectedMethod = HttpMethod.Put;
             _expectedRequestContent = GenerateExpectedRequestContent(responseContent);
-
-            string json = JsonConvert.SerializeObject(responseContent).ToLowerInvariant();
-            json = json.Replace("contenttype", "content_type");
-            _responseContent = json.Replace("lastmodified", "last_modified");
+            _responseContent = SerializeSetting(responseContent);
         }
     }
 
@@ -38,10 +35,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/kv/{responseContent.Key}{GetExtraUriParameters(responseContent)}";
             _expectedMethod = HttpMethod.Put;
             _expectedRequestContent = GenerateExpectedRequestContent(responseContent);
-
-            string json = JsonConvert.SerializeObject(responseContent).ToLowerInvariant();
-            json = json.Replace("contenttype", "content_type");
-            _responseContent = json.Replace("lastmodified", "last_modified");
+            _responseContent = SerializeSetting(responseContent);
         }
     }
 
@@ -52,10 +46,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/kv/{responseContent.Key}{GetExtraUriParameters(responseContent)}";
             _expectedMethod = HttpMethod.Put;
             _expectedRequestContent = GenerateExpectedRequestContent(responseContent);
-
-            string json = JsonConvert.SerializeObject(responseContent).ToLowerInvariant();
-            json = json.Replace("contenttype", "content_type");
-            _responseContent = json.Replace("lastmodified", "last_modified");
+            _responseContent = SerializeSetting(responseContent);
         }
 
         protected override void VerifyRequestCore(HttpRequestMessage request)
@@ -71,10 +62,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/kv/{key}{GetExtraUriParameters(filter)}";
             _expectedRequestContent = null;
             _expectedMethod = HttpMethod.Delete;
-
-            string json = JsonConvert.SerializeObject(result).ToLowerInvariant();
-            json = json.Replace("contenttype", "content_type");
-            _responseContent = json.Replace("lastmodified", "last_modified");
+            _responseContent = SerializeSetting(result);
         }
 
         public DeleteMockTransport(string key, RequestOptions filter, HttpStatusCode statusCode)
@@ -93,10 +81,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedMethod = HttpMethod.Get;
             _expectedUri = $"https://contoso.azconfig.io/kv/{queryKey}{GetExtraUriParameters(filter)}";
             _expectedRequestContent = null;
-
-            string json = JsonConvert.SerializeObject(result).ToLowerInvariant();
-            json = json.Replace("contenttype", "content_type");
-            _responseContent = json.Replace("lastmodified", "last_modified");
+            _responseContent = SerializeSetting(result);
         }
 
         public GetMockTransport(string queryKey, RequestOptions filter, params HttpStatusCode[] statusCodes)
@@ -116,10 +101,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/locks/{responseContent.Key}{GetExtraUriParameters(responseContent)}";
             _expectedRequestContent = null;
             _expectedMethod = lockOtherwiseUnlock ? HttpMethod.Put : HttpMethod.Delete;
-
-            string json = JsonConvert.SerializeObject(responseContent).ToLowerInvariant();
-            json = json.Replace("contenttype", "content_type");
-            _responseContent = json.Replace("lastmodified", "last_modified");
+            _responseContent = SerializeSetting(responseContent);
         }
     }
 
@@ -139,7 +121,7 @@ namespace Azure.ApplicationModel.Configuration.Test
                 var item = new ConfigurationSetting($"key{i}", "val")
                 {
                     Label = "label",
-                    ETag = "c3c231fd-39a0-4cb6-3237-4614474b92c1",
+                    ETag = new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"),
                     ContentType = "text"
                 };
                 KeyValues.Add(item);
@@ -162,6 +144,7 @@ namespace Azure.ApplicationModel.Configuration.Test
                 bathItems.Items.Add(KeyValues[itemIndex++]);
             }
             string json = JsonConvert.SerializeObject(bathItems).ToLowerInvariant();
+            json = json.Replace("etag\":{}", "etag\":\"c3c231fd-39a0-4cb6-3237-4614474b92c1\"");
             json = json.Replace("contenttype", "content_type");
             json = json.Replace("lastmodified", "last_modified");
             response.Content = new StringContent(json, Encoding.UTF8, "application/json");
@@ -224,6 +207,17 @@ namespace Azure.ApplicationModel.Configuration.Test
 
             response.Content.Headers.TryAddWithoutValidation("Last-Modified", "Tue, 05 Dec 2017 02:41:26 GMT");
             response.Content.Headers.TryAddWithoutValidation("Content-Type", "application/vnd.microsoft.appconfig.kv+json; charset=utf-8;");
+        }
+
+        protected string SerializeSetting(ConfigurationSetting responseContent)
+        {
+            if (responseContent == null) return null;
+
+            string json = JsonConvert.SerializeObject(responseContent).ToLowerInvariant();
+            string etagValue = JsonConvert.SerializeObject(responseContent.ETag.ToString());
+            json = json.Replace("etag\":{}", $"etag\":{etagValue}");
+            json = json.Replace("contenttype", "content_type");
+            return json.Replace("lastmodified", "last_modified");
         }
 
         protected string GetExtraUriParameters(RequestOptions filter)

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
@@ -213,11 +213,31 @@ namespace Azure.ApplicationModel.Configuration.Test
         {
             if (responseContent == null) return null;
 
-            string json = JsonConvert.SerializeObject(responseContent).ToLowerInvariant();
-            string etagValue = JsonConvert.SerializeObject(responseContent.ETag.ToString());
-            json = json.Replace("etag\":{}", $"etag\":{etagValue}");
-            json = json.Replace("contenttype", "content_type");
-            return json.Replace("lastmodified", "last_modified");
+            StringBuilder requestContent = new StringBuilder();
+            requestContent.AppendFormat("{{\"key\":\"{0}\",", responseContent.Key);
+            requestContent.AppendFormat("\"label\":\"{0}\",", responseContent.Label);
+            requestContent.AppendFormat("\"value\":\"{0}\",", responseContent.Value);
+            requestContent.AppendFormat("\"content_type\":\"{0}\",", responseContent.ContentType);
+            requestContent.AppendFormat("\"etag\":\"{0}\",", responseContent.ETag.ToString());
+            requestContent.AppendFormat("\"last_modified\":\"{0}\",", responseContent.LastModified.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssK"));
+            requestContent.AppendFormat("\"locked\":{0},", responseContent.Locked);
+            requestContent.AppendFormat("\"tags\":{{");
+
+            bool first = true;
+            foreach (var tag in responseContent.Tags)
+            {
+                if (first)
+                {
+                    requestContent.AppendFormat("\"{0}\":\"{1}\"", tag.Key, tag.Value);
+                    first = false;
+                }
+                else
+                {
+                    requestContent.AppendFormat(",\"{0}\":\"{1}\"", tag.Key, tag.Value);
+                }
+            }
+            requestContent.Append("}}");
+            return requestContent.ToString().ToLowerInvariant();
         }
 
         protected string GetExtraUriParameters(RequestOptions filter)

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
@@ -149,7 +149,7 @@ namespace Azure.ApplicationModel.Configuration
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
                 message.AddHeader(HttpHeader.Common.CreateContentLength(content.Length));
-                if(!string.IsNullOrEmpty(setting.ETag))
+                if(setting.ETag != default)
                 {
                     message.AddHeader(IfMatchName, $"\"{setting.ETag}\"");
                 } else if(options == null)

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSetting.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSetting.cs
@@ -57,7 +57,7 @@ namespace Azure.ApplicationModel.Configuration
         /// <summary>
         /// An ETag indicating the state of a key-value within a configuration store.
         /// </summary>
-        public string ETag { get; set; }
+        public ETag ETag { get; set; }
 
         /// <summary>
         /// The last time a modifying operation was performed on the given key-value.
@@ -93,9 +93,9 @@ namespace Azure.ApplicationModel.Configuration
         public bool Equals(ConfigurationSetting other)
         {
             if (other == null) return false;
-            if (ETag != null && other.ETag != null)
+            if (ETag != default && other.ETag != default)
             {
-                if (!string.Equals(ETag, other.ETag, StringComparison.Ordinal)) return false;
+                if (ETag != other.ETag) return false;
                 if (LastModified != other.LastModified) return false;
             }
             if (!string.Equals(Key, other.Key, StringComparison.Ordinal)) return false;

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSettingParser.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSettingParser.cs
@@ -54,7 +54,7 @@ namespace Azure.ApplicationModel.Configuration
             if (root.TryGetProperty("label", out var labelValue)) setting.Label = labelValue.GetString();
             if (root.TryGetProperty("content_type", out var contentValue)) setting.ContentType = contentValue.GetString();
             if (root.TryGetProperty("locked", out var lockedValue)) setting.Locked = lockedValue.GetBoolean();
-            if (root.TryGetProperty("etag", out var eTagValue)) setting.ETag = eTagValue.GetString();
+            if (root.TryGetProperty("etag", out var eTagValue)) setting.ETag = new ETag(eTagValue.GetString());
             if (root.TryGetProperty("last_modified", out var lastModifiedValue)) setting.LastModified = DateTimeOffset.Parse(lastModifiedValue.GetString());
             if (root.TryGetProperty("tags", out var tagsValue))
             {


### PR DESCRIPTION
Changes ETag from String to ETag type in ConfigurationSetting.

For the mocks, JSON.NET is not serializing ETag as needed. For example,
```
setting = new ConfigurationSetting()
{
   ...
  ETag = new ETag("pepito")
}

string json = JsonConvert.SerializeObject(setting ).ToLowerInvariant();
```
With this code, `json = "{etag:{}}"`. So I am overwriting it so that `json = {etag:pepito}`
but I am sure there must be a better way to do this ....

cc: @KrzysztofCwalina 

-----------------------
**Update**
I'm creating the `_responseContent` instead of leaving it to JSON.NET.
We still have a dependency on it for MockBatch that I will remove later in another PR. Issue https://github.com/Azure/azure-sdk-for-net/issues/5383
