### PR TITLE
Update to netcorepapp2.1 for test projects

### DIFF
--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -14,6 +14,12 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <IsTestProject Condition="$(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
+    <IsTestSupportProject Condition="'$(IsTestProject)' != 'true' and ($(MSBuildProjectDirectory.Contains('/tests/')) or $(MSBuildProjectDirectory.Contains('\tests\')))">true</IsTestSupportProject>
+    <EnableClientSdkAnalyzers Condition="'$(IsClientLibrary)' == 'true' and '$(IsTestProject)' != 'true' and '$(IsTestSupportProject)' != 'true'">true</EnableClientSdkAnalyzers>
+  </PropertyGroup>
+
   <!-- TargetFramework default properties -->
   <PropertyGroup>
     <!-- Client libraries are moving forward to NS 2.0 and Net 4.6.1 as the min supported versions -->
@@ -22,6 +28,16 @@
 
     <RequiredTargetFrameworks>net452;netstandard1.4</RequiredTargetFrameworks>
     <RequiredTargetFrameworks Condition="'$(SupportsNetStandard20)' == 'true'">net461;netstandard2.0</RequiredTargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">
+    <IsPackable>false</IsPackable>
+    <RequiredTargetFrameworks>netcoreapp2.1</RequiredTargetFrameworks>
+    <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.1;net461</RequiredTargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
 
     <IsTargetingNetFx Condition="$(TargetFramework.StartsWith('net4'))">true</IsTargetingNetFx>
     <IsTargetingNetStandard Condition="$(TargetFramework.StartsWith('netstandard'))">true</IsTargetingNetStandard>
@@ -78,6 +94,13 @@
 
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
     <AssemblyOriginatorKeyFile Condition="'$(IsClientLibrary)' == 'true'">$(MSBuildThisFileDirectory)AzureSDKClient.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">
+    <!-- Always fully sign test assemblies since we have a full public/private key -->
+    <PublicSign>false</PublicSign>
+    <DelaySign>false</DelaySign>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzSdkTestLibKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
   <Import Project="Versioning.props" />

--- a/eng/Directory.Build.Data.targets
+++ b/eng/Directory.Build.Data.targets
@@ -10,31 +10,6 @@
     <Error Condition="'@(MissingTargetFrameworks)' != ''" Text="Missing required target frameworks '@(MissingTargetFrameworks)'. Please ensure you add those frameworks." />
   </Target>
 
-  <PropertyGroup>
-    <DefaultReferenceTargets>AzSdk.reference.targets</DefaultReferenceTargets>
-    <IsTestProject Condition="'$(IsTestProject)' == '' and $(MSBuildProjectName.EndsWith('.Tests'))">true</IsTestProject>
-    <IsPerformanceTestProject Condition="'$(IsPerformanceTestProject)' == '' and $(MSBuildProjectName.EndsWith('.Performance'))">true</IsPerformanceTestProject>
-    <EnableClientSdkAnalyzers Condition="'$(EnableClientSdkAnalyzers)' == '' and '$(IsClientLibrary)' == 'true' and '$(IsTestProject)' != 'true' and '$(IsPerformanceTestProject)' != 'true'">true</EnableClientSdkAnalyzers>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(SignAssembly)' == 'true' and ('$(IsTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true')">
-    <!-- Always fully sign test assemblies since we have a full public/private key -->
-    <PublicSign>false</PublicSign>
-    <DelaySign>false</DelaySign>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzSdkTestLibKey.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsPerformanceTestProject)' == 'true' or '$(IsTestHelperLibrary)' == 'true'">
-    <IsPackable>false</IsPackable>
-    <RequiredTargetFrameworks>netcoreapp2.0</RequiredTargetFrameworks>
-    <RequiredTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">netcoreapp2.0;net461</RequiredTargetFrameworks>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <DefaultReferenceTargets>AzSdk.test.reference.targets</DefaultReferenceTargets>
-
-    <!-- Disable running of tests for test helper libraries -->
-    <IsTestProject Condition="'$(IsTestHelperLibrary)' == 'true'">false</IsTestProject>
-  </PropertyGroup>
-
   <!-- This allows us to build .NET Framework targets on non-windows
     TODO: Move the NETFramework reference assemblies to a feed other then the roslyn feed.
   -->
