### PR TITLE
Add AppConfig client performance test

### DIFF
--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -13,20 +13,21 @@
   <PropertyGroup>
     <DefaultReferenceTargets>AzSdk.reference.targets</DefaultReferenceTargets>
     <IsTestProject Condition="'$(IsTestProject)' == '' and $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
-    <EnableClientSdkAnalyzers Condition="'$(EnableClientSdkAnalyzers)' == '' and '$(IsClientLibrary)' == 'true' and '$(IsTestProject)' != 'true'">true</EnableClientSdkAnalyzers>
+    <IsPerformanceTestProject Condition="'$(IsPerformanceTestProject)' == '' and $(MSBuildProjectName.EndsWith('.Performance'))">true</IsPerformanceTestProject>
+    <EnableClientSdkAnalyzers Condition="'$(EnableClientSdkAnalyzers)' == '' and '$(IsClientLibrary)' == 'true' and '$(IsTestProject)' != 'true' and '$(IsPerformanceTestProject)' != 'true'">true</EnableClientSdkAnalyzers>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(SignAssembly)' == 'true' and '$(IsTestProject)' == 'true'">
+  <PropertyGroup Condition="'$(SignAssembly)' == 'true' and ('$(IsTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true')">
     <!-- Always fully sign test assemblies since we have a full public/private key -->
     <PublicSign>false</PublicSign>
     <DelaySign>true</DelaySign>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzSdkTestLibKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestHelperLibrary)' == 'true'">
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true' or '$(IsTestHelperLibrary)' == 'true'">
     <IsPackable>false</IsPackable>
-    <RequiredTargetFrameworks>netcoreapp2.0</RequiredTargetFrameworks>
-    <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.0;net461</RequiredTargetFrameworks>
+    <RequiredTargetFrameworks>netcoreapp2.1</RequiredTargetFrameworks>
+    <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.1;net461</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <DefaultReferenceTargets>AzSdk.test.reference.targets</DefaultReferenceTargets>
 

--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -26,8 +26,8 @@
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true' or '$(IsTestHelperLibrary)' == 'true'">
     <IsPackable>false</IsPackable>
-    <RequiredTargetFrameworks>netcoreapp2.1</RequiredTargetFrameworks>
-    <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.1;net461</RequiredTargetFrameworks>
+    <RequiredTargetFrameworks>netcoreapp2.0</RequiredTargetFrameworks>
+    <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.0;net461</RequiredTargetFrameworks>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <DefaultReferenceTargets>AzSdk.test.reference.targets</DefaultReferenceTargets>
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/Azure.ApplicationModel.Configuration.Performance.csproj
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/Azure.ApplicationModel.Configuration.Performance.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <ImportDefaultReferences>false</ImportDefaultReferences>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.ApplicationModel.Configuration\Azure.Configuration.csproj" />
+  </ItemGroup>
+
+    <!-- Import the Azure.Core project -->
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\Azure.Core\data-plane\Azure.Core\Azure.Core.props" />
+
+</Project>

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/ConfigurationClientBenchmark.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/ConfigurationClientBenchmark.cs
@@ -1,9 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-
 using System;
 using System.Net;
 using System.Net.Http;

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/ConfigurationClientBenchmark.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/ConfigurationClientBenchmark.cs
@@ -19,7 +19,7 @@ namespace Azure.ApplicationModel.Configuration.Performance
 
         private static readonly MockClientHandler GetResponseMessage = new MockClientHandler(request => new HttpResponseMessage((HttpStatusCode)200)
         {
-            Content = new ByteArrayContent(_getBytes)
+            Content = new ByteArrayContent(GetResponseBytes)
         });
 
         private static readonly ConfigurationClient ConfigurationClient = new ConfigurationClient(ConnectionString, new ConfigurationClientOptions()
@@ -27,7 +27,7 @@ namespace Azure.ApplicationModel.Configuration.Performance
             Transport = new HttpClientTransport(new HttpClient(GetResponseMessage))
         });
 
