### PR TITLE
Remove settingfields.none

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -14,19 +14,21 @@ namespace Azure.ApplicationModel.Configuration.Tests
     [Category("Live")]
     public class ConfigurationLiveTests
     {
-        static readonly ConfigurationSetting s_testSetting = new ConfigurationSetting(
-            string.Concat("key-", Guid.NewGuid().ToString("N")),
-            "test_value"
-        )
+        private ConfigurationSetting CreateSetting()
         {
-            Label = "test_label",
-            ContentType = "test_content_type",
-            Tags = new Dictionary<string, string>
+            return new ConfigurationSetting()
             {
-                { "tag1", "value1" },
-                { "tag2", "value2" }
-            }
-        };
+                Key = string.Concat("key-", Guid.NewGuid().ToString("N")),
+                Value = "test_value",
+                Label = "test_label",
+                ContentType = "test_content_type",
+                Tags = new Dictionary<string, string>
+                {
+                    { "tag1", "value1" },
+                    { "tag2", "value2" }
+                }
+            };
+        }
 
         private static bool TagsEqual(IDictionary<string, string> expected, IDictionary<string, string> actual)
         {
@@ -73,8 +75,9 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task DeleteSettingNotFound()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
-            var response = await service.DeleteAsync(s_testSetting.Key);
+            var response = await service.DeleteAsync(testSetting.Key);
 
             Assert.AreEqual(204, response.Status);
             response.Dispose();
@@ -84,13 +87,14 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task DeleteSetting()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
                 // Prepare environment
-                var testSettingDiff = s_testSetting.Clone();
+                var testSettingDiff = testSetting.Clone();
                 testSettingDiff.Label = null;
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
                 await service.SetAsync(testSettingDiff);
 
                 // Test
@@ -106,7 +110,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -114,13 +118,14 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task DeleteSettingWithLabel()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
                 // Prepare environment
-                var testSettingDiff = s_testSetting.Clone();
+                var testSettingDiff = testSetting.Clone();
                 testSettingDiff.Label = "test_label_diff";
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
                 await service.SetAsync(testSettingDiff);
 
                 // Test
@@ -136,7 +141,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -144,17 +149,18 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task DeleteSettingWithETag()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             // Prepare environment
-            await service.SetAsync(s_testSetting);
-            ConfigurationSetting setting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label);
+            await service.SetAsync(testSetting);
+            ConfigurationSetting setting = await service.GetAsync(testSetting.Key, testSetting.Label);
 
             // Test
             await service.DeleteAsync(setting.Key, setting.Label, setting.ETag, CancellationToken.None);
             //Try to get the non-existing setting
             var e = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await service.GetAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.GetAsync(testSetting.Key, testSetting.Label);
             });
 
             Assert.AreEqual(404, e.Status);
@@ -164,15 +170,16 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task SetSetting()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                ConfigurationSetting setting = await service.SetAsync(s_testSetting);
-                Assert.AreEqual(s_testSetting, setting);
+                ConfigurationSetting setting = await service.SetAsync(testSetting);
+                Assert.AreEqual(testSetting, setting);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -180,17 +187,18 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task SetExistingSetting()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                await service.AddAsync(s_testSetting);
+                await service.AddAsync(testSetting);
 
-                ConfigurationSetting setting = await service.SetAsync(s_testSetting);
-                Assert.AreEqual(s_testSetting, setting);
+                ConfigurationSetting setting = await service.SetAsync(testSetting);
+                Assert.AreEqual(testSetting, setting);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -242,17 +250,18 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetRequestId()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                Response<ConfigurationSetting> response = await service.SetAsync(s_testSetting);
+                Response<ConfigurationSetting> response = await service.SetAsync(testSetting);
                 response.TryGetHeader("x-ms-client-request-id", out string requestId);
                 Assert.IsNotEmpty(requestId);
                 response.Dispose();
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -260,21 +269,22 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task AddExistingSetting()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                await service.AddAsync(s_testSetting);
+                await service.AddAsync(testSetting);
 
                 var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
                 {
-                    await service.AddAsync(s_testSetting);
+                    await service.AddAsync(testSetting);
                 });
 
                 Assert.AreEqual(412, exception.Status);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -282,16 +292,17 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task AddSetting()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                ConfigurationSetting setting = await service.AddAsync(s_testSetting);
+                ConfigurationSetting setting = await service.AddAsync(testSetting);
 
