### PR TITLE
Add more header methods

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationMockTests.cs
@@ -103,7 +103,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             AssertRequestCommon(request);
             Assert.AreEqual(HttpPipelineMethod.Put, request.Method);
             Assert.AreEqual("https://contoso.appconfig.io/kv/test_key?label=test_label", request.UriBuilder.ToString());
-            Assert.True(request.TryGetHeader("If-None-Match", out var ifNoneMatch));
+            Assert.True(request.Headers.TryGetValue("If-None-Match", out var ifNoneMatch));
             Assert.AreEqual("*", ifNoneMatch);
             AssertContent(SerializationHelpers.Serialize(s_testSetting, SerializeRequestSetting), request);
             Assert.AreEqual(s_testSetting, setting);
@@ -145,7 +145,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.AreEqual("https://contoso.appconfig.io/kv/test_key?label=test_label", request.UriBuilder.ToString());
             AssertContent(SerializationHelpers.Serialize(s_testSetting, SerializeRequestSetting), request);
             Assert.AreEqual(s_testSetting, setting);
-            Assert.True(request.TryGetHeader("If-Match", out var ifMatch));
+            Assert.True(request.Headers.TryGetValue("If-Match", out var ifMatch));
             Assert.AreEqual("*", ifMatch);
         }
 
@@ -293,7 +293,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
         private void AssertRequestCommon(MockRequest request)
         {
-            Assert.True(request.TryGetHeader("User-Agent", out var value));
+            Assert.True(request.Headers.TryGetValue("User-Agent", out var value));
             StringAssert.Contains("azsdk-net-config/1.0.0.0", value);
         }
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/samples/Sample7_ConfiguringPipeline.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/samples/Sample7_ConfiguringPipeline.cs
@@ -53,7 +53,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
         {
             public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
             {
-                message.Request.AddHeader("User-Agent", "ConfiguraingPipelineSample");
+                message.Request.Headers.Add("User-Agent", "ConfiguraingPipelineSample");
                 await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
             }
         }

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/AuthenticationPolicy.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/AuthenticationPolicy.cs
@@ -53,9 +53,9 @@ namespace Azure.ApplicationModel.Configuration
                 string signedHeaders = "date;host;x-ms-content-sha256"; // Semicolon separated header names
 
                 // TODO (pri 3): should date header writing be moved out from here?
-                message.Request.AddHeader("Date", utcNowString);
-                message.Request.AddHeader("x-ms-content-sha256", contentHash);
-                message.Request.AddHeader("Authorization", $"HMAC-SHA256 Credential={_credential}, SignedHeaders={signedHeaders}, Signature={signature}");
+                message.Request.Headers.Add("Date", utcNowString);
+                message.Request.Headers.Add("x-ms-content-sha256", contentHash);
+                message.Request.Headers.Add("Authorization", $"HMAC-SHA256 Credential={_credential}, SignedHeaders={signedHeaders}, Signature={signature}");
             }
 
             await ProcessNextAsync(pipeline, message);

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient.cs
@@ -59,9 +59,9 @@ namespace Azure.ApplicationModel.Configuration
 
                 BuildUriForKvRoute(request.UriBuilder, setting);
 
-                request.AddHeader(IfNoneMatch, "*");
-                request.AddHeader(MediaTypeKeyValueApplicationHeader);
-                request.AddHeader(HttpHeader.Common.JsonContentType);
+                request.Headers.Add(IfNoneMatch, "*");
+                request.Headers.Add(MediaTypeKeyValueApplicationHeader);
+                request.Headers.Add(HttpHeader.Common.JsonContentType);
 
                 request.Content = HttpPipelineRequestContent.Create(content);
 
@@ -92,12 +92,12 @@ namespace Azure.ApplicationModel.Configuration
 
                 request.Method = HttpPipelineMethod.Put;
                 BuildUriForKvRoute(request.UriBuilder, setting);
-                request.AddHeader(MediaTypeKeyValueApplicationHeader);
-                request.AddHeader(HttpHeader.Common.JsonContentType);
+                request.Headers.Add(MediaTypeKeyValueApplicationHeader);
+                request.Headers.Add(HttpHeader.Common.JsonContentType);
 
                 if (setting.ETag != default)
                 {
-                    request.AddHeader(IfMatchName, $"\"{setting.ETag.ToString()}\"");
+                    request.Headers.Add(IfMatchName, $"\"{setting.ETag.ToString()}\"");
                 }
 
                 request.Content = HttpPipelineRequestContent.Create(content);
@@ -129,16 +129,16 @@ namespace Azure.ApplicationModel.Configuration
 
                 request.Method = HttpPipelineMethod.Put;
                 BuildUriForKvRoute(request.UriBuilder, setting);
