### PR TITLE
 Add TokenCredential and BearerTokenAuthenticationPolicy 

### DIFF
--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -27,5 +27,6 @@
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
   </ItemGroup>
 </Project>

--- a/sdk/core/Azure.Core/src/Pipeline/HttpHeader.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpHeader.cs
@@ -53,7 +53,7 @@ namespace Azure.Core.Pipeline
             public static string ContentType => "Content-Type";
             public static string XMsRequestId => "x-ms-request-id";
             public static string UserAgent => "User-Agent";
-            public static string Accept => "Accept";
+            public static string Authorization => "Authorization";
         }
 
         public static class Common

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/BearerTokenAuthenticationPolicy.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Azure.Core.Pipeline.Policies
+{
+    public class BearerTokenAuthenticationPolicy: HttpPipelinePolicy
+    {
+        private readonly TokenCredential _credential;
+
+        private readonly string[] _scopes;
+
+        private string _currentToken = null;
+
+        private string _headerValue = null;
+
+        public BearerTokenAuthenticationPolicy(TokenCredential credential, string scope) : this(credential, new []{ scope })
+        {
+        }
+
+        public BearerTokenAuthenticationPolicy(TokenCredential credential, IEnumerable<string> scopes)
+        {
+            if (credential == null)
+            {
+                throw new ArgumentNullException(nameof(credential));
+            }
+
+            if (scopes == null)
+            {
+                throw new ArgumentNullException(nameof(scopes));
+            }
+
+            _credential = credential;
+            _scopes = scopes.ToArray();
+        }
+
+        public override Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            return ProcessAsync(message, pipeline, true);
+        }
+
+        public override void Process(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
+        {
+            ProcessAsync(message, pipeline, false).EnsureCompleted();
+        }
+
+        public async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
+        {
+            string token = async ?
+                    await _credential.GetTokenAsync(_scopes, message.Cancellation).ConfigureAwait(false) :
+                    _credential.GetTokenAsync(_scopes, message.Cancellation).GetAwaiter().GetResult();
+
+            if (token != _currentToken)
+            {
+                // Avoid per request allocations
+                _currentToken = token;
+                _headerValue = "Bearer " + token;
+            }
+
+            message.Request.SetHeader(HttpHeader.Names.Authorization, _headerValue);
+
+            if (async)
+            {
+                await ProcessNextAsync(pipeline, message);
+            }
+            else
+            {
+                ProcessNext(pipeline, message);
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/BearerTokenAuthenticationPolicy.cs
@@ -14,9 +14,9 @@ namespace Azure.Core.Pipeline.Policies
 
         private readonly string[] _scopes;
 
-        private string _currentToken = null;
+        private string _currentToken;
 
-        private string _headerValue = null;
+        private string _headerValue;
 
         public BearerTokenAuthenticationPolicy(TokenCredential credential, string scope) : this(credential, new []{ scope })
         {

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/BearerTokenAuthenticationPolicy.cs
@@ -52,7 +52,7 @@ namespace Azure.Core.Pipeline.Policies
         {
             string token = async ?
                     await _credential.GetTokenAsync(_scopes, message.Cancellation).ConfigureAwait(false) :
-                    _credential.GetTokenAsync(_scopes, message.Cancellation).GetAwaiter().GetResult();
+                    _credential.GetToken(_scopes, message.Cancellation);
 
             if (token != _currentToken)
             {

--- a/sdk/core/Azure.Core/src/TokenCredential.cs
+++ b/sdk/core/Azure.Core/src/TokenCredential.cs
@@ -12,5 +12,6 @@ namespace Azure.Core
     public abstract class TokenCredential
     {
         public abstract ValueTask<string> GetTokenAsync(string[] scopes, CancellationToken cancellationToken);
+        public abstract string GetToken(string[] scopes, CancellationToken cancellationToken);
     }
 }

--- a/sdk/core/Azure.Core/src/TokenCredential.cs
+++ b/sdk/core/Azure.Core/src/TokenCredential.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Core
+{
+    /// <summary>
+    /// Represents a credential capable of providing an OAuth token
+    /// </summary>
+    public abstract class TokenCredential
+    {
+        public abstract ValueTask<string> GetTokenAsync(string[] scopes, CancellationToken cancellationToken);
+    }
+}

--- a/sdk/core/Azure.Core/tests/BearerTokenAuthenticationPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/BearerTokenAuthenticationPolicyTests.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline.Policies;
+using Azure.Core.Testing;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class BearerTokenAuthenticationPolicyTests: SyncAsyncPolicyTestBase
+    {
+        public BearerTokenAuthenticationPolicyTests(bool isAsync) : base(isAsync) { }
+
+        [Test]
+        public async Task UsesTokenProvidedByCredentials()
+        {
+            var credentialsMock = new Mock<TokenCredential>();
+            credentialsMock.Setup(
+                    credential => credential.GetTokenAsync(
+                        It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope1", "scope2" })),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync("token");
+
+            var policy = new BearerTokenAuthenticationPolicy(credentialsMock.Object, new [] { "scope1", "scope2" });
+            MockTransport transport = CreateMockTransport(new MockResponse(200));
+            await SendGetRequest(transport, policy);
+
+            Assert.True(transport.SingleRequest.Headers.TryGetValue("Authorization", out string authValue));
+            Assert.AreEqual("Bearer token", authValue);
+        }
+
+        [Test]
+        public async Task RequestsTokenEveryRequest()
+        {
+            string currentToken = null;
+            var credentialsMock = new Mock<TokenCredential>();
+            credentialsMock.Setup(
+                    credential => credential.GetTokenAsync(
+                        It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope1", "scope2" })),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => currentToken);
+
+            var policy = new BearerTokenAuthenticationPolicy(credentialsMock.Object, new [] { "scope1", "scope2" });
+            MockTransport transport = CreateMockTransport(new MockResponse(200), new MockResponse(200));
+
+            currentToken = "token1";
+            await SendGetRequest(transport, policy);
+
+            currentToken = "token2";
+            await SendGetRequest(transport, policy);
+
+            Assert.True(transport.Requests[0].Headers.TryGetValue("Authorization", out string auth1Value));
+            Assert.True(transport.Requests[1].Headers.TryGetValue("Authorization", out string auth2Value));
+
+            Assert.AreEqual("Bearer token1", auth1Value);
+            Assert.AreEqual("Bearer token2", auth2Value);
+        }
+
+        [Test]
+        public async Task CachesHeaderValue()
+        {
+            var credentialsMock = new Mock<TokenCredential>();
+            credentialsMock.Setup(
+                    credential => credential.GetTokenAsync(
+                        It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope"})),
+                        It.IsAny<CancellationToken>()))
+                .ReturnsAsync("token");
+
+            var policy = new BearerTokenAuthenticationPolicy(credentialsMock.Object, "scope");
+            MockTransport transport = CreateMockTransport(new MockResponse(200), new MockResponse(200));
+
+            await SendGetRequest(transport, policy);
+            await SendGetRequest(transport, policy);
+
+            Assert.True(transport.Requests[0].Headers.TryGetValue("Authorization", out string auth1Value));
+            Assert.True(transport.Requests[1].Headers.TryGetValue("Authorization", out string auth2Value));
+
+            Assert.AreSame(auth1Value, auth1Value);
+            Assert.AreEqual("Bearer token", auth2Value);
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/BearerTokenAuthenticationPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/BearerTokenAuthenticationPolicyTests.cs
@@ -19,11 +19,23 @@ namespace Azure.Core.Tests
         public async Task UsesTokenProvidedByCredentials()
         {
             var credentialsMock = new Mock<TokenCredential>();
-            credentialsMock.Setup(
-                    credential => credential.GetTokenAsync(
-                        It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope1", "scope2" })),
-                        It.IsAny<CancellationToken>()))
-                .ReturnsAsync("token");
+
+            if (IsAsync)
+            {
+                credentialsMock.Setup(
+                        credential => credential.GetTokenAsync(
+                            It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope1", "scope2" })),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync("token");
+            }
+            else
+            {
+                credentialsMock.Setup(
+                        credential => credential.GetToken(
+                            It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope1", "scope2" })),
+                            It.IsAny<CancellationToken>()))
+                    .Returns("token");
+            }
 
             var policy = new BearerTokenAuthenticationPolicy(credentialsMock.Object, new [] { "scope1", "scope2" });
             MockTransport transport = CreateMockTransport(new MockResponse(200));
@@ -38,11 +50,23 @@ namespace Azure.Core.Tests
         {
             string currentToken = null;
             var credentialsMock = new Mock<TokenCredential>();
-            credentialsMock.Setup(
-                    credential => credential.GetTokenAsync(
-                        It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope1", "scope2" })),
-                        It.IsAny<CancellationToken>()))
-                .ReturnsAsync(() => currentToken);
+
+            if (IsAsync)
+            {
+                credentialsMock.Setup(
+                        credential => credential.GetTokenAsync(
+                            It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope1", "scope2" })),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(() => currentToken);
+            }
+            else
+            {
+                credentialsMock.Setup(
+                        credential => credential.GetToken(
+                            It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope1", "scope2" })),
+                            It.IsAny<CancellationToken>()))
+                    .Returns(() => currentToken);
+            }
 
             var policy = new BearerTokenAuthenticationPolicy(credentialsMock.Object, new [] { "scope1", "scope2" });
             MockTransport transport = CreateMockTransport(new MockResponse(200), new MockResponse(200));
@@ -64,11 +88,22 @@ namespace Azure.Core.Tests
         public async Task CachesHeaderValue()
         {
             var credentialsMock = new Mock<TokenCredential>();
-            credentialsMock.Setup(
-                    credential => credential.GetTokenAsync(
-                        It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope"})),
-                        It.IsAny<CancellationToken>()))
-                .ReturnsAsync("token");
+            if (IsAsync)
+            {
+                credentialsMock.Setup(
+                        credential => credential.GetTokenAsync(
+                            It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope" })),
+                            It.IsAny<CancellationToken>()))
+                    .ReturnsAsync("token");
+            }
+            else
+            {
+                credentialsMock.Setup(
+                        credential => credential.GetToken(
+                            It.Is<string[]>(strings => strings.SequenceEqual(new[] { "scope" })),
+                            It.IsAny<CancellationToken>()))
+                    .Returns("token");
+            }
 
             var policy = new BearerTokenAuthenticationPolicy(credentialsMock.Object, "scope");
             MockTransport transport = CreateMockTransport(new MockResponse(200), new MockResponse(200));


### PR DESCRIPTION
Adds types and tests.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/6181