### PR TITLE
Update services.proj

### DIFF
--- a/eng/service.proj
+++ b/eng/service.proj
@@ -1,5 +1,15 @@
 <Project Sdk="Microsoft.Build.Traversal">
+  <PropertyGroup>
+    <ServiceDirectory Condition="'$(ServiceDirectory)' == ''">*</ServiceDirectory>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\sdk\$(ServiceDirectory)\**\*.csproj" />
   </ItemGroup>
+  <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
+
+  <Target Name="CheckProjects" AfterTargets="Build">
+    <Error Condition="'@(ProjectReference)' == ''"
+        Text="No Projects found with patttern [..\sdk\$(ServiceDirectory)\**\*.csproj], please make sure you have passed in the correct ServiceDirectory." />
+  </Target>
 </Project>


### PR DESCRIPTION
- Add default value of "*" for ServiceDirectory
- Add validation to ensure we have at least one project
- Add extension so services can add or remove default projects

For example if a service wants to exclude all projects under a tools folder
they would create a file like sdk\service\service.projects with:

```
<Project>
  <ItemGroup>
    <ProjectReference Remove="$(MSBuildThisFileDirectory)**\tools\**\*.csproj" />
  </ItemGroup>
</Project>
```

PTAL @mitchdenny @chidozieononiwu 

cc @azure/azure-sdk-eng