-                request.AddHeader(MediaTypeKeyValueApplicationHeader);
-                request.AddHeader(HttpHeader.Common.JsonContentType);
+                request.Headers.Add(MediaTypeKeyValueApplicationHeader);
+                request.Headers.Add(HttpHeader.Common.JsonContentType);
 
                 if (setting.ETag != default)
                 {
-                    request.AddHeader(IfMatchName, $"\"{setting.ETag}\"");
+                    request.Headers.Add(IfMatchName, $"\"{setting.ETag}\"");
                 }
                 else
                 {
-                    request.AddHeader(IfMatchName, "*");
+                    request.Headers.Add(IfMatchName, "*");
                 }
 
                 request.Content = HttpPipelineRequestContent.Create(content);
@@ -170,7 +170,7 @@ namespace Azure.ApplicationModel.Configuration
 
                 if (etag != default)
                 {
-                    request.AddHeader(IfMatchName, $"\"{etag.ToString()}\"");
+                    request.Headers.Add(IfMatchName, $"\"{etag.ToString()}\"");
                 }
 
                 var response = await _pipeline.SendRequestAsync(request, cancellation).ConfigureAwait(false);
@@ -191,14 +191,14 @@ namespace Azure.ApplicationModel.Configuration
             {
                 request.Method = HttpPipelineMethod.Get;
                 BuildUriForKvRoute(request.UriBuilder, key, label);
-                request.AddHeader(MediaTypeKeyValueApplicationHeader);
+                request.Headers.Add(MediaTypeKeyValueApplicationHeader);
 
                 if (acceptDateTime != default)
                 {
                     var dateTime = acceptDateTime.UtcDateTime.ToString(AcceptDateTimeFormat);
-                    request.AddHeader(AcceptDatetimeHeader, dateTime);
+                    request.Headers.Add(AcceptDatetimeHeader, dateTime);
                 }
-                request.AddHeader(HttpHeader.Common.JsonContentType);
+                request.Headers.Add(HttpHeader.Common.JsonContentType);
 
                 var response = await _pipeline.SendRequestAsync(request, cancellation).ConfigureAwait(false);
 
@@ -215,11 +215,11 @@ namespace Azure.ApplicationModel.Configuration
             {
                 request.Method = HttpPipelineMethod.Get;
                 BuildUriForGetBatch(request.UriBuilder, selector);
-                request.AddHeader(MediaTypeKeyValueApplicationHeader);
+                request.Headers.Add(MediaTypeKeyValueApplicationHeader);
                 if (selector.AsOf.HasValue)
                 {
                     var dateTime = selector.AsOf.Value.UtcDateTime.ToString(AcceptDateTimeFormat);
-                    request.AddHeader(AcceptDatetimeHeader, dateTime);
+                    request.Headers.Add(AcceptDatetimeHeader, dateTime);
                 }
                 var response = await _pipeline.SendRequestAsync(request, cancellation).ConfigureAwait(false);
 
@@ -238,11 +238,11 @@ namespace Azure.ApplicationModel.Configuration
             {
                 request.Method = HttpPipelineMethod.Get;
                 BuildUriForRevisions(request.UriBuilder, selector);
-                request.AddHeader(MediaTypeKeyValueApplicationHeader);
+                request.Headers.Add(MediaTypeKeyValueApplicationHeader);
                 if (selector.AsOf.HasValue)
                 {
                     var dateTime = selector.AsOf.Value.UtcDateTime.ToString(AcceptDateTimeFormat);
-                    request.AddHeader(AcceptDatetimeHeader, dateTime);
+                    request.Headers.Add(AcceptDatetimeHeader, dateTime);
                 }
                 var response = await _pipeline.SendRequestAsync(request, cancellation).ConfigureAwait(false);
 

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSettingParser.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationSettingParser.cs
@@ -118,7 +118,7 @@ namespace Azure.ApplicationModel.Configuration
         static bool TryGetNextAfterValue(ref Response response, out string afterValue)
         {
             afterValue = default;
-            if (!response.TryGetHeader(s_link, out var headerValue)) return false;
+            if (!response.Headers.TryGetValue(s_link, out var headerValue)) return false;
 
             // the headers value is something like this: "</kv?after={token}>; rel=\"next\""
             var afterIndex = headerValue.IndexOf(s_after);

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/ClientRequestIdPolicyTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/ClientRequestIdPolicyTests.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Tests
         {
             var mockTransport = new MockTransport();
             Task<Response> task = SendGetRequest(mockTransport, ClientRequestIdPolicy.Singleton);
-            MockRequest request =  await mockTransport.RequestGate.Cycle(new MockResponse(200));
+            MockRequest request = await mockTransport.RequestGate.Cycle(new MockResponse(200));
             await task;
 
             Assert.True(request.TryGetHeader("x-ms-client-request-id", out string requestId));

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/EventSourceTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/EventSourceTests.cs
@@ -77,8 +77,8 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.SetRequestLine(HttpPipelineMethod.Get, new Uri("https://contoso.a.io"));
-                request.AddHeader("Date", "3/26/2019");
-                request.AddHeader("Custom-Header", "Value");
+                request.Headers.Add("Date", "3/26/2019");
+                request.Headers.Add("Custom-Header", "Value");
                 request.Content = HttpPipelineRequestContent.Create(new byte[] { 1, 2, 3, 4, 5 });
                 requestId = request.RequestId;
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/EventSourceTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/EventSourceTests.cs
@@ -140,7 +140,7 @@ namespace Azure.Core.Tests
             {
                 request.SetRequestLine(HttpPipelineMethod.Get, new Uri("https://contoso.a.io"));
                 request.Content = HttpPipelineRequestContent.Create(Encoding.UTF8.GetBytes("Hello world"));
-                request.AddHeader(new HttpHeader("Content-Type", "text/json"));
+                request.Headers.Add("Content-Type", "text/json");
                 requestId = request.RequestId;
 
                 await pipeline.SendRequestAsync(request, CancellationToken.None);

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/HttpClientTransportTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/HttpClientTransportTests.cs
@@ -206,10 +206,10 @@ namespace Azure.Core.Tests
 
             request.Headers.Add(headerName, headerValue);
 
-            Assert.True(request.TryGetHeader(headerName, out var value));
+            Assert.True(request.Headers.TryGetValue(headerName, out var value));
             Assert.AreEqual(headerValue, value);
 
-            Assert.True(request.TryGetHeader(headerName.ToUpper(), out value));
+            Assert.True(request.Headers.TryGetValue(headerName.ToUpper(), out value));
             Assert.AreEqual(headerValue, value);
 
             CollectionAssert.AreEqual(new []
@@ -240,10 +240,10 @@ namespace Azure.Core.Tests
             request.Headers.Add(headerName, "Random value");
             request.Headers.SetValue(headerName, headerValue);
 
-            Assert.True(request.TryGetHeader(headerName, out var value));
+            Assert.True(request.Headers.TryGetValue(headerName, out var value));
             Assert.AreEqual(headerValue, value);
 
-            Assert.True(request.TryGetHeader(headerName.ToUpper(), out value));
+            Assert.True(request.Headers.TryGetValue(headerName.ToUpper(), out value));
             Assert.AreEqual(headerValue, value);
 
             CollectionAssert.AreEqual(new []
@@ -270,12 +270,12 @@ namespace Azure.Core.Tests
             Request request = CreateRequest(transport);
 
             request.Headers.Add(headerName, headerValue);
-            Assert.True(request.RemoveHeader(headerName));
-            Assert.False(request.RemoveHeader(headerName));
+            Assert.True(request.Headers.Remove(headerName));
+            Assert.False(request.Headers.Remove(headerName));
 
-            Assert.False(request.TryGetHeader(headerName, out _));
-            Assert.False(request.TryGetHeader(headerName.ToUpper(), out _));
-            Assert.False(request.ContainsHeader(headerName.ToUpper()));
+            Assert.False(request.Headers.TryGetValue(headerName, out _));
+            Assert.False(request.Headers.TryGetValue(headerName.ToUpper(), out _));
+            Assert.False(request.Headers.Contains(headerName.ToUpper()));
 
             await ExecuteRequest(request, transport);
         }
@@ -306,10 +306,10 @@ namespace Azure.Core.Tests
 
             var response = await ExecuteRequest(request, transport);
 
-            Assert.True(response.TryGetHeader(headerName, out var value));
+            Assert.True(response.Headers.TryGetValue(headerName, out var value));
             Assert.AreEqual(headerValue, value);
 
-            Assert.True(response.TryGetHeader(headerName.ToUpper(), out value));
+            Assert.True(response.Headers.TryGetValue(headerName.ToUpper(), out value));
             Assert.AreEqual(headerValue, value);
 
             CollectionAssert.Contains(response.Headers, new HttpHeader(headerName, headerValue));
@@ -352,12 +352,12 @@ namespace Azure.Core.Tests
             request.Headers.Add(headerName, headerValue);
             request.Headers.Add(headerName, anotherHeaderValue);
 
-            Assert.True(request.ContainsHeader(headerName));
+            Assert.True(request.Headers.Contains(headerName));
 
-            Assert.True(request.TryGetHeader(headerName, out var value));
+            Assert.True(request.Headers.TryGetValue(headerName, out var value));
             Assert.AreEqual(joinedHeaderValues, value);
 
-            Assert.True(request.TryGetHeaderValues(headerName, out var values));
+            Assert.True(request.Headers.TryGetValues(headerName, out var values));
             CollectionAssert.AreEqual(new [] { headerValue, anotherHeaderValue }, values);
 
             CollectionAssert.AreEqual(new []
@@ -401,12 +401,12 @@ namespace Azure.Core.Tests
 
             var response = await ExecuteRequest(request, transport);
 
-            Assert.True(response.ContainsHeader(headerName));
+            Assert.True(response.Headers.Contains(headerName));
 
-            Assert.True(response.TryGetHeader(headerName, out var value));
+            Assert.True(response.Headers.TryGetValue(headerName, out var value));
             Assert.AreEqual(joinedHeaderValues, value);
 
-            Assert.True(response.TryGetHeaderValues(headerName, out var values));
+            Assert.True(response.Headers.TryGetValues(headerName, out var values));
             CollectionAssert.AreEqual(new [] { headerValue, anotherHeaderValue }, values);
 
             CollectionAssert.Contains(response.Headers, new HttpHeader(headerName, joinedHeaderValues));

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/HttpClientTransportTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/HttpClientTransportTests.cs
@@ -55,7 +55,7 @@ namespace Azure.Core.Tests
             var request = transport.CreateRequest(null);
             request.SetRequestLine(HttpPipelineMethod.Get, new Uri("http://example.com"));
             request.Content = HttpPipelineRequestContent.Create(new byte[10]);
-            request.AddHeader("Content-Length", "50");
+            request.Headers.Add("Content-Length", "50");
 
             await ExecuteRequest(request, transport);
 
@@ -96,7 +96,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             var request = transport.CreateRequest(null);
             request.SetRequestLine(HttpPipelineMethod.Get, new Uri("http://example.com:340"));
-            request.AddHeader("Host", "example.org");
+            request.Headers.Add("Host", "example.org");
 
             await ExecuteRequest(request, transport);
 
@@ -204,7 +204,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = CreateRequest(transport);
 
-            request.AddHeader(headerName, headerValue);
+            request.Headers.Add(headerName, headerValue);
 
             Assert.True(request.TryGetHeader(headerName, out var value));
             Assert.AreEqual(headerValue, value);
@@ -237,8 +237,8 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = CreateRequest(transport);
 
-            request.AddHeader(headerName, "Random value");
-            request.SetHeader(headerName, headerValue);
+            request.Headers.Add(headerName, "Random value");
+            request.Headers.SetValue(headerName, headerValue);
 
             Assert.True(request.TryGetHeader(headerName, out var value));
             Assert.AreEqual(headerValue, value);
@@ -269,7 +269,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = CreateRequest(transport);
 
-            request.AddHeader(headerName, headerValue);
+            request.Headers.Add(headerName, headerValue);
             Assert.True(request.RemoveHeader(headerName));
             Assert.False(request.RemoveHeader(headerName));
 
@@ -324,7 +324,7 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             var request = transport.CreateRequest(null);
             request.SetRequestLine(HttpPipelineMethod.Get, new Uri("http://example.com:340"));
-            request.AddHeader(headerName, headerValue);
+            request.Headers.Add(headerName, headerValue);
 
             await ExecuteRequest(request, transport);
 
@@ -349,8 +349,8 @@ namespace Azure.Core.Tests
             var transport = new HttpClientTransport(new HttpClient(mockHandler));
             Request request = CreateRequest(transport);
 
-            request.AddHeader(headerName, headerValue);
-            request.AddHeader(headerName, anotherHeaderValue);
+            request.Headers.Add(headerName, headerValue);
+            request.Headers.Add(headerName, anotherHeaderValue);
 
             Assert.True(request.ContainsHeader(headerName));
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/PipelineTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/PipelineTests.cs
@@ -47,36 +47,5 @@ namespace Azure.Core.Tests
                 return IsRetriableResponse(response);
             }
         }
-
-        class TestClientOptions : HttpClientOptions
-        {
-        }
-
-        class NullPipelineContext : Request
-        {
-            public override void AddHeader(HttpHeader header)
-            {
-            }
-
-            public override bool TryGetHeader(string name, out string value)
-            {
-                value = null;
-                return false;
-            }
-
-            public override IEnumerable<HttpHeader> Headers
-            {
-                get
-                {
-                    yield break;
-                }
-            }
-
-            public override string RequestId { get; set; }
-
-            public override void Dispose()
-            {
-            }
-        }
     }
 }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/RetriableStreamTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/RetriableStreamTests.cs
@@ -152,7 +152,7 @@ namespace Azure.Core.Tests
             using (Request request = pipeline.CreateRequest())
             {
                 request.SetRequestLine(HttpPipelineMethod.Get, new Uri("http://example.com"));
-                request.AddHeader("Range", "bytes=" + offset);
+                request.Headers.Add("Range", "bytes=" + offset);
 
                 return pipeline.SendRequestAsync(request, CancellationToken.None);
             }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockRequest.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockRequest.cs
@@ -51,12 +51,6 @@ namespace Azure.Core.Testing
             return TryGetHeaderValues(name, out _);
         }
 
-        public override void SetHeader(string name, string value)
-        {
-            RemoveHeader(name);
-            AddHeader(name, value);
-        }
-
         public override bool RemoveHeader(string name)
         {
             return _headers.Remove(name);

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockRequest.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockRequest.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Azure.Core.Pipeline;
 
 namespace Azure.Core.Testing
@@ -14,29 +15,59 @@ namespace Azure.Core.Testing
             RequestId = Guid.NewGuid().ToString();
         }
 
-        private readonly List<HttpHeader> _headers = new List<HttpHeader>();
+        private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
         public override void AddHeader(HttpHeader header)
         {
-            _headers.Add(header);
+            if (!_headers.TryGetValue(header.Name, out var values))
+            {
+                _headers[header.Name] = values = new List<string>();
+            }
+
+            values.Add(header.Value);
         }
 
         public override bool TryGetHeader(string name, out string value)
         {
-            foreach (var httpHeader in _headers)
+            if (_headers.TryGetValue(name, out var values))
             {
-                if (httpHeader.Name.Equals(name, StringComparison.InvariantCultureIgnoreCase))
-                {
-                    value = httpHeader.Value;
-                    return true;
-                }
+                value = JoinHeaderValue(values);
+                return true;
             }
 
             value = null;
             return false;
         }
 
-        public override IEnumerable<HttpHeader> Headers => _headers;
+        public override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+        {
+            var result = _headers.TryGetValue(name, out var valuesList);
+            values = valuesList;
+            return result;
+        }
+
+        public override bool ContainsHeader(string name)
+        {
+            return TryGetHeaderValues(name, out _);
+        }
+
+        public override void SetHeader(string name, string value)
+        {
+            RemoveHeader(name);
+            AddHeader(name, value);
+        }
+
+        public override bool RemoveHeader(string name)
+        {
+            return _headers.Remove(name);
+        }
+
+        public override IEnumerable<HttpHeader> Headers => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
+
+        private static string JoinHeaderValue(IEnumerable<string> values)
+        {
+            return string.Join(",", values);
+        }
 
         public override string RequestId { get; set; }
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockRequest.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockRequest.cs
@@ -39,19 +39,19 @@ namespace Azure.Core.Testing
             return false;
         }
 
-        protected internal  override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+        protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
         {
             var result = _headers.TryGetValue(name, out var valuesList);
             values = valuesList;
             return result;
         }
 
-        protected internal  override bool ContainsHeader(string name)
+        protected internal override bool ContainsHeader(string name)
         {
             return TryGetHeaderValues(name, out _);
         }
 
-        protected internal  override bool RemoveHeader(string name)
+        protected internal override bool RemoveHeader(string name)
         {
             return _headers.Remove(name);
         }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockRequest.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockRequest.cs
@@ -17,17 +17,17 @@ namespace Azure.Core.Testing
 
         private readonly Dictionary<string, List<string>> _headers = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
 
-        public override void AddHeader(HttpHeader header)
+        protected internal override void AddHeader(string name, string value)
         {
-            if (!_headers.TryGetValue(header.Name, out var values))
+            if (!_headers.TryGetValue(name, out var values))
             {
-                _headers[header.Name] = values = new List<string>();
+                _headers[name] = values = new List<string>();
             }
 
-            values.Add(header.Value);
+            values.Add(value);
         }
 
-        public override bool TryGetHeader(string name, out string value)
+        protected internal override bool TryGetHeader(string name, out string value)
         {
             if (_headers.TryGetValue(name, out var values))
             {
@@ -39,24 +39,24 @@ namespace Azure.Core.Testing
             return false;
         }
 
-        public override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+        protected internal  override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
         {
             var result = _headers.TryGetValue(name, out var valuesList);
             values = valuesList;
             return result;
         }
 
-        public override bool ContainsHeader(string name)
+        protected internal  override bool ContainsHeader(string name)
         {
             return TryGetHeaderValues(name, out _);
         }
 
-        public override bool RemoveHeader(string name)
+        protected internal  override bool RemoveHeader(string name)
         {
             return _headers.Remove(name);
         }
 
-        public override IEnumerable<HttpHeader> Headers => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
+        protected internal override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
 
         private static string JoinHeaderValue(IEnumerable<string> values)
         {

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockResponse.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Testing/MockResponse.cs
@@ -47,7 +47,7 @@ namespace Azure.Core.Testing
             values.Add(header.Value);
         }
 
-        public override bool TryGetHeader(string name, out string value)
+        protected internal override bool TryGetHeader(string name, out string value)
         {
             if (_headers.TryGetValue(name, out var values))
             {
@@ -59,19 +59,19 @@ namespace Azure.Core.Testing
             return false;
         }
 
-        public override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
+        protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values)
         {
             var result = _headers.TryGetValue(name, out var valuesList);
             values = valuesList;
             return result;
         }
 
-        public override bool ContainsHeader(string name)
+        protected internal override bool ContainsHeader(string name)
         {
             return TryGetHeaderValues(name, out _);
         }
 
-        public override IEnumerable<HttpHeader> Headers => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
+        protected internal override IEnumerable<HttpHeader> EnumerateHeaders() => _headers.Select(h => new HttpHeader(h.Key, JoinHeaderValue(h.Value)));
 
         private static string JoinHeaderValue(IEnumerable<string> values)
         {

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/samples/Sample1_HelloWorld.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/samples/Sample1_HelloWorld.cs
@@ -22,7 +22,7 @@ namespace Azure.Core.Samples
 
             var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/src/SDKs/Azure.Core/data-plane/README.md");
             request.SetRequestLine(HttpPipelineMethod.Get, uri);
-            request.AddHeader("Host", uri.Host);
+            request.Headers.Add("Host", uri.Host);
 
             Response response = await pipeline.SendRequestAsync(request, cancellationToken: default).ConfigureAwait(false);
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
@@ -146,12 +146,7 @@ namespace Azure.Core.Pipeline
 
             public override string RequestId { get; set; }
 
-            public override void AddHeader(HttpHeader header)
-            {
-                AddHeader(header.Name, header.Value);
-            }
-
-            public override void AddHeader(string name, string value)
+            protected internal override void AddHeader(string name, string value)
             {
                 if (_requestMessage.Headers.TryAddWithoutValidation(name, value))
                 {
@@ -165,15 +160,15 @@ namespace Azure.Core.Pipeline
                 }
             }
 
-            public override bool TryGetHeader(string name, out string value) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out value);
+            protected internal override bool TryGetHeader(string name, out string value) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out value);
 
-            public override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out values);
+            protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out values);
 
