### PR TITLE
Fixed RequestFailedException

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -203,8 +203,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                     await service.AddAsync(setting);
                 });
 
-                var response = exception.Response;
-                Assert.AreEqual(412, response.Status);
+                Assert.AreEqual(412, exception.Status);
             }
             finally
             {
@@ -295,8 +294,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                     await service.UpdateAsync(key, value);
                 });
 
-                var response = exception.Response;
-                Assert.AreEqual(412, response.Status);
+                Assert.AreEqual(412, exception.Status);
             }
             finally
             {
@@ -390,8 +388,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                     await service.UpdateAsync(setting, options, CancellationToken.None);
                 });
 
-                var response = exception.Response;
-                Assert.AreEqual(412, response.Status);
+                Assert.AreEqual(412, exception.Status);
             }
             finally
             {
@@ -424,8 +421,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                     await service.UpdateAsync(testSettingDiff, options, CancellationToken.None);
                 });
 
-                var response = exception.Response;
-                Assert.AreEqual(412, response.Status);
+                Assert.AreEqual(412, exception.Status);
             }
             finally
             {
@@ -496,8 +492,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                     await service.GetAsync(setting.Key, options, CancellationToken.None);
                 });
 
-                var response = exception.Response;
-                Assert.AreEqual(304, response.Status);
+                Assert.AreEqual(304, exception.Status);
             }
             finally
             {
@@ -590,14 +585,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
             var service = new ConfigurationClient(connectionString);
             
-            var e = Assert.ThrowsAsync<RequestFailedException>(async () =>
+            var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
                 await service.GetAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
             });
 
-            var response = e.Response;
-            Assert.AreEqual(404, response.Status);
-            response.Dispose();
+            Assert.AreEqual(404, exception.Status);
         }
 
         [Test]
@@ -733,13 +726,11 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 var testSettingUpdate = s_testSetting.Clone();
                 testSettingUpdate.Value = "test_value_update";
 
-                var e = Assert.ThrowsAsync<RequestFailedException>(async () =>
+                var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
                 {
                     await service.UpdateAsync(testSettingUpdate);
                 });
-                var response = e.Response;
-                Assert.AreEqual(409, response.Status);
-                response.Dispose();
+                Assert.AreEqual(409, exception.Status);
                 
                 // Test Unlock
                 ConfigurationSetting responseUnlockSetting = await service.UnlockAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -73,7 +73,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void GetNotFound()
         {
-            var transport = new GetMockTransport(s_testSetting.Key, default, HttpStatusCode.NotFound);
+            var transport = new GetMockTransport(s_testSetting.Key, default, s_testSetting, HttpStatusCode.NotFound);
             var (service, pool) = CreateTestService(transport);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -210,16 +210,31 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var options = ConfigurationClient.CreateDefaultPipelineOptions();
             options.ApplicationId = "test_application";
             options.AddService(ArrayPool<byte>.Create(1024 * 1024 * 4, maxArraysPerBucket: 4), typeof(ArrayPool<byte>));
-            options.Transport = new GetMockTransport(s_testSetting.Key, default, s_testSetting);
-            options.RetryPolicy = RetryPolicy.CreateFixed(5, TimeSpan.FromMilliseconds(100), 404);
+            options.Transport = new GetMockTransport(s_testSetting.Key, default, s_testSetting, HttpStatusCode.RequestTimeout, HttpStatusCode.OK);
+            options.RetryPolicy = RetryPolicy.CreateFixed(2, TimeSpan.FromMilliseconds(100), 408 /* RequestTimeout */);
+
+            var testPolicy = new TestPolicy();
+            options.AddPerRetryPolicy(testPolicy);
 
             var client = new ConfigurationClient(connectionString, options);
 
-            try {
-                ConfigurationSetting setting = await client.GetAsync(key: s_testSetting.Key, options: null, CancellationToken.None);
-            }
-            catch(RequestFailedException e) {
-                Assert.AreEqual(504, e.Status);
+            ConfigurationSetting setting = await client.GetAsync(key: s_testSetting.Key, options: null, CancellationToken.None);
+            Assert.AreEqual(s_testSetting, setting);
+            Assert.AreEqual(2, testPolicy.Retries);
+        }
+
+        // TODO (pri 2): this should check the UA header, but this in turn requires the ability to read headers.
+        // TODO (pri 2): this should try to retrieve the service, but currently services are not passed to the pipeline.
+        class TestPolicy : HttpPipelinePolicy
+        {
+            int _retries = 0;
+
+            public int Retries => _retries;
+
+            public override async Task ProcessAsync(HttpMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+            {
+                _retries++;
+                await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
             }
         }
     }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -76,14 +76,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new GetMockTransport(s_testSetting.Key, default, HttpStatusCode.NotFound);
             var (service, pool) = CreateTestService(transport);
 
-            var e = Assert.ThrowsAsync<RequestFailedException>(async () =>
+            var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
                 await service.GetAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
             });
