### PR TITLE
[Event Hubs Client] Test Revisions and Improvements

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureStorageCheckpointLeaseManager.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/AzureStorageCheckpointLeaseManager.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.EventHubs.Processor
     class AzureStorageCheckpointLeaseManager : ICheckpointManager, ILeaseManager
     {
         static string MetaDataOwnerName = "OWNINGHOST";
-            
+
         EventProcessorHost host;
         TimeSpan leaseDuration;
         TimeSpan leaseRenewInterval;
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.EventHubs.Processor
 
                 foreach (CloudBlockBlob leaseBlob in leaseBlobsResult.Results)
                 {
-                    // Try getting owner name from existing blob. 
+                    // Try getting owner name from existing blob.
                     // This might return null when run on the existing lease after SDK upgrade.
                     leaseBlob.Metadata.TryGetValue(MetaDataOwnerName, out var owner);
 
@@ -359,9 +359,9 @@ namespace Microsoft.Azure.EventHubs.Processor
                 {
                     ProcessorEventSource.Log.AzureStorageManagerInfo(this.host.HostName, lease.PartitionId, "Need to AcquireLease");
                     newToken = await leaseBlob.AcquireLeaseAsync(
-                        leaseDuration, 
-                        newLeaseId, 
-                        null, 
+                        leaseDuration,
+                        newLeaseId,
+                        null,
                         null,
                         this.operationContext).ConfigureAwait(false);
                 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
@@ -107,10 +107,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 var csb = new EventHubsConnectionStringBuilder(invalidString);
 
                 // ToString should throw.
-                Assert.ThrowsAsync<ArgumentException>(() =>
+                Assert.Throws<ArgumentException>(() =>
                 {
                     csb.ToString();
-                    throw new InvalidOperationException("ToString() should have failed");
                 });
             }
         }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MiscTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MiscTests.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
     using Xunit;
@@ -16,49 +17,52 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionKeyValidation()
         {
-            int NumberOfMessagesToSend = 100;
+            var NumberOfMessagesToSend = 100;
+            var totalReceived = 0;
             var partitionOffsets = new Dictionary<string, string>();
-
-            // Discover the end of stream on each partition.
-            TestUtility.Log("Discovering end of stream on each partition.");
-            foreach (var partitionId in this.PartitionIds)
-            {
-                var lastEvent = await this.EventHubClient.GetPartitionRuntimeInformationAsync(partitionId);
-                partitionOffsets.Add(partitionId, lastEvent.LastEnqueuedOffset);
-                TestUtility.Log($"Partition {partitionId} has last message with offset {lastEvent.LastEnqueuedOffset}");
-            }
-
-            // Now send a set of messages with different partition keys.
-            TestUtility.Log($"Sending {NumberOfMessagesToSend} messages.");
-            Random rnd = new Random();
-            for (int i = 0; i < NumberOfMessagesToSend; i++)
-            {
-                var partitionKey = rnd.Next(10);
-                await this.EventHubClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")), partitionKey.ToString());
-            }
-
-            // It is time to receive all messages that we just sent.
-            // Prepare partition key to partition map while receiving.
-            // Validation: All messages of a partition key should be received from a single partition.
-            TestUtility.Log("Starting to receive all messages from each partition.");
-            var receiveTasks = new Dictionary<string, Task<List<EventData>>>();
             var receivers = new List<PartitionReceiver>();
-            foreach (var partitionId in this.PartitionIds)
-            {
-                var receiver = this.EventHubClient.CreateReceiver(
-                    PartitionReceiver.DefaultConsumerGroupName,
-                    partitionId,
-                    EventPosition.FromOffset(partitionOffsets[partitionId]));
-
-                receivers.Add(receiver);
-                receiveTasks.Add(partitionId, ReceiveAllMessagesAsync(receiver));
-            }
-
-            int totalReceived = 0;
-            var partitionMap = new Dictionary<string, string>();
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var partitions = await this.GetPartitionsAsync(ehClient);
 
             try
             {
+                // Discover the end of stream on each partition.
+                TestUtility.Log("Discovering end of stream on each partition.");
+                foreach (var partitionId in partitions)
+                {
+                    var lastEvent = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                    partitionOffsets.Add(partitionId, lastEvent.LastEnqueuedOffset);
+                    TestUtility.Log($"Partition {partitionId} has last message with offset {lastEvent.LastEnqueuedOffset}");
+                }
+
+                // Now send a set of messages with different partition keys.
+                TestUtility.Log($"Sending {NumberOfMessagesToSend} messages.");
+                Random rnd = new Random();
+                for (int i = 0; i < NumberOfMessagesToSend; i++)
+                {
+                    var partitionKey = rnd.Next(10);
+                    await ehClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")), partitionKey.ToString());
+                }
+
+                // It is time to receive all messages that we just sent.
+                // Prepare partition key to partition map while receiving.
+                // Validation: All messages of a partition key should be received from a single partition.
+                TestUtility.Log("Starting to receive all messages from each partition.");
+                var receiveTasks = new Dictionary<string, Task<List<EventData>>>();
+
+                foreach (var partitionId in partitions)
+                {
+                    var receiver = ehClient.CreateReceiver(
+                        PartitionReceiver.DefaultConsumerGroupName,
+                        partitionId,
+                        EventPosition.FromOffset(partitionOffsets[partitionId]));
+
+                    receivers.Add(receiver);
+                    receiveTasks.Add(partitionId, ReceiveAllMessagesAsync(receiver));
+                }
+
+                var partitionMap = new Dictionary<string, string>();
+
                 foreach (var receiveTask in receiveTasks)
                 {
                     var partitionId = receiveTask.Key;
@@ -80,10 +84,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                foreach (var receiver in receivers)
-                {
-                    await receiver.CloseAsync();
-                }
+                await Task.WhenAll(receivers.Select(receiver => receiver.CloseAsync()));
+                await ehClient.CloseAsync();
             }
 
             Assert.True(totalReceived == NumberOfMessagesToSend,
@@ -97,14 +99,23 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var bodySize = 250 * 1024;
             var targetPartition = "0";
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            var edToSend = new EventData(new byte[bodySize]);
+            try
+            {
+                using (var edToSend = new EventData(new byte[bodySize]))
+                {
+                    TestUtility.Log($"Sending one message with body size {bodySize} bytes.");
+                    var edReceived = await SendAndReceiveEventAsync(targetPartition, edToSend, ehClient);
 
-            TestUtility.Log($"Sending one message with body size {bodySize} bytes.");
-            var edReceived = await SendAndReceiveEventAsync(targetPartition, edToSend);
-
-            // Validate body size.
-            Assert.True(edReceived.Body.Count == bodySize, $"Sent {bodySize} bytes and received {edReceived.Body.Count}");
+                    // Validate body size.
+                    Assert.True(edReceived.Body.Count == bodySize, $"Sent {bodySize} bytes and received {edReceived.Body.Count}");
+                }
+            }
+            finally
+            {
+                await ehClient.CloseAsync();
+            }
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverTests.cs
@@ -18,13 +18,25 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionReceiverReceive()
         {
-            string partitionId = "1";
-            string payloadString = "Hello EventHub!";
+            var partitionId = "1";
+            var payloadString = "Hello EventHub!";
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            TestUtility.Log("Receiving Events via PartitionReceiver.ReceiveAsync");
-            var sendEvent = new EventData(Encoding.UTF8.GetBytes(payloadString));
-            var receivedEvent = await SendAndReceiveEventAsync(partitionId, sendEvent);
-            Assert.True(Encoding.UTF8.GetString(receivedEvent.Body.Array) == payloadString, "Received payload string isn't the same as sent payload string.");
+            try
+            {
+                TestUtility.Log("Receiving Events via PartitionReceiver.ReceiveAsync");
+
+                using (var sendEvent = new EventData(Encoding.UTF8.GetBytes(payloadString)))
+                using (var receivedEvent = await SendAndReceiveEventAsync(partitionId, sendEvent, ehClient))
+                {
+                    Assert.True(Encoding.UTF8.GetString(receivedEvent.Body.Array) == payloadString, "Received payload string isn't the same as sent payload string.");
+                }
+
+            }
+            finally
+            {
+                await ehClient.CloseAsync();
+            }
         }
 
         [Fact]
@@ -32,26 +44,32 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateReceiverWithEndOfStream()
         {
-            // Randomly pick one of the available partitons.
-            var partitionId = this.PartitionIds[new Random().Next(this.PartitionIds.Count())];
-            TestUtility.Log($"Randomly picked partition {partitionId}");
-
-            var partitionSender = this.EventHubClient.CreatePartitionSender(partitionId);
-
-            // Send couple of messages before creating an EndOfStream receiver.
-            // We are not expecting to receive these messages would be sent before receiver creation.
-            for (int i = 0; i < 10; i++)
-            {
-                var ed = new EventData(new byte[1]);
-                await partitionSender.SendAsync(ed);
-            }
-
-            // Create a new receiver which will start reading from the end of the stream.
-            TestUtility.Log($"Creating a new receiver with offset EndOFStream");
-            var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnd());
+            var receiver = default(PartitionReceiver);
+            var partitionSender = default(PartitionSender);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
             try
             {
+                // Randomly pick one of the available partitons.
+                var partitions = await this.GetPartitionsAsync(ehClient);
+                var partitionId = partitions[new Random().Next(partitions.Length)];
+                TestUtility.Log($"Randomly picked partition {partitionId}");
+
+                partitionSender = ehClient.CreatePartitionSender(partitionId);
+
+                // Send couple of messages before creating an EndOfStream receiver.
+                // We are not expecting to receive these messages would be sent before receiver creation.
+                for (int i = 0; i < 10; i++)
+                {
+                    var ed = new EventData(new byte[1]);
+                    await partitionSender.SendAsync(ed);
+                }
+
+                // Create a new receiver which will start reading from the end of the stream.
+                TestUtility.Log($"Creating a new receiver with offset EndOFStream");
+                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnd());
+
+
                 // Attemp to receive the message. This should return only 1 message.
                 var receiveTask = receiver.ReceiveAsync(100);
 
@@ -81,8 +99,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await partitionSender.CloseAsync();
-                await receiver.CloseAsync();
+                await Task.WhenAll(
+                    partitionSender.CloseAsync(),
+                    receiver.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -91,25 +111,28 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateReceiverWithOffset()
         {
-            // Randomly pick one of the available partitons.
-            var partitionId = this.PartitionIds[new Random().Next(this.PartitionIds.Count())];
-            TestUtility.Log($"Randomly picked partition {partitionId}");
-
-            // Send and receive a message to identify the end of stream.
-            var pInfo = await this.EventHubClient.GetPartitionRuntimeInformationAsync(partitionId);
-
-            // Send a new message which is expected to go to the end of stream.
-            // We are expecting to receive only this message.
-            var eventSent = new EventData(new byte[1]);
-            eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
-            await this.EventHubClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
-
-            // Create a new receiver which will start reading from the last message on the stream.
-            TestUtility.Log($"Creating a new receiver with offset {pInfo.LastEnqueuedOffset}");
-            var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset));
+            var receiver = default(PartitionReceiver);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
             try
             {
+                // Randomly pick one of the available partitons.
+                var partitions = await this.GetPartitionsAsync(ehClient);
+                var partitionId = partitions[new Random().Next(partitions.Length)];
+                TestUtility.Log($"Randomly picked partition {partitionId}");
+
+                // Send and receive a message to identify the end of stream.
+                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+
+                // Send a new message which is expected to go to the end of stream.
+                // We are expecting to receive only this message.
+                var eventSent = new EventData(new byte[1]);
+                eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
+                await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
+
+                // Create a new receiver which will start reading from the last message on the stream.
+                TestUtility.Log($"Creating a new receiver with offset {pInfo.LastEnqueuedOffset}");
+                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset));
                 var receivedMessages = await receiver.ReceiveAsync(100);
 
                 // We should have received only 1 message from this call.
@@ -127,7 +150,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await receiver.CloseAsync();
+                await Task.WhenAll(
+                     receiver.CloseAsync(),
+                     ehClient.CloseAsync());
             }
         }
 
@@ -136,25 +161,28 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateReceiverWithInclusiveOffset()
         {
-            // Randomly pick one of the available partitons.
-            var partitionId = this.PartitionIds[new Random().Next(this.PartitionIds.Count())];
-            TestUtility.Log($"Randomly picked partition {partitionId}");
-
-            await TestUtility.SendToPartitionAsync(this.EventHubClient, partitionId, $"{partitionId} event.");
-
-            // Find out where to start reading on the partition.
-            var pInfo = await this.EventHubClient.GetPartitionRuntimeInformationAsync(partitionId);
-
-            // Send a message which is expected to go to the end of stream.
-            // We are expecting to receive this message as well.
-            await TestUtility.SendToPartitionAsync(this.EventHubClient, partitionId, $"{partitionId} event.");
-
-            // Create a new receiver which will start reading from the last message on the stream.
-            TestUtility.Log($"Creating a new receiver with offset {pInfo.LastEnqueuedOffset}");
-            var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset, true));
+            var receiver = default(PartitionReceiver);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
             try
             {
+                // Randomly pick one of the available partitons.
+                var partitions = await this.GetPartitionsAsync(ehClient);
+                var partitionId = partitions[new Random().Next(partitions.Length)];
+                TestUtility.Log($"Randomly picked partition {partitionId}");
+
+                await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
+
+                // Find out where to start reading on the partition.
+                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+
+                // Send a message which is expected to go to the end of stream.
+                // We are expecting to receive this message as well.
+                await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
+
+                // Create a new receiver which will start reading from the last message on the stream.
+                TestUtility.Log($"Creating a new receiver with offset {pInfo.LastEnqueuedOffset}");
+                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset, true));
                 var receivedMessages =  await ReceiveAllMessagesAsync(receiver);
 
                 // We should have received only 1 message from this call.
