### PR TITLE
Allow clients to report if they own or share the underlying connection string (Part 2)

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/IClientEntity.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/IClientEntity.cs
@@ -45,6 +45,11 @@ namespace Microsoft.Azure.ServiceBus
         ServiceBusConnection ServiceBusConnection { get; }
 
         /// <summary>
+        /// Returns true if connection is owned and false if connection is shared.
+        /// </summary>
+        bool OwnsConnection { get; }
+
+        /// <summary>
         /// Gets a list of currently registered plugins for this client.
         /// </summary>
         IList<ServiceBusPlugin> RegisteredPlugins { get; }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -92,6 +92,7 @@ namespace Microsoft.Azure.ServiceBus
         string ClientId { get; }
         bool IsClosedOrClosing { get; }
         System.TimeSpan OperationTimeout { get; set; }
+        bool OwnsConnection { get; }
         string Path { get; }
         System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         Microsoft.Azure.ServiceBus.ServiceBusConnection ServiceBusConnection { get; }


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-net/issues/6032

Breaking change. Should be merged for the next **major**.