-            public override bool ContainsHeader(string name) => HttpClientTransport.ContainsHeader(_requestMessage.Headers, _requestContent, name);
+            protected internal override bool ContainsHeader(string name) => HttpClientTransport.ContainsHeader(_requestMessage.Headers, _requestContent, name);
 
-            public override bool RemoveHeader(string name) => HttpClientTransport.RemoveHeader(_requestMessage.Headers, _requestContent, name);
+            protected internal override bool RemoveHeader(string name) => HttpClientTransport.RemoveHeader(_requestMessage.Headers, _requestContent, name);
 
-            public override IEnumerable<HttpHeader> Headers => HttpClientTransport.GetHeaders(_requestMessage.Headers, _requestContent);
+            protected internal override IEnumerable<HttpHeader> EnumerateHeaders() => HttpClientTransport.GetHeaders(_requestMessage.Headers, _requestContent);
 
             public HttpRequestMessage BuildRequestMessage(CancellationToken cancellation)
             {
@@ -320,13 +315,13 @@ namespace Azure.Core.Pipeline
 
             public override string RequestId { get; set; }
 
-            public override bool TryGetHeader(string name, out string value) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseMessage.Content, name, out value);
+            protected internal override bool TryGetHeader(string name, out string value) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseMessage.Content, name, out value);
 
