### PR TITLE
Remove custom implementation of operations for VPN Profile

### DIFF
--- a/src/SDKs/Network/Management.Network/Customizations/VpnProfileOperationExtensions.cs
+++ b/src/SDKs/Network/Management.Network/Customizations/VpnProfileOperationExtensions.cs
@@ -165,46 +165,7 @@ namespace Microsoft.Azure.Management.Network
             Dictionary<string, List<string>> customHeaders = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            AzureOperationResponse<string> _response =
-                await this.BeginGenerateVpnProfileWithHttpMessagesAsync(resourceGroupName,
-                    virtualNetworkGatewayName,
-                    parameters,
-                    customHeaders,
-                    cancellationToken).ConfigureAwait(false);
-
-            Uri locationResultsUrl = _response.Response.Headers.Location;
-            DateTime giveUpAt = DateTime.UtcNow.AddMinutes(3);
-            // Send the Get locationResults request for operaitonId till either we get StatusCode 200 or it time outs (3 minutes in this case)
-            while (true)
-            {
-                HttpRequestMessage newHttpRequest = new HttpRequestMessage();
-                newHttpRequest.Method = new HttpMethod("GET");
-                newHttpRequest.RequestUri = locationResultsUrl;
-
-                if (Client.Credentials != null)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await Client.Credentials.ProcessHttpRequestAsync(newHttpRequest, cancellationToken).ConfigureAwait(false);
-                }
-
-                HttpResponseMessage newHttpResponse = await Client.HttpClient.SendAsync(newHttpRequest, cancellationToken).ConfigureAwait(false);
-                if ((int)newHttpResponse.StatusCode != 200)
-                {
-                    if (DateTime.UtcNow > giveUpAt)
-                    {
-                        string newResponseContent = await newHttpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-                        throw new Exception(string.Format("GenerateGatewayVpnProfileWithHttpMessagesAsync Operation returned an invalid status code '{0}' with Exception:{1} while retrieving " +
-                                                          "the Vpnclient PackageUrl!", newHttpResponse.StatusCode, string.IsNullOrEmpty(newResponseContent) ? "NotAvailable" : newResponseContent));
-                    }
-                }
-                else
-                {
-                    // Get the content i.e.VPN Client package Url from locationResults
-                    _response.Body = newHttpResponse.Content.ReadAsStringAsync().Result;
-                    return _response;
-                }
-            }
+            return await this.GenerateVpnProfileWithHttpMessagesAsync(resourceGroupName, virtualNetworkGatewayName, parameters, customHeaders, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -239,45 +200,7 @@ namespace Microsoft.Azure.Management.Network
             Dictionary<string, List<string>> customHeaders = null,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            AzureOperationResponse<string> _response =
-                await this.BeginGetVpnProfilePackageUrlWithHttpMessagesAsync(resourceGroupName,
-                    virtualNetworkGatewayName,
-                    customHeaders,
-                    cancellationToken).ConfigureAwait(false);
-
-            Uri locationResultsUrl = _response.Response.Headers.Location;
-            DateTime giveUpAt = DateTime.UtcNow.AddMinutes(3);
-            // Send the Get locationResults request for operaitonId till either we get StatusCode 200 or it time outs (3 minutes in this case)
-            while (true)
-            {
-                HttpRequestMessage newHttpRequest = new HttpRequestMessage();
-                newHttpRequest.Method = new HttpMethod("GET");
-                newHttpRequest.RequestUri = locationResultsUrl;
-
-                if (Client.Credentials != null)
-                {
-                    cancellationToken.ThrowIfCancellationRequested();
-                    await Client.Credentials.ProcessHttpRequestAsync(newHttpRequest, cancellationToken).ConfigureAwait(false);
-                }
-
-                HttpResponseMessage newHttpResponse = await Client.HttpClient.SendAsync(newHttpRequest, cancellationToken).ConfigureAwait(false);
-                if ((int)newHttpResponse.StatusCode != 200)
-                {
-                    if (DateTime.UtcNow > giveUpAt)
-                    {
-                        string newResponseContent = await newHttpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-                        throw new Exception(string.Format("GetGatewayVpnProfileWithHttpMessagesAsync Operation returned an invalid status code '{0}' with Exception:{1} while retrieving " +
-                                                          "the Vpnclient PackageUrl!", newHttpResponse.StatusCode, string.IsNullOrEmpty(newResponseContent) ? "NotAvailable" : newResponseContent));
-                    }
-                }
-                else
-                {
-                    // Get the content i.e.VPN Client package Url from locationResults
-                    _response.Body = newHttpResponse.Content.ReadAsStringAsync().Result;
-                    return _response;
-                }
-            }
+            return await this.GetVpnProfilePackageUrlWithHttpMessagesAsync(resourceGroupName, virtualNetworkGatewayName, customHeaders, cancellationToken).ConfigureAwait(false);
         }
     }
 }

--- a/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
+++ b/src/SDKs/Network/Management.Network/Microsoft.Azure.Management.Network.csproj
@@ -7,13 +7,11 @@
 		<PackageId>Microsoft.Azure.Management.Network</PackageId>
 		<Description>Provides management capabilities for Network services.</Description>
 		<AssemblyName>Microsoft.Azure.Management.Network</AssemblyName>
-		<Version>19.10.0-preview</Version>
+		<Version>19.10.1-preview</Version>
 		<PackageTags>Microsoft Azure Network management;Network;Network management;</PackageTags>    
 		<PackageReleaseNotes>
 		<![CDATA[
-        - Added support for PeerExpressRouteCircuitConnections and WebApplicationFirewallPolicies
-        - Added support for "Local" SKU and GlobalReachEnabled in ExpressRouteCircuit
-        - Added support for HealthProbeLog in ApplicationGatewayBackendHealthServer
+        - Fixed implementation of operations of VPN profile
 		]]></PackageReleaseNotes>
 	</PropertyGroup>
 	<PropertyGroup>

--- a/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Network/Management.Network/Properties/AssemblyInfo.cs
@@ -8,7 +8,7 @@ using System.Resources;
 [assembly: AssemblyDescription("Provides Microsoft Azure Network management functions for managing the Microsoft Azure Network service.")]
 
 [assembly: AssemblyVersion("19.5.0.0")]
-[assembly: AssemblyFileVersion("19.10.0.0")]
+[assembly: AssemblyFileVersion("19.10.1.0")]
 
 [assembly: AssemblyCompany("Microsoft")]
 [assembly: AssemblyProduct("Microsoft Azure .NET SDK")]


### PR DESCRIPTION
Old implementation of two operations for VPN Profile is the same as generated code.
I left operation signatures intact only replacing custom implementation with invokation of generated code. 

Those changes are introduced because custom implementation uses generated methods like BeginGenerateVpnProfileWithHttpMessagesAsync. With recent swagger changes (https://github.com/Azure/azure-rest-api-specs/pull/5223) those methods are no longer generated, so without this PR Network SDK won't compile.
