### PR TITLE
Move logging policy to the base options type

### DIFF
--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientOptions.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientOptions.cs
@@ -12,11 +12,8 @@ namespace Azure.ApplicationModel.Configuration
 
         public FixedRetryPolicy RetryPolicy { get; set; }
 
-        public HttpPipelinePolicy LoggingPolicy { get; set; }
-
         public ConfigurationClientOptions()
         {
-            LoggingPolicy = Core.Pipeline.Policies.LoggingPolicy.Shared;
             RetryPolicy = new FixedRetryPolicy()
             {
                 Delay =  TimeSpan.Zero,

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -73,6 +73,8 @@ namespace Azure.Core.Pipeline
 
             policies.AddRange(options.PerRetryPolicies);
 
+            policies.Add(options.LoggingPolicy);
+
             policies.RemoveAll(policy => policy == null);
 
             return new HttpPipeline(options.Transport, policies.ToArray(), options.ResponseClassifier, options.ServiceProvider);

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
@@ -15,6 +15,7 @@ namespace Azure.Core.Pipeline
         public HttpClientOptions()
         {
             TelemetryPolicy = new TelemetryPolicy(GetType().Assembly);
+            LoggingPolicy = LoggingPolicy.Shared;
         }
 
         public HttpPipelineTransport Transport {
@@ -23,6 +24,8 @@ namespace Azure.Core.Pipeline
         }
 
         public TelemetryPolicy TelemetryPolicy { get; set; }
+
+        public LoggingPolicy LoggingPolicy { get; set; }
 
         public ResponseClassifier ResponseClassifier { get; set; } = new ResponseClassifier();
 

--- a/sdk/keyvault/Azure.Security.Keyvault.Secrets/src/SecretClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.Keyvault.Secrets/src/SecretClientOptions.cs
@@ -8,11 +8,8 @@ namespace Azure.Security.KeyVault.Secrets
     {
         public RetryPolicy RetryPolicy { get; set; }
 
-        public HttpPipelinePolicy LoggingPolicy { get; set; }
-
         public SecretClientOptions()
         {
-            LoggingPolicy = Core.Pipeline.Policies.LoggingPolicy.Shared;
             RetryPolicy = new ExponentialRetryPolicy()
             {
                 Delay = TimeSpan.FromMilliseconds(800),

--- a/sdk/storage/Azure.Storage.Common/src/StorageConnectionOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageConnectionOptions.cs
@@ -25,11 +25,6 @@ namespace Azure.Storage
         public RetryPolicy RetryPolicy { get; set; }
 
         /// <summary>
-        /// Logging 
-        /// </summary>
-        public HttpPipelinePolicy LoggingPolicy { get; set; }
-
-        /// <summary>
         /// Construct the default options for making service requests that
         /// don't require authentication.
         /// </summary>
@@ -86,7 +81,6 @@ namespace Azure.Storage
                 ClientRequestIdPolicy.Singleton,
                 this.RetryPolicy,
                 this.GetAuthenticationPipelinePolicy(this.Credentials),
-                this.LoggingPolicy,
                 // TODO: PageBlob's UploadPagesAsync test currently fails
                 // without buffered responses, so I'm leaving this on for now.
                 // It'd be a great perf win to remove it soon.


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-for-net/issues/6289

## Breaking change

To react remove `LoggingPolicy` property from `ClientOptions` and don't pass it into `HttpPipeline.Build`, it would be handled automatically.