### PR TITLE
Clean-up Track 2 projects properties my moving central

### DIFF
--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -10,6 +10,7 @@
       SemVer 2.0 is supported by NuGet since 3.0.0 (July 2015) in some capacity, and fully since 3.5.0 (October 2016).
     -->
     <NoWarn>$(NoWarn);NU5105</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
@@ -93,7 +94,16 @@
     <DelaySign Condition="'$(PublicSign)' != 'true'">true</DelaySign>
 
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
-    <AssemblyOriginatorKeyFile Condition="'$(IsClientLibrary)' == 'true'">$(MSBuildThisFileDirectory)AzureSDKClient.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(IsClientLibrary)' == 'true'">
+    <!-- Use a full key for the new client libraries and disable delay signing -->
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzureSDKClient.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>false</DelaySign>
+    <PublicSign>false</PublicSign>
+    <ImportDefaultReferences>false</ImportDefaultReferences>
+    <UseProjectReferenceToAzureCore>true</UseProjectReferenceToAzureCore>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Azure.ApplicationModel.Configuration.Samples.Tests.csproj
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Azure.ApplicationModel.Configuration.Samples.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/Azure.ApplicationModel.Configuration.csproj
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/Azure.ApplicationModel.Configuration.csproj
@@ -10,16 +10,9 @@
       ]]>
     </PackageReleaseNotes>
 
-    <!-- Make sure that we don't pull in additional dependencies during build or package -->
-    <ImportDefaultReferences>false</ImportDefaultReferences>
-
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyName>Azure.ApplicationModel.Configuration</AssemblyName>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <UseProjectReferenceToAzureCore>true</UseProjectReferenceToAzureCore>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/tests/Azure.ApplicationModel.Configuration.Tests.csproj
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/tests/Azure.ApplicationModel.Configuration.Tests.csproj
@@ -2,14 +2,12 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <GenerateProgramFile>false</GenerateProgramFile>
-    <LangVersion>preview</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
   </ItemGroup>
   <ItemGroup>

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/tests/Performance/Azure.ApplicationModel.Configuration.Performance.csproj
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/tests/Performance/Azure.ApplicationModel.Configuration.Performance.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <OutputType>Exe</OutputType>
-    <ImportDefaultReferences>false</ImportDefaultReferences>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -9,17 +9,9 @@
       ]]>
     </PackageReleaseNotes>
 
-   <!-- Make sure that we don't pull in additional dependencies during build or package -->
-    <ImportDefaultReferences>false</ImportDefaultReferences>
-
-    <!-- This is a workaorund until https://github.com/Azure/azure-sdk-for-net/issues/5214 is addressed -->
-    <RequiredTargetFrameworks>net461;netstandard2.0</RequiredTargetFrameworks>
-
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
+++ b/sdk/core/Azure.Core/tests/Azure.Core.Tests.csproj
@@ -3,7 +3,6 @@
     <ProjectGuid>{84491222-6C36-4FA7-BBAE-1FA804129151}</ProjectGuid>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <DefineConstants>$(DefineConstants);HAS_INTERNALS_VISIBLE_CORE</DefineConstants>
-      <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,6 +11,7 @@
     <PackageReference Include="Moq" Version="4.9.0" />
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Text.Json" Version="4.6.0-preview6.19226.8" />
   </ItemGroup>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/Directory.Build.props
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/Directory.Build.props
@@ -6,12 +6,9 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
     <!-- Do not inherit implicit dependencies from the engineering system during build or packaging -->
     <ImportDefaultReferences>false</ImportDefaultReferences>
   </PropertyGroup>
-
   <!--
     For Track 1, override the engineering system signing key and use the existing key for
     Azure messaging client libraries.

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -10,15 +10,10 @@
       ]]>
     </PackageReleaseNotes>
 
-    <!-- Make sure that we don't pull in additional dependencies during build or package -->
-    <ImportDefaultReferences>false</ImportDefaultReferences>
-
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AssemblyName>Azure.Identity</AssemblyName>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
-    <UseProjectReferenceToAzureCore>true</UseProjectReferenceToAzureCore>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/keyvault/Azure.Security.Keyvault.Secrets/src/Azure.Security.Keyvault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.Keyvault.Secrets/src/Azure.Security.Keyvault.Secrets.csproj
@@ -10,13 +10,9 @@
       ]]>
     </PackageReleaseNotes>
 
-    <!-- Make sure that we don't pull in additional dependencies during build or package -->
-    <ImportDefaultReferences>false</ImportDefaultReferences>
-
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/Directory.Build.props
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/Directory.Build.props
@@ -6,9 +6,6 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
-
     <!-- Do not inherit implicit dependencies from the engineering system during build or packaging -->
     <ImportDefaultReferences>false</ImportDefaultReferences>
     <!--

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -2,7 +2,7 @@
   <!--
   Import our Directory.Build.props and /eng infrastructure
   -->
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />  
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
   <PropertyGroup>
     <!--
@@ -17,15 +17,6 @@
     fully formalized so we won't enable them just yet.
      -->
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
-
-    <!--
-    The Azure Storage projects don't want the Rest Client Runtimes or default
-    test projects (xunit instead of MSTest).
-    -->
-    <ImportDefaultReferences>false</ImportDefaultReferences>
-
-    <!-- Note that we disable this for DEBUG -->
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
     <!--
     Storage used to point to its main documentation page, but the rest of the
@@ -43,15 +34,6 @@
     <DefineConstants>DEBUG;$(DefineConstants)</DefineConstants>
   </PropertyGroup>
 
-
-  <!-- Add a reference to Azure.Core -->
-  <PropertyGroup>
-    <!--
-    You can set the UseProjectReferenceToAzureCore property to switch between
-    project references and public NuGet references.
-     -->
-    <UseProjectReferenceToAzureCore>true</UseProjectReferenceToAzureCore>
-  </PropertyGroup>
   <Import Project="$(MSBuildThisFileDirectory)..\core\Azure.Core\src\Azure.Core.props" />
 
 

--- a/sdk/template/Azure.Template/tests/Azure.Template.Tests.csproj
+++ b/sdk/template/Azure.Template/tests/Azure.Template.Tests.csproj
@@ -1,4 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.Template.csproj" />
   </ItemGroup>

--- a/sdk/template/Azure.Template/tests/UnitTest1.cs
+++ b/sdk/template/Azure.Template/tests/UnitTest1.cs
@@ -1,12 +1,12 @@
 using Azure.Data;
 using System;
-using Xunit;
+using NUnit.Framework;
 
 namespace Microsoft.Azure.Template.Tests
 {
     public class UnitTest1
     {
-        [Fact]
+        [Test]
         public void Test1()
         {
             var c = new Class1();


### PR DESCRIPTION
Updated Template test project to be nunit based since we want to
start using that for our testing framework.

PTAL @pakrym @maririos @jsquire @schaabs @tg-msft @chidozieononiwu 

cc @Azure/azure-sdk-eng 