### PR TITLE
Don't explicitly set host header in client SDK

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
@@ -68,7 +68,6 @@ namespace Azure.ApplicationModel.Configuration
 
                 message.SetRequestLine(HttpVerb.Put, uri);
 
-                message.AddHeader("Host", uri.Host);
                 message.AddHeader(IfNoneMatch, "*");
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
@@ -105,7 +104,6 @@ namespace Azure.ApplicationModel.Configuration
 
                 message.SetRequestLine(HttpVerb.Put, uri);
 
-                message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
                 if (setting.ETag != default)
@@ -147,7 +145,6 @@ namespace Azure.ApplicationModel.Configuration
 
                 message.SetRequestLine(HttpVerb.Put, uri);
 
-                message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
 
@@ -190,7 +187,6 @@ namespace Azure.ApplicationModel.Configuration
             using (HttpMessage message = _pipeline.CreateMessage(cancellation)) {
                 message.SetRequestLine(HttpVerb.Delete, uri);
 
-                message.AddHeader("Host", uri.Host);
                 if (etag != default)
                 {
                     message.AddHeader(IfMatchName, $"\"{etag.ToString()}\"");
@@ -218,7 +214,6 @@ namespace Azure.ApplicationModel.Configuration
             using (HttpMessage message = _pipeline.CreateMessage(cancellation)) {
                 message.SetRequestLine(HttpVerb.Put, uri);
 
-                message.AddHeader("Host", uri.Host);
                 AddClientRequestID(message);
                 AddAuthenticationHeaders(message, uri, HttpVerb.Put, content: default, _secret, _credential);
 
@@ -241,7 +236,6 @@ namespace Azure.ApplicationModel.Configuration
             using (HttpMessage message = _pipeline.CreateMessage(cancellation)) {
                 message.SetRequestLine(HttpVerb.Delete, uri);
 
-                message.AddHeader("Host", uri.Host);
                 AddClientRequestID(message);
                 AddAuthenticationHeaders(message, uri, HttpVerb.Delete, content: default, _secret, _credential);
 
@@ -264,7 +258,6 @@ namespace Azure.ApplicationModel.Configuration
             using (HttpMessage message = _pipeline.CreateMessage(cancellation)) {
                 message.SetRequestLine(HttpVerb.Get, uri);
 
-                message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
                 AddClientRequestID(message);
@@ -288,7 +281,6 @@ namespace Azure.ApplicationModel.Configuration
             using (HttpMessage message = _pipeline.CreateMessage(cancellation)) {
                 message.SetRequestLine(HttpVerb.Get, uri);
 
-                message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 AddOptionsHeaders(batchOptions, message);
                 AddClientRequestID(message);
@@ -312,7 +304,6 @@ namespace Azure.ApplicationModel.Configuration
             using (HttpMessage message = _pipeline.CreateMessage(cancellation)) {
                 message.SetRequestLine(HttpVerb.Get, uri);
 
-                message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 AddOptionsHeaders(options, message);
                 AddClientRequestID(message);

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/HttpClientTransportTests.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/HttpClientTransportTests.cs
@@ -63,6 +63,47 @@ namespace Azure.Configuration.Tests
             Assert.AreEqual(50, contentLength);
         }
 
+        [Test]
+        public async Task HostHeaderSetFromUri()
+        {
+            string host = null;
+            Uri uri = null;
+            var mockHandler = new MockHttpClientHandler(
+                request => {
+                    uri = request.RequestUri;
+                    host = request.Headers.Host;
+                });
+
+            var transport = new HttpClientTransport(new HttpClient(mockHandler));
+            var message = transport.CreateMessage(null, CancellationToken.None);
+            message.SetRequestLine(HttpVerb.Get, new Uri("http://example.com:340"));
+
+            await transport.ProcessAsync(message);
+
+            // HttpClientHandler would correctly set Host header from Uri when it's not set explicitly
+            Assert.AreEqual("http://example.com:340/", uri.ToString());
+            Assert.Null(host);
+        }
+
+        [Test]
+        public async Task SettingHeaderOverridesDefaultHost()
+        {
+            string host = null;
+            var mockHandler = new MockHttpClientHandler(
+                request => {
+                    host = request.Headers.Host;
+                });
+
+            var transport = new HttpClientTransport(new HttpClient(mockHandler));
+            var message = transport.CreateMessage(null, CancellationToken.None);
+            message.SetRequestLine(HttpVerb.Get, new Uri("http://example.com"));
+            message.AddHeader("Host", "example.org");
+
+            await transport.ProcessAsync(message);
+
+            Assert.AreEqual("example.org", host);
+        }
+
         private class MockHttpClientHandler : HttpMessageHandler
         {
             private readonly Action<HttpRequestMessage> _onSend;


### PR DESCRIPTION
Already the case, add tests, remove usages. `uri.Host` is also a wrong value to set it to, should be `uri.IdnHost + ":" + uri.Port`

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/5558