### PR TITLE
Fix bug with selector

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -761,7 +761,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                SettingSelector selector = new SettingSelector("keyFields-*")
+                SettingSelector selector = new SettingSelector(key)
                 {
                     Fields = SettingFields.Key | SettingFields.Label | SettingFields.ETag
                 };
@@ -794,7 +794,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                SettingSelector selector = new SettingSelector("keyFields-*")
+                SettingSelector selector = new SettingSelector(key)
                 {
                     Fields = SettingFields.All
                 };


### PR DESCRIPTION
The batch with filters methods are only creating one setting, and therefore, should ask for that specific setting.