### PR TITLE
Add support for versioning packages

### DIFF
--- a/Documentation/Versioning.md
+++ b/Documentation/Versioning.md
@@ -1,0 +1,63 @@
+# Azure SDK .NET - Versioning
+
+This document covers the basic versioning strategy and which properties to use. It is based on the rules outlined in our [Azure SDK Releases doc](https://github.com/Azure/azure-sdk/blob/master/docs/engineering-system/releases.md#net) and it closely matches the [.NET versioning rules](https://github.com/dotnet/arcade/blob/master/Documentation/CorePackages/Versioning.md) but simplified to only include the parts necessary for our libraries.
+
+## Package Versioning
+
+Package version will look like:
+```
+MAJOR.MINOR.PATCH-PRERELEASE
+```
+
+In the project file use the `VersionPrefix` property to define the `MAJOR.MINOR.PATCH` part of the version.
+
+```
+<VersionPrefix>1.0.0</VersionPrefix>
+```
+
+`PRERELEASE` will be controlled by:
+
+- **BuildNumber:** Should be in the format `yyyyMMdd.<build revision>` and defaults to today's date `yyyyMMdd.1` but can be set by passing in and msbuild property for `OfficialBuildId` with a matching format.
+- **PreReleaseLabel:** Defaults to `dev` but can be set by passing in the msbuild property for `PreReleaseVersionLabel`. Some examples might be "preview", "preview.1", etc.
+- **VersionKind:** Defaults to "" which results to the default dev build label but can be set by passing in the msbuild property `DotNetFinalVersionKind` to one of the values "", "prerelease", or "release".
+
+Examples:
+
+| VersionKind  | Package version format                  | Example package versions  |
+|--------------|-----------------------------------------|---------------------------|
+| ""           | `1.2.3-<PreReleaseLabel>.<BuildNumber>` | `1.2.3-dev.20190509.1`    |
+| "prerelease" | `1.2.3-<PreReleaseLabel>`               | `1.2.3-preview.1`         |
+| "release"    | `1.2.3`                                 | `1.2.3`                   |
+
+## Assembly Versioning
+
+By default the assembly version will be set to the `VersionPrefix` property but if the assembly version needs to be different for some reason then it can be independently set by the `AssemblyVersion` property.
+
+## File Versioning
+
+File version has 4 parts and needs to increase every official build. This is especially important when building MSIs.
+
+They will use the following format which is also used by the .NET team:
+
+```
+FILEMAJOR.FILEMINOR.FILEPATCH.FILEREVISION
+```
+- `FILEMAJOR`: Specified in the first part of `VersionPrefix` property.
+- `FILEMINOR`: Set to `MINOR * 100 + PATCH / 100`, where `MINOR` and `PATCH` are the 2nd and 3rd parts of `VersionPrefix` property.
+- `FILEPATCH`: Set to `(PATCH % 100) * 100 + yy`.
+- `FILEREVISION`: Set to `(50 * mm + dd) * 100 + r`. This algorithm makes it easy to parse the month and date from `FILEREVISION` while staying in the range of a short which is what a version element uses.
+
+The versioning scheme imposes the following limits on these version parts:
+- `MAJOR` version is in range [0-65535]
+- `MINOR` version is in range [0-654]
+- `PATCH` version is in range [0-9999]
+
+
+## Build Parameters
+
+| Parameter                  | Description                                                  |
+| -------------------------- | ------------------------------------------------------------ |
+| OfficialBuildId            | ID of current build. The accepted format is `yyyyMMdd.r`. Should be passed to build in YAML official build defintion. |
+| DotNetFinalVersionKind     | Specify the kind of version being generated: `release`, `prerelease` or empty. |
+| PreReleaseVersionLabel     | Pre-release label to be used on the string. E.g., `preview`, `preview.1`, etc. |
+| VersionPrefix              | Specify the leading part of the version string. If empty it will default to 1.0.0 from the SDK. |

--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -79,4 +79,6 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
     <AssemblyOriginatorKeyFile Condition="'$(IsClientLibrary)' == 'true'">$(MSBuildThisFileDirectory)AzureSDKClient.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
+
+  <Import Project="Versioning.props" />
 </Project>

--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -53,4 +53,6 @@
   </PropertyGroup>
 
   <Import Project="$(DefaultReferenceTargets)" Condition="Exists('$(DefaultReferenceTargets)') And '$(ImportDefaultReferences)'=='true'" />
+
+  <Import Project="Versioning.targets" />
 </Project>

--- a/eng/Versioning.props
+++ b/eng/Versioning.props
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+    <_BuildNumber Condition="'$(OfficialBuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
+
+    <_PreReleaseLabel>$(PreReleaseVersionLabel)</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(_PreReleaseLabel)' == ''">dev</_PreReleaseLabel>
+
+    <!--
+      If DotNetFinalVersionKind is specified, overrides the package version produced by the build like so:
+        "release"    -> 1.2.3
+        "prerelease" -> 1.2.3-label
+        ""           -> 1.2.3-label.12345.67
+    -->
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == 'release'"/>
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == 'prerelease'">$(_PreReleaseLabel)</VersionSuffix>
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == ''">$(_PreReleaseLabel).$(_BuildNumber)</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/eng/Versioning.targets
+++ b/eng/Versioning.targets
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    Specification: https://github.com/dotnet/arcade/blob/master/Documentation/CoreVersioning.md
+
+    File version has 4 parts and needs to increase every official build. This is especially important when building MSIs.
+    FILEMAJOR.FILEMINOR.FILEPATCH.FILEREVISION
+    FILEMAJOR: Specified in the first part of VersionPrefix property.
+    FILEMINOR: Set to MINOR * 100 + PATCH / 100, where MINOR and PATCH are the 2nd and 3rd parts of VersionPrefix property.
+    FILEPATCH: Set to (PATCH % 100) * 100 + yy.
+    FILEREVISION: Set to (50 * mm + dd) * 100 + r. This algorithm makes it easy to parse the month and date from FILEREVISION while staying in the range of a short which is what a version element uses.
+
+    The versioning scheme defined below imposes the following limits on these version parts:
+    - `MAJOR` version is in range [0-65535]
+    - `MINOR` version is in range [0-654]
+    - `PATCH` version is in range [0-9999]
+  -->
+  <Target Name="_InitializeFileVersion" BeforeTargets="GetAssemblyVersion">
+    <Error Text="Expected _BuildNumber to match OfficialBuildId property!"
+            Condition="'$(OfficialBuildId)' != '' and '$(OfficialBuildId)' != '$(_BuildNumber)'" />
+
+    <Error Text="Invalid format of OfficialBuildId: '$(OfficialBuildId)' should be in form yyyyMMdd.r"
+           Condition="$(OfficialBuildId) != '' and ($(OfficialBuildId.Length) &lt; 10 or '$(OfficialBuildId[8])' != '.')" />
+
+    <!-- Compute an ever increasing build number based on official build id assuming it is passed -->
+    <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+      <_BuildNumberYY>$(_BuildNumber.Substring(2, 2))</_BuildNumberYY>
+      <_BuildNumberMM>$(_BuildNumber.Substring(4, 2))</_BuildNumberMM>
+      <_BuildNumberDD>$(_BuildNumber.Substring(6, 2))</_BuildNumberDD>
+      <_BuildNumberR>$(_BuildNumber.Substring(9))</_BuildNumberR>
+
+      <_VersionPrefixMajor>$(VersionPrefix.Split('.')[0])</_VersionPrefixMajor>
+      <_VersionPrefixMinor>$(VersionPrefix.Split('.')[1])</_VersionPrefixMinor>
+      <_VersionPrefixPatch>$(VersionPrefix.Split('.')[2])</_VersionPrefixPatch>
+
+      <_FileMajor>$(_VersionPrefixMajor)</_FileMajor>
+
+      <!-- MINOR * 100 + PATCH / 100 -->
+      <_FileMinor>$([MSBuild]::Add(
+                    $([MSBuild]::Multiply($(_VersionPrefixMinor), 100)),
+                    $([System.Convert]::ToInt32($([MSBuild]::Divide($(_VersionPrefixPatch), 100))))
+                  ))</_FileMinor>
+
+      <!-- (PATCH % 100) * 100 + yy -->
+      <_FilePatch>$([MSBuild]::Add(
+                    $([MSBuild]::Multiply(
+                      $([MSBuild]::Modulo($(_VersionPrefixPatch), 100)),
+                      100)),
+                    $(_BuildNumberYY)
+                  ))</_FilePatch>
+
+      <!-- mm * 5000 + dd * 100 + r -->
+      <_FileRevision>$([MSBuild]::Add(
+                        $([MSBuild]::Add(
+                          $([MSBuild]::Multiply($(_BuildNumberMM), 5000)),
+                          $([MSBuild]::Multiply($(_BuildNumberDD), 100))
+                        )),
+                        $(_BuildNumberR)
+                     ))</_FileRevision>
+
+      <FileVersion>$(_FileMajor).$(_FileMinor).$(_FilePatch).$(_FileRevision)</FileVersion>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/Azure.Configuration.csproj
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/Azure.Configuration.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Application Configuration Service client library</Description>
     <AssemblyTitle>Microsoft Azure.ApplicationModel.Configuration client library</AssemblyTitle>
-    <Version>1.0.0-preview.2</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <PackageTags>Microsoft Azure Application Configuration</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/sdk/applicationinsights/Microsoft.Azure.ApplicationInsights/src/Microsoft.Azure.ApplicationInsights.Query.csproj
+++ b/sdk/applicationinsights/Microsoft.Azure.ApplicationInsights/src/Microsoft.Azure.ApplicationInsights.Query.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>Microsoft Azure Application Insights Data Library"</AssemblyTitle>
     <Description>Provides Microsoft Azure Application Insights data plane query operations operations.</Description>
-    <Version>0.9.0-preview</Version>
+    <VersionPrefix>0.9.0</VersionPrefix>
     <PackageTags>ApplicationInsights;</PackageTags>
     <PackageReleaseNotes>This is a preview release of the Application Insights Data SDK.</PackageReleaseNotes>
   </PropertyGroup>

--- a/sdk/applicationinsights/Microsoft.Azure.ApplicationInsights/tests/Data.ApplicationInsights.Tests.csproj
+++ b/sdk/applicationinsights/Microsoft.Azure.ApplicationInsights/tests/Data.ApplicationInsights.Tests.csproj
@@ -2,11 +2,11 @@
   <PropertyGroup>
     <Description>Data.ApplicationInsights.Tests Class library</Description>
     <AssemblyTitle>Data ApplicationInsights Tests</AssemblyTitle>
-    <Version>1.0.0-preview</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <None Update="SessionRecords\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Microsoft.Azure.ContainerRegistry.csproj
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/src/Microsoft.Azure.ContainerRegistry.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Provides management capabilities for Azure Container Registry.</Description>
     <AssemblyTitle>Microsoft Azure Container Registry</AssemblyTitle>
-    <Version>0.9.0-preview</Version>
+    <VersionPrefix>0.9.0</VersionPrefix>
     <PackageTags>Microsoft Azure Container Registry;Container Registry;</PackageTags>
     <PackageReleaseNotes>Added capabilities to manage repository, tag and manifest.</PackageReleaseNotes>
   </PropertyGroup>

--- a/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Microsoft.Azure.ContainerRegistry.Tests.csproj
+++ b/sdk/containerregistry/Microsoft.Azure.ContainerRegistry/tests/Microsoft.Azure.ContainerRegistry.Tests.csproj
@@ -3,7 +3,7 @@
     <PackageId>ContainerRegistry.Tests</PackageId>
     <Description>Microsoft.Azure.ContainerRegistry tests Library</Description>
     <AssemblyName>ContainerRegistry.Tests</AssemblyName>
-    <Version>1.0.0</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ContainerRegistry" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="[1.6.0-preview, 2.0.0)" />
-    <ProjectReference Include="..\src\Microsoft.Azure.ContainerRegistry.csproj" />    
+    <ProjectReference Include="..\src\Microsoft.Azure.ContainerRegistry.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Helpers\ACRTestUtil.cs" />

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is the implementation of the Azure Client Pipeline</Description>
     <AssemblyTitle>Microsoft Azure Client Pipeline</AssemblyTitle>
-    <Version>1.0.0-preview.5</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <PackageTags>Microsoft Azure Client Pipeline</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
@@ -1,12 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyTitle>Microsoft.Azure.EventHubs.Processor</AssemblyTitle>
     <Description>This is the next generation Azure Event Hubs .NET Standard Event Processor Host library. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>3.0.0</Version>
-    <AssemblyVersion>3.0.0.0</AssemblyVersion>
-    <FileVersion>3.0.0.0</FileVersion>
     <VersionPrefix>3.0.0</VersionPrefix>
-    <PackageId>Microsoft.Azure.EventHubs.Processor</PackageId>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;Event Processor Host</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-event-hubs-dotnet/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Microsoft.Azure.EventHubs.Processor.xml</DocumentationFile>
@@ -15,14 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);netstandard1.4</TargetFrameworks>
     <RootNamespace>Microsoft.Azure.EventHubs.Processor</RootNamespace>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.4'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD1_4</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.ServiceFabricProcessor/src/Microsoft.Azure.EventHubs.ServiceFabricProcessor.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.ServiceFabricProcessor/src/Microsoft.Azure.EventHubs.ServiceFabricProcessor.csproj
