### PR TITLE
[Service Bus Client] Rename Environment Variables and ReadMe Updates

### DIFF
--- a/.azure-pipelines/tests.yml
+++ b/.azure-pipelines/tests.yml
@@ -56,7 +56,7 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
           APP_CONFIG_CONNECTION: $(AppConfigConnectionString)
-          AZ_SERVICE_BUS_CONNECTION: $(ServiceBusConnectionString)
+          SERVICE_BUS_CONNECTION_STRING: $(ServiceBusConnectionString)
           EVENT_HUBS_CONNECTION_STRING: $(EventHubsConnectionString)
           EVENT_HUBS_STORAGE_CONNECTION_STRING: $(EventHubsStorageConnectionString)
 

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/README.md
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/README.md
@@ -44,7 +44,7 @@ For information on building the Azure Service bus client library, please see [Bu
 
 ## Running tests
 
-1. Deploy the Azure Resource Manager template located at [/assets/azure-deploy-test-dependencies.json](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Microsoft.Azure.ServiceBus/assets/azure-deploy-test-dependencies.json) by clicking the following button:
+1. Deploy the Azure Resource Manager template located at [sdk/servicebus/Microsoft.Azure.ServiceBus/assets/azure-deploy-test-dependencies.json](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Microsoft.Azure.ServiceBus/assets/azure-deploy-test-dependencies.json) by clicking the following button:
 
     <a href="https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Fservicebus%2FMicrosoft.Azure.ServiceBus%2Fassets%2Fazure-deploy-test-dependencies.json" target="_blank">
         <img src="http://azuredeploy.net/deploybutton.png"/>
@@ -52,13 +52,17 @@ For information on building the Azure Service bus client library, please see [Bu
 
     *Running the above template will provision a standard Service Bus namespace along with the required entities to successfully run the unit tests.*
 
-1. Add an Environment Variable named `AZ_SERVICE_BUS_CONNECTION` and set the value as the connection string of the newly created namespace. **Please note that if you are using Visual Studio, you must restart Visual Studio in order to use new Environment Variables.**
+1. Add an Environment Variable named `SERVICE_BUS_CONNECTION_STRING` and set the value as the connection string of the newly created namespace. **Please note that if you are using Visual Studio, you must restart Visual Studio in order to use new Environment Variables.**
 
 Once you have completed the above, you can run `dotnet test` from the `/sdk/servicebus/Microsoft.Azure.ServiceBus/tests` directory.
 
+## Development history
+
+For additional insight and context, the development, release, and issue history for the Azure Service Bus client library will continue to be available in read-only form, located in the stand-alone [Azure Service Bus .NET repository](https://github.com/Azure/azure-service-bus-dotnet).  
+
 ## Versioning information
 
-The Azure Service Bus client library uses [the semantic versioning scheme.](http://semver.org/)
+The Azure Service Bus client library uses [the semantic versioning scheme](http://semver.org/).  
 
 ## Target frameworks
 

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/ServiceBusScope.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/ServiceBusScope.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             {
                 DefaultMessageTimeToLive = TestConstants.QueueDefaultMessageTimeToLive,
                 LockDuration = TestConstants.QueueDefaultLockDuration,
-                DuplicateDetectionHistoryTimeWindow = TestConstants.QueueDefaultDeuplicateDetectionHistory,
+                DuplicateDetectionHistoryTimeWindow = TestConstants.QueueDefaultDuplicateDetectionHistory,
                 MaxSizeInMB = TestConstants.QueueDefaultMaxSizeMegabytes,
                 EnablePartitioning = partitioned,
                 RequiresSession = sessionEnabled
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
             new TopicDescription(name)
             {
                 DefaultMessageTimeToLive = TestConstants.TopicDefaultMessageTimeToLive,
-                DuplicateDetectionHistoryTimeWindow = TestConstants.TopicDefaultDeuplicateDetectionHistory,
+                DuplicateDetectionHistoryTimeWindow = TestConstants.TopicDefaultDuplicateDetectionHistory,
                 MaxSizeInMB = TestConstants.TopicDefaultMaxSizeMegabytes,
                 EnablePartitioning = partitioned
             };

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/TestConstants.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Infrastructure/TestConstants.cs
@@ -8,9 +8,9 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
     static class TestConstants
     {
         // Enviornment Variables
-        internal const string ConnectionStringEnvironmentVariable = "AZ_SERVICE_BUS_CONNECTION";
-        
-        // General 
+        internal const string ConnectionStringEnvironmentVariable = "SERVICE_BUS_CONNECTION_STRING";
+
+        // General
         internal const string SessionPrefix = "session";
         internal const int MaxAttemptsCount = 5;
         internal readonly static TimeSpan WaitTimeBetweenAttempts = TimeSpan.FromSeconds(1);
@@ -24,19 +24,19 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         internal const int QueueDefaultMaxSizeMegabytes = 1024;
         internal static readonly TimeSpan QueueDefaultMessageTimeToLive = TimeSpan.FromDays(10675199);
         internal static readonly TimeSpan QueueDefaultLockDuration = TimeSpan.FromMinutes(1);
-        internal static readonly TimeSpan QueueDefaultDeuplicateDetectionHistory = TimeSpan.FromMinutes(10);
-        
+        internal static readonly TimeSpan QueueDefaultDuplicateDetectionHistory = TimeSpan.FromMinutes(10);
+
         // Topic Property Defaults
         internal const int TopicDefaultMaxSizeMegabytes = 1024;
         internal static readonly TimeSpan TopicDefaultMessageTimeToLive = TimeSpan.FromDays(10675199);
-        internal static readonly TimeSpan TopicDefaultDeuplicateDetectionHistory = TimeSpan.FromMinutes(10);
-        
+        internal static readonly TimeSpan TopicDefaultDuplicateDetectionHistory = TimeSpan.FromMinutes(10);
+
         // Subscription Property Defaults
         internal const string SubscriptionName = "subscription";
         internal const string SessionSubscriptionName = "session-subscription";
         internal const int SubscriptionMaximumDeliveryCount = 10;
         internal const bool SubscriptionDefaultDeadLetterOnExpire = false;
-        internal const bool SubscriptionDefaultDeadLetterOnException = true;        
+        internal const bool SubscriptionDefaultDeadLetterOnException = true;
         internal static readonly TimeSpan SubscriptionDefaultMessageTimeToLive = TimeSpan.FromDays(10675199);
         internal static readonly TimeSpan SubscriptionDefaultLockDuration = TimeSpan.FromMinutes(1);
     }


### PR DESCRIPTION
# Summary

Renaming the environment variable used by tests to conform to the newly adopted convention across libraries.   Updating the README to call out the location of history for the Service Bus client, in its previous location and to correct the environment variable.

# Details

### ReadMe

- Updating the environment variable name used by tests.

- Adding verbiage to call attention to history being available in the read-only stand-alone repository.

### Engineering system

- Renamed environment variable to follow the new patterns chosen as the cross-SDK standard. It is now: `SERVICE_BUS_CONNECTION_STRING`.

### Tests

- Updating environment variable reference.

- Fixing of a typo in other configuration-based constants.

# Last Upstream Rebase

Thursday, April 25, 2019  1:16pm (EDT)

# Related and Follow-Up Issues

- [[Service Bus] Rename test environment variable](https://github.com/Azure/azure-sdk-for-js/issues/2471) (#2471)
- [[Service Bus Client] Enhance ReadMe with History Call-Out](https://github.com/Azure/azure-sdk-for-net/issues/5939) (#5939)