### PR TITLE
Fix retry header order

### DIFF
--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/BufferResponsePolicyTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/BufferResponsePolicyTests.cs
@@ -10,11 +10,9 @@ using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
-    public abstract class BufferResponsePolicyTests: SyncAsyncPolicyTestBase
+    public class BufferResponsePolicyTests: SyncAsyncPolicyTestBase
     {
-        private BufferResponsePolicyTests(bool isAsync) : base(isAsync) { }
-        public class Sync: BufferResponsePolicyTests { public Sync() : base(false) {}}
-        public class Async: BufferResponsePolicyTests { public Async() : base(false) {}}
+        public BufferResponsePolicyTests(bool isAsync) : base(isAsync) { }
 
         [Test]
         public async Task ReadsEntireBodyIntoMemoryStream()

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/EventSourceTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/EventSourceTests.cs
@@ -18,7 +18,7 @@ namespace Azure.Core.Tests
 {
     // Avoid running these tests in parallel with anything else that's sharing the event source
     [NonParallelizable]
-    public abstract class EventSourceTests: SyncAsyncPolicyTestBase
+    public class EventSourceTests: SyncAsyncPolicyTestBase
     {
         private const int RequestEvent = 1;
         private const int RequestContentEvent = 2;
@@ -36,12 +36,9 @@ namespace Azure.Core.Tests
 
         private TestEventListener _listener;
 
-        private EventSourceTests(bool isAsync) : base(isAsync)
+        public EventSourceTests(bool isAsync) : base(isAsync)
         {
         }
-
-        public class Sync: EventSourceTests { public Sync() : base(false) {}}
-        public class Async: EventSourceTests { public Async() : base(false) {}}
 
         [SetUp]
         public void Setup()

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/ExponentialPolicyTest.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/ExponentialPolicyTest.cs
@@ -12,11 +12,9 @@ using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
-    public abstract class ExponentialPolicyTest: RetryPolicyTestBase
+    public class ExponentialPolicyTest: RetryPolicyTestBase
     {
-        private ExponentialPolicyTest(bool isAsync) : base(isAsync) { }
-        public class Sync: ExponentialPolicyTest { public Sync() : base(false) {}}
-        public class Async: ExponentialPolicyTest { public Async() : base(false) {}}
+        public ExponentialPolicyTest(bool isAsync) : base(isAsync) { }
 
         [Test]
         public async Task WaitsBetweenRetries()

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/FixedRetryPolicyTests.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/FixedRetryPolicyTests.cs
@@ -12,11 +12,9 @@ using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
-    public abstract class FixedRetryPolicyTests: RetryPolicyTestBase
+    public class FixedRetryPolicyTests: RetryPolicyTestBase
     {
-        private FixedRetryPolicyTests(bool isAsync) : base(isAsync) { }
-        public class Sync: FixedRetryPolicyTests { public Sync() : base(false) {}}
-        public class Async: FixedRetryPolicyTests { public Async() : base(false) {}}
+        public FixedRetryPolicyTests(bool isAsync) : base(isAsync) { }
 
         [Test]
         public async Task WaitsBetweenRetries()

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/SyncAsyncPolicyTestBase.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core.Tests/SyncAsyncPolicyTestBase.cs
@@ -6,9 +6,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core.Pipeline;
 using Azure.Core.Testing;
+using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
+    [TestFixture(true)]
+    [TestFixture(false)]
     public class SyncAsyncPolicyTestBase
     {
         public bool IsAsync { get; }

--- a/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/RetryPolicy.cs
+++ b/src/SDKs/Azure.Core/data-plane/Azure.Core/Pipeline/Policies/RetryPolicy.cs
@@ -130,7 +130,16 @@ namespace Azure.Core.Pipeline.Policies
 
         protected virtual TimeSpan GetServerDelay(HttpPipelineMessage message)
         {
-            if (message.Response.TryGetHeader(RetryAfterHeaderName, out var retryAfterValue))
+            if (message.Response.TryGetHeader(RetryAfterMsHeaderName, out var retryAfterValue) ||
+                message.Response.TryGetHeader(XRetryAfterMsHeaderName, out retryAfterValue))
+            {
+                if (int.TryParse(retryAfterValue, out var delaySeconds))
+                {
+                    return TimeSpan.FromMilliseconds(delaySeconds);
+                }
+            }
+
+            if (message.Response.TryGetHeader(RetryAfterHeaderName, out retryAfterValue))
             {
                 if (int.TryParse(retryAfterValue, out var delaySeconds))
                 {
@@ -139,15 +148,6 @@ namespace Azure.Core.Pipeline.Policies
                 if (DateTimeOffset.TryParse(retryAfterValue, out var delayTime))
                 {
                     return delayTime - DateTimeOffset.Now;
-                }
-            }
-
-            if (message.Response.TryGetHeader(RetryAfterMsHeaderName, out retryAfterValue) ||
-                message.Response.TryGetHeader(XRetryAfterMsHeaderName, out retryAfterValue))
-            {
-                if (int.TryParse(retryAfterValue, out var delaySeconds))
-                {
-                    return TimeSpan.FromMilliseconds(delaySeconds);
                 }
             }
 


### PR DESCRIPTION
@alzimmermsft pointed out that we are reading headers in the wrong order - `retry-after-ms` should be prefered over `Retry-After` as it's more precise. This was also the intent of my previous PR that was lost during the code cleanup.

Also slightly simplify tests types using previously unknown to me NUnit feature.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/6025