### PR TITLE
*DO NOT MERGE* Add a long running operation result prototype

### DIFF
--- a/sdk/core/Azure.Core/src/LongRunningOperation.cs
+++ b/sdk/core/Azure.Core/src/LongRunningOperation.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure
+{
+    public abstract class LongRunningOperation<T>: IDisposable
+    {
+        public abstract Response Raw { get; }
+        public abstract ValueTask<Response<T>> GetValueAsync(CancellationToken cancellationToken = default);
+        public abstract Response<T> GetValue(CancellationToken cancellationToken = default);
+
+        public abstract ValueTask<Response<LongRunningOperationStatus>> GetStatusAsync(CancellationToken cancellationToken = default);
+        public abstract Response<LongRunningOperationStatus> GetStatus(CancellationToken cancellationToken = default);
+
+        public abstract ValueTask<Response> CancelAsync(CancellationToken cancellationToken = default);
+        public abstract Response Cancel(CancellationToken cancellationToken = default);
+        public abstract void Dispose();
+    }
+}

--- a/sdk/core/Azure.Core/src/LongRunningOperationImpl.cs
+++ b/sdk/core/Azure.Core/src/LongRunningOperationImpl.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline.Policies;
+
+namespace Azure
+{
+    public class LongRunningOperationImpl<T> : LongRunningOperation<T>
+    {
+        private Response<T>? _cachedValue;
+
+        private readonly TimeSpan _pollDelay;
+
+        private readonly Func<CancellationToken, Task<Response<T>>> _asyncValueRequestFactory;
+
+        private readonly Func<CancellationToken, Response<T>> _valueRequestFactory;
+
+        private readonly Func<CancellationToken, Task<Response>> _cancelAsyncRequestFactory;
+
+        private readonly Func<CancellationToken, Response> _cancelRequestFactory;
+
+        private readonly Func<CancellationToken, Task<Response<LongRunningOperationStatus>>> _asyncStatusRequestFactory;
+
+        private readonly Func<CancellationToken, Response<LongRunningOperationStatus>> _statusRequestFactory;
+
+        public override Response Raw { get; }
+
+        public LongRunningOperationImpl(Response raw,
+            TimeSpan pollDelay,
+            Func<CancellationToken, Task<Response<T>>> asyncValueRequestFactory,
+            Func<CancellationToken, Response<T>> valueRequestFactory,
+
+            Func<CancellationToken, Task<Response>> cancelAsyncRequestFactory,
+            Func<CancellationToken, Response> cancelRequestFactory,
+
+            Func<CancellationToken, Task<Response<LongRunningOperationStatus>>> asyncStatusRequestFactory,
+            Func<CancellationToken, Response<LongRunningOperationStatus>> statusRequestFactory)
+        {
+            _pollDelay = pollDelay;
+            _asyncValueRequestFactory = asyncValueRequestFactory;
+            _valueRequestFactory = valueRequestFactory;
+            _cancelAsyncRequestFactory = cancelAsyncRequestFactory;
+            _cancelRequestFactory = cancelRequestFactory;
+            _asyncStatusRequestFactory = asyncStatusRequestFactory;
+            _statusRequestFactory = statusRequestFactory;
+            Raw = raw;
+        }
+
+        public override async ValueTask<Response<T>> GetValueAsync(CancellationToken cancellationToken = default)
+        {
+            return await GetValueAsyncCore(true, cancellationToken);
+        }
+
+        public override Response<T> GetValue(CancellationToken cancellationToken = default)
+        {
+            return GetValueAsyncCore(false, cancellationToken).EnsureCompleted();
+        }
+
+        private async Task<Response<T>> GetValueAsyncCore(bool async, CancellationToken cancellationToken)
+        {
+            if (_cachedValue == null)
+            {
+                Response<LongRunningOperationStatus> status = async ? await GetStatusAsync(cancellationToken) : GetStatus(cancellationToken);
+
+                while (status.Value == LongRunningOperationStatus.Running)
+                {
+                    await Task.Delay(_pollDelay, cancellationToken);
+                }
+
+                // TODO: Cache exception
+                _cachedValue = async ? await _asyncValueRequestFactory(cancellationToken) : _valueRequestFactory(cancellationToken);
+            }
+
+            return _cachedValue.Value;
+        }
+
+        public override async ValueTask<Response<LongRunningOperationStatus>> GetStatusAsync(CancellationToken cancellationToken = default)
+        {
+            // TODO: Rate limit status calls
+            return await _asyncStatusRequestFactory(cancellationToken);
+        }
+
+        public override Response<LongRunningOperationStatus> GetStatus(CancellationToken cancellationToken = default)
+        {
+            // TODO: Rate limit status calls
+            return _statusRequestFactory(cancellationToken);
+        }
+
+        public override async ValueTask<Response> CancelAsync(CancellationToken cancellationToken = default)
+        {
+            return await _cancelAsyncRequestFactory(cancellationToken);
+        }
+
+        public override Response Cancel(CancellationToken cancellationToken = default)
+        {
+            return _cancelRequestFactory(cancellationToken);
+        }
+
+        public override void Dispose()
+        {
+            _cachedValue?.Dispose();
+        }
+    }
+}