-            public override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseMessage.Content, name, out values);
+            protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseMessage.Content, name, out values);
 
-            public override bool ContainsHeader(string name) => HttpClientTransport.ContainsHeader(_responseMessage.Headers, _responseMessage.Content, name);
+            protected internal override bool ContainsHeader(string name) => HttpClientTransport.ContainsHeader(_responseMessage.Headers, _responseMessage.Content, name);
 
-            public override IEnumerable<HttpHeader> Headers => HttpClientTransport.GetHeaders(_responseMessage.Headers, _responseMessage.Content);
+            protected internal override IEnumerable<HttpHeader> EnumerateHeaders() => HttpClientTransport.GetHeaders(_responseMessage.Headers, _responseMessage.Content);
 
             public override void Dispose()
             {

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
@@ -174,12 +174,8 @@ namespace Azure.Core.Pipeline
             public override bool TryGetHeader(string name, out string value) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out value);
 
             public override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out values);
+
             public override bool ContainsHeader(string name) => HttpClientTransport.ContainsHeader(_requestMessage.Headers, _requestContent, name);
-            public override void SetHeader(string name, string value)
-            {
-                RemoveHeader(name);
-                AddHeader(name, value);
-            }
 
             public override bool RemoveHeader(string name) => HttpClientTransport.RemoveHeader(_requestMessage.Headers, _requestContent, name);
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpClientTransport.cs
@@ -58,13 +58,7 @@ namespace Azure.Core.Pipeline
 
         internal static bool TryGetHeader(HttpHeaders headers, HttpContent content, string name, out IEnumerable<string> values)
         {
-            if (headers.TryGetValues(name, out values) ||
-                (content != null && content.Headers.TryGetValues(name, out values)))
-            {
-                return true;
-            }
-
-            return false;
+            return headers.TryGetValues(name, out values) || content?.Headers.TryGetValues(name, out values) == true;
         }
 
         internal static IEnumerable<HttpHeader> GetHeaders(HttpHeaders headers, HttpContent content)

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/ClientRequestIdPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/ClientRequestIdPolicy.cs
@@ -19,8 +19,8 @@ namespace Azure.Core.Pipeline.Policies
 
         public override Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            message.Request.AddHeader(ClientRequestIdHeader, message.Request.RequestId);
