### PR TITLE
Nullable types for Locked and LastModified

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -23,8 +23,6 @@ namespace Azure.ApplicationModel.Configuration.Tests
         {
             Label = "test_label",
             ContentType = "test_content_type",
-            LastModified = new DateTimeOffset(2018, 11, 28, 9, 55, 0, 0, default),
-            Locked = false,
             Tags = new Dictionary<string, string>
             {
                 { "tag1", "value1" },
@@ -726,9 +724,6 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 // Test Lock
                 ConfigurationSetting responseLockSetting = await service.LockAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
 
-                s_testSetting.Locked = true;
-                Assert.AreEqual(s_testSetting, responseLockSetting);
-                
                 //Test update
                 var testSettingUpdate = s_testSetting.Clone();
                 testSettingUpdate.Value = "test_value_update";
@@ -743,9 +738,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 
                 // Test Unlock
                 ConfigurationSetting responseUnlockSetting = await service.UnlockAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
-
-                s_testSetting.Locked = false;
-                Assert.AreEqual(s_testSetting, responseUnlockSetting);
+                await service.UpdateAsync(testSettingUpdate);
             }
             finally
             {
@@ -819,9 +812,6 @@ namespace Azure.ApplicationModel.Configuration.Tests
             {
                 Label = setting.Label,
                 ContentType = setting.ContentType,
-                LastModified = setting.LastModified,
-                Locked = setting.Locked,
-                ETag = default,
                 Tags = tags
             };
         }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -24,8 +24,6 @@ namespace Azure.ApplicationModel.Configuration.Tests
         {
             Label = "test_label",
             ContentType = "test_content_type",
-            LastModified = new DateTimeOffset(2018, 11, 28, 9, 55, 0, 0, default),
-            Locked = false,
             Tags = new Dictionary<string, string>
             {
                 { "tag1", "value1" },
@@ -162,7 +160,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             ConfigurationSetting setting = await service.LockAsync(s_testSetting.Key, s_testSetting.Label);
 
-            Assert.AreEqual(s_testSetting, setting);
+            Assert.True(setting.Locked);
             Assert.AreEqual(0, pool.CurrentlyRented);
         }
 
@@ -173,7 +171,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             ConfigurationSetting setting = await service.UnlockAsync(s_testSetting.Key, s_testSetting.Label);
 
-            Assert.AreEqual(s_testSetting, setting);
+            Assert.False(setting.Locked);
             Assert.AreEqual(0, pool.CurrentlyRented);
         }
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
@@ -24,7 +24,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/kv/{responseContent.Key}{GetExtraUriParameters(responseContent)}";
             _expectedMethod = HttpMethod.Put;
             _expectedRequestContent = GenerateExpectedRequestContent(responseContent);
-            _responseContent = SerializeSetting(responseContent);
+            _responseContent = CreateResponse(responseContent);
         }
     }
 
@@ -35,7 +35,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/kv/{responseContent.Key}{GetExtraUriParameters(responseContent)}";
             _expectedMethod = HttpMethod.Put;
             _expectedRequestContent = GenerateExpectedRequestContent(responseContent);
-            _responseContent = SerializeSetting(responseContent);
+            _responseContent = CreateResponse(responseContent);
         }
     }
 
@@ -46,7 +46,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/kv/{responseContent.Key}{GetExtraUriParameters(responseContent)}";
             _expectedMethod = HttpMethod.Put;
             _expectedRequestContent = GenerateExpectedRequestContent(responseContent);
-            _responseContent = SerializeSetting(responseContent);
+            _responseContent = CreateResponse(responseContent);
         }
 
         protected override void VerifyRequestCore(HttpRequestMessage request)
@@ -62,7 +62,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/kv/{key}{GetExtraUriParameters(filter)}";
             _expectedRequestContent = null;
             _expectedMethod = HttpMethod.Delete;
-            _responseContent = SerializeSetting(result);
+            _responseContent = CreateResponse(result);
         }
 
         public DeleteMockTransport(string key, RequestOptions filter, HttpStatusCode statusCode)
@@ -81,7 +81,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedMethod = HttpMethod.Get;
             _expectedUri = $"https://contoso.azconfig.io/kv/{queryKey}{GetExtraUriParameters(filter)}";
             _expectedRequestContent = null;
-            _responseContent = SerializeSetting(result);
+            _responseContent = CreateResponse(result);
         }
 
         public GetMockTransport(string queryKey, RequestOptions filter, params HttpStatusCode[] statusCodes)
@@ -101,7 +101,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _expectedUri = $"https://contoso.azconfig.io/locks/{responseContent.Key}{GetExtraUriParameters(responseContent)}";
             _expectedRequestContent = null;
             _expectedMethod = lockOtherwiseUnlock ? HttpMethod.Put : HttpMethod.Delete;
-            _responseContent = SerializeSetting(responseContent);
+            _responseContent = CreateResponse(responseContent, lockOtherwiseUnlock);
         }
     }
 
@@ -209,7 +209,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             response.Content.Headers.TryAddWithoutValidation("Content-Type", "application/vnd.microsoft.appconfig.kv+json; charset=utf-8;");
         }
 
