### PR TITLE
Change ReadOnlyJsonContractResolver to DefaultContractResolver

### DIFF
--- a/sdk/eventgrid/Microsoft.Azure.EventGrid/src/Generated/EventGridClient.cs
+++ b/sdk/eventgrid/Microsoft.Azure.EventGrid/src/Generated/EventGridClient.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.EventGrid
                 DateTimeZoneHandling = Newtonsoft.Json.DateTimeZoneHandling.Utc,
                 NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore,
                 ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Serialize,
-                ContractResolver = new ReadOnlyJsonContractResolver(),
+                ContractResolver = new Newtonsoft.Json.Serialization.DefaultContractResolver(),
                 Converters = new List<JsonConverter>
                     {
                         new Iso8601TimeSpanConverter()


### PR DESCRIPTION
Hello Azure team,

I haven't found any clue why, by default, EventGridClient uses ReadOnlyJsonContractResolver. It forces you to create event data classes with public setters. Which, by default in terms of events, should be forbidden. In folowing code
```csharp

    public class ProductCreated
    {
        public ProductCreated(Guid id, string name, decimal price)
        {
            Id = id;
            Name = name;
            Price = price;
        }

        public Guid Id { get; private set; }

        public string Name { get; private set; }

        public decimal Price { get; private set; }
    }
    ...
    EventGridEvent @event = new EventGridEvent(){ ... }
    @event.Data = new ProductCreated(...)
```
Data will be serialized as empty object.