-            message.Request.AddHeader(EchoClientRequestId, "true");
+            message.Request.Headers.Add(ClientRequestIdHeader, message.Request.RequestId);
+            message.Request.Headers.Add(EchoClientRequestId, "true");
 
             return ProcessNextAsync(pipeline, message);
         }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/TelemetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/TelemetryPolicy.cs
@@ -38,7 +38,7 @@ namespace Azure.Core.Pipeline.Policies
 
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            message.Request.AddHeader(HttpHeader.Names.UserAgent, _header);
+            message.Request.Headers.Add(HttpHeader.Names.UserAgent, _header);
             await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
         }
     }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/TelemetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/TelemetryPolicy.cs
@@ -11,7 +11,7 @@ namespace Azure.Core.Pipeline.Policies
 {
     public class TelemetryPolicy : HttpPipelinePolicy
     {
-        private readonly HttpHeader _header;
+        private readonly string _header;
 
         public TelemetryPolicy(Assembly clientAssembly, string applicationId)
         {
@@ -28,17 +28,17 @@ namespace Azure.Core.Pipeline.Policies
             var platformInformation = $"({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})";
             if (applicationId != null)
             {
-                _header = new HttpHeader(HttpHeader.Names.UserAgent, $"{applicationId} azsdk-net-{componentName}/{componentVersion} {platformInformation}");
+                _header = $"{applicationId} azsdk-net-{componentName}/{componentVersion} {platformInformation}";
             }
             else
             {
-                _header = new HttpHeader(HttpHeader.Names.UserAgent, $"azsdk-net-{componentName}/{componentVersion} {platformInformation}");
+                _header = $"azsdk-net-{componentName}/{componentVersion} {platformInformation}";
             }
         }
 
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            message.Request.AddHeader(_header);
+            message.Request.AddHeader(HttpHeader.Names.UserAgent, _header);
             await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
         }
     }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Request.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Request.cs