-        private static byte[] _getBytes = Encoding.UTF8.GetBytes(@"{
+        private static readonly byte[] GetResponseBytes = Encoding.UTF8.GetBytes(@"{
   ""etag"": ""4f6dd610dd5e4deebc7fbaef685fb903"",
   ""key"": ""key"",
   ""label"": ""label"",
@@ -42,7 +42,7 @@ namespace Azure.ApplicationModel.Configuration.Performance
 }");
 
         [Benchmark]
-        public async Task GetSecretBenchmarkCore()
+        public async Task GetAsync()
         {
             await ConfigurationClient.GetAsync("key");
         }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/ConfigurationClientBenchmark.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/ConfigurationClientBenchmark.cs
@@ -1,0 +1,69 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using BenchmarkDotNet.Attributes;
+
+namespace Azure.ApplicationModel.Configuration.Performance
+{
+    [MemoryDiagnoser]
+    public class ConfigurationClientBenchmark
+    {
+        private static readonly string ConnectionString = "Endpoint=https://contoso.appconfig.io;Id=b1d9b31;Secret=aabbccdd";
+
+        private static readonly MockClientHandler GetResponseMessage = new MockClientHandler(request => new HttpResponseMessage((HttpStatusCode)200)
+        {
+            Content = new ByteArrayContent(_getBytes)
+        });
+
+        private static readonly ConfigurationClient ConfigurationClient = new ConfigurationClient(ConnectionString, new ConfigurationClientOptions()
+        {
+            Transport = new HttpClientTransport(new HttpClient(GetResponseMessage))
+        });
+
+        private static byte[] _getBytes = Encoding.UTF8.GetBytes(@"{
+  ""etag"": ""4f6dd610dd5e4deebc7fbaef685fb903"",
+  ""key"": ""key"",
+  ""label"": ""label"",
+  ""content_type"": null,
+  ""value"": ""example value"",
+  ""last_modified"": ""2017-12-05T02:41:26+00:00"",
+  ""locked"": false,
+  ""tags"": {
+    ""t1"": ""value1"",
+    ""t2"": ""value2""
+  }
+}");
+
+        [Benchmark]
+        public async Task GetSecretBenchmarkCore()
+        {
+            await ConfigurationClient.GetAsync("key");
+        }
+
+
+        private class MockClientHandler : HttpClientHandler
+        {
+            private readonly Func<HttpRequestMessage, HttpResponseMessage> _responseMessage;
+
+            public MockClientHandler(Func<HttpRequestMessage, HttpResponseMessage> responseMessage)
+            {
+                _responseMessage = responseMessage;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(_responseMessage(request));
+            }
+        }
+    }
+}

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/ConfigurationClientBenchmark.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/ConfigurationClientBenchmark.cs
@@ -15,19 +15,20 @@ namespace Azure.ApplicationModel.Configuration.Performance
     [MemoryDiagnoser]
     public class ConfigurationClientBenchmark
     {
-        private static readonly string ConnectionString = "Endpoint=https://contoso.appconfig.io;Id=b1d9b31;Secret=aabbccdd";
+        private static readonly string MockConnectionString = "Endpoint=https://contoso.appconfig.io;Id=b1d9b31;Secret=aabbccdd";
 
         private static readonly MockClientHandler GetResponseMessage = new MockClientHandler(request => new HttpResponseMessage((HttpStatusCode)200)
         {
             Content = new ByteArrayContent(GetResponseBytes)
         });
 
-        private static readonly ConfigurationClient ConfigurationClient = new ConfigurationClient(ConnectionString, new ConfigurationClientOptions()
+        private static readonly ConfigurationClient ConfigurationClient = new ConfigurationClient(MockConnectionString, new ConfigurationClientOptions()
         {
             Transport = new HttpClientTransport(new HttpClient(GetResponseMessage))
         });
 
-        private static readonly byte[] GetResponseBytes = Encoding.UTF8.GetBytes(@"{
+        private static readonly byte[] GetResponseBytes = Encoding.UTF8.GetBytes(
+@"{
   ""etag"": ""4f6dd610dd5e4deebc7fbaef685fb903"",
   ""key"": ""key"",
   ""label"": ""label"",

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/Program.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/Program.cs
@@ -1,0 +1,13 @@
+﻿using System.IO;
+using BenchmarkDotNet.Running;
+
+namespace Azure.ApplicationModel.Configuration.Performance
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+        }
+    }
+}

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/Program.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Performance/Program.cs
@@ -1,4 +1,7 @@
-﻿using System.IO;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
 using BenchmarkDotNet.Running;
 
 namespace Azure.ApplicationModel.Configuration.Performance

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.sln
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.sln
@@ -5,11 +5,13 @@ VisualStudioVersion = 15.0.28307.231
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Configuration", "Azure.ApplicationModel.Configuration\Azure.Configuration.csproj", "{25CE0676-8F2C-497B-8FB5-7DA41A31F6F9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Configuration.Tests", "Azure.ApplicationModel.Configuration.Tests\Azure.Configuration.Tests.csproj", "{AAA761F4-D037-46AC-BF7A-496C15310F66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Configuration.Tests", "Azure.ApplicationModel.Configuration.Tests\Azure.Configuration.Tests.csproj", "{AAA761F4-D037-46AC-BF7A-496C15310F66}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core", "..\..\Azure.Core\data-plane\Azure.Core\Azure.Core.csproj", "{019A28FC-EFEA-4431-872C-AB8F9C0049BF}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Core.Tests", "..\..\Azure.Core\data-plane\Azure.Core.Tests\Azure.Core.Tests.csproj", "{84491222-6C36-4FA7-BBAE-1FA804129151}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.ApplicationModel.Configuration.Performance", "Azure.ApplicationModel.Configuration.Performance\Azure.ApplicationModel.Configuration.Performance.csproj", "{2F3CC223-2357-4D24-BCE7-92835C62A201}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,6 +35,10 @@ Global
 		{84491222-6C36-4FA7-BBAE-1FA804129151}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{84491222-6C36-4FA7-BBAE-1FA804129151}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{84491222-6C36-4FA7-BBAE-1FA804129151}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2F3CC223-2357-4D24-BCE7-92835C62A201}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F3CC223-2357-4D24-BCE7-92835C62A201}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F3CC223-2357-4D24-BCE7-92835C62A201}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F3CC223-2357-4D24-BCE7-92835C62A201}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
