### PR TITLE
Support HTTP Proxy for Services.AppAuthentication and ADAL

### DIFF
--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/AdalAuthenticationContext.cs
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Clients/AdalAuthenticationContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using System;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System.Threading.Tasks;
 
@@ -11,6 +12,24 @@ namespace Microsoft.Azure.Services.AppAuthentication
     /// </summary>
     internal class AdalAuthenticationContext : IAuthenticationContext
     {
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        /// <summary>
+        /// Create a context without an HTTP factory
+        /// </summary>
+        public AdalAuthenticationContext()
+        {
+        }
+
+        /// <summary>
+        /// Create a context with an HTTP factory
+        /// </summary>
+        /// <param name="httpClientFactory">Null is allowed</param>
+        public AdalAuthenticationContext(IHttpClientFactory httpClientFactory)
+        {
+            _httpClientFactory = httpClientFactory;
+        }
+
         /// <summary>
         /// Used to get authentication result for Integrated Windows Authentication scenario. 
         /// </summary>
@@ -21,7 +40,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <returns></returns>
         public async Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, string clientId, UserCredential userCredential)
         {
-            AuthenticationContext authenticationContext = new AuthenticationContext(authority);
+            var authenticationContext = GetAuthenticationContext(authority);
             var authResult = await authenticationContext.AcquireTokenAsync(resource, clientId, userCredential).ConfigureAwait(false);
             return AppAuthenticationResult.Create(authResult);
         }
@@ -35,7 +54,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <returns></returns>
         public async Task<AppAuthenticationResult> AcquireTokenSilentAsync(string authority, string resource, string clientId)
         {
-            AuthenticationContext authenticationContext = new AuthenticationContext(authority);
+            var authenticationContext = GetAuthenticationContext(authority);
             var authResult = await authenticationContext.AcquireTokenSilentAsync(resource, clientId).ConfigureAwait(false);
             return AppAuthenticationResult.Create(authResult);
         }
@@ -49,7 +68,7 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <returns></returns>
         public async Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, ClientCredential clientCredential)
         {
-            AuthenticationContext authenticationContext = new AuthenticationContext(authority);
+            var authenticationContext = GetAuthenticationContext(authority);
             var authResult = await authenticationContext.AcquireTokenAsync(resource, clientCredential).ConfigureAwait(false);
             return AppAuthenticationResult.Create(authResult);
         }
@@ -63,9 +82,22 @@ namespace Microsoft.Azure.Services.AppAuthentication
         /// <returns></returns>
         public async Task<AppAuthenticationResult> AcquireTokenAsync(string authority, string resource, IClientAssertionCertificate clientCertificate)
         {
-            AuthenticationContext authenticationContext = new AuthenticationContext(authority);
+            var authenticationContext = GetAuthenticationContext(authority);
             var authResult = await authenticationContext.AcquireTokenAsync(resource, clientCertificate, true).ConfigureAwait(false);
             return AppAuthenticationResult.Create(authResult);
+        }
+
+        /// <summary>
+        /// Creates the ADAL authentication context
+        /// </summary>
+        /// <param name="authority"></param>
+        /// <returns></returns>
+        private AuthenticationContext GetAuthenticationContext(string authority)
+        {
+            return _httpClientFactory == null
+                ? new AuthenticationContext(authority)
+                : new AuthenticationContext(authority, true, TokenCache.DefaultShared,
+                    _httpClientFactory);
         }
     }
 }

--- a/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
+++ b/src/SdkCommon/AppAuthentication/Azure.Services.AppAuthentication/Microsoft.Azure.Services.AppAuthentication.csproj
@@ -2,7 +2,7 @@
     <PropertyGroup>
         <PackageId>Microsoft.Azure.Services.AppAuthentication</PackageId>
         <Description>Enables a service to authenticate to Azure services using the developer's Azure Active Directory/ Microsoft account during development, and authenticate as itself (using OAuth 2.0 Client Credentials flow) when deployed to Azure.</Description>
-        <Version>1.2.0-preview3</Version>
+        <Version>1.2.0-preview4</Version>
         <AssemblyName>Microsoft.Azure.Services.AppAuthentication</AssemblyName>
         <PackageTags>Azure Authentication AppAuthentication</PackageTags>
 	<PackageReleaseNotes>
@@ -27,7 +27,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.4" />
+        <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.0.5" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net472'">


### PR DESCRIPTION
This PR upgrades the ADAL library to the latest (5.0.5) so that HTTP proxies can be properly supported via the IHttpClientFactory interface (https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Providing-an-HttpClient).

The manner for passing this interface into `AzureServiceTokenProvider` is either by constructor parameter (so that upstream libraries can play nice) or via static property `AzureServiceTokenProvider.HttpClientFactory` (so that upstream clients can get proxy support without waiting for upstream libraries). This solves the outstanding issues with #4404

i.e. my client application behind a web proxy can now get a secret from KeyVault using a certificate for service principal authentication.

#5788 is superceded by this PR