-                Assert.AreEqual(s_testSetting, setting);
+                Assert.AreEqual(testSetting, setting);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -299,8 +310,9 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task AddSettingNoLabel()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
-            var testSettingNoLabel = s_testSetting.Clone();
+            ConfigurationSetting testSettingNoLabel = testSetting.Clone();
             testSettingNoLabel.Label = null;
 
             try
@@ -311,7 +323,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key);
+                await service.DeleteAsync(testSetting.Key);
             }
         }
 
@@ -319,7 +331,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task AddKeyValue()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
-
+            
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
 
             try
@@ -340,7 +352,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task AddKeyValueLabel()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
-
+            
             string key = string.Concat("key-", Guid.NewGuid().ToString("N"));
             string value = "my_value";
             string label = "my_label";
@@ -385,16 +397,17 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task UpdateSetting()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
-            var testSettingDiff = s_testSetting.Clone();
+            var testSettingDiff = testSetting.Clone();
             testSettingDiff.Label = "test_label_diff";
 
-            var testSettingUpdate = s_testSetting.Clone();
+            var testSettingUpdate = testSetting.Clone();
             testSettingUpdate.Value = "test_value_update";
 
             try
             {
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
                 await service.SetAsync(testSettingDiff);
 
                 ConfigurationSetting responseSetting = await service.UpdateAsync(testSettingUpdate, CancellationToken.None);
@@ -412,10 +425,11 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public void UpdateNoExistingSetting()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await service.UpdateAsync(s_testSetting);
+                await service.UpdateAsync(testSetting);
             });
             Assert.AreEqual(412, exception.Status);
         }
@@ -424,9 +438,10 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task UpdateSettingIfETag()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
-            await service.SetAsync(s_testSetting);
-            ConfigurationSetting responseGet = await service.GetAsync(s_testSetting.Key, s_testSetting.Label);
+            await service.SetAsync(testSetting);
+            ConfigurationSetting responseGet = await service.GetAsync(testSetting.Key, testSetting.Label);
 
             try
             {
@@ -445,9 +460,10 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task UpdateSettingTags()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
-            await service.SetAsync(s_testSetting);
-            ConfigurationSetting responseGet = await service.GetAsync(s_testSetting.Key, s_testSetting.Label);
+            await service.SetAsync(testSetting);
+            ConfigurationSetting responseGet = await service.GetAsync(testSetting.Key, testSetting.Label);
 
 
             try
@@ -471,7 +487,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -479,9 +495,10 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetRevisions()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             //Prepare environment
-            ConfigurationSetting setting = s_testSetting;
+            ConfigurationSetting setting = testSetting;
             setting.Key = string.Concat("key-", Guid.NewGuid().ToString("N"));
             var testSettingUpdate = setting.Clone();
             testSettingUpdate.Label = "test_label_update";
@@ -525,9 +542,10 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetSetting()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             // Prepare environment
-            var testSettingNoLabel = s_testSetting.Clone();
+            var testSettingNoLabel = testSetting.Clone();
             testSettingNoLabel.Label = null;
 
             try
@@ -547,10 +565,11 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public void GetSettingNotFound()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             var exception = Assert.ThrowsAsync<RequestFailedException>(async () =>
             {
-                await service.GetAsync(s_testSetting.Key);
+                await service.GetAsync(testSetting.Key);
             });
 
             Assert.AreEqual(404, exception.Status);
@@ -560,23 +579,24 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetSettingWithLabel()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             // Prepare environment
-            var testSettingNoLabel = s_testSetting.Clone();
+            var testSettingNoLabel = testSetting.Clone();
             testSettingNoLabel.Label = null;
 
             try
             {
                 await service.SetAsync(testSettingNoLabel);
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
 
                 // Test
-                ConfigurationSetting responseSetting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label);
-                Assert.AreEqual(s_testSetting, responseSetting);
+                ConfigurationSetting responseSetting = await service.GetAsync(testSetting.Key, testSetting.Label);
+                Assert.AreEqual(testSetting, responseSetting);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
                 await service.DeleteAsync(testSettingNoLabel.Key);
             }
         }
@@ -585,18 +605,19 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetWithAcceptDateTime()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
 
                 // Test