@@ -47,9 +22,13 @@
     <PackageReference Condition="'$(EnableClientSdkAnalyzers)' == 'true'" Include="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20190503.1" PrivateAssets="All" />
   </ItemGroup>
 
-  <!-- Import default references if this is not set -->
-  <PropertyGroup Condition="'$(ImportDefaultReferences)'==''">
-    <ImportDefaultReferences>true</ImportDefaultReferences>
+  <PropertyGroup>
+    <ImportDefaultReferences Condition="'$(ImportDefaultReferences)' == ''">true</ImportDefaultReferences>
+    <DefaultReferenceTargets>AzSdk.reference.targets</DefaultReferenceTargets>
+    <DefaultReferenceTargets Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">AzSdk.test.reference.targets</DefaultReferenceTargets>
+
+    <!-- Disable running of tests for test helper libraries -->
+    <IsTestProject Condition="'$(IsTestSupportProject)' == 'true'">false</IsTestProject>
   </PropertyGroup>
 
   <Import Project="$(DefaultReferenceTargets)" Condition="Exists('$(DefaultReferenceTargets)') And '$(ImportDefaultReferences)'=='true'" />

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/Directory.Build.props
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/Directory.Build.props
@@ -1,30 +1,22 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SupportsNetStandard20>true</SupportsNetStandard20>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
-    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
-    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-
-    <!-- This is a workaorund until https://github.com/Azure/azure-sdk-for-net/issues/5214 is addressed -->
-    <RequiredTargetFrameworks>net461;netstandard2.0</RequiredTargetFrameworks>
 
     <!-- Do not inherit implicit dependencies from the engineering system during build or packaging -->
     <ImportDefaultReferences>false</ImportDefaultReferences>
-
-    <!--
-        If the assembly is to be signed, emit a constant so that any constructs which rely on the assembly
-        names, such as declaration of friend assemblies for testing, can be adjusted as necessary
-    -->
-    <DefineConstants Condition="'$(SignAssembly)' == 'true'">$(DefineConstants);CODESIGN</DefineConstants>
   </PropertyGroup>
 
-  <!-- 
+  <!--
     For Track 1, override the engineering system signing key and use the existing key for
     Azure messaging client libraries.
   -->
-  <PropertyGroup Condition="'$(SignAssembly)' == 'true'">
+  <PropertyGroup Condition="'$(SignAssembly)' == 'true' and '$(IsTestProject)' != 'true'">
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)assets\azure-messaging.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <PublicSign>false</PublicSign>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Properties/AssemblyInfo.cs
@@ -3,7 +3,6 @@
 
 using System.Runtime.CompilerServices;
 
