### PR TITLE
RetriableStream fixes

### DIFF
--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/RetriableStreamTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/RetriableStreamTests.cs
@@ -48,8 +48,8 @@ namespace Azure.Core.Tests
         [Test]
         public async Task DoesntRetryNonRetryableExceptions()
         {
-            var stream1 = new NoLengthStream();
-            var stream2 = new MockReadStream(50);
+            var stream1 = new MockReadStream(100, throwAfter: 50);
+            var stream2 = new MockReadStream(50, offset: 50, throwAfter: 0, throwIOException: false);
 
             var mockTransport = new MockTransport(
                 new MockResponse(200) { ContentStream = stream1 },

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/RetriableStream.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/RetriableStream.cs
@@ -13,9 +13,14 @@ namespace Azure.Core
 {
     public static class RetriableStream
     {
-        public static async Task<Stream> Create(Func<long, Task<Response>> responseFactory, ResponseClassifier responseClassifier,  int maxRetries)
+        public static async Task<Stream> Create(Func<long, Task<Response>> responseFactory, ResponseClassifier responseClassifier, int maxRetries)
         {
-            return new RetriableStreamImpl(await responseFactory(0), responseFactory, responseClassifier, maxRetries);
+            return Create(await responseFactory(0), responseFactory, responseClassifier, maxRetries);
+        }
+
+        public static Stream Create(Response initialResponse, Func<long, Task<Response>> responseFactory, ResponseClassifier responseClassifier, int maxRetries)
+        {
+            return new RetriableStreamImpl(initialResponse, responseFactory, responseClassifier, maxRetries);
         }
 
         private class RetriableStreamImpl : ReadOnlyStream
@@ -34,13 +39,15 @@ namespace Azure.Core
 
             private List<Exception> _exceptions;
 
+            private readonly Stream _initialStream;
+
             public RetriableStreamImpl(Response initialResponse, Func<long, Task<Response>> responseFactory, ResponseClassifier responseClassifier, int maxRetries)
             {
+                _initialStream = initialResponse.ContentStream;
                 _currentStream = initialResponse.ContentStream;
                 _responseClassifier = responseClassifier;
                 _responseFactory = responseFactory;
                 _maxRetries = maxRetries;
-                Length = _currentStream.Length;
             }
 
             public override long Seek(long offset, SeekOrigin origin)
@@ -109,7 +116,7 @@ namespace Azure.Core
 
             public override bool CanRead => _currentStream.CanRead;
             public override bool CanSeek { get; } = false;
-            public override long Length { get; }
+            public override long Length => _initialStream.Length;
 
             public override long Position
             {

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/RetriableStream.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/RetriableStream.cs
@@ -15,7 +15,7 @@ namespace Azure.Core
     {
         public static async Task<Stream> Create(Func<long, Task<Response>> responseFactory, ResponseClassifier responseClassifier, int maxRetries)
         {
-            return Create(await responseFactory(0), responseFactory, responseClassifier, maxRetries);
+            return Create(await responseFactory(0).ConfigureAwait(false), responseFactory, responseClassifier, maxRetries);
         }
 
         public static Stream Create(Response initialResponse, Func<long, Task<Response>> responseFactory, ResponseClassifier responseClassifier, int maxRetries)

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/RetriableStream.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/RetriableStream.cs
@@ -31,6 +31,8 @@ namespace Azure.Core
 
             private readonly int _maxRetries;
 
+            private readonly Stream _initialStream;
+
             private Stream _currentStream;
 
             private long _position;
@@ -38,8 +40,6 @@ namespace Azure.Core
             private int _retryCount;
 
             private List<Exception> _exceptions;
-
-            private readonly Stream _initialStream;
 
             public RetriableStreamImpl(Response initialResponse, Func<long, Task<Response>> responseFactory, ResponseClassifier responseClassifier, int maxRetries)
             {


### PR DESCRIPTION
Don't call `.Lenght` eagerly.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/5927
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/5926