-                ConfigurationSetting responseSetting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, DateTimeOffset.MaxValue);
-                Assert.AreEqual(s_testSetting, responseSetting);
+                ConfigurationSetting responseSetting = await service.GetAsync(testSetting.Key, testSetting.Label, DateTimeOffset.MaxValue);
+                Assert.AreEqual(testSetting, responseSetting);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -630,15 +651,16 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetBatchSettingAny()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
 
                 var selector = new SettingSelector();
 
-                Assert.AreEqual(selector.Keys.First(), "*");
-                Assert.AreEqual(selector.Labels.First(), "*");
+                Assert.AreEqual("*", selector.Keys.First());
+                Assert.AreEqual("*", selector.Labels.First());
 
                 SettingBatch batch = await service.GetBatchAsync(selector, CancellationToken.None);
                 int resultsReturned = batch.Count;
@@ -648,7 +670,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -656,21 +678,22 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetBatchSettingKeyLabel()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
 
-                var selector = new SettingSelector(s_testSetting.Key, s_testSetting.Label);
+                var selector = new SettingSelector(testSetting.Key, testSetting.Label);
                 SettingBatch batch = await service.GetBatchAsync(selector, CancellationToken.None);
 
-                Assert.AreEqual(batch.Count, 1);
-                Assert.AreEqual(batch[0].Key, s_testSetting.Key);
-                Assert.AreEqual(batch[0].Label, s_testSetting.Label);
+                Assert.AreEqual(1, batch.Count);
+                Assert.AreEqual(testSetting.Key, batch[0].Key);
+                Assert.AreEqual(testSetting.Label, batch[0].Label);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -678,20 +701,21 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetBatchSettingOnlyKey()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
 
-                var selector = new SettingSelector(s_testSetting.Key);
+                var selector = new SettingSelector(testSetting.Key);
                 SettingBatch batch = await service.GetBatchAsync(selector, CancellationToken.None);
 
-                Assert.AreEqual(batch.Count, 1);
-                Assert.AreEqual(batch[0].Key, s_testSetting.Key);
+                Assert.AreEqual(1, batch.Count);
+                Assert.AreEqual(testSetting.Key, batch[0].Key);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -699,25 +723,26 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task GetBatchSettingOnlyLabel()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
+            ConfigurationSetting testSetting = CreateSetting();
 
             try
             {
-                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSetting);
 
-                var selector = new SettingSelector(null, s_testSetting.Label);
+                var selector = new SettingSelector(null, testSetting.Label);
 
-                Assert.AreEqual(selector.Keys.First(), "*");
+                Assert.AreEqual("*", selector.Keys.First());
 
                 SettingBatch batch = await service.GetBatchAsync(selector, CancellationToken.None);
                 int resultsReturned = batch.Count;
 
                 //At least there should be one key available
                 Assert.GreaterOrEqual(resultsReturned, 1);
-                Assert.AreEqual(batch[0].Label, s_testSetting.Label);
+                Assert.AreEqual(testSetting.Label, batch[0].Label);
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(testSetting.Key, testSetting.Label);
             }
         }
 
