### PR TITLE
Change DateTime to DateTimeOffset

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeletedSecret.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeletedSecret.cs
@@ -16,9 +16,9 @@ namespace Azure.Security.KeyVault.Secrets
 
         public string RecoveryId { get; private set; }
 
-        public DateTime? DeletedDate { get; private set; }
+        public DateTimeOffset? DeletedDate { get; private set; }
 
-        public DateTime? ScheduledPurgeDate { get; private set; }
+        public DateTimeOffset? ScheduledPurgeDate { get; private set; }
 
         internal override void WriteProperties(ref Utf8JsonWriter json)
         {
@@ -31,12 +31,12 @@ namespace Azure.Security.KeyVault.Secrets
 
             if (DeletedDate.HasValue)
             {
-                json.WriteNumber("deletedDate", new DateTimeOffset(DeletedDate.Value).ToUnixTimeMilliseconds());
+                json.WriteNumber("deletedDate", DeletedDate.Value.ToUnixTimeMilliseconds());
             }
 
             if (ScheduledPurgeDate.HasValue)
             {
-                json.WriteNumber("scheduledPurgeDate", new DateTimeOffset(ScheduledPurgeDate.Value).ToUnixTimeMilliseconds());
+                json.WriteNumber("scheduledPurgeDate", ScheduledPurgeDate.Value.ToUnixTimeMilliseconds());
             }
         }
 
@@ -51,12 +51,12 @@ namespace Azure.Security.KeyVault.Secrets
 
             if (json.TryGetProperty("deletedDate", out JsonElement deletedDate))
             {
-                DeletedDate = DateTimeOffset.FromUnixTimeMilliseconds(deletedDate.GetInt64()).UtcDateTime;
+                DeletedDate = DateTimeOffset.FromUnixTimeMilliseconds(deletedDate.GetInt64());
             }
 
             if (json.TryGetProperty("scheduledPurgeDate", out JsonElement scheduledPurgeDate))
             {
-                ScheduledPurgeDate = DateTimeOffset.FromUnixTimeMilliseconds(scheduledPurgeDate.GetInt64()).UtcDateTime;
+                ScheduledPurgeDate = DateTimeOffset.FromUnixTimeMilliseconds(scheduledPurgeDate.GetInt64());
             }
 
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretBase.cs
@@ -40,13 +40,13 @@ namespace Azure.Security.KeyVault.Secrets
 
         public bool? Enabled { get => _attributes.Enabled; set => _attributes.Enabled = value; }
 
-        public DateTime? NotBefore { get => _attributes.NotBefore; set => _attributes.NotBefore = value; }
+        public DateTimeOffset? NotBefore { get => _attributes.NotBefore; set => _attributes.NotBefore = value; }
 
-        public DateTime? Expires { get => _attributes.Expires; set => _attributes.Expires = value; }
+        public DateTimeOffset? Expires { get => _attributes.Expires; set => _attributes.Expires = value; }
 
-        public DateTime? Created => _attributes.Created;
+        public DateTimeOffset? Created => _attributes.Created;
 
-        public DateTime? Updated => _attributes.Updated;
+        public DateTimeOffset? Updated => _attributes.Updated;
 
         public string RecoveryLevel => _attributes.RecoveryLevel;
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/VaultAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/VaultAttributes.cs
@@ -14,22 +14,22 @@ namespace Azure.Security.KeyVault.Secrets
         /// <summary>
         /// Gets or sets not before date in UTC.
         /// </summary>
-        public System.DateTime? NotBefore { get; set; }
+        public System.DateTimeOffset? NotBefore { get; set; }
 
         /// <summary>
         /// Gets or sets expiry date in UTC.
         /// </summary>
-        public System.DateTime? Expires { get; set; }
+        public System.DateTimeOffset? Expires { get; set; }
 
         /// <summary>
         /// Gets creation time in UTC.
         /// </summary>
-        public System.DateTime? Created { get; private set; }
+        public System.DateTimeOffset? Created { get; private set; }
 
         /// <summary>
         /// Gets last updated time in UTC.
         /// </summary>
-        public System.DateTime? Updated { get; private set; }
+        public System.DateTimeOffset? Updated { get; private set; }
 
         /// <summary>
         /// Gets reflects the deletion recovery level currently in effect for
@@ -51,22 +51,22 @@ namespace Azure.Security.KeyVault.Secrets
 
             if (json.TryGetProperty("nbf", out JsonElement nbf))
             {
-                NotBefore = DateTimeOffset.FromUnixTimeMilliseconds(nbf.GetInt64()).UtcDateTime;
+                NotBefore = DateTimeOffset.FromUnixTimeMilliseconds(nbf.GetInt64());
             }
 
             if (json.TryGetProperty("exp", out JsonElement exp))
             {
-                Expires = DateTimeOffset.FromUnixTimeMilliseconds(exp.GetInt64()).UtcDateTime;
+                Expires = DateTimeOffset.FromUnixTimeMilliseconds(exp.GetInt64());
             }
 
             if (json.TryGetProperty("created", out JsonElement created))
             {
-                Created = DateTimeOffset.FromUnixTimeMilliseconds(created.GetInt64()).UtcDateTime;
+                Created = DateTimeOffset.FromUnixTimeMilliseconds(created.GetInt64());
             }
 
             if (json.TryGetProperty("updated", out JsonElement updated))
             {
-                Updated = DateTimeOffset.FromUnixTimeMilliseconds(updated.GetInt64()).UtcDateTime;
+                Updated = DateTimeOffset.FromUnixTimeMilliseconds(updated.GetInt64());
             }
 
             if (json.TryGetProperty("recoveryLevel", out JsonElement recoveryLevel))
@@ -84,12 +84,12 @@ namespace Azure.Security.KeyVault.Secrets
 
             if (NotBefore.HasValue)
             {
-                json.WriteNumber("nbf", new DateTimeOffset(NotBefore.Value).ToUnixTimeMilliseconds());
+                json.WriteNumber("nbf", NotBefore.Value.ToUnixTimeMilliseconds());
             }
 
             if (Expires.HasValue)
             {
-                json.WriteNumber("exp", new DateTimeOffset(Expires.Value).ToUnixTimeMilliseconds());
+                json.WriteNumber("exp", Expires.Value.ToUnixTimeMilliseconds());
             }
 
             // Created is read-only don't serialize


### PR DESCRIPTION
Change from `DateTime` to `DateTimeOffset` for the Secrets API.

/cc @maririos @schaabs 

Fixes #6423.