### PR TITLE
Remove string replace etag hack

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -4,7 +4,6 @@
     <SignTestAssembly>true</SignTestAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="System.Memory" Version="4.5.1" />

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -206,7 +206,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                     SettingBatch batch = response.Result;
                     for (int i = 0; i < batch.Count; i++)
                     {
-                        var value = batch[i];
+                        ConfigurationSetting value = batch[i];
                         Assert.AreEqual("key" + keyIndex.ToString(), value.Key);
                         keyIndex++;
                     }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
@@ -4,7 +4,6 @@
 
 using Azure.Base.Http;
 using Azure.Base.Http.Pipeline;
-using Newtonsoft.Json;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -139,14 +138,18 @@ namespace Azure.ApplicationModel.Configuration.Test
             var bathItems = new MockBatch();
             int itemIndex = batch.index;
             int count = batch.count;
+
+            StringBuilder responseContent = new StringBuilder();
+
+            responseContent.Append("{\"items\":[");
             while (count-- > 0)
             {
-                bathItems.Items.Add(KeyValues[itemIndex++]);
+                responseContent.Append(CreateResponse(KeyValues[itemIndex++]));
+                if(count != 0) responseContent.Append(",");
             }
-            string json = JsonConvert.SerializeObject(bathItems).ToLowerInvariant();
-            json = json.Replace("etag\":{}", "etag\":\"c3c231fd-39a0-4cb6-3237-4614474b92c1\"");
-            json = json.Replace("contenttype", "content_type");
-            json = json.Replace("lastmodified", "last_modified");
+            responseContent.Append("]}");
+
+            string json = responseContent.ToString().ToLowerInvariant();
             response.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
             long jsonByteCount = Encoding.UTF8.GetByteCount(json);
@@ -208,7 +211,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             response.Content.Headers.TryAddWithoutValidation("Last-Modified", "Tue, 05 Dec 2017 02:41:26 GMT");
             response.Content.Headers.TryAddWithoutValidation("Content-Type", "application/vnd.microsoft.appconfig.kv+json; charset=utf-8;");
         }
-
+        
         protected string CreateResponse(ConfigurationSetting responseContent, bool? locked = null)
         {
             if (responseContent == null) return null;

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/MockHttpClientTransport.cs
@@ -27,11 +27,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             if(responseContent != null)
             {
                 ReadOnlyMemory<byte> content = Serialize(responseContent);
-                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray()).ToLowerInvariant();
-            }
-            else
-            {
-                _responseContent = null;
+                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray());
             }
         }
     }
@@ -46,11 +42,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             if (responseContent != null)
             {
                 ReadOnlyMemory<byte> content = Serialize(responseContent);
-                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray()).ToLowerInvariant();
-            }
-            else
-            {
-                _responseContent = null;
+                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray());
             }
         }
     }
@@ -65,11 +57,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             if (responseContent != null)
             {
                 ReadOnlyMemory<byte> content = Serialize(responseContent);
-                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray()).ToLowerInvariant();
-            }
-            else
-            {
-                _responseContent = null;
+                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray());
             }
         }
 
@@ -89,11 +77,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             if (responseContent != null)
             {
                 ReadOnlyMemory<byte> content = Serialize(responseContent);
-                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray()).ToLowerInvariant();
-            }
-            else
-            {
-                _responseContent = null;
+                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray());
             }
         }
 
@@ -116,11 +100,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             if (responseContent != null)
             {
                 ReadOnlyMemory<byte> content = Serialize(responseContent);
-                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray()).ToLowerInvariant();
-            }
-            else
-            {
-                _responseContent = null;
+                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray());
             }
         }
 
@@ -145,11 +125,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             {
                 responseContent.Locked = lockOtherwiseUnlock;
                 ReadOnlyMemory<byte> content = Serialize(responseContent);
-                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray()).ToLowerInvariant();
-            }
-            else
-            {
-                _responseContent = null;
+                _responseContent = Encoding.UTF8.GetString(content.Span.ToArray());
             }
         }
     }
@@ -194,7 +170,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             }
             ReadOnlyMemory<byte> content = Serialize(bathItems);
 
-            string json = Encoding.UTF8.GetString(content.Span.ToArray()).ToLowerInvariant();
+            string json = Encoding.UTF8.GetString(content.Span.ToArray());
             response.Content = new StringContent(json, Encoding.UTF8, "application/json");
 
             long jsonByteCount = Encoding.UTF8.GetByteCount(json);
@@ -295,7 +271,6 @@ namespace Azure.ApplicationModel.Configuration.Test
         protected virtual void WriteResponseCore(HttpResponseMessage response)
         {
             response.Content = new StringContent(_responseContent, Encoding.UTF8, "application/json");
-            
             long jsonByteCount = Encoding.UTF8.GetByteCount(_responseContent);
             response.Content.Headers.Add("Content-Length", jsonByteCount.ToString()); // TODO (pri 3): the service actually responds with chunked encoding
 


### PR DESCRIPTION
Remove string replace Etag in batch mock hack.

See comment [here](https://github.com/Azure/azure-sdk-for-net/pull/5469#discussion_r266527685) for more information.

cc: @KrzysztofCwalina 