@@ -32,7 +32,11 @@ namespace Azure
 
         public abstract bool ContainsHeader(string name);
 
-        public abstract void SetHeader(string name, string value);
+        public virtual void SetHeader(string name, string value)
+        {
+            RemoveHeader(name);
+            AddHeader(name, value);
+        }
 
         public abstract bool RemoveHeader(string name);
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Request.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Request.cs
@@ -28,6 +28,14 @@ namespace Azure
 
         public abstract bool TryGetHeader(string name, out string value);
 
+        public abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
+
+        public abstract bool ContainsHeader(string name);
+
+        public abstract void SetHeader(string name, string value);
+
+        public abstract bool RemoveHeader(string name);
+
         public abstract IEnumerable<HttpHeader> Headers { get; }
 
         public abstract string RequestId { get; set; }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Request.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Request.cs
@@ -21,28 +21,27 @@ namespace Azure
 
         public virtual HttpPipelineRequestContent Content { get; set; }
 
-        public abstract void AddHeader(HttpHeader header);
+        protected internal abstract void AddHeader(string name, string value);
 
-        public virtual void AddHeader(string name, string value)
-            => AddHeader(new HttpHeader(name, value));
+        protected internal abstract bool TryGetHeader(string name, out string value);
 
-        public abstract bool TryGetHeader(string name, out string value);
+        protected internal abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
 