@@ -166,7 +194,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await receiver.CloseAsync();
+                await Task.WhenAll(
+                     receiver.CloseAsync(),
+                     ehClient.CloseAsync());
             }
         }
 
@@ -175,25 +205,28 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateReceiverWithDateTime()
         {
-            // Randomly pick one of the available partitons.
-            var partitionId = this.PartitionIds[new Random().Next(this.PartitionIds.Count())];
-            TestUtility.Log($"Randomly picked partition {partitionId}");
-
-            // Send and receive a message to identify the end of stream.
-            var pInfo = await this.EventHubClient.GetPartitionRuntimeInformationAsync(partitionId);
-
-            // Send a new message which is expected to go to the end of stream.
-            // We are expecting to receive only this message.
-            var eventSent = new EventData(new byte[1]);
-            eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
-            await this.EventHubClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
-
-            // Create a new receiver which will start reading from the last message on the stream.
-            TestUtility.Log($"Creating a new receiver with date-time {pInfo.LastEnqueuedTimeUtc}");
-            var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(pInfo.LastEnqueuedTimeUtc));
+            var receiver = default(PartitionReceiver);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
             try
             {
+                // Randomly pick one of the available partitons.
+                var partitions = await this.GetPartitionsAsync(ehClient);
+                var partitionId = partitions[new Random().Next(partitions.Length)];
+                TestUtility.Log($"Randomly picked partition {partitionId}");
+
+                // Send and receive a message to identify the end of stream.
+                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+
+                // Send a new message which is expected to go to the end of stream.
+                // We are expecting to receive only this message.
+                var eventSent = new EventData(new byte[1]);
+                eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
+                await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
+
+                // Create a new receiver which will start reading from the last message on the stream.
+                TestUtility.Log($"Creating a new receiver with date-time {pInfo.LastEnqueuedTimeUtc}");
+                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(pInfo.LastEnqueuedTimeUtc));
                 var receivedMessages = await receiver.ReceiveAsync(100);
 
                 // We should have received only 1 message from this call.
