### PR TITLE
[Service Bus Client] Dependency Version Revisions

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Microsoft.Azure.ServiceBus.Tests.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Microsoft.Azure.ServiceBus.Tests.csproj
@@ -27,7 +27,7 @@
 
   <ItemGroup Condition="'$(IsTargetingNetFx)' == 'true'">
     <Reference Include="System.Transactions" />
-    <PackageReference Include="WindowsAzure.ServiceBus" Version="5.1.0" />
+    <PackageReference Include="WindowsAzure.ServiceBus" Version="5.2.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,8 +38,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="PublicApiGenerator" Version="8.1.0" />
-    <PackageReference Include="ApprovalTests" Version="3.0.21" NoWarn="NU1701" />
-    <PackageReference Include="ApprovalUtilities" Version="3.0.21" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalTests" Version="3.0.22" NoWarn="NU1701" />
+    <PackageReference Include="ApprovalUtilities" Version="3.0.22" NoWarn="NU1701" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
   </ItemGroup>
 


### PR DESCRIPTION
# Summary

Update package versions for dependencies that were identified via pull requests in the stand-alone repository.

# Goals

- Address the updates that were expressed as pull requests in the stand-alone repository, so that they can be closed.

# Non-Goals

- Revise dependency versions that were not associated with an open pull request.

- Refactoring of the general implementation, approach for testing, the test cases, code style, and other artifacts of the codebase; changes should be kept as tightly scoped and as minimal as possible.

# Last Upstream Rebase

Thursday, May 2, 2019 12:30pm (EDT)

# Related and Follow-Up Issues

- [Bump WindowsAzure.ServiceBus from 5.1.0 to 5.2.0](https://github.com/Azure/azure-service-bus-dotnet/pull/686) (#686)
- [Bump ApprovalUtilities from 3.0.21 to 3.0.22](https://github.com/Azure/azure-service-bus-dotnet/pull/681) (#681)
- [Bump ApprovalTests from 3.0.21 to 3.0.22](https://github.com/Azure/azure-service-bus-dotnet/pull/680) (#680)