-        public abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
+        protected internal abstract bool ContainsHeader(string name);
 
-        public abstract bool ContainsHeader(string name);
-
-        public virtual void SetHeader(string name, string value)
+        protected internal virtual void SetHeader(string name, string value)
         {
             RemoveHeader(name);
             AddHeader(name, value);
         }
 
-        public abstract bool RemoveHeader(string name);
+        protected internal abstract bool RemoveHeader(string name);
 
-        public abstract IEnumerable<HttpHeader> Headers { get; }
+        protected internal abstract IEnumerable<HttpHeader> EnumerateHeaders();
 
         public abstract string RequestId { get; set; }
+
+        public RequestHeaders Headers => new RequestHeaders(this);
 
         public abstract void Dispose();
     }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/RequestHeaders.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/RequestHeaders.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using Azure.Core.Pipeline;
+
+namespace Azure
+{
+    public readonly struct RequestHeaders: IEnumerable<HttpHeader>
+    {
+        private readonly Request _request;
+
+        public RequestHeaders(Request request)
+        {
+            _request = request;
+        }
+
+        public IEnumerator<HttpHeader> GetEnumerator()
+        {
+            return _request.EnumerateHeaders().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _request.EnumerateHeaders().GetEnumerator();
+        }
+
+        public void Add(HttpHeader header)
+        {
+            _request.AddHeader(header.Name, header.Value);
+        }
+
+        public void Add(string name, string value)
+        {
+            _request.AddHeader(name, value);
+        }
+
+        public bool TryGetValue(string name, out string value)
+        {
+            return _request.TryGetHeader(name, out value);
+        }
+
+        public bool TryGetValues(string name, out IEnumerable<string> values)
+        {
+            return _request.TryGetHeaderValues(name, out values);
+        }
+
+        public bool Contains(string name)
+        {
+            return _request.ContainsHeader(name);
+        }
+
+        public void SetValue(string name, string value)
+        {
+            _request.SetHeader(name, value);
+        }
+
+        public bool Remove(string name)
+        {
+            return _request.RemoveHeader(name);
+        }
+    }
+}

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Response.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Response.cs
@@ -16,14 +16,17 @@ namespace Azure
 
         public abstract string RequestId { get; set; }
 
