### PR TITLE
Removed eng/ path filter.

### DIFF
--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/appconfiguration/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/appconfiguration/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -5,6 +5,10 @@ trigger:
   branches:
     include:
     - master
+  paths:
+    include:
+    - sdk/appconfiguration/
+    - sdk/core/
 
 pr:
   branches:
@@ -14,7 +18,6 @@ pr:
     include:
     - sdk/appconfiguration/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/applicationinsights/ci.yml
+++ b/sdk/applicationinsights/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/applicationinsights/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/applicationinsights/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/applicationinsights/ci.yml
+++ b/sdk/applicationinsights/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/applicationinsights/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/applicationinsights/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/eventgrid/ci.yml
+++ b/sdk/eventgrid/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/eventgrid/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/eventgrid/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/eventgrid/ci.yml
+++ b/sdk/eventgrid/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/eventgrid/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/eventgrid/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/eventhub/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/eventhub/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/eventhub/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/eventhub/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/hdinsight/ci.yml
+++ b/sdk/hdinsight/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/hdinsight/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/hdinsight/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/hdinsight/ci.yml
+++ b/sdk/hdinsight/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/hdinsight/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/hdinsight/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/identity/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/identity/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/identity/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/identity/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/keyvault/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/keyvault/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/keyvault/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/keyvault/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/operationalinsights/ci.yml
+++ b/sdk/operationalinsights/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/operationalinsights/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/operationalinsights/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/operationalinsights/ci.yml
+++ b/sdk/operationalinsights/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/operationalinsights/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/operationalinsights/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/servicebus/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/servicebus/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/servicebus/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/servicebus/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -8,7 +8,6 @@ trigger:
   paths:
     include:
     - sdk/storage/
-    - sdk/core/
 
 pr:
   branches:
@@ -17,7 +16,6 @@ pr:
   paths:
     include:
     - sdk/storage/
-    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -9,7 +9,6 @@ trigger:
     include:
     - sdk/storage/
     - sdk/core/
-    - eng/
 
 pr:
   branches:
@@ -19,7 +18,6 @@ pr:
     include:
     - sdk/storage/
     - sdk/core/
-    - eng/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml


### PR DESCRIPTION
This is to stop the bleeding of pipelines triggering from changes we are making in /eng. We'll still accumulate changes based on non-eng changes when folks don't rebase but it should be significantly less volume.