### PR TITLE
Implement Retry-After support in RetryPolicy

### DIFF
--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/FixedRetryPolicyTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/FixedRetryPolicyTests.cs
@@ -55,6 +55,31 @@ namespace Azure.Core.Tests
             Assert.AreEqual(500, response.Status);
         }
 
+        [Theory]
+        [TestCase(2, 3, 3)]
+        [TestCase(3, 2, 3)]
+        public async Task UsesLargerOfDelayAndServerDelay(int delay, int retryAfter, int expected)
+        {
+            var responseClassifier = new MockResponseClassifier(retriableCodes: new [] { 500 });
+            var policy = new FixedRetryPolicyMock(delay: TimeSpan.FromSeconds(delay));
+            var mockTransport = new MockTransport();
+            var task = SendRequest(mockTransport, policy, responseClassifier);
+
+            MockResponse mockResponse = new MockResponse(500);
+            mockResponse.AddHeader(new HttpHeader("Retry-After", retryAfter.ToString()));
+
+            await mockTransport.RequestGate.Cycle(mockResponse);
+
+            var retryDelay = await policy.DelayGate.Cycle();
+
+            await mockTransport.RequestGate.Cycle(new MockResponse(501));
+
+            var response = await task.TimeoutAfterDefault();
+
+            Assert.AreEqual(TimeSpan.FromSeconds(expected), retryDelay);
+            Assert.AreEqual(501, response.Status);
+        }
+
         protected override (HttpPipelinePolicy, AsyncGate<TimeSpan, object>) CreateRetryPolicy(int maxRetries = 3)
         {
             var policy = new FixedRetryPolicyMock(maxRetries, TimeSpan.FromSeconds(3));

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/RetryPolicyTestBase.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/RetryPolicyTestBase.cs
@@ -201,8 +201,10 @@ namespace Azure.Core.Tests
             Assert.AreEqual(501, response.Status);
         }
 
-        [Test]
-        public async Task RespectsXRetryAfterMSHeader()
+        [Theory]
+        [TestCase("retry-after-ms")]
+        [TestCase("x-ms-retry-after-ms")]
+        public async Task RespectsRetryAfterMSHeader(string headerName)
         {
             var responseClassifier = new MockResponseClassifier(retriableCodes: new [] { 500 });
             var (policy, gate) = CreateRetryPolicy(maxRetries: 3);
@@ -210,7 +212,7 @@ namespace Azure.Core.Tests
             var task = SendRequest(mockTransport, policy, responseClassifier);
 
             MockResponse mockResponse = new MockResponse(500);
-            mockResponse.AddHeader(new HttpHeader("x-ms-retry-after-ms", "200"));
+            mockResponse.AddHeader(new HttpHeader(headerName, "200"));
 
             await mockTransport.RequestGate.Cycle(mockResponse);
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/RetryPolicyTestBase.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/RetryPolicyTestBase.cs
@@ -140,7 +140,7 @@ namespace Azure.Core.Tests
             var task = SendRequest(mockTransport, policy, responseClassifier);
 
             MockResponse mockResponse = new MockResponse(500);
-            mockResponse.AddHeader(new HttpHeader("Retry-After", "2"));
+            mockResponse.AddHeader(new HttpHeader("Retry-After", "25"));
 
             await mockTransport.RequestGate.Cycle(mockResponse);
 
@@ -150,7 +150,7 @@ namespace Azure.Core.Tests
 
             var response = await task.TimeoutAfterDefault();
 
-            Assert.AreEqual(TimeSpan.FromSeconds(2), retryDelay);
+            Assert.AreEqual(TimeSpan.FromSeconds(25), retryDelay);
             Assert.AreEqual(501, response.Status);
         }
 
@@ -212,7 +212,7 @@ namespace Azure.Core.Tests
             var task = SendRequest(mockTransport, policy, responseClassifier);
 
             MockResponse mockResponse = new MockResponse(500);
-            mockResponse.AddHeader(new HttpHeader(headerName, "200"));
+            mockResponse.AddHeader(new HttpHeader(headerName, "120000"));
 
             await mockTransport.RequestGate.Cycle(mockResponse);
 
@@ -222,7 +222,7 @@ namespace Azure.Core.Tests
 
             var response = await task.TimeoutAfterDefault();
 
