### PR TITLE
Prevent failing tests from building in non-Windows builds

### DIFF
--- a/eng/data-plane.proj
+++ b/eng/data-plane.proj
@@ -1,7 +1,5 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <!-- Issue https://github.com/Azure/azure-sdk-for-net/issues/5089 some KeyVault tests don't work on linux -->
-    <ExcludeDataPlaneProjects Include="$(RepoRoot)\sdk\keyvault\**\Microsoft.Azure.KeyVault.Tests.csproj" Condition="'$(OS)' != 'Windows_NT'" />
     <ExcludeDataPlaneProjects Include="$(RepoSrcPath)\*\data-plane\**\*.Tests.*proj" Condition="'$(SkipTests)' == 'true'" />
     <ExcludeDataPlaneProjects Include="$(RepoRoot)\sdk\*\Microsoft.Azure.*\**\*.Tests.*proj" Condition="'$(SkipTests)' == 'true'" />
     <DataPlaneProjectReference Include="$(RepoSrcPath)\*\data-plane\**\*.*proj" Exclude="@(ExcludeDataPlaneProjects)" />

--- a/sdk/keyvault/Microsoft.Azure.KeyVault/tests/Microsoft.Azure.KeyVault.Tests.csproj
+++ b/sdk/keyvault/Microsoft.Azure.KeyVault/tests/Microsoft.Azure.KeyVault.Tests.csproj
@@ -14,7 +14,10 @@
 
   <ItemGroup>
     <Compile Remove="TestFramework\**\*.cs" />
+
+    <!-- Issue https://github.com/Azure/azure-sdk-for-net/issues/5089 some KeyVault tests don't work on linux -->
     <Compile Remove="KeyVaultOperationsTest.cs" Condition="'$(OS)' != 'Windows_NT'" />
+    
     <ProjectReference Include="..\src\Microsoft.Azure.KeyVault.csproj" />
     <ProjectReference Include="TestFramework\Microsoft.Azure.KeyVault.TestFramework.csproj" />
   </ItemGroup>

--- a/sdk/keyvault/Microsoft.Azure.KeyVault/tests/Microsoft.Azure.KeyVault.Tests.csproj
+++ b/sdk/keyvault/Microsoft.Azure.KeyVault/tests/Microsoft.Azure.KeyVault.Tests.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <Compile Remove="TestFramework\**\*.cs" />
+    <Compile Remove="KeyVaultOperationsTest.cs" Condition="'$(OS)' != 'Windows_NT'" />
     <ProjectReference Include="..\src\Microsoft.Azure.KeyVault.csproj" />
     <ProjectReference Include="TestFramework\Microsoft.Azure.KeyVault.TestFramework.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Exclude KeyVaultOperationsTest.cs on non-Windows systems in Microsoft.Azure.KeyVault.Tests.csproj

Update `eng\data-plane.proj` to not exclude the whole KV test project. 

This pushes the logic of deciding where tests should run from the SDK's client build to the build on the particular csproj containing offending code which is better than omitting the test farther upstream in the build process.

In the future the decision to run tests should happen at runtime instead of build time.