### PR TITLE
LUIS: Improve thrown Exception of  "AddIntentWithHttpMessagesAsync"

### DIFF
--- a/src/SDKs/CognitiveServices/dataPlane/Language/LUIS/Authoring/Generated/IModel.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/LUIS/Authoring/Generated/IModel.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        /// <exception cref="Microsoft.Rest.HttpOperationException">
+        /// <exception cref="ErrorResponseException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
         /// <exception cref="Microsoft.Rest.SerializationException">

--- a/src/SDKs/CognitiveServices/dataPlane/Language/LUIS/Authoring/Generated/Model.cs
+++ b/src/SDKs/CognitiveServices/dataPlane/Language/LUIS/Authoring/Generated/Model.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        /// <exception cref="HttpOperationException">
+        /// <exception cref="ErrorResponseException">
         /// Thrown when the operation returned an invalid status code
         /// </exception>
         /// <exception cref="SerializationException">
@@ -166,12 +166,19 @@ namespace Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring
             string _responseContent = null;
             if ((int)_statusCode != 201)
             {
-                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
-                if (_httpResponse.Content != null) {
+                var ex = new ErrorResponseException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
                     _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    ErrorResponse _errorBody = Rest.Serialization.SafeJsonConvert.DeserializeObject<ErrorResponse>(_responseContent, Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
                 }
-                else {
-                    _responseContent = string.Empty;
+                catch (JsonException)
+                {
+                    // Ignore the exception
                 }
                 ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
                 ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);


### PR DESCRIPTION
Now, the method throws an ErrorResponseException instead of a HttpOperationException (equivalent to all LUIS authoring methods).