### PR TITLE
Reference variable group entries directly (#5956)

### DIFF
--- a/.azure-pipelines/tests.yml
+++ b/.azure-pipelines/tests.yml
@@ -55,10 +55,10 @@ jobs:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
-          APP_CONFIG_CONNECTION: $(AppConfigConnectionString)
-          SERVICE_BUS_CONNECTION_STRING: $(ServiceBusConnectionString)
-          EVENT_HUBS_CONNECTION_STRING: $(EventHubsConnectionString)
-          EVENT_HUBS_STORAGE_CONNECTION_STRING: $(EventHubsStorageConnectionString)
+          APP_CONFIG_CONNECTION: $(net-azconfig-test-connection-string)
+          SERVICE_BUS_CONNECTION_STRING: $(net-service-bus-test-connection-string)
+          EVENT_HUBS_CONNECTION_STRING: $(net-eventhubs-internal-namespace-connection-string)
+          EVENT_HUBS_STORAGE_CONNECTION_STRING: $(net-eventhubs-internal-storage-connection-string)
 
         inputs:
           command: test


### PR DESCRIPTION
Eliminates one layer of indirection. 

Of note: there is no standard template for naming variables at the time of this PR. This means that the Event Hubs names look different from the others. This is an area where we could provide some additional guidance to keep names more consistent. 