### PR TITLE
[HDInsight] - Update SDK version to 5.0.0

### DIFF
--- a/src/SDKs/HDInsight/Management/Management.HDInsight/Management.HDInsight.csproj
+++ b/src/SDKs/HDInsight/Management/Management.HDInsight/Management.HDInsight.csproj
@@ -11,7 +11,14 @@
 		<PackageTags>Microsoft Azure HDInsight Management;HDInsight;HDInsight Management</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[
-        This is a public stable release of the Azure HDInsight SDK.
+This release contains some important changes to allow for more fine-grained role-based access to obtain sensitive credentials. As part of these changes, ACTION MAY BE REQUIRED if you are using one of the affected methods: 
+1) ConfigurationOperationsExtensions.Get will NO LONGER RETURN SENSITIVE PARAMETERS like storage keys (core-site) or HTTP credentials (gateway). 
+- To retrieve all configurations, including sensitive parameters, use ConfigurationOperationsExtensions.List going forward.  Note that users with the 'Reader' role will not be able to use this method to allow for fine-grained control over which users can access cluster secrets. 
+- To retrieve just HTTP gateway credentials, use ClusterOperationsExtensions.GetGatewaySettings. 
+2) ConfigurationsOperationsExtensions.Update is now deprecated and has been replaced by ClusterOperationsExtensions.UpdateGatewaySettings. 
+3) ConfigurationsOperationsExtensions.EnableHttp and DisableHttp are now deprecated. Http is now always enabled, so these methods are no longer needed. 
+
+For more information, please visit https://aka.ms/hdi-config-update
       ]]>
 		</PackageReleaseNotes>
     

--- a/src/SDKs/HDInsight/Management/Management.HDInsight/Management.HDInsight.csproj
+++ b/src/SDKs/HDInsight/Management/Management.HDInsight/Management.HDInsight.csproj
@@ -7,11 +7,11 @@
 		<PackageId>Microsoft.Azure.Management.HDInsight</PackageId>
 		<Description>Azure HDInsight Management SDK Library</Description>
 		<AssemblyName>Microsoft.Azure.Management.HDInsight</AssemblyName>
-		<Version>4.4.0-preview</Version>
+		<Version>5.0.0</Version>
 		<PackageTags>Microsoft Azure HDInsight Management;HDInsight;HDInsight Management</PackageTags>
 		<PackageReleaseNotes>
 			<![CDATA[
-        This is a public preview release of the Azure HDInsight SDK. Add support for get/update gatewaysettings.
+        This is a public stable release of the Azure HDInsight SDK.
       ]]>
 		</PackageReleaseNotes>
     

--- a/src/SDKs/HDInsight/Management/Management.HDInsight/Properties/AssemblyInfo.cs
+++ b/src/SDKs/HDInsight/Management/Management.HDInsight/Properties/AssemblyInfo.cs
@@ -21,8 +21,8 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Microsoft Azure HDInsight Management Library")]
 [assembly: AssemblyDescription("Provides management functionality for Microsoft Azure HDInsight.")]
-[assembly: AssemblyVersion("4.0.0.0")]
-[assembly: AssemblyFileVersion("4.4.0.0")]
+[assembly: AssemblyVersion("5.0.0.0")]
+[assembly: AssemblyFileVersion("5.0.0.0")]
 
 [assembly: InternalsVisibleTo("Microsoft.Azure.Management.HDInsight.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100b5fc90e7027f67871e773a8fde8938c81dd402ba65b9201d60593e96c492651e889cc13f1415ebb53fac1131ae0bd333c5ee6021672d9718ea31a8aebd0da0072f25d87dba6fc90ffd598ed4da35e44c398c454307e8e33b8426143daec9f596836f97c8f74750e5975c64e2189f45def46b2a2b1247adc3652bf5c308055da9")]
 


### PR DESCRIPTION
## Swagger PR Links

- [Azure/azure-rest-api-specs#5538: [HDInsight] - Move API with version 2018-06-01-preview to stable folder](https://github.com/Azure/azure-rest-api-specs/pull/5538)

## Note

This PR aims to update SDK version from 4.4.0-preview to 5.0.0. This is the first Swagger-based HDInsight SDK with stable version number.