@@ -1,20 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyTitle>Microsoft.Azure.EventHubs.ServiceFabricProcessor</AssemblyTitle>
     <Description>This is the next generation Azure Event Hubs .NET Standard Service Fabric Processor library, which integrates Event Hub event consumption with Service Fabric. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <Version>0.5.3</Version>
-    <AssemblyVersion>0.5.3.0</AssemblyVersion>
-    <FileVersion>0.5.3.0</FileVersion>
-    <VersionPrefix>0.5.3-PREVIEW</VersionPrefix>
-    <PackageId>Microsoft.Azure.EventHubs.ServiceFabricProcessor</PackageId>
+    <VersionPrefix>0.5.3</VersionPrefix>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-event-hubs-dotnet/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)Microsoft.Azure.EventHubs.Processor.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <RootNamespace>Microsoft.Azure.EventHubs.ServiceFabricProcessor</RootNamespace>
   </PropertyGroup>
 
    <!-- Because Service Fabric is involved, force the platform to x64. -->

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
@@ -1,17 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyName>Microsoft.Azure.EventHubs.Tests</AssemblyName>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <Version>2.2.0</Version>
-  </PropertyGroup>
-  
-  <PropertyGroup>
+    <VersionPrefix>2.2.0</VersionPrefix>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <RootNamespace>Microsoft.Azure.EventHubs.Tests</RootNamespace>       
   </PropertyGroup>
 
   <!-- Because Service Fabric is involved, force the platform to x64. -->
