### PR TITLE
Rename AddHeader to Telemetry policy

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -293,9 +293,8 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
         private void AssertRequestCommon(MockRequest request)
         {
-            var expected = HttpHeader.Common.CreateUserAgent("config", "1.0.0.0").Value;
             Assert.True(request.TryGetHeader("User-Agent", out var value));
-            StringAssert.StartsWith(expected, value);
+            StringAssert.Contains("azsdk-net-config/1.0.0.0", value);
         }
 
         private static ConfigurationSetting CreateSetting(int i)

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/HeadersTests.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/HeadersTests.cs
@@ -28,20 +28,6 @@ namespace Azure.Base.Tests
             Assert.AreEqual(header, header2);
             Assert.AreEqual(header.GetHashCode(), header2.GetHashCode());
         }
-
-        [Test]
-        public void UserAgentHeaderBasics()
-        {
-            var userAgent = HttpHeader.Common.CreateUserAgent("sdk_name", "sdk_version", "application_id").ToString();
-
-            var isValidFormat = Regex.IsMatch(userAgent, @"^User-Agent:application_id azsdk-net-sdk_name/sdk_version \(.*;.*\)", RegexOptions.IgnoreCase);
-            Assert.True(isValidFormat);
-
-            var userAgentWithApplication = HttpHeader.Common.CreateUserAgent("sdk_name", "sdk_version").ToString();
-
-            isValidFormat = Regex.IsMatch(userAgentWithApplication, @"^User-Agent:azsdk-net-sdk_name/sdk_version \(.*;.*\)", RegexOptions.IgnoreCase);
-            Assert.True(isValidFormat);
-        }
     }
 
     static class Utf8

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/PipelineTests.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/PipelineTests.cs
@@ -7,8 +7,6 @@ using Azure.Base.Testing;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -30,28 +28,6 @@ namespace Azure.Base.Tests
             var response = await pipeline.SendRequestAsync(request, CancellationToken.None);
 
             Assert.AreEqual(1, response.Status);
-        }
-
-        [Test]
-        public async Task ComponentNameAndVersionReadFromAssembly()
-        {
-            string userAgent = null;
-
-            var mockTransport = new MockTransport(
-                req => {
-                    Assert.True(req.TryGetHeader("User-Agent", out userAgent));
-                    return new MockResponse(200);
-                });
-
-            var pipeline = HttpPipeline.Build(new TestClientOptions() { Transport = mockTransport }, new HttpPipelinePolicy[0]);
-
-            var request = pipeline.CreateRequest();
-            request.SetRequestLine(HttpPipelineMethod.Get, new Uri("https://contoso.a.io"));
-            await pipeline.SendRequestAsync(request, CancellationToken.None);
-
-            var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-
-            Assert.AreEqual(userAgent, $"azsdk-net-base-test/{assemblyVersion} ({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})");
         }
 
         class CustomRetryPolicy : RetryPolicy

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/PipelineTests.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/PipelineTests.cs
@@ -30,8 +30,9 @@ namespace Azure.Base.Tests
             var response = await pipeline.SendRequestAsync(request, CancellationToken.None);
 
             Assert.AreEqual(1, response.Status);
-#endif
         }
+#endif
+
 /* Issue https://github.com/Azure/azure-sdk-for-net/issues/5773 test skipped for net461 */
 #if !FullNetFx
         class CustomRetryPolicy : RetryPolicy

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/TelemetryPolicyTests.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/TelemetryPolicyTests.cs
@@ -31,11 +31,10 @@ namespace Azure.Base.Tests
             var transport = new MockTransport(new MockResponse(200));
             var telemetryPolicy = new TelemetryPolicy(typeof(TelemetryPolicyTests).Assembly, "application-id");
 
-            var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
             await SendGetRequest(transport, telemetryPolicy);
 
             Assert.True(transport.SingleRequest.TryGetHeader("User-Agent", out var userAgent));
-            Assert.AreEqual(userAgent, $"application-id azsdk-net-base-test/{assemblyVersion} ({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})");
+            StringAssert.StartsWith("application-id ", userAgent);
         }
     }
 }

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/TelemetryPolicyTests.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base.Tests/TelemetryPolicyTests.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Azure.Base.Pipeline.Policies;
+using Azure.Base.Testing;
+using NUnit.Framework;
+
+namespace Azure.Base.Tests
+{
+    public class TelemetryPolicyTests: PolicyTestBase
+    {
+        [Test]
+        public async Task ComponentNameAndVersionReadFromAssembly()
+        {
+            var transport = new MockTransport(new MockResponse(200));
+            var telemetryPolicy = new TelemetryPolicy(typeof(TelemetryPolicyTests).Assembly, null);
+
+            var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            await SendGetRequest(transport, telemetryPolicy);
+
+            Assert.True(transport.SingleRequest.TryGetHeader("User-Agent", out var userAgent));
+            Assert.AreEqual(userAgent, $"azsdk-net-base-test/{assemblyVersion} ({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})");
+        }
+
+        [Test]
+        public async Task ApplicationIdIsIncluded()
+        {
+            var transport = new MockTransport(new MockResponse(200));
+            var telemetryPolicy = new TelemetryPolicy(typeof(TelemetryPolicyTests).Assembly, "application-id");
+
+            var assemblyVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            await SendGetRequest(transport, telemetryPolicy);
+
+            Assert.True(transport.SingleRequest.TryGetHeader("User-Agent", out var userAgent));
+            Assert.AreEqual(userAgent, $"application-id azsdk-net-base-test/{assemblyVersion} ({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})");
+        }
+    }
+}

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Pipeline/HttpHeader.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Pipeline/HttpHeader.cs
@@ -64,25 +64,6 @@ namespace Azure.Base.Pipeline
 
             public static readonly HttpHeader JsonContentType = new HttpHeader(Names.ContentType, s_applicationJson);
             public static readonly HttpHeader OctetStreamContentType = new HttpHeader(Names.ContentType, s_applicationOctetStream);
