### PR TITLE
Expose Raw response as a property

### DIFF
--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationLiveTests.cs
@@ -260,7 +260,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             try
             {
                 Response<ConfigurationSetting> response = await service.SetAsync(testSetting);
-                response.TryGetHeader("x-ms-client-request-id", out string requestId);
+                response.Raw.Headers.TryGetValue("x-ms-client-request-id", out string requestId);
                 Assert.IsNotEmpty(requestId);
                 response.Dispose();
             }
@@ -336,7 +336,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task AddKeyValue()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
-            
+
             string key = GenerateKeyId("key-");
 
             try
@@ -357,7 +357,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         public async Task AddKeyValueLabel()
         {
             ConfigurationClient service = TestEnvironment.GetClient();
-            
+
             string key = GenerateKeyId("key-");
             string value = "my_value";
             string label = "my_label";

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationWatcher.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/ConfigurationWatcher.cs
@@ -28,7 +28,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         }
 
         public TimeSpan Interval { get; set; } = TimeSpan.FromSeconds(1);
-        
+
         public void Start(CancellationToken token = default)
         {
             lock (_sync) {
@@ -84,7 +84,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 for (int i = 0; i < _keysToWatch.Count; i++) {
 
                     var response = await _client.GetAsync(_keysToWatch[i], null, default, cancellationToken).ConfigureAwait(false);
-                    if (response.Status == 200) {
+                    if (response.Raw.Status == 200) {
                         var setting = response.Value;
                         _lastPolled[setting.Key] = setting;
                     }
@@ -110,7 +110,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             foreach(var task in tasks) {
                 var response = task.Result;
-                if (response.Status == 200) {
+                if (response.Raw.Status == 200) {
                     ConfigurationSetting current = response.Value;
                     _lastPolled.TryGetValue(current.Key, out var previous);
                     if (CompareSetting(current, previous)) {

--- a/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/samples/Sample4_Logging.cs
+++ b/src/SDKs/Azure.ApplicationModel.Configuration/data-plane/Azure.ApplicationModel.Configuration.Tests/samples/Sample4_Logging.cs
@@ -28,7 +28,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
             listener.EnableEvents(EventLevel.LogAlways);
 
             Response<ConfigurationSetting> setResponse = await client.SetAsync(new ConfigurationSetting("some_key", "some_value"));
-            if (setResponse.Status != 200) {
+            if (setResponse.Raw.Status != 200) {
                 throw new Exception("could not set configuration setting");
             }
 

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/ResponseOfT.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/ResponseOfT.cs
@@ -8,34 +8,21 @@ namespace Azure
 {
     public readonly struct Response<T> : IDisposable
     {
-        private readonly Response _response;
-
         public Response(Response response, T parsed)
         {
-            _response = response;
+            Raw = response;
             Value = parsed;
         }
 
-        public void Deconstruct(out T value, out Response response)
-        {
-            value = Value;
-            response = _response;
-        }
-
-        public static implicit operator T(Response<T> response) => response.Value;
+        public Response Raw { get; }
 
         public T Value { get; }
 
-        public int Status => _response.Status;
+        public static implicit operator T(Response<T> response) => response.Value;
 
         public void Dispose()
         {
-            _response.Dispose();
-        }
-
-        public bool TryGetHeader(string name, out string values)
-        {
-            return _response.TryGetHeader(name, out values);
+            Raw.Dispose();
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
It's easier to access and avoids duplicating all methods/properties on `Response<T>`