-  <PropertyGroup>    
+  <PropertyGroup>
     <Platform>x64</Platform>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
@@ -36,11 +31,10 @@
   <ItemGroup>
     <ProjectReference Include="..\src\Microsoft.Azure.EventHubs.csproj" />
     <ProjectReference Include="..\..\Microsoft.Azure.EventHubs.ServiceFabricProcessor\src\Microsoft.Azure.EventHubs.ServiceFabricProcessor.csproj" />
-    <ProjectReference Include="..\..\Microsoft.Azure.EventHubs.Processor\src\Microsoft.Azure.EventHubs.Processor.csproj" />    
+    <ProjectReference Include="..\..\Microsoft.Azure.EventHubs.Processor\src\Microsoft.Azure.EventHubs.Processor.csproj" />
   </ItemGroup>
 
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>  
+  </ItemGroup>
 </Project>

--- a/sdk/keyvault/Azure.Security.Keyvault.Secrets/src/Azure.Security.Keyvault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.Keyvault.Secrets/src/Azure.Security.Keyvault.Secrets.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>This is the Microsoft Azure Key Vault Secrets client library</Description>
     <AssemblyTitle>Microsoft Azure.Security.KeyVault.Secrets client library</AssemblyTitle>
-    <Version>1.0.0-preview.1</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault Secrets</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/sdk/keyvault/Directory.Build.props
+++ b/sdk/keyvault/Directory.Build.props
@@ -1,8 +1,8 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <Version>3.0.3</Version>
+    <VersionPrefix>3.0.3</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault;Key Vault;REST HTTP client;azureofficial;windowsazureofficial</PackageTags>
-    <PackageReleaseNotes>      
+    <PackageReleaseNotes>
       <![CDATA[
         Republishing to publish symbols
       ]]>

