### PR TITLE
Cleaning tests for consistency with other languages + filter tests

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -29,7 +29,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         };
 
-        private static string SetEnvironment()
+        private static string GetEnvironment()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
@@ -80,7 +80,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task DeleteSettingNotFound()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var response = await service.DeleteAsync(s_testSetting.Key);
@@ -92,7 +92,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task DeleteSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -123,7 +123,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task DeleteSettingWithLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -154,7 +154,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task DeleteSettingWithETag()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             // Prepare environment
@@ -175,7 +175,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task SetSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -192,7 +192,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task SetExistingSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -211,7 +211,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task SetKeyValue()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -233,7 +233,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task SetKeyValueLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -257,7 +257,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetRequestId()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -276,7 +276,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddExistingSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -299,7 +299,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -317,7 +317,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddSettingNoLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var testSettingNoLabel = s_testSetting.Clone();
@@ -338,7 +338,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddKeyValue()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -360,7 +360,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddKeyValueLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -384,7 +384,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task UpdateKeyValue()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -407,7 +407,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task UpdateSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var testSettingDiff = s_testSetting.Clone();
@@ -435,7 +435,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void UpdateNoExistingSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -448,7 +448,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task UpdateSettingIfETag()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             await service.SetAsync(s_testSetting);
@@ -470,7 +470,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task UpdateSettingTags()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             await service.SetAsync(s_testSetting);
@@ -505,7 +505,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetRevisions()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             //Prepare environment
@@ -552,7 +552,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             // Prepare environment
@@ -575,7 +575,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void GetSettingNotFound()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -589,7 +589,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetSettingWithLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             // Prepare environment
@@ -615,7 +615,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetWithAcceptDateTime()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -635,7 +635,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingPagination()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             const int expectedEvents = 105;
@@ -662,7 +662,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingAny()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -689,7 +689,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingKeyLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -712,7 +712,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingOnlyKey()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -734,7 +734,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingOnlyLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -761,7 +761,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingWithFields()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -788,7 +788,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task LockUnlockSetting()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -822,7 +822,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void LockSettingNotFound()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -836,7 +836,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void UnlockSettingNotFound()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -850,7 +850,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterReservedCharacter()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
             var selector = new SettingSelector()
             {
@@ -868,7 +868,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterContains()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
             var selector = new SettingSelector()
             {
@@ -885,7 +885,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterNullLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
             var selector = new SettingSelector()
             {
@@ -901,7 +901,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterOnlyKey()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var key = "my-key";
@@ -916,7 +916,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterOnlyLabel()
         {
-            string connectionString = SetEnvironment();
+            string connectionString = GetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var label = "my-label";

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -29,6 +29,13 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
         };
 
+        private static string SetEnvironment()
+        {
+            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
+            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            return connectionString;
+        }
+
         private static bool TagsEqual(IDictionary<string, string> expected, IDictionary<string, string> actual)
         {
             if (expected == null && actual == null) return true;
@@ -73,8 +80,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task DeleteSettingNotFound()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var response = await service.DeleteAsync(s_testSetting.Key);
@@ -86,8 +92,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task DeleteSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -118,8 +123,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task DeleteSettingWithLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -150,8 +154,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task DeleteSettingWithETag()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             // Prepare environment
@@ -172,8 +175,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task SetSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -190,8 +192,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task SetExistingSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -210,8 +211,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task SetKeyValue()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -233,8 +233,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task SetKeyValueLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -243,7 +242,6 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                
                 ConfigurationSetting setting = await service.SetAsync(key, value, label);
 
                 Assert.AreEqual(key, setting.Key);
@@ -255,12 +253,11 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 await service.DeleteAsync(key, label);
             }
         }
-
+        
         [Test]
         public async Task GetRequestId()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -279,8 +276,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddExistingSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -303,8 +299,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -322,8 +317,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddSettingNoLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var testSettingNoLabel = s_testSetting.Clone();
@@ -344,8 +338,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddKeyValue()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -367,8 +360,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task AddKeyValueLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -392,8 +384,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task UpdateKeyValue()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
@@ -416,8 +407,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task UpdateSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var testSettingDiff = s_testSetting.Clone();
@@ -445,8 +435,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void UpdateNoExistingSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -459,8 +448,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task UpdateSettingIfETag()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             await service.SetAsync(s_testSetting);
@@ -482,8 +470,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task UpdateSettingTags()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             await service.SetAsync(s_testSetting);
@@ -518,8 +505,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetRevisions()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             //Prepare environment
@@ -566,8 +552,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             // Prepare environment
@@ -590,8 +575,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void GetSettingNotFound()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -605,8 +589,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetSettingWithLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             // Prepare environment
@@ -632,8 +615,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetWithAcceptDateTime()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -653,8 +635,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingPagination()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             const int expectedEvents = 105;
@@ -681,8 +662,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingAny()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -709,8 +689,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingKeyLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -733,8 +712,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingOnlyKey()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -756,8 +734,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingOnlyLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -784,8 +761,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task GetBatchSettingWithFields()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -812,8 +788,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task LockUnlockSetting()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             try
@@ -847,8 +822,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void LockSettingNotFound()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -862,8 +836,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void UnlockSettingNotFound()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
@@ -877,8 +850,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterReservedCharacter()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
             var selector = new SettingSelector()
             {
@@ -896,8 +868,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterContains()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
             var selector = new SettingSelector()
             {
@@ -914,8 +885,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterNullLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
             var selector = new SettingSelector()
             {
@@ -931,8 +901,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterOnlyKey()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var key = "my-key";
@@ -947,8 +916,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public void FilterOnlyLabel()
         {
-            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
-            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            string connectionString = SetEnvironment();
             var service = new ConfigurationClient(connectionString);
 
             var label = "my-label";

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient_private.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient_private.cs
@@ -155,13 +155,9 @@ namespace Azure.ApplicationModel.Configuration
                     {
                         labelsCopy.Add("\0");
                     }
-                    else if (label.IndexOfAny(ReservedCharacters) != -1)
-                    {
-                        labelsCopy.Add(EscapeReservedCharacters(label));
-                    }
                     else
                     {
-                        labelsCopy.Add(label);
+                        labelsCopy.Add(EscapeReservedCharacters(label));
                     }
                 }
                 var labels = string.Join(",", labelsCopy).ToLower();

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/Options.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/Options.cs
@@ -53,14 +53,7 @@ namespace Azure.ApplicationModel.Configuration
         public SettingSelector(string key, string label = default)
         {
             Keys = new List<string>();
-            if (key == null)
-            {
-                Keys.Add(Any);
-            }
-            else
-            {
-                Keys.Add(key);
-            }
+            Keys.Add(key ?? Any);
 
             Labels = new List<string>();
             if (label != null) Labels.Add(label);

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/Options.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/Options.cs
@@ -52,7 +52,16 @@ namespace Azure.ApplicationModel.Configuration
 
         public SettingSelector(string key, string label = default)
         {
-            Keys = new List<string> { key };
+            Keys = new List<string>();
+            if (key == null)
+            {
+                Keys.Add(Any);
+            }
+            else
+            {
+                Keys.Add(key);
+            }
+
             Labels = new List<string>();
             if (label != null) Labels.Add(label);
         }


### PR DESCRIPTION
- Filter tests: #5384 
- Consistency with other languages: #5631 
  - Update name of the tests to include `Setting` like other languages do
  - Add missing tests
  - More information: https://microsoft.sharepoint.com/teams/AzureDeveloperExperience/Shared%20Documents/Service%20-%20Azconfig/Azure%20SDK%20-%20Service%20-%20Azconfig/Azconfig.one#Standardization%20across%20languages%20&section-id={50856656-5D71-2640-B240-11758DB2FB6E}&page-id={79180E7A-F7B4-4221-8398-D440467E3782}&object-id={AD444C44-9B38-0225-20E9-23FDAB509498}&22

cc: @YijunXieMS @alzimmermsft 