-        protected string SerializeSetting(ConfigurationSetting responseContent)
+        protected string CreateResponse(ConfigurationSetting responseContent, bool? locked = null)
         {
             if (responseContent == null) return null;
 
@@ -219,8 +219,8 @@ namespace Azure.ApplicationModel.Configuration.Test
             requestContent.AppendFormat("\"value\":\"{0}\",", responseContent.Value);
             requestContent.AppendFormat("\"content_type\":\"{0}\",", responseContent.ContentType);
             requestContent.AppendFormat("\"etag\":\"{0}\",", responseContent.ETag.ToString());
-            requestContent.AppendFormat("\"last_modified\":\"{0}\",", responseContent.LastModified.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssK"));
-            requestContent.AppendFormat("\"locked\":{0},", responseContent.Locked);
+            requestContent.AppendFormat("\"last_modified\":\"{0}\",", DateTimeOffset.Now.UtcDateTime.ToString("yyyy'-'MM'-'dd'T'HH':'mm':'ssK"));
+            if (locked.HasValue) requestContent.AppendFormat("\"locked\":{0},", locked);
             requestContent.AppendFormat("\"tags\":{{");
 
             bool first = true;

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSetting.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSetting.cs
@@ -62,13 +62,13 @@ namespace Azure.ApplicationModel.Configuration
         /// <summary>
         /// The last time a modifying operation was performed on the given key-value.
         /// </summary>
-        public DateTimeOffset? LastModified { get; set; }
+        public DateTimeOffset? LastModified { get; internal set; }
 
         /// <summary>
         /// A value indicating whether the key-value is locked.
         /// A locked key-value may not be modified until it is unlocked.
         /// </summary>
-        public bool? Locked { get; set; }
+        public bool? Locked { get; internal set; }
 
         /// <summary>
         /// A dictionary of tags that can help identify what a key-value may be applicable for.
@@ -97,12 +97,12 @@ namespace Azure.ApplicationModel.Configuration
             {
                 if (ETag != other.ETag) return false;
                 if (LastModified != other.LastModified) return false;
+                if (Locked != other.Locked) return false;
             }
             if (!string.Equals(Key, other.Key, StringComparison.Ordinal)) return false;
             if (!string.Equals(Value, other.Value, StringComparison.Ordinal)) return false;
             if (!string.Equals(Label, other.Label, StringComparison.Ordinal)) return false;
             if (!string.Equals(ContentType, other.ContentType, StringComparison.Ordinal)) return false;
-            if (Locked != other.Locked) return false;
             if (!TagsEquals(other.Tags)) return false;
             
             return true;

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSetting.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSetting.cs
@@ -62,13 +62,13 @@ namespace Azure.ApplicationModel.Configuration
         /// <summary>
         /// The last time a modifying operation was performed on the given key-value.
         /// </summary>
-        public DateTimeOffset LastModified { get; set; }
+        public DateTimeOffset? LastModified { get; set; }
 
         /// <summary>
         /// A value indicating whether the key-value is locked.
         /// A locked key-value may not be modified until it is unlocked.
         /// </summary>
-        public bool Locked { get; set; }
+        public bool? Locked { get; set; }
 
         /// <summary>
         /// A dictionary of tags that can help identify what a key-value may be applicable for.

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSettingParser.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSettingParser.cs
@@ -53,9 +53,29 @@ namespace Azure.ApplicationModel.Configuration
             if (root.TryGetProperty("value", out var value)) setting.Value = value.GetString();
             if (root.TryGetProperty("label", out var labelValue)) setting.Label = labelValue.GetString();
             if (root.TryGetProperty("content_type", out var contentValue)) setting.ContentType = contentValue.GetString();
-            if (root.TryGetProperty("locked", out var lockedValue)) setting.Locked = lockedValue.GetBoolean();
             if (root.TryGetProperty("etag", out var eTagValue)) setting.ETag = new ETag(eTagValue.GetString());
-            if (root.TryGetProperty("last_modified", out var lastModifiedValue)) setting.LastModified = DateTimeOffset.Parse(lastModifiedValue.GetString());
+            if (root.TryGetProperty("last_modified", out var lastModified))
+            {
+                if(lastModified.Type == JsonValueType.Null)
+                {
+                    setting.LastModified = null;
+                }
+                else
+                {
+                    setting.LastModified = DateTimeOffset.Parse(lastModified.GetString());
+                }
+            }
+            if (root.TryGetProperty("locked", out var lockedValue))
+            {
+                if(lockedValue.Type == JsonValueType.Null)
+                {
+                    setting.Locked = null;
+                }
+                else
+                {
+                    setting.Locked = lockedValue.GetBoolean();
+                }
+            }
             if (root.TryGetProperty("tags", out var tagsValue))
             {
                 foreach (var element in tagsValue.EnumerateObject())


### PR DESCRIPTION
This in order to be able to have filters, so returning Configuration Settings that don't have all fields populated

**update**
This PR also is hiding the setter for `Locked` and `LastModified` properties from the user. It changes the test to reflect that too.