### PR TITLE
[Engineering System] Increase Timeout for Live Tests

### DIFF
--- a/.azure-pipelines/tests.yml
+++ b/.azure-pipelines/tests.yml
@@ -15,9 +15,9 @@ variables:
 jobs:
   - job: 'Test'
 
-    # Increase timeout so Event Hubs tests do not timeout (Windows runs for ~2h 25m, on average due to having two target platforms)
+    # Increase timeout so Event Hubs tests do not timeout (Windows runs for ~2h 35m, on average due to having two target platforms)
     # https://github.com/Azure/azure-sdk-for-net/issues/5982
-    timeoutInMinutes: 155
+    timeoutInMinutes: 175
 
     strategy:
       maxParallel: $[ variables['MaxParallelTestJobs'] ]


### PR DESCRIPTION
# Summary

The last couple of days have seen the Windows tests fail to complete in the allowed timeout window, surpassing the 155 minute mark, though it is believed that they would have completed if given another 5 minutes.  I'd like to increase the timeout value once more to give them a bit of extra cushion and allow the runs to complete.

We recognize that this is not ideal and continue to have plans to enhance the suite with better isolation, durability, and to support parallelization, though the timeline to address this is not yet clear.

# Last Upstream Rebase

Monday, May 6, 2019 2:28pm (EDT)