--- a/sdk/keyvault/Microsoft.Azure.KeyVault.Extensions/tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
+++ b/sdk/keyvault/Microsoft.Azure.KeyVault.Extensions/tests/Microsoft.Azure.KeyVault.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Microsoft Azure Key Vault Extensions tests</Description>
-    <Version>1.0.0</Version>
+    <VersionPrefix>1.0.0</VersionPrefix>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/operationalinsights/Microsoft.Azure.OperationalInsights/src/Microsoft.Azure.OperationalInsights.csproj
+++ b/sdk/operationalinsights/Microsoft.Azure.OperationalInsights/src/Microsoft.Azure.OperationalInsights.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <Description>Provides Microsoft Azure Operational Insights data operations</Description>
     <AssemblyTitle>Microsoft Azure Operational Insights Data Library</AssemblyTitle>
-    <VersionPrefix>0.10.0-preview</VersionPrefix>
-    <PackageTags>Microsoft Azure OperationalInsights;OperationalInsights</PackageTags>    
+    <VersionPrefix>0.10.0</VersionPrefix>
+    <PackageTags>Microsoft Azure OperationalInsights;OperationalInsights</PackageTags>
 	  <PackageReleaseNotes>Taking dependency on 10.0.3 version of Newtonsoft nuget package.</PackageReleaseNotes>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Microsoft.Azure.ServiceBus.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyTitle>Azure ServiceBus SDK</AssemblyTitle>
     <Description>This is the next generation Azure Service Bus .NET Standard client library that focuses on queues &amp; topics. For more information about Service Bus, see https://azure.microsoft.com/en-us/services/service-bus/</Description>
