### PR TITLE
Move type out of `Azure` namespace

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationSettingTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationSettingTests.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Azure.Core;
 
 namespace Azure.ApplicationModel.Configuration.Tests
 {

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient_private.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/ConfigurationClient_private.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Core;
 using Azure.Core.Pipeline;
 
 namespace Azure.ApplicationModel.Configuration

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration/Properties/AssemblyInfo.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core.Attributes;
+﻿using Azure.Core;
 using System.Runtime.CompilerServices;
 
 [assembly:AzureSdkClientLibrary("config")]

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Properties/AssemblyInfo.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/Properties/AssemblyInfo.cs
@@ -1,3 +1,3 @@
-﻿using Azure.Core.Attributes;
+﻿using Azure.Core;
 
 [assembly: AzureSdkClientLibrary("base-test")]

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/AzureSdkComponentAttribute.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/AzureSdkComponentAttribute.cs
@@ -3,7 +3,7 @@
 
 using System;
 
-namespace Azure.Core.Attributes
+namespace Azure.Core
 {
     [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
     public class AzureSdkClientLibraryAttribute: Attribute

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/HttpPipelineUriBuilder.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/HttpPipelineUriBuilder.cs
@@ -4,9 +4,8 @@
 using System;
 using System.Text;
 
-namespace Azure
+namespace Azure.Core
 {
-
     public class HttpPipelineUriBuilder
     {
         private const char QuerySeparator = '?';

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpPipeline.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/HttpPipeline.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
-using Azure.Core.Attributes;
+using Azure.Core;
 using Azure.Core.Pipeline.Policies;
 
 namespace Azure.Core.Pipeline

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/TelemetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/TelemetryPolicy.cs
@@ -5,7 +5,7 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
-using Azure.Core.Attributes;
+using Azure.Core;
 
 namespace Azure.Core.Pipeline.Policies
 {

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Request.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Request.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using Azure.Core;
 using Azure.Core.Pipeline;
 
 namespace Azure


### PR DESCRIPTION
Move `AzureSdkClientLibraryAttribute` and `HttpPipelineUriBuilder` to `Azure.Core`

Contributes to https://github.com/Azure/azure-sdk-for-net/issues/5922