@@ -726,24 +751,85 @@ namespace Azure.ApplicationModel.Configuration.Tests
         {
             ConfigurationClient service = TestEnvironment.GetClient();
 
+            string key = string.Concat("keyFields-", Guid.NewGuid().ToString("N"));
+            string value = "my_value";
+            string label = "my_label";
+            ConfigurationSetting setting = await service.AddAsync(key, value, label);
+
+            string key2 = string.Concat("keyFields-", Guid.NewGuid().ToString("N"));
+            string value2 = "my_value_2";
+            string label2 = "my_label_2";
+            ConfigurationSetting setting2 = await service.AddAsync(key2, value2, label2);
+
             try
             {
-                await service.SetAsync(s_testSetting);
-
-                SettingSelector selector = new SettingSelector()
+                SettingSelector selector = new SettingSelector("keyFields-*")
                 {
-                    Fields = SettingFields.Key | SettingFields.Label | SettingFields.Value,
+                    Fields = SettingFields.Key | SettingFields.Label | SettingFields.ETag
                 };
 
                 SettingBatch batch = await service.GetBatchAsync(selector, CancellationToken.None);
                 int resultsReturned = batch.Count;
 
-                //At least there should be one key available
-                Assert.GreaterOrEqual(resultsReturned, 1);
+                Assert.GreaterOrEqual(2, resultsReturned);
+
+                for (int i = 0; i < resultsReturned; i++)
+                {
+                    Assert.IsNotNull(batch[i].Key);
+                    Assert.IsNotNull(batch[i].Label);
+                    Assert.IsNotNull(batch[i].ETag);
+                    Assert.IsNull(batch[i].Value);
+                }
             }
             finally
             {
-                await service.DeleteAsync(s_testSetting.Key, s_testSetting.Label);
+                await service.DeleteAsync(setting.Key, setting.Label);
+                await service.DeleteAsync(setting2.Key, setting2.Label);
+            }
+        }
+
+        [Test]
+        public async Task GetBatchSettingWithAllFields()
+        {
+            ConfigurationClient service = TestEnvironment.GetClient();
+
+            string key = string.Concat("keyFields-", Guid.NewGuid().ToString("N"));
+            string value = "my_value";
+            string label = "my_label";
+            ConfigurationSetting setting = await service.AddAsync(key, value, label);
+
+            string key2 = string.Concat("keyFields-", Guid.NewGuid().ToString("N"));
+            string value2 = "my_value_2";
+            string label2 = "my_label_2";
+            ConfigurationSetting setting2 = await service.AddAsync(key2, value2, label2);
+
+            try
+            {
+                SettingSelector selector = new SettingSelector("keyFields-*")
+                {
+                    Fields = SettingFields.All
+                };
+
+                SettingBatch batch = await service.GetBatchAsync(selector, CancellationToken.None);
+                int resultsReturned = batch.Count;
+
+                Assert.GreaterOrEqual(2, resultsReturned);
+
+                for (int i = 0; i < resultsReturned; i++)
+                {
+                    Assert.IsNotNull(batch[i].Key);
+                    Assert.IsNotNull(batch[i].Label);
+                    Assert.IsNotNull(batch[i].Value);
+                    Assert.IsNotNull(batch[i].ContentType);
+                    Assert.IsNotNull(batch[i].ETag);
+                    Assert.IsNotNull(batch[i].LastModified);
+                    Assert.IsNotNull(batch[i].Locked);
+                }
+            }
+            finally
+            {
+                await service.DeleteAsync(setting.Key, setting.Label);
+                await service.DeleteAsync(setting2.Key, setting2.Label);
             }
             
         }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -205,17 +205,17 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var response1 = new MockResponse(200);
             response1.SetContent(SerializationHelpers.Serialize(new []
             {
-                CreateSetting(0),
-                CreateSetting(1),
+                CreateResponseSetting(0),
+                CreateResponseSetting(1),
             }, SerializeBatch));
             response1.AddHeader(new HttpHeader("Link", $"</kv?after=5>;rel=\"next\""));
 
             var response2 = new MockResponse(200);
             response2.SetContent(SerializationHelpers.Serialize(new []
             {
-                CreateSetting(2),
-                CreateSetting(3),
-                CreateSetting(4),
+                CreateResponseSetting(2),
+                CreateResponseSetting(3),
+                CreateResponseSetting(4),
             }, SerializeBatch));
 
             var mockTransport = new MockTransport(response1, response2);
@@ -255,6 +255,76 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.AreEqual(HttpPipelineMethod.Get, request2.Method);
             Assert.AreEqual("https://contoso.azconfig.io/kv/?key=*&label=*&after=5", request2.UriBuilder.ToString());
             AssertRequestCommon(request1);