-    <Version>3.4.0</Version>
+    <VersionPrefix>3.4.0</VersionPrefix>
     <PackageTags>Microsoft;Azure;Service Bus;ServiceBus;.NET;AMQP;IoT;Queue;Topic</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[

--- a/sdk/template/Azure.Template/src/Azure.Template.csproj
+++ b/sdk/template/Azure.Template/src/Azure.Template.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>This is a template project to demonstrate how to create a package as well as use for testing our build and release pipelines</Description>
     <AssemblyTitle>Azure SDK Template</AssemblyTitle>
-    <Version>1.0.2-preview1</Version>
+    <VersionPrefix>1.0.2</VersionPrefix>
     <PackageTags>Azure Template</PackageTags>
     <PackageReleaseNotes>
       <![CDATA[


### PR DESCRIPTION
Adds support for versioning packages which will include
a build number based on a date that is part of the prerelease
label so we can publish daily without worrying about overwriting
an existing packages on the feed.

Also include support for releasing with a different prerelease
label or no prerelease label.

See Documentation/Versioning.md for all the details.

cc @Azure/azure-sdk-eng @chidozieononiwu 
cc @AlexGhiondea @pakrym @jsquire

fyi @dsgouda @shahabhijeet 

contributes to https://github.com/Azure/azure-sdk-for-net/issues/5753. 