### PR TITLE
Add common properties file to test framework

### DIFF
--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/tests/Azure.ApplicationModel.Configuration.Tests.csproj
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/tests/Azure.ApplicationModel.Configuration.Tests.csproj
@@ -10,10 +10,9 @@
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="..\..\..\core\Azure.Core\tests\TestFramework\*.cs" />
-    <None Update="SessionRecords\**\*.json" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
+
+  <Import Project="..\..\..\core\Azure.Core\tests\TestFramework.props" />
+
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.ApplicationModel.Configuration.csproj" />
   </ItemGroup>

--- a/sdk/core/Azure.Core/tests/TestFramework.props
+++ b/sdk/core/Azure.Core/tests/TestFramework.props
@@ -1,0 +1,6 @@
+﻿<Project ToolsVersion="15.0">
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\TestFramework\*.cs" Link="TestFramework\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <None Update="SessionRecords\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Improving 2 things:
1. Groups shared files into a directory:

Before:
![image](https://user-images.githubusercontent.com/1697911/58726107-b6197c00-8395-11e9-9e41-32aa919bc8dc.png)

After:
![image](https://user-images.githubusercontent.com/1697911/58726078-a1d57f00-8395-11e9-9d56-5aea2d73e8b0.png)

2. Avoiding everyone having to add `None Update="SessionRecords\**\*.json"` into every test project.