### PR TITLE
Update signing targets

### DIFF
--- a/.azure-pipelines/client.yml
+++ b/.azure-pipelines/client.yml
@@ -22,7 +22,7 @@ jobs:
         inputs:
           version: '$(DotNetCoreVersion)'
 
-      - script: 'dotnet pack $(ProjectFile) -o $(Build.ArtifactStagingDirectory) -warnaserror'
+      - script: 'dotnet pack $(ProjectFile) -o $(Build.ArtifactStagingDirectory) -warnaserror /p:PublicSign=false'
         displayName: 'Build and Package'
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/eng/AzSdk.test.reference.targets
+++ b/eng/AzSdk.test.reference.targets
@@ -3,6 +3,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+    <None Include="$(MSBuildThisFileDirectory)xunit.runner.json" CopyToOutputDirectory="PreserveNewest" Visible="false" />
 
     <PackageReference Include="Microsoft.Azure.Test.HttpRecorder" Version="[1.13.1, 2.0.0)" />
     <PackageReference Include="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="[1.7.5, 2.0.0)" />

--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -10,7 +10,6 @@
       SemVer 2.0 is supported by NuGet since 3.0.0 (July 2015) in some capacity, and fully since 3.5.0 (October 2016).
     -->
     <NoWarn>$(NoWarn);NU5105</NoWarn>
-    <SignAssembly>true</SignAssembly>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -63,5 +62,20 @@
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <NeutralLanguage>en-US</NeutralLanguage>
+  </PropertyGroup>
+
+  <!-- Signing properties -->
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+
+    <!--
+      In order to be able to run our tests on .NET Framework we should use public signing by default so
+      we don't have to disable strong name validation for things that are delay signed.
+    -->
+    <PublicSign Condition="'$(PublicSign)' == ''">true</PublicSign>
+    <DelaySign Condition="'$(PublicSign)' == 'true'">false</DelaySign>
+    <DelaySign Condition="'$(PublicSign)' != 'true'">true</DelaySign>
+
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 </Project>

--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -16,13 +16,15 @@
     <EnableClientSdkAnalyzers Condition="'$(EnableClientSdkAnalyzers)' == '' and '$(IsClientLibrary)' == 'true' and '$(IsTestProject)' != 'true'">true</EnableClientSdkAnalyzers>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' != 'true' and '$(IsTestHelperLibrary)' != 'true'">
-    <SignTestAssembly>false</SignTestAssembly>
+  <PropertyGroup Condition="'$(SignAssembly)' == 'true' and '$(IsTestProject)' == 'true'">
+    <!-- Always fully sign test assemblies since we have a full public/private key -->
+    <PublicSign>false</PublicSign>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzSdkTestLibKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestHelperLibrary)' == 'true'">
     <IsPackable>false</IsPackable>
-    <SignAssembly>false</SignAssembly>
     <RequiredTargetFrameworks>netcoreapp2.0</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <DefaultReferenceTargets>AzSdk.test.reference.targets</DefaultReferenceTargets>
@@ -42,20 +44,6 @@
   <ItemGroup>
     <PackageReference Condition="'$(EnableClientSdkAnalyzers)' == 'true'" Include="Azure.ClientSdk.Analyzers" Version="0.1.1-preview1" PrivateAssets="All" />
   </ItemGroup>
-
-  <!-- If signing is enabled for an SDK library, delay sign using the shared key -->
-  <PropertyGroup Condition="'$(SignAssembly)' != 'false'">
-    <SignAssembly>true</SignAssembly>
-    <DelaySign>true</DelaySign>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
-  <!-- If signing is enabled for a Test library, sign immediately using the test key -->
-  <PropertyGroup Condition="'$(SignTestAssembly)' == 'true'">
-    <SignAssembly>true</SignAssembly>
-    <DelaySign>false</DelaySign>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzSdkTestLibKey.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
 
   <!-- Import default references if this is not set -->
   <PropertyGroup Condition="'$(ImportDefaultReferences)'==''">

--- a/eng/xunit.runner.json
+++ b/eng/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+  "shadowCopy": false,
+}

--- a/sdk/template/Azure.Template/tests/Azure.Template.Tests.csproj
+++ b/sdk/template/Azure.Template/tests/Azure.Template.Tests.csproj
@@ -1,5 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Azure.Template.csproj" />
+  </ItemGroup>
 </Project>

--- a/sdk/template/Azure.Template/tests/UnitTest1.cs
+++ b/sdk/template/Azure.Template/tests/UnitTest1.cs
@@ -1,3 +1,4 @@
+using Azure.Runtime;
 using System;
 using Xunit;
 
@@ -8,7 +9,9 @@ namespace Microsoft.Azure.Template.Tests
         [Fact]
         public void Test1()
         {
+            var c = new Class1();
 
+            Assert.NotNull(c);
         }
     }
 }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/Azure.Configuration.Tests.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/Azure.Configuration.Tests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <SignTestAssembly>true</SignTestAssembly>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.10.1" />
@@ -17,6 +16,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\..\..\Azure.Base\data-plane\Azure.Base.Tests\Testing\TestPool.cs" Link="TestPool.cs" />
   </ItemGroup>
 
-  <!-- Import the Azure.Base project -->  
+  <!-- Import the Azure.Base project -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\Azure.Base\data-plane\Azure.Base\Azure.Base.props" />
 </Project>

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/Azure.Base.Tests.csproj
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/Azure.Base.Tests.csproj
@@ -1,10 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <IsPackable>false</IsPackable>
     <ProjectGuid>{84491222-6C36-4FA7-BBAE-1FA804129151}</ProjectGuid>
-    <LangVersion>7.2</LangVersion>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <SignTestAssembly>true</SignTestAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/SDKs/ServiceBus/data-plane/tests/Microsoft.Azure.ServiceBus.Tests/xunit.runner.json
+++ b/src/SDKs/ServiceBus/data-plane/tests/Microsoft.Azure.ServiceBus.Tests/xunit.runner.json
@@ -3,5 +3,6 @@
     "longRunningTestSeconds": 61,
     "diagnosticMessages": true,
     "internalDiagnosticMessages": true,
-    "parallelizeAssembly": true
+    "parallelizeAssembly": true,
+    "shadowCopy" : false
 }


### PR DESCRIPTION
In order to prepare for testing on .NET framework
we needed to switch some signing setting around so
that we can run the test localling without requiring
global machine setting changes to disable strong name
verification. Do do this we will use a new public signing
feature which is what the .NET team does to test these
scenarios.

- Default to using PublicSign for sdk libraries
- Enable signing for all test libraries by default
- Add xunit config file to disable shadow copying which
  doesn't work with public signing
- Update template test project to actually use the template library


PTAL @jsquire @chidozieononiwu 

cc @Azure/azure-sdk-eng 