### PR TITLE
Ignore the generator folder.

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -47,6 +47,7 @@ jobs:
         displayName: "Component Detection"
         # ComponentGovernance is currently unable to run on pull requests of public projects.  Running on
         # scheduled builds should be good enough.
+        ignoreDirectories: "sdk\storage\Azure.Storage.Common\swagger\Generator"
         condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
   - job: "Test"
     variables:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -47,7 +47,7 @@ jobs:
         displayName: "Component Detection"
         # ComponentGovernance is currently unable to run on pull requests of public projects.  Running on
         # scheduled builds should be good enough.
-        ignoreDirectories: "sdk\storage\Azure.Storage.Common\swagger\Generator"
+        ignoreDirectories: "sdk/storage/Azure.Storage.Common/swagger/Generator"
         condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
   - job: "Test"
     variables:

--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -47,7 +47,8 @@ jobs:
         displayName: "Component Detection"
         # ComponentGovernance is currently unable to run on pull requests of public projects.  Running on
         # scheduled builds should be good enough.
-        ignoreDirectories: "sdk/storage/Azure.Storage.Common/swagger/Generator"
+        inputs:
+          ignoreDirectories: "sdk/storage/Azure.Storage.Common/swagger/Generator"
         condition: and(succeededOrFailed(), ne(variables['Build.Reason'],'PullRequest'))
   - job: "Test"
     variables:


### PR DESCRIPTION
An example of how to use the ignoreDirectories option on the CG task.