### PR TITLE
Normalize ProcessNext parameter order

### DIFF
--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/AuthenticationPolicy.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/AuthenticationPolicy.cs
@@ -25,7 +25,7 @@ namespace Azure.ApplicationModel.Configuration
         {
             await ProcessAsync(message, async: true);
 
-            await ProcessNextAsync(pipeline, message);
+            await ProcessNextAsync(message, pipeline);
         }
 
         private async Task ProcessAsync(HttpPipelineMessage message, bool async)
@@ -77,7 +77,7 @@ namespace Azure.ApplicationModel.Configuration
         {
             ProcessAsync(message, async: false).GetAwaiter().GetResult();
 
-            ProcessNext(pipeline, message);
+            ProcessNext(message, pipeline);
         }
     }
 }

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs
@@ -26,18 +26,13 @@ namespace Azure.Core.Pipeline
         /// <param name="message">The <see cref="HttpPipelineMessage"/> next policy would be applied to.</param>
         /// <param name="pipeline">The set of <see cref="HttpPipelinePolicy"/> to execute after next one.</param>
         /// <returns></returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static async Task ProcessNextAsync(ReadOnlyMemory<HttpPipelinePolicy> pipeline, HttpPipelineMessage message)
+        protected static Task ProcessNextAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            if (pipeline.IsEmpty) throw new InvalidOperationException("last policy in the pipeline must be a transport");
-            var next = pipeline.Span[0];
-            await next.ProcessAsync(message, pipeline.Slice(1)).ConfigureAwait(false);
+            return pipeline.Span[0].ProcessAsync(message, pipeline.Slice(1));
         }
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected static void ProcessNext(ReadOnlyMemory<HttpPipelinePolicy> pipeline, HttpPipelineMessage message)
+        protected static void ProcessNext(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            if (pipeline.IsEmpty) throw new InvalidOperationException("last policy in the pipeline must be a transport");
             pipeline.Span[0].Process(message, pipeline.Slice(1));
         }
     }

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/BearerTokenAuthenticationPolicy.cs
@@ -65,11 +65,11 @@ namespace Azure.Core.Pipeline.Policies
 
             if (async)
             {
-                await ProcessNextAsync(pipeline, message);
+                await ProcessNextAsync(message, pipeline);
             }
             else
             {
-                ProcessNext(pipeline, message);
+                ProcessNext(message, pipeline);
             }
         }
     }

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/BufferResponsePolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/BufferResponsePolicy.cs
@@ -17,13 +17,13 @@ namespace Azure.Core.Pipeline.Policies
 
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            await ProcessNextAsync(pipeline, message);
+            await ProcessNextAsync(message, pipeline);
             await BufferResponse(message, true);
         }
 
         public override void Process(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            ProcessNext(pipeline, message);
+            ProcessNext(message, pipeline);
             BufferResponse(message, false).GetAwaiter().GetResult();
         }
 

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/LoggingPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/LoggingPolicy.cs
@@ -30,11 +30,11 @@ namespace Azure.Core.Pipeline.Policies
             {
                 if (async)
                 {
-                    await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
+                    await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
                 }
                 else
                 {
-                    ProcessNext(pipeline, message);
+                    ProcessNext(message, pipeline);
                 }
                 return;
             }
@@ -75,11 +75,11 @@ namespace Azure.Core.Pipeline.Policies
             var before = Stopwatch.GetTimestamp();
             if (async)
             {
-                await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
+                await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
             }
             else
             {
-                ProcessNext(pipeline, message);
+                ProcessNext(message, pipeline);
             }
 
             var after = Stopwatch.GetTimestamp();

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/RetryPolicy.cs
@@ -44,11 +44,11 @@ namespace Azure.Core.Pipeline.Policies
                 {
                     if (async)
                     {
-                        await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
+                        await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
                     }
                     else
                     {
-                        ProcessNext(pipeline, message);
+                        ProcessNext(message, pipeline);
                     }
                 }
                 catch (Exception ex)

--- a/sdk/core/Azure.Core/src/Pipeline/SynchronousHttpPipelinePolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/SynchronousHttpPipelinePolicy.cs
@@ -11,14 +11,14 @@ namespace Azure.Core.Pipeline
         public override void Process(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
             OnSendingRequest(message);
-            ProcessNext(pipeline, message);
+            ProcessNext(message, pipeline);
             OnReceivedResponse(message);
         }
 
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
             OnSendingRequest(message);
-            await ProcessNextAsync(pipeline, message);
+            await ProcessNextAsync(message, pipeline);
             OnReceivedResponse(message);
         }
 

--- a/sdk/storage/Azure.Storage.Common/src/SharedKeyPipelinePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/SharedKeyPipelinePolicy.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
             this.AddAuthorizationHeader(message);
-            await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
+            await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -51,7 +51,7 @@ namespace Azure.Storage
         public override void Process(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
             this.AddAuthorizationHeader(message);
-            ProcessNext(pipeline, message);
+            ProcessNext(message, pipeline);
         }
 
         private void AddAuthorizationHeader(HttpPipelineMessage message, bool includeXmsDate = true)

--- a/sdk/storage/Azure.Storage.Common/src/TokenPipelinePolicy.cs
+++ b/sdk/storage/Azure.Storage.Common/src/TokenPipelinePolicy.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage
             this.AddAuthorization(message);
 
             // Continue processing the request
-            await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
+            await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -53,7 +53,7 @@ namespace Azure.Storage
             this.AddAuthorization(message);
 
             // Continue processing the request
-            ProcessNext(pipeline, message);
+            ProcessNext(message, pipeline);
         }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/FaultyHttpClientFactory.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/FaultyHttpClientFactory.cs
@@ -25,7 +25,7 @@ namespace Azure.Storage.Test.Shared
 
         public override async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            await ProcessNextAsync(pipeline, message).ConfigureAwait(false);
+            await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
 
             // Copy to a MemoryStream first because RetriableStreamImpl
             // doesn't support Position
@@ -43,7 +43,7 @@ namespace Azure.Storage.Test.Shared
 
         public override void Process(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline)
         {
-            ProcessNext(pipeline, message);
+            ProcessNext(message, pipeline);
 
             // Copy to a MemoryStream first because RetriableStreamImpl
             // doesn't support Position
@@ -59,7 +59,7 @@ namespace Azure.Storage.Test.Shared
                 this._exceptionToRaise);
         }
     }
-    
+
     /*
     sealed class FaultyUploadHttpClientFactory : IPipelinePolicyFactory
     {
@@ -67,7 +67,7 @@ namespace Azure.Storage.Test.Shared
 
         static readonly int retriesBeforeSuccess = 3;
         static int currentCount = 0;
-        
+
         readonly Exception exceptionToRaise;
 
         public FaultyUploadHttpClientFactory(Exception exceptionToRaise) => this.exceptionToRaise = exceptionToRaise;
@@ -116,7 +116,7 @@ namespace Azure.Storage.Test.Shared
 
             this.faultyStream = faultyStream;
         }
-    
+
         protected override Task<Stream> CreateContentReadStreamAsync() => Task.FromResult(this.faultyStream);
 
         protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) => this.faultyStream.CopyToAsync(stream);


### PR DESCRIPTION
ProcessNextAsync/ProcessNext had reverse parameter order of Process/ProcessAsync.

## Breaking change

Before:
``` C#
ProcessNext(pipeline, message); 
```

After:
``` C#
ProcessNext(message, pipeline); 
```