-        public abstract bool TryGetHeader(string name, out string value);
-
-        public abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
-
-        public abstract bool ContainsHeader(string name);
-
-        public abstract IEnumerable<HttpHeader> Headers { get; }
+        public virtual ResponseHeaders Headers => new ResponseHeaders(this);
 
         public abstract void Dispose();
+
+        protected internal abstract bool TryGetHeader(string name, out string value);
+
+        protected internal abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
+
+        protected internal abstract bool ContainsHeader(string name);
+
+        protected internal abstract IEnumerable<HttpHeader> EnumerateHeaders();
+
     }
 }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Response.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Response.cs
@@ -12,11 +12,15 @@ namespace Azure
     {
         public abstract int Status { get; }
 
-        public abstract bool TryGetHeader(string name, out string value);
-
         public abstract Stream ContentStream { get; set; }
 
         public abstract string RequestId { get; set; }
+
+        public abstract bool TryGetHeader(string name, out string value);
+
+        public abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
+
+        public abstract bool ContainsHeader(string name);
 
         public abstract IEnumerable<HttpHeader> Headers { get; }
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/ResponseHeaders.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/ResponseHeaders.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections;
+using System.Collections.Generic;
+using Azure.Core.Pipeline;
+
+namespace Azure
+{
+    public readonly struct ResponseHeaders: IEnumerable<HttpHeader>
+    {
+        private readonly Response _response;
+
+        public ResponseHeaders(Response response)
+        {
+            _response = response;
+        }
+
+        public IEnumerator<HttpHeader> GetEnumerator()
+        {
+            return _response.EnumerateHeaders().GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _response.EnumerateHeaders().GetEnumerator();
+        }
+
+        public bool TryGetValue(string name, out string value)
+        {
+            return _response.TryGetHeader(name, out value);
+        }
+
+        public bool TryGetValues(string name, out IEnumerable<string> values)
+        {
+            return _response.TryGetHeaderValues(name, out values);
+        }
+
+        public bool Contains(string name)
+        {
+            return _response.ContainsHeader(name);
+        }
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/5920

Adds `TryGetHeaderValues`, `ContainsHeader`, `SetHeader`, `RemoveHeader` methods to `Request` and `TryGetHeaderValues`, `ContainsHeader` methods to Response.

cc @tg-msft