@@ -91,6 +91,7 @@ namespace Azure.Core.Pipeline
 
         sealed class PipelineRequest : HttpPipelineRequest
         {
+            private bool _wasSent = false;
             private readonly HttpRequestMessage _requestMessage;
 
             private PipelineContentAdapter _requestContent;
@@ -144,9 +145,16 @@ namespace Azure.Core.Pipeline
 
             public HttpRequestMessage BuildRequestMessage(CancellationToken cancellation)
             {
+                if (_wasSent == false)
+                {
+                    _wasSent = true;
+                    _requestMessage.RequestUri = UriBuilder.Uri;
+                    return _requestMessage;
+                }
+
                 // A copy of a message needs to be made because HttpClient does not allow sending the same message twice,
                 // and so the retry logic fails.
-                var request = new HttpRequestMessage(_requestMessage.Method, UriBuilder.ToString());
+                var request = new HttpRequestMessage(_requestMessage.Method, UriBuilder.Uri);
 
                 CopyHeaders(_requestMessage.Headers, request.Headers);
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
@@ -160,7 +160,7 @@ namespace Azure.Core.Pipeline
                     _wasSent = true;
                 }
 
-                _requestMessage.RequestUri = UriBuilder.Uri;
+                currentRequest.RequestUri = UriBuilder.Uri;
 
                 if (_requestContent?.PipelineContent != null)
                 {

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
@@ -145,30 +145,34 @@ namespace Azure.Core.Pipeline
 
             public HttpRequestMessage BuildRequestMessage(CancellationToken cancellation)
             {
-                if (_wasSent == false)
+                HttpRequestMessage currentRequest;
+                if (_wasSent)
                 {
+                    // A copy of a message needs to be made because HttpClient does not allow sending the same message twice,
+                    // and so the retry logic fails.
+                    currentRequest = new HttpRequestMessage(_requestMessage.Method, UriBuilder.Uri);
+                    CopyHeaders(_requestMessage.Headers, currentRequest.Headers);
+
+                }
+                else
+                {
+                    currentRequest = _requestMessage;
                     _wasSent = true;
-                    _requestMessage.RequestUri = UriBuilder.Uri;
-                    return _requestMessage;
                 }
 
-                // A copy of a message needs to be made because HttpClient does not allow sending the same message twice,
-                // and so the retry logic fails.
-                var request = new HttpRequestMessage(_requestMessage.Method, UriBuilder.Uri);
-
-                CopyHeaders(_requestMessage.Headers, request.Headers);
+                _requestMessage.RequestUri = UriBuilder.Uri;
 
                 if (_requestContent?.PipelineContent != null)
                 {
-                    request.Content = new PipelineContentAdapter()
+                    currentRequest.Content = new PipelineContentAdapter()
                     {
                         CancellationToken = cancellation,
                         PipelineContent = _requestContent.PipelineContent
                     };
-                    CopyHeaders(_requestContent.Headers, request.Content.Headers);
+                    CopyHeaders(_requestContent.Headers, currentRequest.Content.Headers);
                 }
 
-                return request;
+                return currentRequest;
             }
 
             public override void Dispose()

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/BufferResponsePolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/BufferResponsePolicy.cs
@@ -19,7 +19,7 @@ namespace Azure.Core.Pipeline.Policies
         {
             await ProcessNextAsync(pipeline, message);
 
-            if (message.Response.ResponseContentStream != null)
+            if (message.Response.ResponseContentStream != null && !message.Response.ResponseContentStream.CanSeek)
             {
                 Stream responseContentStream = message.Response.ResponseContentStream;
                 var bufferedStream = new MemoryStream();

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/LoggingPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/LoggingPolicy.cs
@@ -27,6 +27,12 @@ namespace Azure.Core.Pipeline.Policies
         // TODO (pri 1): we should remove sensitive information, e.g. keys
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
+            if (!s_eventSource.IsEnabled())
+            {
+                await ProcessNextAsync(pipeline, message);
+                return;
+            }
+
             s_eventSource.Request(message.Request);
 
             Encoding requestTextEncoding = null;


### PR DESCRIPTION
I've added a microbenchmark for AppConfig client GetAsync overhead

Did a couple simple perf optimization in our version:

1. Avoid re-creating HttpRequestMessage when sending only once
2. Avoid examining request/response if logging is disabled
3. Avoid buffering if response stream is already buffered

Results compared to https://github.com/Azure/Azconfig-DotnetSdk (GetSecretBenchmarkAz) on .net core 2.1

```

|                 Method |     Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------- |---------:|----------:|----------:|-------:|------:|------:|----------:|
|   GetSecretBenchmarkAz | 33.09 us | 0.6594 us | 0.7593 us | 1.9531 |     - |     - |  12.32 KB |
| GetSecretBenchmarkCore | 25.80 us | 0.5282 us | 0.6487 us | 1.0681 |     - |     - |   6.71 KB |

```

For net461 and netcoreapp2.0 iteration time is similar between both libraries but allocation for Azure.Core one is almost 2x less.