### PR TITLE
Add Service Bus performance test

### DIFF
--- a/src/SDKs/ServiceBus/data-plane/Microsoft.Azure.ServiceBus.sln
+++ b/src/SDKs/ServiceBus/data-plane/Microsoft.Azure.ServiceBus.sln
@@ -1,13 +1,13 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.421
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28803.202
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus", "src\Microsoft.Azure.ServiceBus\Microsoft.Azure.ServiceBus.csproj", "{E33D09D9-D809-472C-82E6-6A26BDB86FC2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus.Tests", "tests\Microsoft.Azure.ServiceBus.Tests\Microsoft.Azure.ServiceBus.Tests.csproj", "{4F476D56-DDE7-43D3-8CB4-BA1E77F5A300}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus.Performance", "tests\Microsoft.Azure.ServiceBus.Performance\Microsoft.Azure.ServiceBus.Performance.csproj", "{14DE67E0-1196-4E27-9CD9-71942479482A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus.Performance", "tests\Microsoft.Azure.ServiceBus.Performance\Microsoft.Azure.ServiceBus.Performance.csproj", "{BA46F80E-1A79-4185-BD75-2F0E541DA1C8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,10 +23,10 @@ Global
 		{4F476D56-DDE7-43D3-8CB4-BA1E77F5A300}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F476D56-DDE7-43D3-8CB4-BA1E77F5A300}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F476D56-DDE7-43D3-8CB4-BA1E77F5A300}.Release|Any CPU.Build.0 = Release|Any CPU
-		{14DE67E0-1196-4E27-9CD9-71942479482A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{14DE67E0-1196-4E27-9CD9-71942479482A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{14DE67E0-1196-4E27-9CD9-71942479482A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{14DE67E0-1196-4E27-9CD9-71942479482A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BA46F80E-1A79-4185-BD75-2F0E541DA1C8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BA46F80E-1A79-4185-BD75-2F0E541DA1C8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BA46F80E-1A79-4185-BD75-2F0E541DA1C8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BA46F80E-1A79-4185-BD75-2F0E541DA1C8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SDKs/ServiceBus/data-plane/Microsoft.Azure.ServiceBus.sln
+++ b/src/SDKs/ServiceBus/data-plane/Microsoft.Azure.ServiceBus.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus.Tests", "tests\Microsoft.Azure.ServiceBus.Tests\Microsoft.Azure.ServiceBus.Tests.csproj", "{4F476D56-DDE7-43D3-8CB4-BA1E77F5A300}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.ServiceBus.Performance", "tests\Microsoft.Azure.ServiceBus.Performance\Microsoft.Azure.ServiceBus.Performance.csproj", "{14DE67E0-1196-4E27-9CD9-71942479482A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{4F476D56-DDE7-43D3-8CB4-BA1E77F5A300}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4F476D56-DDE7-43D3-8CB4-BA1E77F5A300}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4F476D56-DDE7-43D3-8CB4-BA1E77F5A300}.Release|Any CPU.Build.0 = Release|Any CPU
+		{14DE67E0-1196-4E27-9CD9-71942479482A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{14DE67E0-1196-4E27-9CD9-71942479482A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{14DE67E0-1196-4E27-9CD9-71942479482A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{14DE67E0-1196-4E27-9CD9-71942479482A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/SDKs/ServiceBus/data-plane/tests/Microsoft.Azure.ServiceBus.Performance/Microsoft.Azure.ServiceBus.Performance.csproj
+++ b/src/SDKs/ServiceBus/data-plane/tests/Microsoft.Azure.ServiceBus.Performance/Microsoft.Azure.ServiceBus.Performance.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <RootNamespace>Microsoft.Azure.ServiceBus.Performance</RootNamespace>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Azure.ServiceBus\Microsoft.Azure.ServiceBus.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/SDKs/ServiceBus/data-plane/tests/Microsoft.Azure.ServiceBus.Performance/Program.cs
+++ b/src/SDKs/ServiceBus/data-plane/tests/Microsoft.Azure.ServiceBus.Performance/Program.cs
@@ -1,12 +1,15 @@
-﻿using Microsoft.Azure.ServiceBus;
-using Microsoft.Azure.ServiceBus.Core;
-using System;
-using System.Diagnostics;
-using System.Threading;
-using System.Threading.Tasks;
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 namespace Microsoft.Azure.ServiceBus.Performance
 {
+    using Microsoft.Azure.ServiceBus;
+    using Microsoft.Azure.ServiceBus.Core;
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+
     class Program
     {
         private static readonly Stopwatch _stopwatch = Stopwatch.StartNew();

--- a/src/SDKs/ServiceBus/data-plane/tests/Microsoft.Azure.ServiceBus.Performance/Program.cs
+++ b/src/SDKs/ServiceBus/data-plane/tests/Microsoft.Azure.ServiceBus.Performance/Program.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.Azure.ServiceBus;
+using Microsoft.Azure.ServiceBus.Core;
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Azure.ServiceBus.Performance
+{
+    class Program
+    {
+        private static readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+
+        private static readonly byte[] _payload = new byte[1024];
+
+        private static long _messages;
+
+        static async Task Main(string[] args)
+        {
+            var maxInflight = (args.Length >= 1 ? int.Parse(args[0]) : 1);
+            Log($"Maximum inflight messages: {maxInflight}");
+
+            var messages = (args.Length >= 2 ? long.Parse(args[1]) : 10);
+
+            var connectionString = Environment.GetEnvironmentVariable("SERVICE_BUS_CONNECTION_STRING");
+            var entityPath = Environment.GetEnvironmentVariable("SERVICE_BUS_QUEUE_NAME");
+
+            var writeResultsTask = WriteResults(messages);
+
+            await RunTest(connectionString, entityPath, maxInflight, messages);
+
+            await writeResultsTask;
+        }
+
+        private static async Task RunTest(string connectionString, string entityPath, int maxInflight, long messages)
+        {
+            var sender = new MessageSender(connectionString, entityPath);
+
+            var tasks = new Task[maxInflight];
+            for (var i = 0; i < maxInflight; i++)
+            {
+                var task = ExecuteSendsAsync(sender, messages);
+                tasks[i] = task;
+            }
+
+            await Task.WhenAll(tasks);
+        }
+
+        private static async Task ExecuteSendsAsync(MessageSender sender, long messages)
+        {
+            while (Interlocked.Increment(ref _messages) <= messages)
+            {
+                await sender.SendAsync(new Message(_payload));
+            }
+            
+            // Undo last increment, since a message was never sent on the final loop iteration
+            Interlocked.Decrement(ref _messages);
+        }
+
+        private static async Task WriteResults(long messages)
+        {
+            var lastMessages = (long)0;
+            var lastElapsed = TimeSpan.Zero;
+            var maxMessages = (long)0;
+            var maxElapsed = TimeSpan.MaxValue;
+
+            do
+            {
+                await Task.Delay(TimeSpan.FromSeconds(1));
+
+                var sentMessages = _messages;
+                var currentMessages = sentMessages - lastMessages;
+                lastMessages = sentMessages;
+
+                var elapsed = _stopwatch.Elapsed;
+                var currentElapsed = elapsed - lastElapsed;
+                lastElapsed = elapsed;
+
+                if ((currentMessages / currentElapsed.TotalSeconds) > (maxMessages / maxElapsed.TotalSeconds)) {
+                    maxMessages = currentMessages;
+                    maxElapsed = currentElapsed;
+                }
+
+                WriteResult(sentMessages, elapsed, currentMessages, currentElapsed, maxMessages, maxElapsed);
+            }
+            while (Interlocked.Read(ref _messages) < messages);
+        }
+
+        private static void WriteResult(long totalMessages, TimeSpan totalElapsed,
+            long currentMessages, TimeSpan currentElapsed, long maxMessages, TimeSpan maxElapsed)
+        {
+            Log($"\tTot Msg\t{totalMessages}" +
+                $"\tCur MPS\t{Math.Round(currentMessages / currentElapsed.TotalSeconds)}" +
+                $"\tAvg MPS\t{Math.Round(totalMessages / totalElapsed.TotalSeconds)}" +
+                $"\tMax MPS\t{Math.Round(maxMessages / maxElapsed.TotalSeconds)}"
+            );
+        }
+
+        private static void Log(string message)
+        {
+            Console.WriteLine($"[{DateTime.Now.ToString("hh:mm:ss.fff")}] {message}");
+        }
+    }
+}


### PR DESCRIPTION
.NET implementation of Service Bus performance test for `send`.  Equivalent to JS implementation at https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/test/perf/service-bus.