@@ -211,34 +244,39 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await receiver.CloseAsync();
+                await Task.WhenAll(
+                    receiver.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
-        [Fact(Skip = "This test was disabled by removing the [Fact]")]
+        [Fact(Skip = "This test was disabled by removing the [Fact] prior to the central migration")]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task CreateReceiverWithSequenceNumber()
         {
-            // Randomly pick one of the available partitons.
-            var partitionId = this.PartitionIds[new Random().Next(this.PartitionIds.Count())];
-            TestUtility.Log($"Randomly picked partition {partitionId}");
-
-            // Send and receive a message to identify the end of stream.
-            var pInfo = await this.EventHubClient.GetPartitionRuntimeInformationAsync(partitionId);
-
-            // Send a new message which is expected to go to the end of stream.
-            // We are expecting to receive only this message.
-            var eventSent = new EventData(new byte[1]);
-            eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
-            await this.EventHubClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
-
-            // Create a new receiver which will start reading from the last message on the stream.
-            TestUtility.Log($"Creating a new receiver with sequence number {pInfo.LastEnqueuedSequenceNumber}");
-            var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromSequenceNumber(pInfo.LastEnqueuedSequenceNumber));
+            var receiver = default(PartitionReceiver);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
             try
             {
+                // Randomly pick one of the available partitons.
+                var partitions = await this.GetPartitionsAsync(ehClient);
+                var partitionId = partitions[new Random().Next(partitions.Length)];
+                TestUtility.Log($"Randomly picked partition {partitionId}");
+
+                // Send and receive a message to identify the end of stream.
+                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+
+                // Send a new message which is expected to go to the end of stream.
+                // We are expecting to receive only this message.
+                var eventSent = new EventData(new byte[1]);
+                eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
+                await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
+
+                // Create a new receiver which will start reading from the last message on the stream.
+                TestUtility.Log($"Creating a new receiver with sequence number {pInfo.LastEnqueuedSequenceNumber}");
+                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromSequenceNumber(pInfo.LastEnqueuedSequenceNumber));
                 var receivedMessages = await receiver.ReceiveAsync(100);
 
                 // We should have received only 1 message from this call.
@@ -256,34 +294,39 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await receiver.CloseAsync();
+                await Task.WhenAll(
+                    receiver.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
-        [Fact(Skip = "This test was disabled by removing the [Fact]")]
+        [Fact(Skip = "This test was disabled by removing the [Fact] prior to the central migration")]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task CreateReceiverWithInclusiveSequenceNumber()
         {
-            // Randomly pick one of the available partitons.
-            var partitionId = this.PartitionIds[new Random().Next(this.PartitionIds.Count())];
-            TestUtility.Log($"Randomly picked partition {partitionId}");
-
-            await TestUtility.SendToPartitionAsync(this.EventHubClient, partitionId, $"{partitionId} event.");
-
-            // Find out where to start reading on the partition.
-            var pInfo = await this.EventHubClient.GetPartitionRuntimeInformationAsync(partitionId);
-
-            // Send a message which is expected to go to the end of stream.
-            // We are expecting to receive this message as well.
-            await TestUtility.SendToPartitionAsync(this.EventHubClient, partitionId, $"{partitionId} event.");
-
-            // Create a new receiver which will start reading from the last message on the stream.
-            TestUtility.Log($"Creating a new receiver with sequence number {pInfo.LastEnqueuedSequenceNumber}");
-            var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromSequenceNumber(pInfo .LastEnqueuedSequenceNumber, true));
+            var receiver = default(PartitionReceiver);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
             try
             {
+                // Randomly pick one of the available partitons.
+                var partitions = await this.GetPartitionsAsync(ehClient);
+                var partitionId = partitions[new Random().Next(partitions.Length)];
+                TestUtility.Log($"Randomly picked partition {partitionId}");
+
+                await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
+
+                // Find out where to start reading on the partition.
+                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+
+                // Send a message which is expected to go to the end of stream.
+                // We are expecting to receive this message as well.
+                await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
+
+                // Create a new receiver which will start reading from the last message on the stream.
+                TestUtility.Log($"Creating a new receiver with sequence number {pInfo.LastEnqueuedSequenceNumber}");
+                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromSequenceNumber(pInfo .LastEnqueuedSequenceNumber, true));
                 var receivedMessages = await receiver.ReceiveAsync(100);
 
                 // We should have received only 1 message from this call.
@@ -295,7 +338,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await receiver.CloseAsync();
+                await Task.WhenAll(
+                    receiver.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -307,8 +352,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             const int MaxBatchSize = 5;
             TestUtility.Log("Receiving Events via PartitionReceiver.ReceiveAsync(BatchSize)");
             const string partitionId = "0";
-            PartitionSender partitionSender = this.EventHubClient.CreatePartitionSender(partitionId);
-            PartitionReceiver partitionReceiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(-10)));
+
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var partitionSender = ehClient.CreatePartitionSender(partitionId);
+            var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(-10)));
 
             try
             {
@@ -340,8 +387,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await partitionReceiver.CloseAsync();
-                await partitionSender.CloseAsync();
+                await Task.WhenAll(
+                    partitionReceiver.CloseAsync(),
+                    partitionSender.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -351,8 +400,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task PartitionReceiverEpochReceive()
         {
             TestUtility.Log("Testing EpochReceiver semantics");
-            var epochReceiver1 = this.EventHubClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
-            var epochReceiver2 = this.EventHubClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 2);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var epochReceiver1 = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
+            var epochReceiver2 = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 2);
             try
             {
                 // Read the events from Epoch 1 Receiver until we're at the end of the stream
@@ -395,8 +445,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await epochReceiver1.CloseAsync();
-                await epochReceiver2.CloseAsync();
+                await Task.WhenAll(
+                    epochReceiver1.CloseAsync(),
+                    epochReceiver2.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -405,8 +457,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateNonEpochReceiverAfterEpochReceiver()
         {
-            var epochReceiver = this.EventHubClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
-            var nonEpochReceiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var epochReceiver = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
+            var nonEpochReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
 
             try
             {
@@ -428,8 +481,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await epochReceiver.CloseAsync();
-                await nonEpochReceiver.CloseAsync();
+                await Task.WhenAll(
+                    epochReceiver.CloseAsync(),
+                    nonEpochReceiver.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -438,8 +493,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateEpochReceiverAfterNonEpochReceiver()
         {
-            var nonEpochReceiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
-            var epochReceiver = this.EventHubClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var nonEpochReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
+            var epochReceiver = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
 
             try
             {
@@ -466,8 +522,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
             finally
             {
-                await epochReceiver.CloseAsync();
-                await nonEpochReceiver.CloseAsync();
+                await Task.WhenAll(
+                    epochReceiver.CloseAsync(),
+                    nonEpochReceiver.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -476,8 +534,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CloseReceiverClient()
         {
-            var pSender = this.EventHubClient.CreatePartitionSender("0");
-            var pReceiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var pSender = ehClient.CreatePartitionSender("0");
+            var pReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
 
             try
             {
@@ -492,14 +551,15 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             finally
             {
                 TestUtility.Log("Closing partition receiver");
-                await pReceiver.CloseAsync();
+                await Task.WhenAll(
+                    pReceiver.CloseAsync(),
+                    ehClient.CloseAsync());
             }
 
             await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
             {
                 TestUtility.Log("Receiving another event from partition 0 on the closed receiver, this should fail");
                 await pReceiver.ReceiveAsync(1);
-                throw new InvalidOperationException("Receive should have failed");
             });
         }
 
@@ -508,14 +568,15 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task ReceiverIdentifier()
         {
-            List<PartitionReceiver> receivers = new List<PartitionReceiver>();
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var receivers = new List<PartitionReceiver>();
 
             try
             {
                 for (int i=0; i < 5; i++)
                 {
                     TestUtility.Log($"Creating receiver {i}");
-                    var newReceiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(),
+                    var newReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(),
                         new ReceiverOptions()
                         {
                             Identifier = $"receiver{i}"
@@ -529,7 +590,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 try
                 {
                     // Attempt to create 6th receiver. This should fail.
-                    var failReceiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
+                    var failReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
                     await failReceiver.ReceiveAsync(10);
                     throw new InvalidOperationException("6th receiver should have encountered QuotaExceededException.");
                 }
@@ -547,7 +608,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 // Close all receivers.
                 foreach (var receiver in receivers)
                 {
-                    await receiver.CloseAsync();
+                    await Task.WhenAll(
+                        receiver.CloseAsync(),
+                        ehClient.CloseAsync());
                 }
             }
         }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
@@ -19,11 +19,22 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task SendAndReceiveZeroLengthBody()
         {
             var targetPartition = "0";
-            var zeroBodyEventData = new EventData(new byte[0]);
-            var edReceived = await SendAndReceiveEventAsync(targetPartition, zeroBodyEventData);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            // Validate body.
-            Assert.True(edReceived.Body.Count == 0, $"Received event's body isn't zero byte long.");
+            try
+            {
+                using (var zeroBodyEventData = new EventData(new byte[0]))
+                {
+                    var edReceived = await SendAndReceiveEventAsync(targetPartition, zeroBodyEventData, ehClient);
+
+                    // Validate body.
+                    Assert.True(edReceived.Body.Count == 0, $"Received event's body isn't zero byte long.");
+                }
+            }
+            finally
+            {
+                await ehClient.CloseAsync();
+            }
         }
 
         [Fact]
@@ -32,8 +43,20 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task SendSingleEvent()
         {
             TestUtility.Log("Sending single Event via EventHubClient.SendAsync(EventData, string)");
-            var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!"));
-            await this.EventHubClient.SendAsync(eventData, "SomePartitionKeyHere");
+
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+
+            try
+            {
+                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!")))
+                {
+                    await ehClient.SendAsync(eventData, "SomePartitionKeyHere");
+                }
+            }
+            finally
+            {
+                await ehClient.CloseAsync();
+            }
         }
 
         [Fact]
@@ -42,10 +65,22 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task SendBatch()
         {
             TestUtility.Log("Sending multiple Events via EventHubClient.SendAsync(IEnumerable<EventData>)");
-            var eventData1 = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-            var eventData2 = new EventData(Encoding.UTF8.GetBytes("This is another message in the batch!"));
-            eventData2.Properties["ContosoEventType"] = "some value here";
-            await this.EventHubClient.SendAsync(new[] { eventData1, eventData2 });
+
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+
+            try
+            {
+                using (var eventData1 = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
+                using (var eventData2 = new EventData(Encoding.UTF8.GetBytes("This is another message in the batch!")))
+                {
+                    eventData2.Properties["ContosoEventType"] = "some value here";
+                    await ehClient.SendAsync(new[] { eventData1, eventData2 });
+                }
+            }
+            finally
+            {
+                await ehClient.CloseAsync();
+            }
         }
 
         [Fact]
@@ -54,15 +89,22 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task PartitionSenderSend()
         {
             TestUtility.Log("Sending single Event via PartitionSender.SendAsync(EventData)");
-            PartitionSender partitionSender1 = this.EventHubClient.CreatePartitionSender("1");
+
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var partitionSender1 = ehClient.CreatePartitionSender("1");
+
             try
             {
-                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello again EventHub Partition 1!"));
-                await partitionSender1.SendAsync(eventData);
+                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello again EventHub Partition 1!")))
+                {
+                    await partitionSender1.SendAsync(eventData);
+                }
             }
             finally
             {
-                await partitionSender1.CloseAsync();
+                await Task.WhenAll(
+                    partitionSender1?.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -72,17 +114,24 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task PartitionSenderSendBatch()
         {
             TestUtility.Log("Sending single Event via PartitionSender.SendAsync(IEnumerable<EventData>)");
-            PartitionSender partitionSender1 = this.EventHubClient.CreatePartitionSender("1");
+
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var partitionSender1 = ehClient.CreatePartitionSender("1");
+
             try
             {
-                var eventData1 = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-                var eventData2 = new EventData(Encoding.UTF8.GetBytes("This is another message in the batch!"));
-                eventData2.Properties["ContosoEventType"] = "some value here";
-                await partitionSender1.SendAsync(new[] { eventData1, eventData2 });
+                using (var eventData1 = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
+                using (var eventData2 = new EventData(Encoding.UTF8.GetBytes("This is another message in the batch!")))
+                {
+                    eventData2.Properties["ContosoEventType"] = "some value here";
+                    await partitionSender1.SendAsync(new[] { eventData1, eventData2 });
+                }
             }
             finally
             {
-                await partitionSender1.CloseAsync();
+                await Task.WhenAll(
+                    partitionSender1?.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -92,13 +141,23 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task SendAndReceiveArraySegmentEventData()
         {
             var targetPartition = "0";
-            byte[] byteArr = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var byteArr = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            var edToSend = new EventData(new ArraySegment<byte>(byteArr));
-            var edReceived = await SendAndReceiveEventAsync(targetPartition, edToSend);
+            try
+            {
+                using (var edToSend = new EventData(new ArraySegment<byte>(byteArr)))
+                {
+                    var edReceived = await SendAndReceiveEventAsync(targetPartition, edToSend, ehClient);
 
-            // Validate array segment count.
-            Assert.True(edReceived.Body.Count == byteArr.Count(), $"Sent {byteArr.Count()} bytes and received {edReceived.Body.Count}");
+                    // Validate array segment count.
+                    Assert.True(edReceived.Body.Count == byteArr.Count(), $"Sent {byteArr.Count()} bytes and received {edReceived.Body.Count}");
+                }
+            }
+            finally
+            {
+                await ehClient.CloseAsync();
+            }
         }
 
         [Fact]
@@ -107,7 +166,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task MultipleClientsSend()
         {
             var maxNumberOfClients = 100;
-            var syncEvent = new ManualResetEventSlim(false);
+            var startGate = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             TestUtility.Log($"Starting {maxNumberOfClients} SendAsync tasks in parallel.");
 
@@ -116,17 +175,24 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             {
                 var task = Task.Run(async () =>
                 {
-                    syncEvent.Wait();
+                    await startGate.Task;
                     var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-                    await ehClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")));
+
+                    try
+                    {
+                        await ehClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")));
+                    }
+                    finally
+                    {
+                        await ehClient.CloseAsync();
+                    }
                 });
 
                 tasks.Add(task);
             }
 
-            var waitForAccountToInitialize = Task.Delay(10000);
-            await waitForAccountToInitialize;
-            syncEvent.Set();
+            await Task.Delay(10000);
+            startGate.TrySetResult(true);
             await Task.WhenAll(tasks);
 
             TestUtility.Log("All Send tasks have completed.");
@@ -137,29 +203,34 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CloseSenderClient()
         {
-            var pSender = this.EventHubClient.CreatePartitionSender("0");
-            var pReceiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var pSender = ehClient.CreatePartitionSender("0");
+            var pReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
 
             try
             {
                 TestUtility.Log("Sending single event to partition 0");
-                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-                await pSender.SendAsync(eventData);
-
-                TestUtility.Log("Closing partition sender");
-                await pSender.CloseAsync();
+                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
+                {
+                    await pSender.SendAsync(eventData);
+                    TestUtility.Log("Closing partition sender");
+                    await pSender.CloseAsync();
+                }
 
                 await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
                 {
                     TestUtility.Log("Sending another event to partition 0 on the closed sender, this should fail");
-                    eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-                    await pSender.SendAsync(eventData);
-                    throw new InvalidOperationException("Send should have failed");
+                    using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
+                    {
+                        await pSender.SendAsync(eventData);
+                    }
                 });
             }
             finally
             {
-                await pReceiver.CloseAsync();
+                await Task.WhenAll(
+                    pReceiver.CloseAsync(),
+                    ehClient.CloseAsync());
             }
         }
 
@@ -170,41 +241,56 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             string targetPartitionKey = "this is the partition key";
 
-            // Mark end of each partition so that we can start reading from there.
-            var partitions = await TestUtility.DiscoverEndOfStreamForPartitionsAsync(this.EventHubClient, this.PartitionIds);
+            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var receiver = default(PartitionReceiver);
 
-            // Send a batch of 2 messages.
-            var eventData1 = new EventData(Guid.NewGuid().ToByteArray());
-            var eventData2 = new EventData(Guid.NewGuid().ToByteArray());
-            await this.EventHubClient.SendAsync(new[] { eventData1, eventData2 }, targetPartitionKey);
-
-            // Now find out the partition where our messages landed.
-            var targetPartition = "";
-            foreach (var pId in this.PartitionIds)
+            try
             {
-                var pInfo = await this.EventHubClient.GetPartitionRuntimeInformationAsync(pId);
-                if (pInfo.LastEnqueuedOffset != partitions[pId])
+                // Mark end of each partition so that we can start reading from there.
+                var partitionIds = await this.GetPartitionsAsync(ehClient);
+                var partitions = await TestUtility.DiscoverEndOfStreamForPartitionsAsync(ehClient, partitionIds);
+
+                // Send a batch of 2 messages.
+                using (var eventData1 = new EventData(Guid.NewGuid().ToByteArray()))
+                using (var eventData2 = new EventData(Guid.NewGuid().ToByteArray()))
                 {
-                    targetPartition = pId;
-                    TestUtility.Log($"Batch landed on partition {targetPartition}");
+                    await ehClient.SendAsync(new[] { eventData1, eventData2 }, targetPartitionKey);
                 }
+
+                // Now find out the partition where our messages landed.
+                var targetPartition = "";
+                foreach (var pId in partitionIds)
+                {
+                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(pId);
+                    if (pInfo.LastEnqueuedOffset != partitions[pId])
+                    {
+                        targetPartition = pId;
+                        TestUtility.Log($"Batch landed on partition {targetPartition}");
+                    }
+                }
+
+                // Confirm that we identified the partition with our messages.
+                Assert.True(targetPartition != "", "None of the partition offsets moved.");
+
+                // Receive all messages from target partition.
+                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartition, EventPosition.FromOffset(partitions[targetPartition]));
+                var messages = await ReceiveAllMessagesAsync(receiver);
+
+                // Validate 2 messages received.
+                Assert.True(messages.Count == 2, $"Received {messages.Count} messages instead of 2.");
+
+                // Validate both messages carry correct partition id.
+                Assert.True(messages[0].SystemProperties.PartitionKey == targetPartitionKey,
+                    $"First message returned partition key value '{messages[0].SystemProperties.PartitionKey}'");
+                Assert.True(messages[1].SystemProperties.PartitionKey == targetPartitionKey,
+                    $"Second message returned partition key value '{messages[1].SystemProperties.PartitionKey}'");
             }
-
-            // Confirm that we identified the partition with our messages.
-            Assert.True(targetPartition != "", "None of the partition offsets moved.");
-
-            // Receive all messages from target partition.
-            var receiver = this.EventHubClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartition, EventPosition.FromOffset(partitions[targetPartition]));
-            var messages = await ReceiveAllMessagesAsync(receiver);
-
-            // Validate 2 messages received.
-            Assert.True(messages.Count == 2, $"Received {messages.Count} messages instead of 2.");
-
-            // Validate both messages carry correct partition id.
-            Assert.True(messages[0].SystemProperties.PartitionKey == targetPartitionKey,
-                $"First message returned partition key value '{messages[0].SystemProperties.PartitionKey}'");
-            Assert.True(messages[1].SystemProperties.PartitionKey == targetPartitionKey,
-                $"Second message returned partition key value '{messages[1].SystemProperties.PartitionKey}'");
+            finally
+            {
+                await Task.WhenAll(
+                    receiver?.CloseAsync(),
+                    ehClient.CloseAsync());
+            }
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
@@ -113,7 +113,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
                 var edToFail = new EventData(Encoding.UTF8.GetBytes("This is a sample event."));
                 await ehClient.SendAsync(edToFail);
-                throw new InvalidOperationException("Send call should have failed");
             });
 
             // Receive call should fail.
@@ -122,7 +121,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 var ehClient = EventHubClient.CreateFromConnectionString(webSocketConnString);
                 ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
                 await ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart()).ReceiveAsync(1);
-                throw new InvalidOperationException("Receive call should have failed");
             });
 
             // Management link call should fail.
@@ -131,13 +129,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 var ehClient = EventHubClient.CreateFromConnectionString(webSocketConnString);
                 ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
                 await ehClient.GetRuntimeInformationAsync();
-                throw new InvalidOperationException("GetRuntimeInformation call should have failed");
             });
 
             // Send/receive should work fine w/o proxy.
             var ehNoProxyClient = EventHubClient.CreateFromConnectionString(webSocketConnString);
             var eventData = new EventData(Encoding.UTF8.GetBytes("This is a sample event."));
-            await this.SendAndReceiveEventAsync("0", eventData, ehNoProxyClient);
         }
 #endif
     }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TaskExtensions.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TaskExtensions.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs.Tests
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    ///   The set of extension methods for the <see cref="Task" /> class.
+    /// </summary>
+    ///
+    public static class TaskExtensions
+    {
+        /// <summary>
+        ///   Executes a task with a timeout period, ignoring any result should the timeout period elapse.
+        /// </summary>
+        ///
+        /// <param name="instance">The target of task execution.</param>
+        /// <param name="timeout">The timeout period to allow for the <paramref name="instance"/> to complete.</param>
+        /// <param name="cancellationToken">A cancellation token for signaling the <paramref name="instance" /> that a timeout has occurred and work should be stopped.</param>
+        /// <param name="timeoutAction">An action to take on timeout; if not specified, a <see cref="TimeoutException" /> will be thrown.</param>
+        ///
+        /// <returns>A task to be resolved on completion or timeout.</returns>
+        ///
+        public static async Task WithTimeout(this Task instance, TimeSpan timeout, CancellationTokenSource cancellationToken = null, Action timeoutAction = null)
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            if (instance.IsCompleted || Debugger.IsAttached)
+            {
+                return;
+            }
+
+            using (var timeoutTokenSource = new CancellationTokenSource())
+            {
+                if (instance == await Task.WhenAny(instance, Task.Delay(timeout, timeoutTokenSource.Token)))
+                {
+                    timeoutTokenSource.Cancel();
+                    instance.GetAwaiter().GetResult();
+                    return;
+                }
+            }
+
+            // A timeout occured.  Perform the needed actions to request cancellation, allow the task to
+            // complete unobserved, and to signal the caller.
+            cancellationToken?.Cancel();
+
+            if (timeoutAction != null)
+            {
+                timeoutAction();
+                return;
+            }
+
+            throw new TimeoutException();
+        }
+
+        /// <summary>
+        ///   Executes a task with a timeout period, ignoring any result should the timeout period elapse.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The type of return value of the task.</typeparam>
+        ///
+        /// <param name="instance">The target of task execution.</param>
+        /// <param name="timeout">The timeout period to allow for the <paramref name="instance"/> to complete.</param>
+        /// <param name="cancellationToken">A cancellation token for signaling the <paramref name="instance" /> that a timeout has occurred and work should be stopped.</param>
+        /// <param name="timeoutCallback">An action to take on timeout which is expected to produce the value of <typeparamref name="T"/> to be used as the result; if not specified, a <see cref="TimeoutException" /> will be thrown.</param>
+        ///
+        /// <returns>A task to be resolved on completion or timeout.</returns>
+        ///
+        public static async Task<T> WithTimeout<T>(this Task<T> instance, TimeSpan timeout, CancellationTokenSource cancellationToken = null, Func<T> timeoutCallback = null)
+        {
+            if (instance == null)
+            {
+                throw new ArgumentNullException(nameof(instance));
+            }
+
+            if (instance.IsCompleted || Debugger.IsAttached)
+            {
+                return await instance;
+            }
+
+            using (var timeoutTokenSource = new CancellationTokenSource())
+            {
+                if (instance == await Task.WhenAny(instance, Task.Delay(timeout, timeoutTokenSource.Token)))
+                {
+                    timeoutTokenSource.Cancel();
+                    return instance.GetAwaiter().GetResult();
+                }
+            }
+
+            // A timeout occured.  Perform the needed actions to request cancellation, allow the task to
+            // complete unobserved, and to signal the caller.
+            cancellationToken?.Cancel();
+
+            if (timeoutCallback != null)
+            {
+                return timeoutCallback();
+            }
+
+            throw new TimeoutException();
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Instrastructure.Tests/TaskExtensionTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Instrastructure.Tests/TaskExtensionTests.cs
@@ -1,0 +1,195 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.EventHubs.Tests
+{
+    using System;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    public class TaskExtensionsTests
+    {
+        // It has been observed during the CI build that test runs can cause delays that were noted at
+        // 1-2 seconds and were causing intermitten failures as a result.  The long delay has been set at 5
+        // seconds arbitrarily, which may delay results should tests fail but is otherwise not expected to
+        // be an actual wait time under normal circumstances.
+        private readonly TimeSpan LongDelay = TimeSpan.FromSeconds(5);
+        private readonly TimeSpan TinyDelay = TimeSpan.FromMilliseconds(1);
+
+        [Fact]
+        public void WithTimeoutThrowsWhenATimeoutOccursAndNoActionIsSpecified()
+        {
+            Func<Task> actionUnderTest = async () =>
+                await Task.Delay(LongDelay)
+                    .WithTimeout(TinyDelay);
+
+            Assert.ThrowsAsync<TimeoutException>(actionUnderTest);
+        }
+
+        [Fact]
+        public async Task WithTimeoutExecutesTheTimeoutActionWhenATimeoutOccurs()
+        {
+            var timeoutActionInvoked = false;
+
+            Action timeoutAction = () => { timeoutActionInvoked = true; };
+
+            await Task.Delay(LongDelay).WithTimeout(TinyDelay, null, timeoutAction);
+            Assert.True(timeoutActionInvoked, "The timeout action should have been invoked.");
+        }
+
+        [Fact]
+        public async Task WithTimeoutGenericThrowsWhenATimeoutOccursAndNoActionIsSpecified()
+        {
+            Func<Task> actionUnderTest = async () =>
+                await Task.Delay(LongDelay)
+                    .ContinueWith( _ => "blue")
+                    .WithTimeout(TinyDelay);
+
+            await Assert.ThrowsAsync<TimeoutException>(actionUnderTest);
+        }
+
+        [Fact]
+        public async Task WithTimeoutGeneticExecutesTheTimeoutCallbackWhenATimeoutOccurs()
+        {
+            var timeoutActionInvoked = false;
+            var expectedResult = "green";
+
+            Func<string> timeoutCallback = () =>
+            {
+                timeoutActionInvoked = true;
+                return expectedResult;
+            };
+
+            var result = await Task.Delay(LongDelay)
+                .ContinueWith( _ => "blue")
+                .WithTimeout(TinyDelay, null, timeoutCallback);
+
+            Assert.True(timeoutActionInvoked, "The timeout action should have been invoked.");
+            Assert.Equal(expectedResult, result);
+        }
+
+        [Fact]
+        public async Task WithTimeoutDoesNotThrowWhenATimeoutDoesNotOccur()
+        {
+            var exceptionObserved = false;
+
+            try
+            {
+                await Task.Delay(TinyDelay).WithTimeout(LongDelay);
+            }
+            catch (TimeoutException)
+            {
+                exceptionObserved = true;
+            }
+
+            Assert.False(exceptionObserved, "There should not have been a timeout exception thrown.");
+        }
+
+        [Fact]
+        public async Task WithTimeoutGenericDoesNotThrowsWhenATimeoutDoesNotOccur()
+        {
+            var exceptionObserved = false;
+
+            try
+            {
+                await Task.Delay(TinyDelay).ContinueWith( _ => "blue").WithTimeout(LongDelay);
+            }
+            catch (TimeoutException)
+            {
+                exceptionObserved = true;
+            }
+
+            Assert.False(exceptionObserved, $"There should not have been a timeout exception thrown.");
+        }
+
+        [Fact]
+        public async Task WithTimeoutGenericReturnsTheValueWhenATimeoutDoesNotOccur()
+        {
+            var expected = "hello";
+            var result = await  Task.Delay(TinyDelay).ContinueWith( _ => expected).WithTimeout(LongDelay);
+            Assert.Equal(result, expected);
+        }
+
+        [Fact]
+        public async Task WithTimeoutPropagatesAnExceptionForACompletedTask()
+        {
+            var completionSource = new TaskCompletionSource<object>();
+            completionSource.SetException(new MissingFieldException("oops"));
+
+            Func<Task> actionUnderTest = async () => await completionSource.Task.WithTimeout(LongDelay);
+            await Assert.ThrowsAsync<MissingFieldException>(actionUnderTest);
+        }
+
+        [Fact]
+        public async Task WithTimeoutPropagatesAnExceptionThatCompletesBeforeTimeout()
+        {
+            Func<Task> actionUnderTest = async () =>
+                await Task.Delay(TinyDelay)
+                    .ContinueWith( _ => throw new MissingMemberException("oh no"))
+                    .WithTimeout(LongDelay);
+
+            await Assert.ThrowsAsync<MissingMemberException>(actionUnderTest);
+        }
+
+        [Fact]
+        public async Task WithTimeoutGenericPropagatesAnExceptionThatCompletesBeforeTimeout()
+        {
+           Func<Task> actionUnderTest = async () =>
+               await Task.Delay(TinyDelay)
+                   .ContinueWith<string>( _ => throw new MissingMemberException("oh no"))
+                   .WithTimeout(LongDelay);
+
+            await Assert.ThrowsAsync<MissingMemberException>(actionUnderTest);
+        }
+
+        [Fact]
+        public async Task WithTimeoutPropagatesACancelledTask()
+        {
+            var completionSource = new TaskCompletionSource<object>();
+            completionSource.SetCanceled();
+
+            Func<Task> actionUnderTest = async () => await completionSource.Task.WithTimeout(LongDelay);
+            await Assert.ThrowsAsync<TaskCanceledException>(actionUnderTest);
+        }
+
+        [Fact]
+        public async Task WithTimeoutInvokesTheCancellationTokenWhenATimeoutOccurs()
+        {
+            var token = new CancellationTokenSource();
+
+            try
+            {
+                await Task.Delay(LongDelay).WithTimeout(TinyDelay, token);
+            }
+
+            catch (TimeoutException)
+            {
+                // Expected; do nothing
+            }
+
+            Assert.True(token.IsCancellationRequested, "The cancellation should be requested at timeout.");
+        }
+
+        [Fact]
+        public async Task WithTimeoutGenericInvokesTheCancellationTokenWhenATimeoutOccurs()
+        {
+            var token  = new CancellationTokenSource();
+
+            try
+            {
+                await Task.Delay(LongDelay)
+                    .ContinueWith( _ => "hello")
+                    .WithTimeout(TinyDelay, token);
+            }
+
+            catch (TimeoutException)
+            {
+                // Expected; do nothing
+            }
+
+            Assert.True(token.IsCancellationRequested, "The cancellation should be requested at timeout.");
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The goal of these changes to help improve the Event Hubs test suite, primarily focused on increased compatibility with the central engineering system, consistency during nightly runs, and working towards tests which are fully isolated and safe to run in parallel.

# Goals

- Refactor tests relying on class-level state and using class disposal to clean up;  tests will own their own resources and have responsibility for managing their lifespan.

- Revise the approach used for synchronization in tests utilizing `ManualResetEvents` and similar primitives; these will be converted to `TaskCompletionSource` instances to align better with the `async` patterns.

- Make minor improvements to overall quality and approach while working through the code; attempt to provide consistency and embrace common patterns.

# Non-Goals

- Refactoring of the general implementation, approach for testing, the test cases, code style, and other artifacts of the codebase; changes should be kept as tightly scoped and as minimal as possible.

- Adding of additional test cases or new testing scenarios.

- Enabling test parallelism; this will be a stretch goal in the second phase of these efforts.

# Details 

###  Infrastructure

A set of task extensions has been added to normalize the technique used for applying a timeout to asynchronous activities, ensuring that it is done in a consistent way, and also improving readability.

###  Class-Level State Restructuring

A number of tests were employing the the pattern of creating class-level messaging entities within each test and relying on the `IDisposible` mechanism to clean up those instances, which makes the flow less clear and, depending on the test runner in use, potentially impacts the ability to run tests in parallel.   

These have been refactored to scope resources used to the test itself, with the goal of keeping tests self-contained.

### Synchronization Primitives Revisions

Some tests were making use of `ManualResetEvents` as synchronization gates to coordinate the flow around asynchronous activities, which required blocking and may lead to thread pool issues.  These have been refactored to make use of `TaskCompletionSource`, allowing them to be awaited in  non-blocking fashion.

### Enforcing Isolated and Sequential Testing for Diagnostics

Because they deal with global resources, the diagnostics tests are not safe to run in parallel with other classes, assemblies, nor test cases. Applied metadata to isolate them to a single unit of execution with parallelism disabled;  this will ensure that future efforts towards paralellizing tests do not impact the diagnostics tests.

 ### Miscellaneous Refactoring

Other minor improvements were made in the tests, such as changing the approach for error expectations from `try`/`catch` blocks to `Assert.ThrowsAsync` use, ensuring that disposable objects were cleaned up and attempting to normalize styles.

# Last Upstream Rebase

Thursday, May 2, 2019 4:47pm (EDT)

# Related and Follow-Up Issues

- [[Epic][Event Hubs Client] Test Suite Improvements](https://github.com/Azure/azure-sdk-for-net/issues/5982) (#5982)
- [[Event Hubs Client] Revisit Tests with Class-Level State and Cleanup](https://github.com/Azure/azure-sdk-for-net/issues/5986) (#5986)
- [[Event Hubs Client] Enable Tests to Manage Service Needs](https://github.com/Azure/azure-sdk-for-net/issues/5987) (#5987)
- [[Event Hubs Client] Enable Test Parallelization](https://github.com/Azure/azure-sdk-for-net/issues/5988) (#5988)
- [[Event Hubs Client] Revisit Live Test Timing Dependencies](https://github.com/Azure/azure-sdk-for-net/issues/5989) (#5989)
- [[Event Hubs Client] Cleanup for Orphaned Live Test Entities](https://github.com/Azure/azure-sdk-for-net/issues/5983) (#5983)