### PR TITLE
Move buffering policy before logging

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
@@ -34,8 +34,8 @@ namespace Azure.ApplicationModel.Configuration
                     options.RetryPolicy,
                     ClientRequestIdPolicy.Singleton,
                     new AuthenticationPolicy(credential, secret),
-                    BufferResponsePolicy.Singleton,
-                    options.LoggingPolicy);
+                    options.LoggingPolicy,
+                    BufferResponsePolicy.Singleton);
         }
 
         [KnownException(typeof(HttpRequestException), Message = "The request failed due to an underlying issue such as network connectivity, DNS failure, or timeout.")]


### PR DESCRIPTION
Enabling streaming responses revealed a problem with LoggingPolicy (https://github.com/Azure/azure-sdk-for-net/issues/5757) that I thought was fixed by having a buffering policy in the pipeline but I've put it before after logging instead of before.

This fixes failing live tests.