### PR TITLE
[Azure Search] Make StandardAsciiFoldingLucene const

### DIFF
--- a/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/Models/AnalyzerName.cs
+++ b/src/SDKs/Search/DataPlane/Microsoft.Azure.Search.Service/Customizations/Indexes/Models/AnalyzerName.cs
@@ -945,7 +945,7 @@ namespace Microsoft.Azure.Search.Models
             /// Standard ASCII Folding Lucene analyzer.
             /// <see href="https://docs.microsoft.com/rest/api/searchservice/Custom-analyzers-in-Azure-Search#Analyzers" /> 
             /// </summary>
-            public static readonly string StandardAsciiFoldingLucene = "standardasciifolding.lucene";
+            public const string StandardAsciiFoldingLucene = "standardasciifolding.lucene";
 
             /// <summary>
             /// Treats the entire content of a field as a single token. This is useful


### PR DESCRIPTION
Previously it was static readonly, which prevented it from being used in attribute parameters, and therefore in declarative index definitions.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/5705

FYI @Yahnossh @natinimni @shmed @ishansrivastava90 @updixit 