-
-            static readonly string PlatformInformation = $"({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})";
-
-            public static HttpHeader CreateUserAgent(string componentName, string componentVersion, string applicationId = default)
-            {
-                if (applicationId != null)
-                {
-                    return new HttpHeader(Names.UserAgent, $"{applicationId} azsdk-net-{componentName}/{componentVersion} {PlatformInformation}");
-                }
-
-                return new HttpHeader(Names.UserAgent, $"azsdk-net-{componentName}/{componentVersion} {PlatformInformation}");
-            }
-
-
-
-            public static HttpHeader CreateHost(string hostName)
-            {
-                return new HttpHeader(Names.Host, hostName);
-            }
         }
     }
 }

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Pipeline/HttpPipeline.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Pipeline/HttpPipeline.cs
@@ -56,7 +56,7 @@ namespace Azure.Base.Pipeline
 
             if (!options.DisableTelemetry)
             {
-                policies.Add(CreateTelemetryPolicy(options));
+                policies.Add(new TelemetryPolicy(options.GetType().Assembly, options.ApplicationId));
             }
 
             policies.AddRange(clientPolicies);
@@ -66,22 +66,6 @@ namespace Azure.Base.Pipeline
             policies.RemoveAll(policy => policy == null);
 
             return new HttpPipeline(options.Transport, policies.ToArray(), options.ServiceProvider);
-        }
-
-        private static AddHeadersPolicy CreateTelemetryPolicy(HttpClientOptions options)
-        {
-            var clientAssembly = options.GetType().Assembly;
-            var componentAttribute = clientAssembly.GetCustomAttribute<AzureSdkClientLibraryAttribute>();
-            if (componentAttribute == null)
-            {
-                throw new InvalidOperationException(
-                    $"{nameof(AzureSdkClientLibraryAttribute)} is required to be set on client SDK assembly '{clientAssembly.FullName}'.");
-            }
-
-            var assemblyVersion = clientAssembly.GetName().Version.ToString();
-            var addHeadersPolicy = new AddHeadersPolicy();
-            addHeadersPolicy.AddHeader(HttpHeader.Common.CreateUserAgent(componentAttribute.ComponentName, assemblyVersion, options.ApplicationId));
-            return addHeadersPolicy;
         }
     }
 }

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Pipeline/Policies/TelemetryPolicy.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Pipeline/Policies/TelemetryPolicy.cs
@@ -2,21 +2,32 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections.Generic;
+using System.Reflection;
 using System.Threading.Tasks;
+using Azure.Base.Attributes;
 
 namespace Azure.Base.Pipeline.Policies
 {
-    public class AddHeadersPolicy : HttpPipelinePolicy
+    public class TelemetryPolicy : HttpPipelinePolicy
     {
-        List<HttpHeader> _headersToAdd = new List<HttpHeader>();
+        private readonly HttpHeader _header;
 
-        public void AddHeader(HttpHeader header)
-            => _headersToAdd.Add(header);
+        public TelemetryPolicy(Assembly clientAssembly, string applicationId)
+        {
+            var componentAttribute = clientAssembly.GetCustomAttribute<AzureSdkClientLibraryAttribute>();
+            if (componentAttribute == null)
+            {
+                throw new InvalidOperationException(
+                    $"{nameof(AzureSdkClientLibraryAttribute)} is required to be set on client SDK assembly '{clientAssembly.FullName}'.");
+            }
+
+            var assemblyVersion = clientAssembly.GetName().Version.ToString();
+            _header = HttpHeader.Common.CreateUserAgent(componentAttribute.ComponentName, assemblyVersion, applicationId);
+        }
 
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            foreach (var header in _headersToAdd) message.Request.AddHeader(header);
+            message.Request.AddHeader(_header);
             await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
         }
     }

--- a/src/SDKs/Azure.Base/data-plane/Azure.Base/Pipeline/Policies/TelemetryPolicy.cs
+++ b/src/SDKs/Azure.Base/data-plane/Azure.Base/Pipeline/Policies/TelemetryPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Azure.Base.Attributes;
 
@@ -21,8 +22,18 @@ namespace Azure.Base.Pipeline.Policies
                     $"{nameof(AzureSdkClientLibraryAttribute)} is required to be set on client SDK assembly '{clientAssembly.FullName}'.");
             }
 
-            var assemblyVersion = clientAssembly.GetName().Version.ToString();
-            _header = HttpHeader.Common.CreateUserAgent(componentAttribute.ComponentName, assemblyVersion, applicationId);
+            var componentName = componentAttribute.ComponentName;
+            var componentVersion = clientAssembly.GetName().Version.ToString();
+
+            var platformInformation = $"({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})";
+            if (applicationId != null)
+            {
+                _header = new HttpHeader(HttpHeader.Names.UserAgent, $"{applicationId} azsdk-net-{componentName}/{componentVersion} {platformInformation}");
+            }
+            else
+            {
+                _header = new HttpHeader(HttpHeader.Names.UserAgent, $"azsdk-net-{componentName}/{componentVersion} {platformInformation}");
+            }
         }
 
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)


### PR DESCRIPTION
Now that https://github.com/Azure/azure-sdk/pull/290 calls out Telemetry policy as a required one to have, rename AddHeader to TelemetryPolicy and cleanup tests.