### PR TITLE
[Event Hubs Client] ReadMe Update for Development History

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/README.md
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/README.md
@@ -71,6 +71,10 @@ For information on building the Azure Event Hubs client library, please see [Bui
 
 Once you have completed the above, you can run `dotnet test` from the `/sdk/eventhub/Microsoft.Azure.EventHubs/tests` directory.
 
+## Development history
+
+For additional insight and context, the development, release, and issue history for the Azure Event Hubs client library will continue to be available in read-only form, located in the stand-alone [Azure Event Hubs .NET repository](https://github.com/Azure/azure-event-hubs-dotnet).
+
 ## Versioning information
 
 The Azure Event Hubs client library uses [the semantic versioning scheme.](http://semver.org/)


### PR DESCRIPTION
# Summary

Updating the README to call out the location of history for the Event Hubs client, as read-only information in its previous repository.

# Details

### ReadMe

- Adding verbiage to call attention to history being available in the read-only stand-alone repository.

# Last Upstream Rebase

Thursday, April 25, 2019  1:16pm (EDT)

# Related and Follow-Up Issues

- [[Event Hubs Client] Enhance ReadMe with History Call-Out](https://github.com/Azure/azure-sdk-for-net/issues/5941) (#5941)