+        }
+
+        [Test]
+        public async Task GetBatchWithfilters()
+        {
+            var selector = new SettingSelector()
+            {
+                Fields = SettingFields.Key | SettingFields.Label | SettingFields.ETag
+            };
+
+            var response1 = new MockResponse(200);
+            response1.SetContent(SerializationHelpers.Serialize(new[]
+            {
+                CreateResponseSetting(0, selector),
+                CreateResponseSetting(1, selector),
+            }, SerializeBatch));
+
+            var mockTransport = new MockTransport(response1);
+            ConfigurationClient service = CreateTestService(mockTransport);
+
+            int keyIndex = 0;
+            using (Response<SettingBatch> response = await service.GetBatchAsync(selector, CancellationToken.None))
+            {
+                SettingBatch batch = response.Value;
+                for (int i = 0; i < batch.Count; i++)
+                {
+                    ConfigurationSetting value = batch[i];
+                    Assert.AreEqual("key" + keyIndex, value.Key);
+                    Assert.IsNotNull(value.Label);
+                    Assert.IsNotNull(value.ETag);
+                    Assert.IsNull(value.Value);
+                    keyIndex++;
+                }
+            }
+        }
+
+        [Test]
+        public async Task GetBatchWithAllfilters()
+        {
+            var selector = new SettingSelector()
+            {
+                Fields = SettingFields.All
+            };
+
+            var response1 = new MockResponse(200);
+            response1.SetContent(SerializationHelpers.Serialize(new[]
+            {
+                CreateResponseSetting(0, selector),
+                CreateResponseSetting(1, selector),
+            }, SerializeBatch));
+
+            var mockTransport = new MockTransport(response1);
+            ConfigurationClient service = CreateTestService(mockTransport);
+
+            int keyIndex = 0;
+            using (Response<SettingBatch> response = await service.GetBatchAsync(selector, CancellationToken.None))
+            {
+                SettingBatch batch = response.Value;
+                for (int i = 0; i < batch.Count; i++)
+                {
+                    ConfigurationSetting value = batch[i];
+                    Assert.AreEqual("key" + keyIndex, value.Key);
+                    Assert.IsNotNull(value.Label);
+                    Assert.IsNotNull(value.Value);
+                    Assert.IsNotNull(value.ContentType);
+                    Assert.IsNotNull(value.ETag);
+                    
+                    keyIndex++;
+                }
+            }
         }
 
         [Test]
@@ -299,9 +369,26 @@ namespace Azure.ApplicationModel.Configuration.Tests
             StringAssert.StartsWith(expected, value);
         }
 
