### PR TITLE
Update Network test to avoid broken build

### DIFF
--- a/src/SDKs/Network/Network.Tests/Tests/TestHelper.cs
+++ b/src/SDKs/Network/Network.Tests/Tests/TestHelper.cs
@@ -132,7 +132,7 @@ namespace Networks.Tests
                     },
                     LegacyMode = Convert.ToInt32(true)
                 },
-                RouteFilter = filter
+                RouteFilter = { Id = filter.Id }
             };
 
             var peerResponse = nrpClient.ExpressRouteCircuitPeerings.CreateOrUpdate(resourceGroupName, circuitName,


### PR DESCRIPTION
Next Network release has a bugfix that's going to cause breaking change in SDK (changing type of property from RouteFilter to Id-reference type). It has already been merged in Swagger and this causes our validation scripts to fail on step with SDK build. This PR fixes that.