### PR TITLE
Fix core live tests

### DIFF
--- a/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
@@ -20,7 +20,7 @@ namespace Azure.Core.Samples
 
             var request = pipeline.CreateRequest();
 
-            var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/sdk/core/Azure.Core/README.md");
+            var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/README.md");
             request.SetRequestLine(HttpPipelineMethod.Get, uri);
             request.Headers.Add("Host", uri.Host);
 

--- a/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
@@ -20,7 +20,7 @@ namespace Azure.Core.Samples
 
             var request = pipeline.CreateRequest();
 
-            var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/src/SDKs/Azure.Core/data-plane/README.md");
+            var uri = new Uri(@"https://raw.githubusercontent.com/Azure/azure-sdk-for-net/master/sdk/core/Azure.Core/README.md");
             request.SetRequestLine(HttpPipelineMethod.Get, uri);
             request.Headers.Add("Host", uri.Host);
 


### PR DESCRIPTION
The change from #6057 would have passed live testing before being checked into master but it now fails because the README.md file is no longer present at that URL. 

Should anyone else be reviewing this change? 