-        private static ConfigurationSetting CreateSetting(int i)
+        private static ConfigurationSetting CreateResponseSetting(int i, SettingSelector selector = null)
         {
-            return new ConfigurationSetting($"key{i}", "val") {  Label = "label", ETag = new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"), ContentType = "text" };
+            if(selector == null)
+            {
+                return new ConfigurationSetting($"key{i}", "val") { Label = "label", ETag = new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1"), ContentType = "text" };
+            }
+
+            var setting = new ConfigurationSetting();
+            if ((selector.Fields & SettingFields.Key) != 0)
+                setting.Key = $"key{i}";
+            if ((selector.Fields & SettingFields.Value) != 0 )
+                setting.Value = "val";
+            if ((selector.Fields & SettingFields.Label) != 0)
+                setting.Label = "label";
+            if ((selector.Fields & SettingFields.ETag) != 0)
+                setting.ETag = new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1");
+            if ((selector.Fields & SettingFields.ContentType) != 0)
+                setting.ContentType = "text";
+
+            return setting;
         }
 
         private void SerializeRequestSetting(ref Utf8JsonWriter json, ConfigurationSetting setting)
@@ -327,10 +414,14 @@ namespace Azure.ApplicationModel.Configuration.Tests
         private void SerializeSetting(ref Utf8JsonWriter json, ConfigurationSetting setting)
         {
             json.WriteStartObject();
-            json.WriteString("key", setting.Key);
-            json.WriteString("label", setting.Label);
-            json.WriteString("value", setting.Value);
-            json.WriteString("content_type", setting.ContentType);
+            if(setting.Key != null)
+                json.WriteString("key", setting.Key);
+            if (setting.Label != null)
+                json.WriteString("label", setting.Label);
+            if (setting.Value != null)
+                json.WriteString("value", setting.Value);
+            if (setting.ContentType != null)
+                json.WriteString("content_type", setting.ContentType);
             if (setting.Tags != null)
             {
                 json.WriteStartObject("tags");

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -377,15 +377,15 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
 
             var setting = new ConfigurationSetting();
-            if ((selector.Fields & SettingFields.Key) != 0)
+            if (selector.Fields.HasFlag(SettingFields.Key))
                 setting.Key = $"key{i}";
-            if ((selector.Fields & SettingFields.Value) != 0 )
+            if (selector.Fields.HasFlag(SettingFields.Value))
                 setting.Value = "val";
-            if ((selector.Fields & SettingFields.Label) != 0)
+            if (selector.Fields.HasFlag(SettingFields.Label))
                 setting.Label = "label";
-            if ((selector.Fields & SettingFields.ETag) != 0)
+            if (selector.Fields.HasFlag(SettingFields.ETag))
                 setting.ETag = new ETag("c3c231fd-39a0-4cb6-3237-4614474b92c1");
-            if ((selector.Fields & SettingFields.ContentType) != 0)
+            if (selector.Fields.HasFlag(SettingFields.ContentType))
                 setting.ContentType = "text";
 
             return setting;
@@ -414,7 +414,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         private void SerializeSetting(ref Utf8JsonWriter json, ConfigurationSetting setting)
         {
             json.WriteStartObject();
-            if(setting.Key != null)
+            if (setting.Key != null)
                 json.WriteString("key", setting.Key);
             if (setting.Label != null)
                 json.WriteString("label", setting.Label);
@@ -431,9 +431,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 }
                 json.WriteEndObject();
             }
-            if (setting.ETag != default) json.WriteString("etag", setting.ETag.ToString());
-            if (setting.LastModified.HasValue) json.WriteString("last_modified", setting.LastModified.Value.ToString());
-            if (setting.Locked.HasValue) json.WriteBoolean("locked", setting.Locked.Value);
+            if (setting.ETag != default)
+                json.WriteString("etag", setting.ETag.ToString());
+            if (setting.LastModified.HasValue)
+                json.WriteString("last_modified", setting.LastModified.Value.ToString());
+            if (setting.Locked.HasValue)
+                json.WriteBoolean("locked", setting.Locked.Value);
             json.WriteEndObject();
         }
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationSettingTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationSettingTests.cs
@@ -105,6 +105,40 @@ namespace Azure.ApplicationModel.Configuration.Tests
         }
 
         [Test]
+        public void SettingSomeFields()
+        {
+            var service = new ConfigurationClient(s_connectionString);
+
+            var selector = new SettingSelector("key")
+            {
+                Fields = SettingFields.Key | SettingFields.Value
+            };
+
+            var builder = new HttpPipelineUriBuilder();
+            builder.Uri = new Uri("http://localhost/");
+            service.BuildBatchQuery(builder, selector);
+
+            Assert.AreEqual($"http://localhost/?key=key&$select=key,%20value", builder.Uri.AbsoluteUri);
+        }
+
+        [Test]
+        public void SettingAllFields()
+        {
+            var service = new ConfigurationClient(s_connectionString);
+
+            var selector = new SettingSelector("key")
+            {
+                Fields = SettingFields.All
+            };
+
+            var builder = new HttpPipelineUriBuilder();
+            builder.Uri = new Uri("http://localhost/");
+            service.BuildBatchQuery(builder, selector);
+
+            Assert.AreEqual($"http://localhost/?key=key", builder.Uri.AbsoluteUri);
+        }
+
+        [Test]
         public void ConfigurationSettingEquals()
         {
             //Case tests
@@ -116,7 +150,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.AreNotEqual(testSettingUpperCase, testSettingLowerCase);
 
             var testSettingsameCase = s_testSetting.Clone();
-            Assert.AreEqual(testSettingsameCase, s_testSetting);
+            Assert.AreEqual(s_testSetting, testSettingsameCase);
 
             //Etag tests
             var testSettingEtagDiff = testSettingsameCase.Clone();

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient_private.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient_private.cs
@@ -128,7 +128,7 @@ namespace Azure.ApplicationModel.Configuration
                         keysCopy.Add(key);
                     }
                 }
-                var keys = string.Join(",", keysCopy).ToLower();
+                var keys = string.Join(",", keysCopy);
                 builder.AppendQuery(KeyQueryFilter, keys);
             }
 
@@ -146,7 +146,7 @@ namespace Azure.ApplicationModel.Configuration
                         labelsCopy.Add(EscapeReservedCharacters(label));
                     }
                 }
-                var labels = string.Join(",", labelsCopy).ToLower();
+                var labels = string.Join(",", labelsCopy);
                 builder.AppendQuery(LabelQueryFilter, labels);
             }
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/SettingFields.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/SettingFields.cs
@@ -9,7 +9,6 @@ namespace Azure.ApplicationModel.Configuration
     [Flags]
     public enum SettingFields : uint
     {
-        None = 0x0000,
         Key = 0x0001,
         Label = 0x0002,
         Value = 0x0004,


### PR DESCRIPTION
Fixes #5415 
-------------
**Update**
It also includes:
- More live test for SettingFields
- Mock test for SettingFields
- Other test for SettingFields
- Creating a `testSetting` per method
- Organize parameters during `Assert.AreEquals` to make sure that the first one is the one we are expecting.