-            Assert.AreEqual(TimeSpan.FromMilliseconds(200), retryDelay);
+            Assert.AreEqual(TimeSpan.FromMilliseconds(120000), retryDelay);
             Assert.AreEqual(501, response.Status);
         }
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/ExponentialRetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/ExponentialRetryPolicy.cs
@@ -29,6 +29,12 @@ namespace Azure.Core.Pipeline.Policies
 
         protected override void GetDelay(HttpPipelineMessage message, int attempted, out TimeSpan delay)
         {
+            base.GetDelay(message, attempted, out delay);
+            if (delay > TimeSpan.Zero)
+            {
+                return;
+            }
+
             delay = CalculateDelay(attempted);
         }
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/ExponentialRetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/ExponentialRetryPolicy.cs
@@ -29,13 +29,12 @@ namespace Azure.Core.Pipeline.Policies
 
         protected override void GetDelay(HttpPipelineMessage message, int attempted, out TimeSpan delay)
         {
-            base.GetDelay(message, attempted, out delay);
-            if (delay > TimeSpan.Zero)
-            {
-                return;
-            }
-
             delay = CalculateDelay(attempted);
+            TimeSpan serverDelay = GetServerDelay(message);
+            if (serverDelay > delay)
+            {
+                delay = serverDelay;
+            }
         }
 
         protected override void GetDelay(HttpPipelineMessage message, Exception exception, int attempted, out TimeSpan delay)

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/FixedRetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/FixedRetryPolicy.cs
@@ -15,12 +15,18 @@ namespace Azure.Core.Pipeline.Policies
 
         protected override void GetDelay(HttpPipelineMessage message, int attempted, out TimeSpan delay)
         {
+            base.GetDelay(message, attempted, out delay);
+            if (delay > TimeSpan.Zero)
+            {
+                return;
+            }
+
             delay = Delay;
         }
 
         protected override void GetDelay(HttpPipelineMessage message, Exception exception, int attempted, out TimeSpan delay)
         {
             delay = Delay;
-        } 
+        }
     }
 }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/FixedRetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/FixedRetryPolicy.cs
@@ -15,13 +15,13 @@ namespace Azure.Core.Pipeline.Policies
 
         protected override void GetDelay(HttpPipelineMessage message, int attempted, out TimeSpan delay)
         {
-            base.GetDelay(message, attempted, out delay);
-            if (delay > TimeSpan.Zero)
-            {
-                return;
-            }
-
             delay = Delay;
+
+            TimeSpan serverDelay = GetServerDelay(message);
+            if (serverDelay > delay)
+            {
+                delay = serverDelay;
+            }
         }
 
         protected override void GetDelay(HttpPipelineMessage message, Exception exception, int attempted, out TimeSpan delay)

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/RetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/RetryPolicy.cs
@@ -12,6 +12,10 @@ namespace Azure.Core.Pipeline.Policies
 {
     public abstract class RetryPolicy : HttpPipelinePolicy
     {
+        private const string RetryAfterHeaderName = "Retry-After";
+        private const string RetryAfterMsHeaderName = "retry-after-ms";
+        private const string XRetryAfterMsHeaderName = "x-ms-retry-after-ms";
+
         /// <summary>
         /// Gets or sets the maximum number of retry attempts before giving up.
         /// </summary>
@@ -96,7 +100,7 @@ namespace Azure.Core.Pipeline.Policies
         protected virtual void GetDelay(HttpPipelineMessage message, int attempted, out TimeSpan delay)
         {
             delay = TimeSpan.Zero;
-            if (message.Response.TryGetHeader("Retry-After", out var retryAfterValue))
+            if (message.Response.TryGetHeader(RetryAfterHeaderName, out var retryAfterValue))
             {
                 if (int.TryParse(retryAfterValue, out var delaySeconds))
                 {
@@ -108,7 +112,8 @@ namespace Azure.Core.Pipeline.Policies
                 }
             }
 
-            if (message.Response.TryGetHeader("x-ms-retry-after-ms", out retryAfterValue))
+            if (message.Response.TryGetHeader(RetryAfterMsHeaderName, out retryAfterValue) ||
+                message.Response.TryGetHeader(XRetryAfterMsHeaderName, out retryAfterValue))
             {
                 if (int.TryParse(retryAfterValue, out var delaySeconds))
                 {

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/RetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/RetryPolicy.cs
@@ -107,6 +107,14 @@ namespace Azure.Core.Pipeline.Policies
                     delay = delayTime - DateTimeOffset.Now;
                 }
             }
+
+            if (message.Response.TryGetHeader("x-ms-retry-after-ms", out retryAfterValue))
+            {
+                if (int.TryParse(retryAfterValue, out var delaySeconds))
+                {
+                    delay = TimeSpan.FromMilliseconds(delaySeconds);
+                }
+            }
         }
 
         protected abstract void GetDelay(HttpPipelineMessage message, Exception exception, int attempted, out TimeSpan delay);


### PR DESCRIPTION
Supports `Retry-After` header in numeric and date form and `retry-after-ms` and `x-ms-retry-after-ms` in numeric form.

Fixes: https://github.com/Azure/azure-sdk-for-net-lab/issues/88