### PR TITLE
Update dependency on Microsoft.IdentityModel.Clients.ActiveDirectory

### DIFF
--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -27,7 +27,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.4" />
+        <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.0" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
This library builds with Microsoft.IdentityModel.Clients.ActiveDirectory >= 3.19.4. This version of the library has an additional DLL named 'Microsoft.IdentityModel.Clients.ActiveDirectory.Platform' which has been removed in version of Microsoft.IdentityModel.Clients.ActiveDirectory >= 4.

I have other dependencies which require Microsoft.IdentityModel.Clients.ActiveDirectory >= 4.5.0 which forces this library to use 4.5.0 and fail with a FileNotFoundException when trying to load 'Microsoft.IdentityModel.Clients.ActiveDirectory.Platform'