-#if CODESIGN
 [assembly: InternalsVisibleTo("Microsoft.Azure.EventHubs.Tests,PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]
 [assembly: InternalsVisibleTo("Microsoft.Azure.EventHubs.Processor,PublicKey=" +
     "0024000004800000940000000602000000240000525341310004000001000100fdf4acac3b2244" +
@@ -11,7 +10,3 @@ using System.Runtime.CompilerServices;
     "4bc51e6f018dca44fdd26a219c27cb2b263956a80620223c8e9c2f8913c3c903e1e453e9e4e840" +
     "98afdad5f4badb8c1ebe0a7b0a4b57a08454646a65886afe3e290a791ff3260099ce0edf0bdbcc" +
     "afadfeb6")]
-#else
-    [assembly: InternalsVisibleTo("Microsoft.Azure.EventHubs.Tests")]
-    [assembly: InternalsVisibleTo("Microsoft.Azure.EventHubs.Processor")]
-#endif

--- a/sdk/keyvault/Microsoft.Azure.KeyVault.WebKey/tests/WebKeyRsaValidationTest.cs
+++ b/sdk/keyvault/Microsoft.Azure.KeyVault.WebKey/tests/WebKeyRsaValidationTest.cs
@@ -36,10 +36,8 @@ namespace Microsoft.Azure.KeyVault.WebKey.Tests
             {
                 throw new CryptographicException( string.Format( "{0} is not supported", key.GetType().FullName ) );
             }
-#elif NETCOREAPP2_0
-            plainText = key.Decrypt(cipherText, RSAEncryptionPadding.OaepSHA1);
 #else
-#error Unknown Build Flavor
+            plainText = key.Decrypt(cipherText, RSAEncryptionPadding.OaepSHA1);
 #endif
 
             return plainText;
@@ -61,10 +59,8 @@ namespace Microsoft.Azure.KeyVault.WebKey.Tests
             {
                 throw new CryptographicException( string.Format( "{0} is not supported", key.GetType().FullName ) );
             }
-#elif NETCOREAPP2_0
-            cipherText = key.Encrypt( _plainText, RSAEncryptionPadding.OaepSHA1 );
 #else
-            #error Unknown Build Flavor
+            cipherText = key.Encrypt( _plainText, RSAEncryptionPadding.OaepSHA1 );
 #endif
 
             return cipherText;

--- a/sdk/keyvault/Microsoft.Azure.KeyVault/tests/TestFramework/Microsoft.Azure.KeyVault.TestFramework.csproj
+++ b/sdk/keyvault/Microsoft.Azure.KeyVault/tests/TestFramework/Microsoft.Azure.KeyVault.TestFramework.csproj
@@ -2,7 +2,6 @@
   <PropertyGroup>
     <Description>Microsoft Azure Key Vault Test Framework</Description>
     <AssemblyTitle>Microsoft Azure Key Vault Test Framework</AssemblyTitle>
-    <IsTestHelperLibrary>true</IsTestHelperLibrary>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/Directory.Build.props
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/Directory.Build.props
@@ -1,21 +1,16 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SupportsNetStandard20>true</SupportsNetStandard20>
+  </PropertyGroup>
+
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
-    <!-- This is a workaorund until https://github.com/Azure/azure-sdk-for-net/issues/5214 is addressed -->
-    <RequiredTargetFrameworks>net461;netstandard2.0</RequiredTargetFrameworks>
 
     <!-- Do not inherit implicit dependencies from the engineering system during build or packaging -->
     <ImportDefaultReferences>false</ImportDefaultReferences>
-    
-    <!--
-        If the assembly is to be signed, emit a constant so that any constructs which rely on the assembly
-        names, such as declaration of friend assemblies for testing, can be adjusted as necessary
-    -->
-    <DefineConstants Condition="'$(SignAssembly)' == 'true'">$(DefineConstants);CODESIGN</DefineConstants>
-
     <!--
         Certain tests are only relevant on a Windows platform, due to behavioral differences of third-party
         dependencies.  Emit a constant to allow such tests to be skipped on non-Windows platforms.
@@ -23,11 +18,11 @@
     <DefineConstants Condition="'$(OS)' == 'Windows_NT'">$(DefineConstants);WINDOWS</DefineConstants>
   </PropertyGroup>
 
-  <!-- 
+  <!--
     For Track 1, override the engineering system signing key and use the existing key for
     Azure messaging client libraries.
   -->
-  <PropertyGroup Condition="'$(SignAssembly)' == 'true'">
+  <PropertyGroup Condition="'$(SignAssembly)' == 'true' and '$(IsTestProject)' != 'true'">
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)assets\azure-messaging.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
     <PublicSign>false</PublicSign>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Properties/AssemblyInfo.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Properties/AssemblyInfo.cs
@@ -3,11 +3,6 @@
 
 using System.Runtime.CompilerServices;
 
-// Allow internal members to be accessed by the tests, adjusting for signing, if needed. 
-#if CODESIGN
 [assembly: InternalsVisibleTo("Microsoft.Azure.ServiceBus.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]
-#else
-[assembly: InternalsVisibleTo("Microsoft.Azure.ServiceBus.Tests")]
-#endif
 
 

--- a/sdk/template/Azure.Template/tests/Azure.Template.Tests.csproj
+++ b/sdk/template/Azure.Template/tests/Azure.Template.Tests.csproj
@@ -1,7 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.Template.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Refactor the target frameworks and test properties so they
are in the props instead of the targets file and thus can be
successfully overridden the project if needed.

Update the target framework for testing to netcoreapp2.1 from 2.0

cc @pakrym @jsquire @azure/azure-sdk-eng