### PR TITLE
ServiceBus SDK: Added connection string support for RBAC with AAD and Managed Identity token provider changes

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/AzureActiveDirectoryTokenProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/AzureActiveDirectoryTokenProvider.cs
@@ -5,59 +5,28 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
     /// <summary>
     /// Represents the Azure Active Directory token provider for the Service Bus.
     /// </summary>
     public class AzureActiveDirectoryTokenProvider : TokenProvider
     {
-        readonly AuthenticationContext authContext;
-        readonly ClientCredential clientCredential;
-#if !UAP10_0
-        readonly ClientAssertionCertificate clientAssertionCertificate;
-#endif
-        readonly string clientId;
-        readonly Uri redirectUri;
-        readonly IPlatformParameters platformParameters;
-        readonly UserIdentifier userIdentifier;
+        /// <summary>
+        /// Common authority for Azure Active Directory.
+        /// </summary>
+        public const string CommonAuthority = "https://login.microsoftonline.com/common";
 
-        enum AuthType
+        readonly string authority;
+        readonly object authCallbackState;
+        event AuthenticationCallback AuthCallback;
+
+        public delegate Task<string> AuthenticationCallback(string audience, string authority, object state);
+
+        internal AzureActiveDirectoryTokenProvider(AuthenticationCallback authenticationCallback, string authority, object state)
         {
-            ClientCredential,
-            UserPasswordCredential,
-            ClientAssertionCertificate,
-            InteractiveUserLogin
-        }
-
-        readonly AuthType authType;
-
-        internal AzureActiveDirectoryTokenProvider(AuthenticationContext authContext, ClientCredential credential)
-        {
-            this.clientCredential = credential;
-            this.authContext = authContext;
-            this.authType = AuthType.ClientCredential;
-            this.clientId = clientCredential.ClientId;
-        }
-
-#if !UAP10_0
-        internal AzureActiveDirectoryTokenProvider(AuthenticationContext authContext, ClientAssertionCertificate clientAssertionCertificate)
-        {
-            this.clientAssertionCertificate = clientAssertionCertificate;
-            this.authContext = authContext;
-            this.authType = AuthType.ClientAssertionCertificate;
-            this.clientId = clientAssertionCertificate.ClientId;
-        }
-#endif
-
-        internal AzureActiveDirectoryTokenProvider(AuthenticationContext authContext, string clientId, Uri redirectUri, IPlatformParameters platformParameters, UserIdentifier userIdentifier)
-        {
-            this.authContext = authContext;
-            this.clientId = clientId;
-            this.redirectUri = redirectUri;
-            this.platformParameters = platformParameters;
-            this.userIdentifier = userIdentifier;
-            this.authType = AuthType.InteractiveUserLogin;
+            this.authority = authority;
+            this.AuthCallback = authenticationCallback;
+            this.authCallbackState = state;
         }
 
         /// <summary>
@@ -68,29 +37,8 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         /// <returns><see cref="SecurityToken"/></returns>
         public override async Task<SecurityToken> GetTokenAsync(string appliesTo, TimeSpan timeout)
         {
-            AuthenticationResult authResult;
-
-            switch (this.authType)
-            {
-                case AuthType.ClientCredential:
-                    authResult = await this.authContext.AcquireTokenAsync(Constants.AadServiceBusAudience, this.clientCredential);
-                    break;
-
-#if !UAP10_0
-                case AuthType.ClientAssertionCertificate:
-                    authResult = await this.authContext.AcquireTokenAsync(Constants.AadServiceBusAudience, this.clientAssertionCertificate);
-                    break;
-#endif
-
-                case AuthType.InteractiveUserLogin:
-                    authResult = await this.authContext.AcquireTokenAsync(Constants.AadServiceBusAudience, this.clientId, this.redirectUri, this.platformParameters, this.userIdentifier);
-                    break;
-
-                default:
-                    throw new NotSupportedException();
-            }
-
-            return new JsonSecurityToken(authResult.AccessToken, appliesTo);
+            var tokenString = await this.AuthCallback(appliesTo, this.authority, this.authCallbackState).ConfigureAwait(false);
+            return new JsonSecurityToken(tokenString, appliesTo);
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ManagedIdentityTokenProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ManagedIdentityTokenProvider.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
     /// <summary>
     /// Represents the Azure Active Directory token provider for Azure Managed Service Identity integration.
     /// </summary>
-    public class ManagedServiceIdentityTokenProvider : TokenProvider
+    public class ManagedIdentityTokenProvider : TokenProvider
     {
         static AzureServiceTokenProvider azureServiceTokenProvider = new AzureServiceTokenProvider();
 

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/TokenProvider.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/TokenProvider.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.IdentityModel.Clients.ActiveDirectory;
 
     /// <summary>
     /// This abstract base class can be extended to implement additional token providers.
@@ -74,88 +73,28 @@ namespace Microsoft.Azure.ServiceBus.Primitives
             return new SharedAccessSignatureTokenProvider(keyName, sharedAccessKey, tokenTimeToLive, tokenScope);
         }
 
-        /// <summary>Creates an Azure Active Directory token provider.</summary>
-        /// <param name="authContext">AuthenticationContext for AAD.</param>
-        /// <param name="clientCredential">The app credential.</param>
-        /// <returns>The <see cref="TokenProvider" /> for returning Json web token.</returns>
-        public static TokenProvider CreateAadTokenProvider(AuthenticationContext authContext, ClientCredential clientCredential)
+        /// <param name="authCallback">The authentication delegate to provide access token.</param>
+        /// <param name="authority">Address of the authority to issue token.</param>
+        /// <param name="state">State to be delivered to callback.</param>
+        /// <returns>The <see cref="Microsoft.ServiceBus.TokenProvider" /> for returning Json web token.</returns>
+        public static TokenProvider CreateAzureActiveDirectoryTokenProvider(
+            AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback,
+            string authority = AzureActiveDirectoryTokenProvider.CommonAuthority,
+            object state = null)
         {
-            if (authContext == null)
+            if (authCallback == null)
             {
-                throw new ArgumentNullException(nameof(authContext));
+                throw new ArgumentNullException(nameof(authCallback));
             }
 
-            if (clientCredential == null)
-            {
-                throw new ArgumentNullException(nameof(clientCredential));
-            }
-
-            return new AzureActiveDirectoryTokenProvider(authContext, clientCredential);
+            return new AzureActiveDirectoryTokenProvider(authCallback, authority, state);
         }
 
-        /// <summary>Creates an Azure Active Directory token provider.</summary>
-        /// <param name="authContext">AuthenticationContext for AAD.</param>
-        /// <param name="clientId">ClientId for AAD.</param>
-        /// <param name="redirectUri">The redirectUri on Client App.</param>
-        /// <param name="platformParameters">Platform parameters</param>
-        /// <param name="userIdentifier">User Identifier</param>
+        /// <summary>Creates Azure Managed Identity token provider.</summary>
         /// <returns>The <see cref="TokenProvider" /> for returning Json web token.</returns>
-        public static TokenProvider CreateAadTokenProvider(
-            AuthenticationContext authContext,
-            string clientId,
-            Uri redirectUri,
-            IPlatformParameters platformParameters,
-            UserIdentifier userIdentifier = null)
+        public static TokenProvider CreateManagedIdentityTokenProvider()
         {
-            if (authContext == null)
-            {
-                throw new ArgumentNullException(nameof(authContext));
-            }
-
-            if (string.IsNullOrEmpty(clientId))
-            {
-                throw new ArgumentNullException(nameof(clientId));
-            }
-
-            if (redirectUri == null)
-            {
-                throw new ArgumentNullException(nameof(redirectUri));
-            }
-
-            if (platformParameters == null)
-            {
-                throw new ArgumentNullException(nameof(platformParameters));
-            }
-
-            return new AzureActiveDirectoryTokenProvider(authContext, clientId, redirectUri, platformParameters, userIdentifier);
-        }
-
-#if !UAP10_0
-        /// <summary>Creates an Azure Active Directory token provider.</summary>
-        /// <param name="authContext">AuthenticationContext for AAD.</param>
-        /// <param name="clientAssertionCertificate">The client assertion certificate credential.</param>
-        /// <returns>The <see cref="TokenProvider" /> for returning Json web token.</returns>
-        public static TokenProvider CreateAadTokenProvider(AuthenticationContext authContext, ClientAssertionCertificate clientAssertionCertificate)
-        {
-            if (authContext == null)
-            {
-                throw new ArgumentNullException(nameof(authContext));
-            }
-
-            if (clientAssertionCertificate == null)
-            {
-                throw new ArgumentNullException(nameof(clientAssertionCertificate));
-            }
-
-            return new AzureActiveDirectoryTokenProvider(authContext, clientAssertionCertificate);
-        }
-#endif
-
-        /// <summary>Creates Azure Managed Service Identity token provider.</summary>
-        /// <returns>The <see cref="TokenProvider" /> for returning Json web token.</returns>
-        public static TokenProvider CreateManagedServiceIdentityTokenProvider()
-        {
-            return new ManagedServiceIdentityTokenProvider();
+            return new ManagedIdentityTokenProvider();
         }
 
         /// <summary>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
@@ -152,6 +152,54 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>
+        /// Creates a new instance of the Queue client using Azure Active Directory authentication.
+        /// </summary>
+        /// <param name="endpoint">Fully qualified domain name for Service Bus. Most likely, {yournamespace}.servicebus.windows.net</param>
+        /// <param name="entityPath">Queue path.</param>
+        /// <param name="authCallback">User provided delegate that will provide the access token.</param>
+        /// <param name="authority">Address of the authority to issue token.</param>
+        /// <param name="transportType">Transport type.</param>
+        /// <param name="receiveMode">Mode of receive of messages. Defaults to <see cref="ReceiveMode"/>.PeekLock.</param>
+        /// <param name="retryPolicy">Retry policy for queue operations. Defaults to <see cref="RetryPolicy.Default"/></param>
+        /// <remarks>Creates a new connection to the queue, which is opened during the first send/receive operation.</remarks>
+        public static QueueClient CreateWithAzureActiveDirectory(
+            string endpoint,
+            string entityPath,
+            AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback,
+            string authority = AzureActiveDirectoryTokenProvider.CommonAuthority,
+            TransportType transportType = TransportType.Amqp,
+            ReceiveMode receiveMode = ReceiveMode.PeekLock,
+            RetryPolicy retryPolicy = null)
+        {
+            return new QueueClient(new ServiceBusConnection(endpoint, transportType, retryPolicy)
+            {
+                TokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, authority)
+            }, entityPath, receiveMode, retryPolicy);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the Queue client by using Azure Managed Identity authentication.
+        /// </summary>
+        /// <param name="endpoint">Fully qualified domain name for Service Bus. Most likely, {yournamespace}.servicebus.windows.net</param>
+        /// <param name="entityPath">Queue path.</param>
+        /// <param name="transportType">Transport type.</param>
+        /// <param name="receiveMode">Mode of receive of messages. Defaults to <see cref="ReceiveMode"/>.PeekLock.</param>
+        /// <param name="retryPolicy">Retry policy for queue operations. Defaults to <see cref="RetryPolicy.Default"/></param>
+        /// <remarks>Creates a new connection to the queue, which is opened during the first send/receive operation.</remarks>
+        public static QueueClient CreateWithManagedIdentity(
+            string endpoint,
+            string entityPath,
+            TransportType transportType = TransportType.Amqp,
+            ReceiveMode receiveMode = ReceiveMode.PeekLock,
+            RetryPolicy retryPolicy = null)
+        {
+            return new QueueClient(new ServiceBusConnection(endpoint, transportType, retryPolicy)
+            {
+                TokenProvider = TokenProvider.CreateManagedIdentityTokenProvider()
+            }, entityPath, receiveMode, retryPolicy);
+        }
+
+        /// <summary>
         /// Gets the name of the queue.
         /// </summary>
         public string QueueName { get; }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Resources.Designer.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.ServiceBus {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -75,6 +75,15 @@ namespace Microsoft.Azure.ServiceBus {
         internal static string AmqpMessageSizeExceeded {
             get {
                 return ResourceManager.GetString("AmqpMessageSizeExceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following arguments must all be provided or none at all: {0}..
+        /// </summary>
+        internal static string ArgumentInvalidCombination {
+            get {
+                return ResourceManager.GetString("ArgumentInvalidCombination", resourceCulture);
             }
         }
         

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Resources.resx
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Resources.resx
@@ -216,4 +216,7 @@
   <data name="TimeoutMustBePositiveNonZero" xml:space="preserve">
     <value>Argument {0} must be a positive non-zero timeout value. The provided value was {1}.</value>
   </data>
+  <data name="ArgumentInvalidCombination" xml:space="preserve">
+    <value>The following arguments must all be provided or none at all: {0}.</value>
+  </data>
 </root>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/ServiceBusConnection.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/ServiceBusConnection.cs
@@ -218,6 +218,10 @@ namespace Microsoft.Azure.ServiceBus
             {
                 this.TokenProvider = new SharedAccessSignatureTokenProvider(builder.SasKeyName, builder.SasKey);
             }
+            else if (!string.Equals(builder.Authentication, "Managed Identity", StringComparison.OrdinalIgnoreCase))
+            {
+                this.TokenProvider = Primitives.TokenProvider.CreateManagedIdentityTokenProvider();
+            }
 
             this.OperationTimeout = builder.OperationTimeout;
             this.TransportType = builder.TransportType;

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SubscriptionClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SubscriptionClient.cs
@@ -157,6 +157,58 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>
+        /// Creates a new instance of the Subscription client using Azure Active Directory authentication.
+        /// </summary>
+        /// <param name="endpoint">Fully qualified domain name for Service Bus. Most likely, {yournamespace}.servicebus.windows.net</param>
+        /// <param name="subscriptionPath">Subscription path.</param>
+        /// <param name="subscriptionName">Subscription name.</param>
+        /// <param name="authCallback">User provided delegate that will provide the access token.</param>
+        /// <param name="authority">Address of the authority to issue token.</param>
+        /// <param name="transportType">Transport type.</param>
+        /// <param name="receiveMode">Mode of receive of messages. Defaults to <see cref="ReceiveMode"/>.PeekLock.</param>
+        /// <param name="retryPolicy">Retry policy for subscription operations. Defaults to <see cref="RetryPolicy.Default"/></param>
+        /// <remarks>Creates a new connection to the subscription, which is opened during the first send/receive operation.</remarks>
+        public static SubscriptionClient CreateWithAzureActiveDirectory(
+            string endpoint,
+            string subscriptionPath,
+            string subscriptionName,
+            AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback,
+            string authority = AzureActiveDirectoryTokenProvider.CommonAuthority,
+            TransportType transportType = TransportType.Amqp,
+            ReceiveMode receiveMode = ReceiveMode.PeekLock,
+            RetryPolicy retryPolicy = null)
+        {
+            return new SubscriptionClient(new ServiceBusConnection(endpoint, transportType, retryPolicy)
+            {
+                TokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, authority)
+            }, subscriptionPath, subscriptionName, receiveMode, retryPolicy);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the Subscription client with the specified endpoint and entity path by using Azure Managed Identity authentication.
+        /// </summary>
+        /// <param name="endpoint">Fully qualified domain name for Service Bus. Most likely, {yournamespace}.servicebus.windows.net</param>
+        /// <param name="subscriptionPath">Subscription path.</param>
+        /// <param name="subscriptionName">Subscription name.</param>
+        /// <param name="transportType">Transport type.</param>
+        /// <param name="receiveMode">Mode of receive of messages. Defaults to <see cref="ReceiveMode"/>.PeekLock.</param>
+        /// <param name="retryPolicy">Retry policy for subscription operations. Defaults to <see cref="RetryPolicy.Default"/></param>
+        /// <remarks>Creates a new connection to the subscription, which is opened during the first send/receive operation.</remarks>
+        public static SubscriptionClient CreateWithManagedIdentity(
+            string endpoint,
+            string subscriptionPath,
+            string subscriptionName,
+            TransportType transportType = TransportType.Amqp,
+            ReceiveMode receiveMode = ReceiveMode.PeekLock,
+            RetryPolicy retryPolicy = null)
+        {
+            return new SubscriptionClient(new ServiceBusConnection(endpoint, transportType, retryPolicy)
+            {
+                TokenProvider = TokenProvider.CreateManagedIdentityTokenProvider()
+            }, subscriptionPath, subscriptionName, receiveMode, retryPolicy);
+        }
+
+        /// <summary>
         /// Gets the path of the corresponding topic.
         /// </summary>
         public string TopicPath { get; }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/TopicClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/TopicClient.cs
@@ -117,6 +117,52 @@ namespace Microsoft.Azure.ServiceBus
         }
 
         /// <summary>
+        /// Creates a new instance of the Topic client using Azure Active Directory authentication.
+        /// </summary>
+        /// <param name="endpoint">Fully qualified domain name for Service Bus. Most likely, {yournamespace}.servicebus.windows.net</param>
+        /// <param name="entityPath">Topic path.</param>
+        /// <param name="authCallback">User provided delegate that will provide the access token.</param>
+        /// <param name="authority">Address of the authority to issue token.</param>
+        /// <param name="transportType">Transport type.</param>
+        /// <param name="retryPolicy">Retry policy for topic operations. Defaults to <see cref="RetryPolicy.Default"/></param>
+        /// <remarks>Creates a new connection to the topic, which is opened during the first send/receive operation.</remarks>
+        public static TopicClient CreateWithAzureActiveDirectory(
+            string endpoint,
+            string entityPath,
+            AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback,
+            string authority = AzureActiveDirectoryTokenProvider.CommonAuthority,
+            TransportType transportType = TransportType.Amqp,
+            ReceiveMode receiveMode = ReceiveMode.PeekLock,
+            RetryPolicy retryPolicy = null)
+        {
+            return new TopicClient(new ServiceBusConnection(endpoint, transportType, retryPolicy)
+            {
+                TokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, authority)
+            }, entityPath, retryPolicy);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the Topic client by using Azure Managed Identity authentication.
+        /// </summary>
+        /// <param name="endpoint">Fully qualified domain name for Service Bus. Most likely, {yournamespace}.servicebus.windows.net</param>
+        /// <param name="entityPath">Topic path.</param>
+        /// <param name="transportType">Transport type.</param>
+        /// <param name="retryPolicy">Retry policy for topic operations. Defaults to <see cref="RetryPolicy.Default"/></param>
+        /// <remarks>Creates a new connection to the topic, which is opened during the first send/receive operation.</remarks>
+        public static TopicClient CreateWithManagedIdentity(
+            string endpoint,
+            string entityPath,
+            TransportType transportType = TransportType.Amqp,
+            ReceiveMode receiveMode = ReceiveMode.PeekLock,
+            RetryPolicy retryPolicy = null)
+        {
+            return new TopicClient(new ServiceBusConnection(endpoint, transportType, retryPolicy)
+            {
+                TokenProvider = TokenProvider.CreateManagedIdentityTokenProvider()
+            }, entityPath, retryPolicy);
+        }
+
+        /// <summary>
         /// Gets the name of the topic.
         /// </summary>
         public string TopicName { get; }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/ServiceBusConnectionStringBuilderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/ServiceBusConnectionStringBuilderTests.cs
@@ -191,5 +191,15 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
                 await receiver.CloseAsync();
             });
         }
+
+        [Fact]
+        public void InvalidAadConnectionStringTest()
+        {
+            String connecitionString = "Endpoint=sb://test.servicebus.windows.net/;authentication=Managed Identity;SHAREDACCESSKEYNAME=val";
+            Assert.Throws<ArgumentException>(() => new ServiceBusConnectionStringBuilder(connecitionString));
+
+            connecitionString = "Endpoint=sb://test.servicebus.windows.net/;AUTHENTICATION=Managed Identity;SharedAccessSignature=sig";
+            Assert.Throws<ArgumentException>(() => new ServiceBusConnectionStringBuilder(connecitionString));
+        }
     }
 }


### PR DESCRIPTION
- Added connection string support for AAD and Managed Identity token providers
- Removed dependency on ADAL
- Support creation of Queue/Topic/Subscription with the modified token providers