### PR TITLE
[Engineering System] Increase Timeout for Live Tests

### DIFF
--- a/.azure-pipelines/tests.yml
+++ b/.azure-pipelines/tests.yml
@@ -15,9 +15,9 @@ variables:
 jobs:
   - job: 'Test'
 
-    # Increase timeout so Event Hubs tests do not timeout
+    # Increase timeout so Event Hubs tests do not timeout (Windows runs for ~2h 25m, on average due to having two target platforms)
     # https://github.com/Azure/azure-sdk-for-net/issues/5982
-    timeoutInMinutes: 90
+    timeoutInMinutes: 155
 
     strategy:
       maxParallel: $[ variables['MaxParallelTestJobs'] ]


### PR DESCRIPTION
# Summary

Due to the current state of the Event Hubs test suite, a live test run for a given platform is taking roughly 90 minutes on average.  Because Windows is running two target platforms, the test run has been averaging roughly 2 hours and 25 minutes.

Until we're able to refactor the Event Hubs tests for test timings, isolation, and parallelization, adjusting the timeout to allow nightly runs to complete without timing out.

# Last Upstream Rebase

Thursday, May 2, 2019 6:17pm (EDT)