--- a/sdk/core/Azure.Core/src/LongRunningOperationStatus.cs
+++ b/sdk/core/Azure.Core/src/LongRunningOperationStatus.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure
+{
+    public enum LongRunningOperationStatus
+    {
+        Running,
+        Completed,
+        Aborted,
+        Failed
+    }
+}

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -27,7 +27,7 @@ namespace Azure.Storage.Blobs.Specialized
         public Uri Uri { get; }
 
         /// <summary>
-        /// The <see cref="HttpPipeline"/> transport pipeline used to send 
+        /// The <see cref="HttpPipeline"/> transport pipeline used to send
         /// every request.
         /// </summary>
         protected HttpPipeline Pipeline { get; private set; }
@@ -40,7 +40,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A connection string includes the authentication information
         /// required for your application to access data in an Azure Storage
         /// account at runtime.
-        /// 
+        ///
         /// For more information, <see href="https://docs.microsoft.com/en-us/azure/storage/common/storage-configure-connection-string"/>.
         /// </param>
         /// <param name="containerName">
@@ -61,7 +61,7 @@ namespace Azure.Storage.Blobs.Specialized
         {
             var conn = StorageConnectionString.Parse(connectionString);
 
-            var builder = 
+            var builder =
                 new BlobUriBuilder(conn.BlobEndpoint)
                 {
                     ContainerName = containerName,
@@ -117,7 +117,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// Initializes a new instance of the <see cref="BlobClient"/>
         /// class with an identical <see cref="Uri"/> source but the specified
         /// <paramref name="snapshot"/> timestamp.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob" />.
         /// </summary>
         /// <param name="snapshot">The snapshot identifier.</param>
@@ -163,7 +163,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="DownloadAsync"/> operation downloads a blob from
         /// the service, including its metadata and properties.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
         /// </summary>
         /// <param name="range">
@@ -197,7 +197,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public async Task<Response<BlobDownloadInfo>> DownloadAsync(
             HttpRange range = default,
-            BlobAccessConditions? accessConditions = default, 
+            BlobAccessConditions? accessConditions = default,
             bool rangeGetContentHash = default,
             CancellationToken cancellation = default)
         {
@@ -325,19 +325,19 @@ namespace Azure.Storage.Blobs.Specialized
         /// the <see cref="BlobProperties.CopyStatus"/> returned from the
         /// <see cref="GetPropertiesAsync"/> to determine if the copy has
         /// completed.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
         /// </summary>
         /// <param name="source">
         /// Specifies the <see cref="Uri"/> of the source blob.  The value may
         /// be a <see cref="Uri" /> of up to 2 KB in length that specifies a
-        /// blob.  A source blob in the same storage account can be 
+        /// blob.  A source blob in the same storage account can be
         /// authenticated via Shared Key.  However, if the source is a blob in
         /// another account, the source blob must either be public or must be
         /// authenticated via a shared access signature. If the source blob
         /// is public, no authentication is required to perform the copy
         /// operation.
-        /// 
+        ///
         /// The source object may be a file in the Azure File service.  If the
         /// source object is a file that is to be copied to a blob, then the
         /// source file must be authenticated using a shared access signature,
@@ -367,9 +367,9 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public async Task<Response<BlobCopyInfo>> StartCopyFromUriAsync(
-            Uri source, 
-            Metadata metadata = default, 
-            BlobAccessConditions? sourceAccessConditions = default, 
+            Uri source,
+            Metadata metadata = default,
+            BlobAccessConditions? sourceAccessConditions = default,
             BlobAccessConditions? destinationAccessConditions = default,
             CancellationToken cancellation = default)
         {
@@ -395,7 +395,7 @@ namespace Azure.Storage.Blobs.Specialized
                         ifModifiedSince: destinationAccessConditions?.HttpAccessConditions?.IfModifiedSince,
                         ifUnmodifiedSince: destinationAccessConditions?.HttpAccessConditions?.IfUnmodifiedSince,
                         ifMatch: destinationAccessConditions?.HttpAccessConditions?.IfMatch,
-                        ifNoneMatch: destinationAccessConditions?.HttpAccessConditions?.IfNoneMatch,                    
+                        ifNoneMatch: destinationAccessConditions?.HttpAccessConditions?.IfNoneMatch,
                         leaseId: destinationAccessConditions?.LeaseAccessConditions?.LeaseId,
                         metadata: metadata,
                         cancellation: cancellation)
@@ -412,12 +412,85 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        public async Task<LongRunningOperation<BlobProperties>> StartCopyAsync(
+            Uri source,
+            Metadata metadata = default,
+            BlobAccessConditions? sourceAccessConditions = default,
+            BlobAccessConditions? destinationAccessConditions = default,
+            CancellationToken cancellation = default)
+        {
+            using (this.Pipeline.BeginLoggingScope(nameof(BlobClient)))
+            {
+                this.Pipeline.LogMethodEnter(
+                    nameof(BlobClient),
+                    message:
+                    $"{nameof(this.Uri)}: {this.Uri}\n" +
+                    $"{nameof(source)}: {source}\n" +
+                    $"{nameof(sourceAccessConditions)}: {sourceAccessConditions}\n" +
+                    $"{nameof(destinationAccessConditions)}: {destinationAccessConditions}");
+                try
+                {
+                    var startResponse = await BlobRestClient.Blob.StartCopyFromUriAsync(
+                            this.Pipeline,
+                            this.Uri,
+                            copySource: source,
+                            sourceIfModifiedSince: sourceAccessConditions?.HttpAccessConditions?.IfModifiedSince,
+                            sourceIfUnmodifiedSince: sourceAccessConditions?.HttpAccessConditions?.IfUnmodifiedSince,
+                            sourceIfMatch: sourceAccessConditions?.HttpAccessConditions?.IfMatch,
+                            sourceIfNoneMatch: sourceAccessConditions?.HttpAccessConditions?.IfNoneMatch,
+                            ifModifiedSince: destinationAccessConditions?.HttpAccessConditions?.IfModifiedSince,
+                            ifUnmodifiedSince: destinationAccessConditions?.HttpAccessConditions?.IfUnmodifiedSince,
+                            ifMatch: destinationAccessConditions?.HttpAccessConditions?.IfMatch,
+                            ifNoneMatch: destinationAccessConditions?.HttpAccessConditions?.IfNoneMatch,
+                            leaseId: destinationAccessConditions?.LeaseAccessConditions?.LeaseId,
+                            metadata: metadata,
+                            cancellation: cancellation)
+                        .ConfigureAwait(false);
+
+                    return new LongRunningOperationImpl<BlobProperties>(
+                        startResponse.Raw, TimeSpan.FromSeconds(5),
+                        token => this.GetPropertiesAsync(sourceAccessConditions, token),
+                        token => this.GetPropertiesAsync(sourceAccessConditions, token).GetAwaiter().GetResult(),
+                        token => this.AbortCopyFromUriAsync(startResponse.Value.CopyId, cancellation: token),
+                        token => this.AbortCopyFromUriAsync(startResponse.Value.CopyId, cancellation: token).GetAwaiter().GetResult(),
+                        async token => GetLongRunningOperationStatus(await this.GetPropertiesAsync(cancellation: cancellation).ConfigureAwait(false)),
+                        token => GetLongRunningOperationStatus(this.GetPropertiesAsync(cancellation: cancellation).GetAwaiter().GetResult())
+                        );
+                }
+                catch (Exception ex)
+                {
+                    this.Pipeline.LogException(ex);
+                    throw;
+                }
+                finally
+                {
+                    this.Pipeline.LogMethodExit(nameof(BlobClient));
+                }
+            }
+        }
+
+        private static Response<LongRunningOperationStatus> GetLongRunningOperationStatus(Response<BlobProperties> getPropertiesAsync)
+        {
+            switch (getPropertiesAsync.Value.CopyStatus)
+            {
+                case CopyStatus.Pending:
+                    return new Response<LongRunningOperationStatus>(getPropertiesAsync.Raw, LongRunningOperationStatus.Running);
+                case CopyStatus.Success:
+                    return new Response<LongRunningOperationStatus>(getPropertiesAsync.Raw, LongRunningOperationStatus.Completed);
+                case CopyStatus.Aborted:
+                    return new Response<LongRunningOperationStatus>(getPropertiesAsync.Raw, LongRunningOperationStatus.Aborted);
+                case CopyStatus.Failed:
+                    return new Response<LongRunningOperationStatus>(getPropertiesAsync.Raw, LongRunningOperationStatus.Failed);
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(getPropertiesAsync), $"Unknown copy status {getPropertiesAsync.Value.CopyStatus}");
+            }
+        }
 
         /// <summary>
         /// The <see cref="AbortCopyFromUriAsync"/> operation aborts a pending
         /// <see cref="StartCopyFromUriAsync"/> operation, and leaves a this
         /// blob with zero length and full metadata.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob" />.
         /// </summary>
         /// <param name="copyId">
@@ -439,7 +512,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public async Task<Response> AbortCopyFromUriAsync(
-            string copyId, 
+            string copyId,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellation = default)
         {
@@ -477,11 +550,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="DeleteAsync"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
         /// garbage collection.
-        /// 
+        ///
         /// Note that in order to delete a blob, you must delete all of its
-        /// snapshots. You can delete both at the same time using 
+        /// snapshots. You can delete both at the same time using
         /// <see cref="DeleteSnapshotsOption.Include"/>.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-blob" />.
         /// </summary>
         /// <param name="deleteOptions">
@@ -550,7 +623,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="UndeleteAsync"/> operation restores the contents
         /// and metadata of a soft deleted blob and any associated soft
         /// deleted snapshots.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/undelete-blob" />.
         /// </summary>
         /// <param name="cancellation">
@@ -593,7 +666,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="GetAccountInfoAsync"/> operation returns the sku
         /// name and account kind for the account of the blob.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information" />.
         /// </summary>
         /// <param name="cancellation">
@@ -638,7 +711,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the blob. It does not return the content of the
         /// blob.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob-properties" />.
         /// </summary>
         /// <param name="accessConditions">
@@ -696,7 +769,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="SetHttpHeadersAsync"/> operation sets system
         /// properties on the blob.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
         /// </summary>
         /// <param name="httpHeaders">
@@ -772,9 +845,9 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="SetMetadataAsync"/> operation sets user-defined 
+        /// The <see cref="SetMetadataAsync"/> operation sets user-defined
         /// metadata for the specified blob as one or more name-value pairs.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
         /// </summary>
         /// <param name="metadata">
@@ -797,7 +870,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public async Task<Response<BlobInfo>> SetMetadataAsync(
-            Metadata metadata, 
+            Metadata metadata,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellation = default)
         {
@@ -845,7 +918,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="CreateSnapshotAsync"/> operation creates a
         /// read-only snapshot of a blob.
-        /// 
+        ///
         /// For more infomration, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-blob" />.
         /// </summary>
         /// <param name="metadata">
@@ -868,7 +941,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public async Task<Response<BlobSnapshotInfo>> CreateSnapshotAsync(
-            Metadata metadata = default, 
+            Metadata metadata = default,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellation = default)
         {
@@ -907,16 +980,16 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The <see cref="AcquireLeaseAsync"/> operation acquires a lease on
-        /// the blob for write and delete operations.  The lease 
+        /// the blob for write and delete operations.  The lease
         /// <paramref name="duration"/> must be between 15 to 60 seconds, or
         /// infinite (-1).
-        /// 
+        ///
         /// If the blob does not have an active lease, the Blob service
         /// creates a lease on the blob and returns it.  If the blob has an
         /// active lease, you can only request a new lease using the active
         /// lease ID as <paramref name="proposedId"/>, but you can specify a
         /// new <paramref name="duration"/>.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-blob" />.
         /// </summary>
         /// <param name="duration">
@@ -945,7 +1018,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public async Task<Response<Lease>> AcquireLeaseAsync( 
+        public async Task<Response<Lease>> AcquireLeaseAsync(
             int duration,
             string proposedID = default,
             HttpAccessConditions? httpAccessConditions = default,
@@ -988,13 +1061,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="RenewLeaseAsync"/> operation renews the blob's
         /// previously-acquired lease.
-        /// 
-        /// The lease can be renewed if the <paramref name="leaseId"/> 
+        ///
+        /// The lease can be renewed if the <paramref name="leaseId"/>
         /// matches that associated with the blob.  Note that the lease may be
         /// renewed even if it has expired as long as the blob has not been
         /// modified or leased again since the expiration of that lease.  When
         /// you renew a lease, the lease duration clock resets.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-blob" />.
         /// </summary>
         /// <param name="leaseId">
@@ -1016,7 +1089,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public async Task<Response<Lease>> RenewLeaseAsync(
-            string leaseID, 
+            string leaseID,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellation = default)
         {
@@ -1054,14 +1127,14 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="ReleaseLeaseAsync"/> operation releases the 
+        /// The <see cref="ReleaseLeaseAsync"/> operation releases the
         /// blob's previously-acquired lease.
-        /// 
+        ///
         /// The lease may be released if the <paramref name="leaseId"/>
-        /// matches that associated with the blob.  Releasing the lease allows 
+        /// matches that associated with the blob.  Releasing the lease allows
         /// another client to immediately acquire the lease for the blob as
         /// soon as the release is complete.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-blob" />.
         /// </summary>
         /// <param name="leaseId">
@@ -1124,8 +1197,8 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="BreakLeaseAsync"/> operation breaks the blob's
         /// previously-acquired lease (if it exists).
-        /// 
-        /// Once a lease is broken, it cannot be renewed.  Any authorized 
+        ///
+        /// Once a lease is broken, it cannot be renewed.  Any authorized
         /// request can break the lease; the request is not required to
         /// specify a matching lease ID.  When a lease is broken, the lease
         /// break <paramref name="period"/> is allowed to elapse, during which
@@ -1133,10 +1206,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="ReleaseLeaseAsync"/> can be performed on the blob.
         /// When a lease is successfully broken, the response indicates the
         /// interval in seconds until a new lease can be acquired.
-        /// 
+        ///
         /// A lease that has been broken can also be released.  A client can
         /// immediately acquire a blob lease that has been released.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-blob" />.
         /// </summary>
         /// <param name="period">
@@ -1165,7 +1238,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// a failure occurs.
         /// </remarks>
         public async Task<Response<Lease>> BreakLeaseAsync(
-            int? breakPeriodInSeconds = default, 
+            int? breakPeriodInSeconds = default,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellation = default)
         {
@@ -1204,11 +1277,11 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="ChangeLeaseAsync"/> operation changes the lease 
+        /// The <see cref="ChangeLeaseAsync"/> operation changes the lease
         /// of an active lease.  A change must include the current
         /// <paramref name="leaseId"/> and a new
         /// <paramref name="proposedId"/>.
-        /// 
+        ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-blob" />.
         /// </summary>
         /// <param name="leaseId">
@@ -1236,7 +1309,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public async Task<Response<Lease>> ChangeLeaseAsync(
             string leaseID,
-            string proposedID, 
+            string proposedID,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellation = default)
         {
@@ -1280,13 +1353,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// The operation is allowed on a page blob in a premium storage
         /// account and on a block blob in a blob storage or general purpose
         /// v2 account.
-        /// 
+        ///
         /// A premium page blob's tier determines the allowed size, IOPS, and
         /// bandwidth of the blob.  A block blob's tier determines
         /// Hot/Cool/Archive storage type.  This operation does not update the
         /// blob's ETag.  For detailed information about block blob level
         /// tiering <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />
-        /// 
+        ///
         /// For more information about setting the tier, see
         /// <see href="https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers" />.
         /// </summary>
@@ -1400,7 +1473,7 @@ namespace Azure.Storage.Blobs.Models
         /// Properties returned when downloading a Blob
         /// </summary>
         public BlobDownloadProperties Properties { get; private set; }
-        
+
         /// <summary>
         /// Creates a new DownloadInfo backed by FlattenedDownloadProperties
         /// </summary>
@@ -1471,7 +1544,7 @@ namespace Azure.Storage.Blobs.Models
         /// The current sequence number for a page blob. This header is not returned for block blobs or append blobs
         /// </summary>
         public long BlobSequenceNumber => this._flattened.BlobSequenceNumber;
-        
+
         /// <summary>
         /// Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob. This value can specify the time of a completed, aborted, or failed copy attempt. This header does not appear if a copy is pending, if this blob has never been the destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties, Put Blob, or Put Block List.
         /// </summary>


### PR DESCRIPTION
**NOTE:** `StartCopyAsync` is only used as an example to exercise the API. It's still undecided if LRO is the right shape for this particular API.

Adds a return type for long-running operations that provides consumers with a consistent way to wait for them to finish or query status.

Notes:

1. Support for sync makes the object creation very wordy
2. No support for progress reporting
3. Allows rate-limiting status calls (not implementing)
4. Allows caching result (that's why return type is `ValueTask`)
5. Cancellation tokens are used to cancel HTTP calls and loop inside GetValueAsync, an explicit call to CancelAsync is required to cancel the operation itself.
6. Exposes raw responses for every HTTP call we make