-            var response = e.Response;
-            Assert.AreEqual(404, response.Status);
+            Assert.AreEqual(404, exception.Status);
 
-            response.Dispose();
             Assert.AreEqual(0, pool.CurrentlyRented);
         }
 
@@ -144,14 +142,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new DeleteMockTransport(s_testSetting.Key, default, HttpStatusCode.NotFound);
             var (service, pool) = CreateTestService(transport);
 
-            var e = Assert.ThrowsAsync<RequestFailedException>(async () =>
+            var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
                 await service.DeleteAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
             });
-            var response = e.Response;
-            Assert.AreEqual(404, response.Status);
+            Assert.AreEqual(404, exception.Status);
 
-            response.Dispose();
             Assert.AreEqual(0, pool.CurrentlyRented);
         }
 
@@ -209,7 +205,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         }
 
         [Test]
-        public void ConfiguringTheClient()
+        public async Task ConfiguringTheClient()
         {
             var options = ConfigurationClient.CreateDefaultPipelineOptions();
             options.ApplicationId = "test_application";
@@ -219,12 +215,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var client = new ConfigurationClient(connectionString, options);
 
-            var e = Assert.ThrowsAsync<RequestFailedException>(async () =>
-            {
-                await client.GetAsync(key: s_testSetting.Key, options: null, CancellationToken.None);
-            });
-            var response = e.Response;
-            response.Dispose();
+            try {
+                ConfigurationSetting setting = await client.GetAsync(key: s_testSetting.Key, options: null, CancellationToken.None);
+            }
+            catch(RequestFailedException e) {
+                Assert.AreEqual(504, e.Status);
+            }
         }
     }
 }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
@@ -99,8 +99,8 @@ namespace Azure.ApplicationModel.Configuration.Test
             _responseContent = json.Replace("lastmodified", "last_modified");
         }
 
-        public GetMockTransport(string queryKey, RequestOptions filter, params HttpStatusCode[] statusCodes)
-            : this(queryKey, filter, result: null)
+        public GetMockTransport(string queryKey, RequestOptions filter, ConfigurationSetting result, params HttpStatusCode[] statusCodes)
+            : this(queryKey, filter, result)
         {
             Responses.Clear();
             foreach (var statusCode in statusCodes) {

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.props
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Azure.Base.props
@@ -1,4 +1,8 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <UseProjectReferenceToAzureBase>true</UseProjectReferenceToAzureBase>
+  </PropertyGroup>
+  
   <!-- Project references -->
   <ItemGroup Condition="'$(UseProjectReferenceToAzureBase)'=='true'">
     <ProjectReference Include="$(MSBuildThisFileDirectory)Azure.Base.csproj" />

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/FailedResponseException.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/FailedResponseException.cs
@@ -7,15 +7,28 @@ namespace Azure
 {
     public class RequestFailedException : Exception
     {
-        Response _response;
-        string _reason;
+        int _status;
 
-        public RequestFailedException(Response response, string reason = null)
+        public RequestFailedException(Response response, string summary = null)
+            : this(response, summary, null)
+        {}
+
+        public RequestFailedException(Response response, string summary, Exception innerException)
+            : base(FormatMessage(response, summary), innerException)
         {
-            _response = response;
-            _reason = reason;
+            _status = response.Status;
         }
 
-        public Response Response => _response; 
+        private static string FormatMessage(Response response, string summary)
+        {
+            if (summary != null) {
+                return $"{summary}{Environment.NewLine}{response}";
+            }
+            else {
+                return response.ToString();
+            }
+        }
+
+        public int Status => _status; 
     }
 }

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/HttpClientTransport.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Http/Pipeline/HttpClientTransport.cs
@@ -132,8 +132,9 @@ namespace Azure.Base.Http.Pipeline
                 return true;
             }
 
-            // TODO (pri 1): is it ok to just call .Result here?
-            protected internal override Stream ResponseContentStream => _responseMessage.Content.ReadAsStreamAsync().Result;
+            // TODO (pri 1): is it ok to just call GetResult here?
+            protected internal override Stream ResponseContentStream
+                => _responseMessage?.Content?.ReadAsStreamAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             #endregion
 
             public override void Dispose()

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Response.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Response.cs
@@ -68,18 +68,6 @@ namespace Azure
         public override int GetHashCode() => base.GetHashCode();
 
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public override string ToString()
-        {
-            var responseStream = _message.ResponseContentStream;
-            if (responseStream.CanSeek) {
-                var position = responseStream.Position;
-                var reader = new StreamReader(responseStream);
-                var result = $"{Status} {reader.ReadToEnd()}";
-                responseStream.Seek(position, SeekOrigin.Begin);
-                return result;
-            }
-
-            return $"Status : {Status.ToString()}";
-        }
+        public override string ToString() => _message.ToString();
     }
 }


### PR DESCRIPTION
During yesterday's UX study, I noticed our exception doesn't carry any useful message information. This is because when an exception is thrown, Response is being disposed. This change captures all interesting information inside the exception, so that Response can be disposed without affecting the exception.