### PR TITLE
Script to verify agent OS, downloaded from Github release

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -106,7 +106,7 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: 'Build & Test (no live tests)'
-        condition: eq(variables['System.TeamProject'], 'playground')
+        condition: eq(variables['System.TeamProject'], 'public')
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -119,7 +119,7 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: 'Build & Test (with live tests)'
-        condition: ne(variables['System.TeamProject'], 'playground')
+        condition: ne(variables['System.TeamProject'], 'public')
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -87,13 +87,16 @@ jobs:
       vmImage: '$(OSVmImage)'
 
     steps:
-      - powershell:  'Invoke-WebRequest -Uri "$(VerifyAgentOSBlobPath)" -OutFile "./verify_agent_os.py"'
-        displayName: 'Download VerifyAgentOS Script From Github Release'
+      - powershell: |
+          Invoke-WebRequest -Uri "https://github.com/chidozieononiwu/azure-sdk-for-net/releases/download/verifyAgentOS_v1.1/verify_agent_os.zip" `
+          -OutFile "verify_agent_os.zip" | Wait-Process; Expand-Archive -Path "verify_agent_os.zip" -DestinationPath "./azure-sdk-tools/"
+        workingDirectory: '$(System.DefaultWorkingDirectory)'
+        displayName: 'Download Tools Archive Script From Github Release and Extract it'
 
       - task: PythonScript@0
         displayName: 'Run VerifyAgentOS script'
         inputs:
-          scriptPath: './verify_agent_os.py'
+          scriptPath: './azure-sdk-tools/verify_agent_os.py'
           arguments: $(OSName)
 
       - task: DotNetCoreInstaller@0

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -87,6 +87,15 @@ jobs:
       vmImage: '$(OSVmImage)'
 
     steps:
+      - powershell:  'Invoke-WebRequest -Uri "$(VerifyAgentOSBlobPath)" -OutFile "./verify_agent_os.py"'
+        displayName: 'Download VerifyAgentOS Script From Github Release'
+
+      - task: PythonScript@0
+        displayName: 'Run VerifyAgentOS script'
+        inputs:
+          scriptPath: './verify_agent_os.py'
+          arguments: $(OSName)
+
       - task: DotNetCoreInstaller@0
         displayName: 'Use .NET Core sdk $(DotNetCoreVersion)'
         inputs:

--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -88,15 +88,15 @@ jobs:
 
     steps:
       - powershell: |
-          Invoke-WebRequest -Uri "https://github.com/chidozieononiwu/azure-sdk-for-net/releases/download/verifyAgentOS_v1.1/verify_agent_os.zip" `
-          -OutFile "verify_agent_os.zip" | Wait-Process; Expand-Archive -Path "verify_agent_os.zip" -DestinationPath "./azure-sdk-tools/"
-        workingDirectory: '$(System.DefaultWorkingDirectory)'
-        displayName: 'Download Tools Archive Script From Github Release and Extract it'
+          Invoke-WebRequest -Uri "https://github.com/chidozieononiwu/azure-sdk-tools/releases/download/sdk-tools_v1.0/sdk-tools.zip" `
+          -OutFile "sdk-tools.zip" | Wait-Process; Expand-Archive -Path "sdk-tools.zip" -DestinationPath "./sdk-tools/"
+        workingDirectory: '$(Build.BinariesDirectory)'
+        displayName: 'Download Tools Archive From Github Release and Extract it'
 
       - task: PythonScript@0
         displayName: 'Run VerifyAgentOS script'
         inputs:
-          scriptPath: './azure-sdk-tools/verify_agent_os.py'
+          scriptPath: '$(Build.BinariesDirectory)/sdk-tools/verify_agent_os.py'
           arguments: $(OSName)
 
       - task: DotNetCoreInstaller@0
@@ -106,7 +106,7 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: 'Build & Test (no live tests)'
-        condition: eq(variables['System.TeamProject'], 'public')
+        condition: eq(variables['System.TeamProject'], 'playground')
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
@@ -119,7 +119,7 @@ jobs:
 
       - task: DotNetCoreCLI@2
         displayName: 'Build & Test (with live tests)'
-        condition: ne(variables['System.TeamProject'], 'public')
+        condition: ne(variables['System.TeamProject'], 'playground')
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/eng/data-plane.proj
+++ b/eng/data-plane.proj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <!-- Issue https://github.com/Azure/azure-sdk-for-net/issues/5089 some KeyVault tests don't work on linix -->
+    <!-- Issue https://github.com/Azure/azure-sdk-for-net/issues/5089 some KeyVault tests don't work on linux -->
     <ExcludeDataPlaneProjects Include="$(RepoSrcPath)\KeyVault\data-plane\**\Microsoft.Azure.KeyVault.Tests.csproj" Condition="'$(OS)' != 'Windows_NT'" />
     <ExcludeDataPlaneProjects Include="$(RepoSrcPath)\*\data-plane\**\*.Tests.*proj" Condition="'$(SkipTests)' == 'true'" />
     <DataPlaneProjectReference Include="$(RepoSrcPath)\*\data-plane\**\*.*proj" Exclude="@(ExcludeDataPlaneProjects)" />


### PR DESCRIPTION
Getting script from Github release rather than blob storage. This is a temporary solution till we can get it to work from the devops feed.