### PR TITLE
Standardize signatures and clean tests

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -62,7 +62,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new GetMockTransport(s_testSetting.Key, default, s_testSetting);
             var (service, pool) = CreateTestService(transport);
 
-            ConfigurationSetting setting = await service.GetAsync(key: s_testSetting.Key, options : default, CancellationToken.None);
+            ConfigurationSetting setting = await service.GetAsync(s_testSetting.Key);
 
             Assert.AreEqual(s_testSetting, setting);
             Assert.AreEqual(0, pool.CurrentlyRented);
@@ -76,7 +76,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await service.GetAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
+                await service.GetAsync(key: s_testSetting.Key);
             });
             Assert.AreEqual(404, exception.Status);
 
@@ -113,12 +113,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new UpdateMockTransport(s_testSetting);
             var (service, pool) = CreateTestService(transport);
 
-            RequestOptions options = new RequestOptions()
-            {
-                ETag = new ETagFilter() { IfMatch = new ETag("*") }
-            };
-
-            ConfigurationSetting setting = await service.UpdateAsync(s_testSetting, options, CancellationToken.None);
+            ConfigurationSetting setting = await service.UpdateAsync(s_testSetting, CancellationToken.None);
 
             Assert.AreEqual(s_testSetting, setting);
             Assert.AreEqual(0, pool.CurrentlyRented);
@@ -130,7 +125,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new DeleteMockTransport(s_testSetting.Key, new RequestOptions() {Label = s_testSetting.Label }, s_testSetting);
             var (service, pool) = CreateTestService(transport);
 
-            await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label);
+            await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
             Assert.AreEqual(0, pool.CurrentlyRented);
         }
 
@@ -142,7 +137,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await service.DeleteAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
+                await service.DeleteAsync(s_testSetting.Key);
             });
             Assert.AreEqual(404, exception.Status);
 
@@ -216,7 +211,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var client = new ConfigurationClient(connectionString, options);
 
-            ConfigurationSetting setting = await client.GetAsync(key: s_testSetting.Key, options: null, CancellationToken.None);
+            ConfigurationSetting setting = await client.GetAsync(s_testSetting.Key);
             Assert.AreEqual(s_testSetting, setting);
             Assert.AreEqual(2, testPolicy.Retries);
         }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient_private.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient_private.cs
@@ -111,27 +111,28 @@ namespace Azure.ApplicationModel.Configuration
         }
 
         Uri BuildUriForKvRoute(ConfigurationSetting keyValue)
-            => BuildUriForKvRoute(keyValue.Key, new RequestOptions() { Label = keyValue.Label }); // TODO (pri 2) : does this need to filter ETag?
+            => BuildUriForKvRoute(keyValue.Key, keyValue.Label); // TODO (pri 2) : does this need to filter ETag?
 
-        Uri BuildUriForKvRoute(string key, RequestOptions options)
+        Uri BuildUriForKvRoute(string key, string label)
         {
             var builder = new UriBuilder(_baseUri);
             builder.Path = KvRoute + key;
 
-            if (options != null && options.Label != null) {
-                builder.AppendQuery(LabelQueryFilter, options.Label);                 
+            if (label != null)
+            {
+                builder.AppendQuery(LabelQueryFilter, label);
             }
 
             return builder.Uri;
         }
 
-        Uri BuildUriForLocksRoute(string key, RequestOptions options)
+        Uri BuildUriForLocksRoute(string key, string label)
         {
             var builder = new UriBuilder(_baseUri);
             builder.Path = LocksRoute + key;
 
-            if (options != null && options.Label != null) {
-                builder.AppendQuery(LabelQueryFilter, options.Label);
+            if (label != null) {
+                builder.AppendQuery(LabelQueryFilter, label);
             }
 
             return builder.Uri;


### PR DESCRIPTION
Match the API we've been discussing. Also, cleans the tests to reflect the changes applied.
With these changes, and the latest updates on Python, now it looks like this:

Python | .NET
-- | --
KeyValue   add_key_value(self, key_value) | AddAsync(string key,   string value, string label = default, CancellationToken cancellation =   default)
  | AddAsync(ConfigurationSetting   setting, CancellationToken cancellation = default)
KeyValue   update_key_value(self, key, value=None, content_type=None, tags=None,   label=None, etag=None) | UpdateAsync(string   key, string value, string label = default, CancellationToken cancellation =   default)
  | UpdateAsync(ConfigurationSetting   setting, CancellationToken cancellation = default)
KeyValue   set_key_value(self, key_value) | SetAsync(string key,   string value, string label = default, CancellationToken cancellation =   default)
  | SetAsync(ConfigurationSetting   setting, CancellationToken cancellation = default)
KeyValue   get_key_value(self, key, label=None) | GetAsync(string key,   string label = default, CancellationToken cancellation = default)
KeyValue   delete_key_value(self, key, label=None, etag=None) | DeleteAsync(string   key, string label = default, ETag etag = default, CancellationToken   cancellation = default)
KeyValue   lock_key_value(self, key, label=None) | LockAsync(string key,   string label = default, CancellationToken cancellation = default)
KeyValue   unlock_key_value(self, key, label=None) | UnlockAsync(string   key, string label = default, CancellationToken cancellation = default)

It also follow the ETag behavior agreed between languages for set/update/delete:
- if etag is specified, add it into if-match, override custom-header's if-match setting
- if etag is not specified, use the setting from custom header
- if neither etag nor custom header is set, add "if-match *" for update. no "if-match" for set and delete.

**Note** : This PR doesn't include list/batch operations or revision operations