### PR TITLE
[Event Hubs Client - Track Two Preview 1] Baseline Event Hub Client Infrastructure

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -9,6 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Folder Include="Compatibility\" />
     <Folder Include="Properties\" />
   </ItemGroup>
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ConnectionStringParser.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ConnectionStringParser.cs
@@ -1,0 +1,153 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.EventHubs.Metadata;
+
+namespace Azure.Messaging.EventHubs.Core
+{
+    /// <summary>
+    ///   Allows for parsing Event Hubs connection strings.
+    /// </summary>
+    ///
+    internal class ConnectionStringParser
+    {
+        /// <summary>The character used to separate a token and its value in the connection string.</summary>
+        protected const char TokenValueSeparator = '=';
+
+        /// <summary>The character used to mark the beginning of a new token/value pair in the connection string.</summary>
+        protected const char TokenValuePairDelimiter = ';';
+
+        /// <summary>The formatted protocol used by an Event Hubs endpoint. </summary>
+        protected const string EventHubsEndpointScheme = "sb://";
+
+        /// <summary>The token that identifies the endpoint address for the Event Hubs namespace.</summary>
+        protected const string EndpointToken = "Endpoint";
+
+        /// <summary>The token that identifies the path to a specific Event Hub under the namespace.</summary>
+        protected const string EventHubPathToken = "EntityPath";
+
+        /// <summary>The token that identifies the name of a shared access key.</summary>
+        protected const string SharedAccessKeyNameToken = "SharedAccessKeyName";
+
+        /// <summary>The token that identifies the value of a shared access key.</summary>
+        protected const string SharedAccessKeyValueToken = "SharedAccessKey";
+
+        /// <summary>
+        ///   Parses the specified Event Hubs connection string into its component properties.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string to parse.</param>
+        ///
+        /// <returns>The component properties parsed from the connection string.</returns>
+        ///
+        /// <seealso cref="ConnectionStringProperties" />
+        ///
+        public static ConnectionStringProperties Parse(string connectionString)
+        {
+            Guard.ArgumentNotNullOrEmpty(nameof(connectionString), connectionString);
+
+            int tokenPositionModifier = (connectionString[0] == TokenValuePairDelimiter) ? 0 : 1;
+            int lastPosition = 0;
+            int currentPosition = 0;
+            int valueStart;
+
+            string slice;
+            string token;
+            string value;
+
+            var parsedValues =
+            (
+                EndpointToken : default(UriBuilder),
+                EventHubPathToken : default(string),
+                SharedAccessKeyNameToken : default(string),
+                SharedAccessKeyValueToken : default(string)
+            );
+
+            while (currentPosition != -1)
+            {
+                // Slice the string into the next token/value pair.
+
+                currentPosition = connectionString.IndexOf(TokenValuePairDelimiter, lastPosition + 1);
+
+                if (currentPosition >= 0)
+                {
+                    slice = connectionString.Substring(lastPosition, (currentPosition - lastPosition));
+                }
+                else
+                {
+                    slice = connectionString.Substring(lastPosition);
+                }
+
+                // Break the token and value apart, if this is a legal pair.
+
+                valueStart = slice.IndexOf(TokenValueSeparator);
+
+                if (valueStart >= 0)
+                {
+                    token = slice.Substring((1 - tokenPositionModifier), (valueStart - 1 + tokenPositionModifier));
+                    value = slice.Substring(valueStart + 1);
+
+                    // Guard against leading and trailing spaces, only trimming if there is a need.
+
+                    if ((!String.IsNullOrEmpty(token)) && (Char.IsWhiteSpace(token[0])) || Char.IsWhiteSpace(token[token.Length - 1]))
+                    {
+                       token = token.Trim();
+                    }
+
+                    if ((!String.IsNullOrEmpty(value)) && (Char.IsWhiteSpace(value[0]) || Char.IsWhiteSpace(value[value.Length - 1])))
+                    {
+                       value = value.Trim();
+                    }
+
+                    // If there was no value for a key, then consider the connection string to
+                    // be malformed.
+
+                    if (String.IsNullOrEmpty(value))
+                    {
+                        throw new FormatException(Resources.InvalidConnectionString);
+                    }
+
+                    // Compare the token against the known connection string properties and capture the
+                    // pair if they are a known attribute.
+
+                    if (String.Compare(EndpointToken, token, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        parsedValues.EndpointToken = new UriBuilder(value);
+                        parsedValues.EndpointToken.Scheme = EventHubsEndpointScheme;
+                    }
+                    else if (String.Compare(EventHubPathToken, token, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        parsedValues.EventHubPathToken = value;
+                    }
+                    else if (String.Compare(SharedAccessKeyNameToken, token, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        parsedValues.SharedAccessKeyNameToken = value;
+                    }
+                    else if (String.Compare(SharedAccessKeyValueToken, token, StringComparison.OrdinalIgnoreCase) == 0)
+                    {
+                        parsedValues.SharedAccessKeyValueToken = value;
+                    }
+                }
+                else if ((slice.Length != 1) || (slice[0] != TokenValuePairDelimiter))
+                {
+                    // This wasn't a legal pair it is not simply a trailing delmieter; consider
+                    // the connection string to be malformed.
+
+                    throw new FormatException(Resources.InvalidConnectionString);
+                }
+
+                tokenPositionModifier = 0;
+                lastPosition = currentPosition;
+            }
+
+            return new ConnectionStringProperties
+            (
+                parsedValues.EndpointToken?.Uri,
+                parsedValues.EventHubPathToken,
+                parsedValues.SharedAccessKeyNameToken,
+                parsedValues.SharedAccessKeyValueToken
+            );
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/Guard.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/Guard.cs
@@ -43,7 +43,7 @@ namespace Azure.Messaging.EventHubs.Core
         {
             if (String.IsNullOrEmpty(argumentValue))
             {
-                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.ArgumentNullOrEmpty, argumentName));
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.ArgumentNullOrEmpty, argumentName), argumentName);
             }
         }
 
@@ -60,7 +60,7 @@ namespace Azure.Messaging.EventHubs.Core
         {
             if (String.IsNullOrWhiteSpace(argumentValue))
             {
-                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.ArgumentNullOrWhiteSpace, argumentName));
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.ArgumentNullOrWhiteSpace, argumentName), argumentName);
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClientOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Net;
 
 namespace Azure.Messaging.EventHubs
@@ -14,12 +15,14 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventHubClientOptions
     {
-        /// <summary>
-        ///   The policy to use for determining whether a failed operation should be retried and,
-        ///   if so, the amount of time to wait between retry attempts.
-        /// </summary>
-        ///
-        public Retry Retry { get; set; } = Retry.Default;
+        /// <summary>The value to use as the default for the <see cref="DefaultTimeout" /> property.</summary>
+        protected static readonly TimeSpan DefaultTimeoutValue = TimeSpan.FromMinutes(1);
+
+        /// <summary>The retry policy to apply to operations.</summary>
+        protected Retry _retry = Retry.Default;
+
+        /// <summary>the timeout that will be used by default for operations.</summary>
+        protected TimeSpan _defaultTimeout = DefaultTimeoutValue;
 
         /// <summary>
         ///   The type of connection that will be used for communicating with the Event Hubs
@@ -29,23 +32,55 @@ namespace Azure.Messaging.EventHubs
         public ConnectionType ConnectionType { get; set; } = ConnectionType.AmqpTcp;
 
         /// <summary>
-        ///   Gets or sets the timeout that will be used by default for operations associated with
-        ///   the requested Event Hub.
-        /// </summary>
-        ///
-        public TimeSpan DefaultTimeout { get; set; } = TimeSpan.FromMinutes(1);
-
-        /// <summary>
         ///   The proxy to use for communication over web sockets.  If not specified,
         ///   the system-wide proxy settings will be honored.
         /// </summary>
         ///
         /// <remarks>
         ///   A proxy cannot be used for communication over TCP; if web sockets are not in
-        ///   use, any specified proxy will be ignored.
+        ///   use, specifying a proxy is an invalid option.
         /// </remarks>
         ///
         public IWebProxy Proxy { get; set; } = null;
+
+        /// <summary>
+        ///   The policy to use for determining whether a failed operation should be retried and,
+        ///   if so, the amount of time to wait between retry attempts.
+        /// </summary>
+        ///
+        public Retry Retry
+        {
+            get => _retry;
+
+            set
+            {
+                ValidateRetry(value);
+                _retry = value;
+            }
+        }
+
+        /// <summary>
+        ///   Gets or sets the timeout that will be used by default for operations associated with
+        ///   the requested Event Hub.
+        /// </summary>
+        ///
+        public TimeSpan DefaultTimeout
+        {
+            get => _defaultTimeout;
+
+            set
+            {
+                ValidateDefaultTimeout(value);
+                _defaultTimeout = value;
+            }
+        }
+
+        /// <summary>
+        ///   Normalizes the specified timeout value, returning the timeout period or the
+        ///   a <c>null</c> value if no timeout was specified.
+        /// </summary>
+        ///
+        internal TimeSpan? TimeoutOrDefault => (_defaultTimeout == TimeSpan.Zero) ? DefaultTimeoutValue : _defaultTimeout;
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" />, is equal to this instance.
@@ -75,5 +110,49 @@ namespace Azure.Messaging.EventHubs
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates a new copy of the current <see cref="EventHubClientOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="EventHubClientOptions" />.</returns>
+        ///
+        internal EventHubClientOptions Clone() =>
+            new EventHubClientOptions
+            {
+                Retry = this.Retry.Clone(),
+                ConnectionType = this.ConnectionType,
+                DefaultTimeout = this.DefaultTimeout,
+                Proxy = this.Proxy
+            };
+
+        /// <summary>
+        ///   Validates the time period specified as the default operation timeout, throwing an <see cref="ArgumentException" /> if
+        ///   it is not valid.
+        /// </summary>
+        ///
+        /// <param name="timeout">The time period to validate.</param>
+        ///
+        protected virtual void ValidateDefaultTimeout(TimeSpan timeout)
+        {
+            if (timeout < TimeSpan.Zero)
+            {
+                throw new ArgumentException(Resources.TimeoutMustBePositive, nameof(DefaultTimeout));
+            }
+        }
+
+        /// <summary>
+        ///   Validates the retry policy specified, throwing an <see cref="ArgumentException" /> if it is not valid.
+        /// </summary>
+        ///
+        /// <param name="retry">The time period to validae.</param>
+        ///
+        protected virtual void ValidateRetry(Retry retry)
+        {
+            if (retry == null)
+            {
+                throw new ArgumentException(Resources.RetryMustBeSet, nameof(Retry));
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventSender.cs
@@ -45,7 +45,13 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <value>If <c>null</c>, the sender is not specific to a partition and events will be automatically routed; otherwise, the identifier of the partition events will be sent to.</value>
         ///
-        public string PartitionId { get; protected set; }
+        public string PartitionId { get; }
+
+        /// <summary>
+        ///   The set of options used for creation of this sender.
+        /// </summary>
+        ///
+        protected SenderOptions Options { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventSender"/> class.
@@ -55,15 +61,22 @@ namespace Azure.Messaging.EventHubs
         /// <param name="eventHubPath">The path of the Event Hub to which events will be sent.</param>
         /// <param name="senderOptions">The set of options to use for this receiver.</param>
         ///
+        /// <remarks>
+        ///   Because this is a non-public constructor, it is assumed that the <paramref name="senderOptions" /> passed are
+        ///   owned by this instance and are safe from changes made by consumers.  It is considered the responsibility of the
+        ///   caller to ensure that any needed cloning of options is performed.
+        /// </remarks>
+        ///
         protected internal EventSender(ConnectionType connectionType,
                                        string         eventHubPath,
                                        SenderOptions  senderOptions)
         {
             Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
+            Guard.ArgumentNotNull(nameof(senderOptions), senderOptions);
 
             PartitionId = senderOptions?.PartitionId;
+            Options = senderOptions;
 
-            //TODO: Validate and clone the options (to avoid any changes on the options being carried over)
             //TODO: Connection Type drives the contained receiver used for service operations. For example, an AmqpEventSender.
         }
 
@@ -88,7 +101,7 @@ namespace Azure.Messaging.EventHubs
         /// <seealso cref="SendAsync(IEnumerable{EventData}, EventBatchingOptions, CancellationToken)"/>
         ///
         public virtual Task SendAsync(IEnumerable<EventData> events,
-                                      CancellationToken      cancellationToken = default) => throw new NotImplementedException();
+                                      CancellationToken      cancellationToken = default) => SendAsync(events, null, cancellationToken);
 
         /// <summary>
         ///   Sends a set of events to the associated Event Hub using a batched approach.  If the size of events exceed the

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/ConnectionStringProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/ConnectionStringProperties.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs.Metadata
+{
+    /// <summary>
+    ///   The set of properties that comprise a connection string from the
+    ///   Azure portal.
+    /// </summary>
+    ///
+    public struct ConnectionStringProperties
+    {
+        /// <summary>
+        ///   The endpoint to be used for connecting to the Event Hubs namespace.
+        /// </summary>
+        ///
+        /// <value>The endpoint address, including protocol, from the connection string.</value>
+        ///
+        public Uri Endpoint { get; }
+
+        /// <summary>
+        ///   The path to the specific Event Hub under the namespace.
+        /// </summary>
+        ///
+        public string EventHubPath { get; }
+
+        /// <summary>
+        ///   The name of the shared access key, either for the Event Hubs namespace
+        ///   or the Event Hub.
+        /// </summary>
+        ///
+        public string SharedAccessKeyName { get; }
+
+        /// <summary>
+        ///   The value of the shared access key, either for the Event Hubs namespace
+        ///   or the Event Hub.
+        /// </summary>
+        ///
+        public string SharedAccessKey { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ConnectionStringProperties"/> struct.
+        /// </summary>
+        ///
+        /// <param name="endpoint">The endpoint of the EVent Hubs namespace.</param>
+        /// <param name="eventHubPath">The path to the specific Event Hub under the namespace.</param>
+        /// <param name="sharedAccessKeyName">The name of the shared access key, to use authorization.</param>
+        /// <param name="sharedAccessKey">The shared access key to use for authorization.</param>
+        ///
+        public ConnectionStringProperties(Uri    endpoint,
+                                          string eventHubPath,
+                                          string sharedAccessKeyName,
+                                          string sharedAccessKey)
+        {
+            Endpoint = endpoint;
+            EventHubPath = eventHubPath;
+            SharedAccessKeyName = sharedAccessKeyName;
+            SharedAccessKey = sharedAccessKey;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/PartitionReceiver.cs
@@ -7,7 +7,6 @@ using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Core;
-using Azure.Messaging.EventHubs.Metadata;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -31,14 +30,14 @@ namespace Azure.Messaging.EventHubs
         ///   only from this partition.
         /// </summary>
         ///
-        public string PartitionId { get; protected set; }
+        public string PartitionId { get; }
 
         /// <summary>
         ///   The name of the consumer group that this receiver is associated with.  Events will be read
         ///   only in the context of this group.
         /// </summary>
         ///
-        public string ConsumerGroupName { get; protected set; }
+        public string ConsumerGroup { get; }
 
         /// <summary>
         ///   When populated, the priority indicates that a receiver is intended to be the only reader of events for the
@@ -52,7 +51,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <value>The priority to associated with an exclusive receiver; for a non-exclusive receiver, this value will be <c>null</c>.</value>
         ///
-        public long? ExclusiveReceiverPriority { get; protected set; }
+        public long? ExclusiveReceiverPriority { get; }
 
         /// <summary>
         ///   The position of the event in the partition where the receiver should begin reading.
@@ -64,7 +63,7 @@ namespace Azure.Messaging.EventHubs
         ///   The set of event receiver options used for creation of this receiver.
         /// </summary>
         ///
-        protected ReceiverOptions ReceiverOptions { get; }
+        protected ReceiverOptions Options { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="PartitionReceiver"/> class.
@@ -79,6 +78,10 @@ namespace Azure.Messaging.EventHubs
         ///   If the starting event position is not specified in the <paramref name="receiverOptions"/>, the receiver will
         ///   default to ignoring events in the partition that were queued prior to the receiver being created and read only
         ///   events which appear after that point.
+        ///
+        ///   Because this is a non-public constructor, it is assumed that the <paramref name="receiverOptions" /> passed are
+        ///   owned by this instance and are safe from changes made by consumers.  It is considered the responsibility of the
+        ///   caller to ensure that any needed cloning of options is performed.
         /// </remarks>
         ///
         protected internal PartitionReceiver(ConnectionType  connectionType,
@@ -88,17 +91,14 @@ namespace Azure.Messaging.EventHubs
         {
             Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
             Guard.ArgumentNotNullOrEmpty(nameof(partitionId), partitionId);
+            Guard.ArgumentNotNull(nameof(receiverOptions), receiverOptions);
 
-            //TODO: Validate and clone the options (to avoid any changes on the options being carried over)
             //TODO: Connection Type drives the contained receiver used for service operations. For example, an AmqpPartitionReceiver.
-
-            //TODO: Remove this line.
-            receiverOptions = receiverOptions ?? new ReceiverOptions();
 
             PartitionId = partitionId;
             StartingPosition = receiverOptions.BeginReceivingAt;
-            ReceiverOptions = receiverOptions;
             ExclusiveReceiverPriority = receiverOptions.ExclusiveReceiverPriority;
+            Options = receiverOptions.Clone();
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/ReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/ReceiverOptions.cs
@@ -16,13 +16,19 @@ namespace Azure.Messaging.EventHubs
     public class ReceiverOptions
     {
         /// <summary>The name of the default consumer group in the Event Hubs service.</summary>
-        public const string DefaultConsumerGroupName = "$Default";
+        public const string DefaultConsumerGroup = "$Default";
 
         /// <summary>The minimum value allowed for the prefetch count of the receiver.</summary>
         protected const int MinimumPrefetchCount = 10;
 
         /// <summary>The maximum length, in characters, for the identifier assigned to a receiver.</summary>
         protected const int MaximumIdentifierLength = 64;
+
+        /// <summary>The retry policy to apply to operations.</summary>
+        protected Retry _retry = Retry.Default;
+
+        /// <summary>The amount of time to wait for messages when receiving.</summary>
+        protected TimeSpan? _maximumReceiveWaitTime = TimeSpan.FromMinutes(1);
 
         /// <summary>The prefetch count to use for the receiver.</summary>
         protected int _prefetchCount = 300;
@@ -37,7 +43,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <value>If not specified, the default consumer group will be assumed.</value>
         ///
-        public string ConsumerGroup { get; set; } = DefaultConsumerGroupName;
+        public string ConsumerGroup { get; set; } = DefaultConsumerGroup;
 
         /// <summary>
         ///   The position within the partition where the receiver should begin reading events.
@@ -82,7 +88,23 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <value>If not specified, the operation timeout requested for the associated <see cref="EventHubClient" /> will be used.</value>
         ///
-        public TimeSpan? DefaultMaximumReceiveWaitTime { get; set; }
+        public TimeSpan? DefaultMaximumReceiveWaitTime
+        {
+            get => _maximumReceiveWaitTime;
+
+            set
+            {
+               ValidateMaximumReceiveWaitTime(value);
+               _maximumReceiveWaitTime = value;
+            }
+        }
+
+        /// <summary>
+        ///   Normalizes the specified wait time value, returning the timeout period or the
+        ///   a <c>null</c> value if no wait time was specified.
+        /// </summary>
+        ///
+        internal TimeSpan? MaximumReceiveWaitTimeOrDefault => (_maximumReceiveWaitTime == TimeSpan.Zero) ? null : _maximumReceiveWaitTime;
 
         /// <summary>
         ///     An optional text-based identifierlabel to assign to an event receiver.
@@ -147,6 +169,25 @@ namespace Azure.Messaging.EventHubs
         public override string ToString() => base.ToString();
 
         /// <summary>
+        ///   Creates a new copy of the current <see cref="ReceiverOptions" />, cloning its attributes into a new instance.
+        /// </summary>
+        ///
+        /// <returns>A new copy of <see cref="ReceiverOptions" />.</returns>
+        ///
+        internal ReceiverOptions Clone() =>
+            new ReceiverOptions
+            {
+                ConsumerGroup = this.ConsumerGroup,
+                BeginReceivingAt = this.BeginReceivingAt,
+                ExclusiveReceiverPriority = this.ExclusiveReceiverPriority,
+                Retry = this.Retry?.Clone(),
+
+                _identifier = this._identifier,
+                _prefetchCount = this._prefetchCount,
+                _maximumReceiveWaitTime = this._maximumReceiveWaitTime
+            };
+
+        /// <summary>
         ///   Validates that the identifier requested for the receiver can be used, throwing an <see cref="ArgumentException" /> if
         ///   it is not valid.
         /// </summary>
@@ -158,6 +199,21 @@ namespace Azure.Messaging.EventHubs
             if ((!String.IsNullOrEmpty(identifier)) && (identifier.Length > MaximumIdentifierLength))
             {
                 throw new ArgumentException(nameof(identifier), String.Format(CultureInfo.CurrentCulture, Resources.ReceiverIdentifierOverMaxValue, MaximumIdentifierLength));
+            }
+        }
+
+        /// <summary>
+        ///   Validates the time period specified as the maximum time to wait when receiving, throwing an <see cref="ArgumentException" /> if
+        ///   it is not valid.
+        /// </summary>
+        ///
+        /// <param name="maximumWaitTime">The time period to validae.</param>
+        ///
+        protected virtual void ValidateMaximumReceiveWaitTime(TimeSpan? maximumWaitTime)
+        {
+            if (maximumWaitTime < TimeSpan.Zero)
+            {
+                throw new ArgumentException(Resources.TimeoutMustBePositive, nameof(DefaultMaximumReceiveWaitTime));
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -61,24 +61,6 @@ namespace Azure.Messaging.EventHubs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The received message (delivery-id:{0}, size:{1} bytes) exceeds the limit ({2} bytes) currently allowed on the link..
-        /// </summary>
-        internal static string AmqpMessageSizeExceeded {
-            get {
-                return ResourceManager.GetString("AmqpMessageSizeExceeded", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Please make sure either all or none of the following arguments are defined: &apos;{0},{1}&apos;..
-        /// </summary>
-        internal static string ArgumentInvalidCombination {
-            get {
-                return ResourceManager.GetString("ArgumentInvalidCombination", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; may not be null or empty..
         /// </summary>
         internal static string ArgumentNullOrEmpty {
@@ -106,29 +88,11 @@ namespace Azure.Messaging.EventHubs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Sending empty {0} is not a valid operation..
+        ///   Looks up a localized string similar to The connection string could not be parsed; either it was malformed or contains no well-known tokens..
         /// </summary>
-        internal static string CannotSendAnEmptyEvent {
+        internal static string InvalidConnectionString {
             get {
-                return ResourceManager.GetString("CannotSendAnEmptyEvent", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to There are no event data supplied. Please make sure input events are not empty..
-        /// </summary>
-        internal static string EventDataListIsNullOrEmpty {
-            get {
-                return ResourceManager.GetString("EventDataListIsNullOrEmpty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Serialization operation failed due to unsupported type {0}..
-        /// </summary>
-        internal static string FailedToSerializeUnsupportedType {
-            get {
-                return ResourceManager.GetString("FailedToSerializeUnsupportedType", resourceCulture);
+                return ResourceManager.GetString("InvalidConnectionString", resourceCulture);
             }
         }
         
@@ -151,11 +115,29 @@ namespace Azure.Messaging.EventHubs {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The connection string used for an Event Hub client must specify the Event Hubs namespace host, the path to an Event Hub, and a Shared Access Signature (both the name and value) to be valid..
+        /// </summary>
+        internal static string MalformedEventHubClientConnectionString {
+            get {
+                return ResourceManager.GetString("MalformedEventHubClientConnectionString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to System property &apos;{0}&apos; is missing in the event..
         /// </summary>
         internal static string MissingSystemProperty {
             get {
                 return ResourceManager.GetString("MissingSystemProperty", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A proxy may only be used for a websockets connection..
+        /// </summary>
+        internal static string ProxyMustUseWebsockets {
+            get {
+                return ResourceManager.GetString("ProxyMustUseWebsockets", resourceCulture);
             }
         }
         
@@ -169,16 +151,16 @@ namespace Azure.Messaging.EventHubs {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to {0} cannot be specified along with {1}. {0} alone should be sufficient to Authenticate the request..
+        ///   Looks up a localized string similar to A retry must be set for the options; if no retry is desired, please set the value to Retry.NoRetry.
         /// </summary>
-        internal static string SasTokenShouldBeAlone {
+        internal static string RetryMustBeSet {
             get {
-                return ResourceManager.GetString("SasTokenShouldBeAlone", resourceCulture);
+                return ResourceManager.GetString("RetryMustBeSet", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Argument {0} must be a positive timeout value. The provided value was {1}..
+        ///   Looks up a localized string similar to A timeout value must be positive.  To request using the default timeout, please use TimeSpan.Zero or null..
         /// </summary>
         internal static string TimeoutMustBePositive {
             get {
@@ -192,24 +174,6 @@ namespace Azure.Messaging.EventHubs {
         internal static string TimeSpanMustBeNonNegative {
             get {
                 return ResourceManager.GetString("TimeSpanMustBeNonNegative", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The provided token does not specify the &apos;Audience&apos; value..
-        /// </summary>
-        internal static string TokenMissingAudience {
-            get {
-                return ResourceManager.GetString("TokenMissingAudience", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The provided token does not specify the &apos;ExpiresOn&apos; value..
-        /// </summary>
-        internal static string TokenMissingExpiresOn {
-            get {
-                return ResourceManager.GetString("TokenMissingExpiresOn", resourceCulture);
             }
         }
         

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -117,12 +117,6 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="AmqpMessageSizeExceeded" xml:space="preserve">
-    <value>The received message (delivery-id:{0}, size:{1} bytes) exceeds the limit ({2} bytes) currently allowed on the link.</value>
-  </data>
-  <data name="ArgumentInvalidCombination" xml:space="preserve">
-    <value>Please make sure either all or none of the following arguments are defined: '{0},{1}'.</value>
-  </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
     <value>The argument '{0}' may not be null or empty.</value>
   </data>
@@ -131,15 +125,6 @@
   </data>
   <data name="ArgumentStringTooBig" xml:space="preserve">
     <value>The argument '{0}' cannot exceed {1} characters.</value>
-  </data>
-  <data name="CannotSendAnEmptyEvent" xml:space="preserve">
-    <value>Sending empty {0} is not a valid operation.</value>
-  </data>
-  <data name="EventDataListIsNullOrEmpty" xml:space="preserve">
-    <value>There are no event data supplied. Please make sure input events are not empty.</value>
-  </data>
-  <data name="FailedToSerializeUnsupportedType" xml:space="preserve">
-    <value>Serialization operation failed due to unsupported type {0}.</value>
   </data>
   <data name="InvalidEncoding" xml:space="preserve">
     <value>The string has an invalid encoding format.</value>
@@ -153,22 +138,25 @@
   <data name="ReceiverIdentifierOverMaxValue" xml:space="preserve">
     <value>The 'identifier' parameter exceeds the maximum allowed size of {0} characters.</value>
   </data>
-  <data name="SasTokenShouldBeAlone" xml:space="preserve">
-    <value>{0} cannot be specified along with {1}. {0} alone should be sufficient to Authenticate the request.</value>
-  </data>
   <data name="TimeoutMustBePositive" xml:space="preserve">
-    <value>Argument {0} must be a positive timeout value. The provided value was {1}.</value>
+    <value>A timeout value must be positive.  To request using the default timeout, please use TimeSpan.Zero or null.</value>
   </data>
   <data name="TimeSpanMustBeNonNegative" xml:space="preserve">
     <value>Argument {0} must be a non-negative timespan value. The provided value was {1}.</value>
   </data>
-  <data name="TokenMissingAudience" xml:space="preserve">
-    <value>The provided token does not specify the 'Audience' value.</value>
-  </data>
-  <data name="TokenMissingExpiresOn" xml:space="preserve">
-    <value>The provided token does not specify the 'ExpiresOn' value.</value>
-  </data>
   <data name="ValueOutOfRange" xml:space="preserve">
     <value>The value supplied must be between {0} and {1}.</value>
+  </data>
+  <data name="ProxyMustUseWebsockets" xml:space="preserve">
+    <value>A proxy may only be used for a websockets connection.</value>
+  </data>
+  <data name="RetryMustBeSet" xml:space="preserve">
+    <value>A retry must be set for the options; if no retry is desired, please set the value to Retry.NoRetry</value>
+  </data>
+  <data name="InvalidConnectionString" xml:space="preserve">
+    <value>The connection string could not be parsed; either it was malformed or contains no well-known tokens.</value>
+  </data>
+  <data name="MalformedEventHubClientConnectionString" xml:space="preserve">
+    <value>The connection string used for an Event Hub client must specify the Event Hubs namespace host, the path to an Event Hub, and a Shared Access Signature (both the name and value) to be valid.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Retry.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Retry.cs
@@ -50,7 +50,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns><c>true</c> if the operation that produced the exception may be retried; otherwise, <c>false</c>.</returns>
         ///
-        internal static bool IsRetriableException(Exception exception) => throw new NotImplementedException();
+        internal virtual bool IsRetriableException(Exception exception) => throw new NotImplementedException();
 
         /// <summary>
         ///   Calculates the amount of time to delay before the next retry attempt.
@@ -62,10 +62,9 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <returns>The amount of time to delay before retrying the associated operation; if <c>null</c>, then the operation is no longer eligible to be retried.</returns>
         ///
-        public TimeSpan? GetNextRetryInterval(Exception lastException,
-                                              TimeSpan  remainingTime,
-                                              int       retryCount) => throw new NotImplementedException();
-
+        internal TimeSpan? GetNextRetryInterval(Exception lastException,
+                                                TimeSpan  remainingTime,
+                                                int       retryCount) => throw new NotImplementedException();
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" />, is equal to this instance.
         /// </summary>
@@ -120,9 +119,9 @@ namespace Azure.Messaging.EventHubs
         ///   <see cref="Retry.GetNextRetryInterval" /> implementation.
         /// </remarks>
         ///
-        protected abstract TimeSpan? OnGetNextRetryInterval(Exception lastException,
-                                                            TimeSpan  remainingTime,
-                                                            int       baseWaitSeconds,
-                                                            int       retryCount);
+        protected abstract TimeSpan? CalculateNextRetryInterval(Exception lastException,
+                                                                TimeSpan  remainingTime,
+                                                                int       baseWaitSeconds,
+                                                                int       retryCount);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Moq" Version="4.11.0" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.2.1" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
   </ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionStringParserTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionStringParserTests.cs
@@ -1,0 +1,286 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using Azure.Messaging.EventHubs.Core;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="ConnectionStringParser" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Category(TestCategory.BuildVerification)]
+    public class ConnectionStringParserTests
+    {
+        /// <summary>
+        ///   Provides the reordered token test cases for the <see cref="ConnectionStringParser.Parse" /> tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ParseDoesNotforceTokenOrderingCases()
+        {
+            var endpoint = "test.endpoint.com";
+            var eventHub = "some-path";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+
+            yield return new object[] { $"Endpoint=sb://{ endpoint };SharedAccessKeyName={ sasKeyName };SharedAccessKey={ sasKey };EntityPath={ eventHub }", endpoint, eventHub, sasKeyName, sasKey };
+            yield return new object[] { $"Endpoint=sb://{ endpoint };SharedAccessKey={ sasKey };EntityPath={ eventHub };SharedAccessKeyName={ sasKeyName }", endpoint, eventHub, sasKeyName, sasKey };
+            yield return new object[] { $"Endpoint=sb://{ endpoint };EntityPath={ eventHub };SharedAccessKeyName={ sasKeyName };SharedAccessKey={ sasKey }", endpoint, eventHub, sasKeyName, sasKey };
+            yield return new object[] { $"SharedAccessKeyName={ sasKeyName };SharedAccessKey={ sasKey };Endpoint=sb://{ endpoint };EntityPath={ eventHub }", endpoint, eventHub, sasKeyName, sasKey };
+            yield return new object[] { $"EntityPath={ eventHub };SharedAccessKey={ sasKey };SharedAccessKeyName={ sasKeyName };Endpoint=sb://{ endpoint }", endpoint, eventHub, sasKeyName, sasKey };
+        }
+
+        /// <summary>
+        ///   Provides the reordered token test cases for the <see cref="ConnectionStringParser.Parse" /> tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ParseCorrectlyParsesPartialConnectionStrings()
+        {
+            var endpoint = "test.endpoint.com";
+            var eventHub = "some-path";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+
+            yield return new object[] { $"Endpoint=sb://{ endpoint }", endpoint, null, null, null };
+            yield return new object[] { $"SharedAccessKey={ sasKey }", null, null, sasKeyName, null };
+            yield return new object[] { $"EntityPath={ eventHub };SharedAccessKeyName={ sasKeyName }", null, eventHub, sasKeyName, null };
+            yield return new object[] { $"SharedAccessKeyName={ sasKeyName };SharedAccessKey={ sasKey }", null, null, sasKeyName, sasKey };
+            yield return new object[] { $"EntityPath={ eventHub };SharedAccessKey={ sasKey };SharedAccessKeyName={ sasKeyName }", null, eventHub, sasKeyName, sasKey };
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ParseValidatesArguments(string connectionString)
+        {
+            Assert.That(() => ConnectionStringParser.Parse(connectionString), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ParseCorrectlyParsesANamespaceConnectionString()
+        {
+            var endpoint = "test.endpoint.com";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+            var connectionString = $"Endpoint=sb://{ endpoint };SharedAccessKeyName={ sasKeyName };SharedAccessKey={ sasKey }";
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.Null, "The Event Hub path was not included in the connection string");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ParseCorrectlyParsesAnEventHubConnectionString()
+        {
+            var endpoint = "test.endpoint.com";
+            var eventHub = "some-path";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+            var connectionString = $"Endpoint=sb://{ endpoint };SharedAccessKeyName={ sasKeyName };SharedAccessKey={ sasKey };EntityPath={ eventHub }";
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ParseDoesNotforceTokenOrderingCases))]
+        public void ParseCorrectlyParsesPartialConnectionStrings(string connectionString,
+                                                                 string endpoint,
+                                                                 string eventHub,
+                                                                 string sasKeyName,
+                                                                 string sasKey)
+        {
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ParseToleratesLeadingDelimiters()
+        {
+            var endpoint = "test.endpoint.com";
+            var eventHub = "some-path";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+            var connectionString = $";Endpoint=sb://{ endpoint };SharedAccessKeyName={ sasKeyName };SharedAccessKey={ sasKey };EntityPath={ eventHub }";
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ParseToleratesTrailingDelimiters()
+        {
+            var endpoint = "test.endpoint.com";
+            var eventHub = "some-path";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+            var connectionString = $"Endpoint=sb://{ endpoint };SharedAccessKeyName={ sasKeyName };SharedAccessKey={ sasKey };EntityPath={ eventHub };";
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ParseToleratesSpacesBetweenPairs()
+        {
+            var endpoint = "test.endpoint.com";
+            var eventHub = "some-path";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+            var connectionString = $"Endpoint=sb://{ endpoint }; SharedAccessKeyName={ sasKeyName }; SharedAccessKey={ sasKey }; EntityPath={ eventHub }";
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ParseToleratesSpacesBetweenValues()
+        {
+            var endpoint = "test.endpoint.com";
+            var eventHub = "some-path";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+            var connectionString = $"Endpoint = sb://{ endpoint };SharedAccessKeyName ={ sasKeyName };SharedAccessKey= { sasKey }; EntityPath  =  { eventHub }";
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ParseDoesNotforceTokenOrderingCases))]
+        public void ParseDoesNotForceTokenOrdering(string connectionString,
+                                                   string endpoint,
+                                                   string eventHub,
+                                                   string sasKeyName,
+                                                   string sasKey)
+        {
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ParseIgnoresUnknownTokens()
+        {
+            var endpoint = "test.endpoint.com";
+            var eventHub = "some-path";
+            var sasKey = "sasKey";
+            var sasKeyName = "sasName";
+            var connectionString = $"Endpoint=sb://{ endpoint };SharedAccessKeyName={ sasKeyName };Unknown=INVALID;SharedAccessKey={ sasKey };EntityPath={ eventHub };Trailing=WHOAREYOU";
+            var parsed = ConnectionStringParser.Parse(connectionString);
+
+            Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
+            Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
+            Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
+            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void ParseDoesNotAllowAnInvalidEndpointFormat()
+        {
+            var connectionString = $"Endpoint=notvalid=[broke]";
+            Assert.That(() => ConnectionStringParser.Parse(connectionString), Throws.InstanceOf<FormatException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ConnectionStringParser.Parse" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("Endpoint;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]")]
+        [TestCase("Endpoint=value.com;SharedAccessKeyName=;SharedAccessKey=[value];EntityPath=[value]")]
+        [TestCase("Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey;EntityPath=[value]")]
+        [TestCase("Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath")]
+        [TestCase("Endpoint;SharedAccessKeyName=;SharedAccessKey;EntityPath=")]
+        [TestCase("Endpoint=;SharedAccessKeyName;SharedAccessKey;EntityPath=")]
+        public void ParseConsidersMissingValuesAsMalformed(string connectionString)
+        {
+            Assert.That(() => ConnectionStringParser.Parse(connectionString), Throws.InstanceOf<FormatException>());
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ExponentialRetryTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ExponentialRetryTests.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="ExponentialRetry" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Category(TestCategory.BuildVerification)]
+    public class ExponentialRetryTests
+    {
+        /// <summary>
+        ///   Provides the invalid test cases for the <see cref="ExponentialRetry.Equals" /> tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> InequalityCases()
+        {
+            yield return new object[] { null, new ExponentialRetry(TimeSpan.Zero, TimeSpan.Zero, 0), "the first operand is null" };
+            yield return new object[] { new ExponentialRetry(TimeSpan.Zero, TimeSpan.Zero, 0), null, "the second operand is null" };
+            yield return new object[] { new ExponentialRetry(TimeSpan.Zero, TimeSpan.Zero, 0), new ExponentialRetry(TimeSpan.FromMilliseconds(1), TimeSpan.Zero, 0), "the minimum backoffs differ" };
+            yield return new object[] { new ExponentialRetry(TimeSpan.Zero, TimeSpan.Zero, 0), new ExponentialRetry(TimeSpan.Zero, TimeSpan.FromMilliseconds(1), 0), "the maximum backoffs differ" };
+            yield return new object[] { new ExponentialRetry(TimeSpan.Zero, TimeSpan.Zero, 0), new ExponentialRetry(TimeSpan.Zero, TimeSpan.Zero, 2), "the maximum retries differ" };
+        }
+
+        /// <summary>
+        ///   Provides the invalid test cases for the <see cref="ExponentialRetry.Equals" /> tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> EqualityCases()
+        {
+            yield return new object[]
+            {
+                new ExponentialRetry(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(7), 20),
+                new ExponentialRetry(TimeSpan.FromMilliseconds(1), TimeSpan.FromMilliseconds(7), 20),
+                "the attributes of the retries are the same"
+            };
+
+            var instance =  new ExponentialRetry(TimeSpan.Zero, TimeSpan.Zero, 0);
+            yield return new object[] { instance, instance, "the operands are the same instance" };
+            yield return new object[] { null, null, "both operands are null" };
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesArguments()
+        {
+            Assert.That(() => new ExponentialRetry(TimeSpan.FromSeconds(-100), TimeSpan.Zero, 1), Throws.InstanceOf<ArgumentOutOfRangeException>(), "A negative minimum should not be allowed.");
+            Assert.That(() => new ExponentialRetry(TimeSpan.FromSeconds(200), TimeSpan.FromMilliseconds(-1), 72), Throws.InstanceOf<ArgumentOutOfRangeException>(), "A negative maximum should not be allowed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExponentialRetry.Equals" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(EqualityCases))]
+        public void EqualityIsRecognized(ExponentialRetry first,
+                                         ExponentialRetry second,
+                                         string           description)
+        {
+            if (first != null)
+            {
+                Assert.That(first.Equals(second), Is.True, $"The method call should recognize the following as true:  [{ description }]");
+            }
+
+            Assert.That((first == second), Is.True, $"The equality operator should recognize the following as true: [{ description }]");
+            Assert.That((first != second), Is.False, $"The inequality operator should recognize the following as false: [{ description }]");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExponentialRetry.Equals" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(InequalityCases))]
+        public void InequalityIsRecognized(ExponentialRetry first,
+                                           ExponentialRetry second,
+                                           string           description)
+        {
+            if (first != null)
+            {
+                Assert.That(first.Equals(second), Is.False, $"The method call should recognize the following as false:  [{ description }]");
+            }
+
+            Assert.That((first == second), Is.False, $"The equality operator should recognize the following as false: [{ description }]");
+            Assert.That((first != second), Is.True, $"The inequality operator should recognize the following as true: [{ description }]");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExponentialRetry.GetHashCode" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void GetHashCodeIsStable()
+        {
+            var codes = new List<int>();
+            var retry = new ExponentialRetry(TimeSpan.FromMinutes(1), TimeSpan.FromHours(1), 22);
+
+            for (var index = 0; index < 10; ++index)
+            {
+                codes.Add(retry.GetHashCode());
+            }
+
+            Assert.That(codes.Distinct().Count(), Is.EqualTo(1));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExponentialRetry.GetHashCode" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void GetHashCodeIsTheSameWhenPropertiesMatch()
+        {
+            ExponentialRetry retry;
+            var codes = new List<int>();
+
+            for (var index = 0; index < 10; ++index)
+            {
+                retry = new ExponentialRetry(TimeSpan.FromMinutes(1), TimeSpan.FromHours(1), 22);
+                codes.Add(retry.GetHashCode());
+            }
+
+            Assert.That(codes.Distinct().Count(), Is.EqualTo(1));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExponentialRetry.GetHashCode" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void GetHashCodeDiffersWhenPropertiesDoNotMatch()
+        {
+            ExponentialRetry retry;
+
+            var count = 10;
+            var codes = new List<int>();
+
+            for (var index = 0; index < count; ++index)
+            {
+                retry = new ExponentialRetry(TimeSpan.FromMinutes(index), TimeSpan.FromMilliseconds(index + 1), (index + 22));
+                codes.Add(retry.GetHashCode());
+            }
+
+            Assert.That(codes.Distinct().Count(), Is.EqualTo(count));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ExponentialRetry.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var retry = new ExponentialRetry(TimeSpan.FromSeconds(1), TimeSpan.FromMilliseconds(2), 123);
+            var clone = retry.Clone();
+
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+            Assert.That(clone, Is.EqualTo(retry), "The clone should be considered equal.");
+            Assert.That(clone, Is.Not.SameAs(retry), "The clone should be a copy, not the same instance.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/GuardTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/GuardTests.cs
@@ -95,7 +95,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="Guard.ArgumentNotNullOrEmpty" /> method.
+        ///   Verifies functionality of the <see cref="Guard.ArgumentNotNullOrWhitespace" /> method.
         /// </summary>
         ///
         [Test]
@@ -109,7 +109,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="Guard.ArgumentNotNullOrEmpty" /> method.
+        ///   Verifies functionality of the <see cref="Guard.ArgumentNotNullOrWhitespace" /> method.
         /// </summary>
         ///
         [Test]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientOptionsTests.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Net;
+using System.Reflection;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventHubClientOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Category(TestCategory.BuildVerification)]
+    public class EventHubClientOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClientOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var options = new EventHubClientOptions
+            {
+                Retry = new ExponentialRetry(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), 3),
+                ConnectionType = ConnectionType.AmqpWebSockets,
+                DefaultTimeout = TimeSpan.FromDays(1),
+                Proxy = Mock.Of<IWebProxy>()
+            };
+
+            var clone = options.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+
+            Assert.That(clone.ConnectionType, Is.EqualTo(options.ConnectionType), "The connection type of the clone should match.");
+            Assert.That(clone.DefaultTimeout, Is.EqualTo(options.DefaultTimeout), "The default timeout of the clone should match.");
+            Assert.That(clone.Proxy, Is.EqualTo(options.Proxy), "The proxy of the clone should match.");
+
+            Assert.That(clone.Retry, Is.EqualTo(options.Retry), "The retry of the clone should be considered equal.");
+            Assert.That(clone.Retry, Is.Not.SameAs(options.Retry), "The retry of the clone should be a copy, not the same instance.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClientOptions.Retry" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void RetryIsValidated()
+        {
+            Assert.That(() => new EventHubClientOptions { Retry = null }, Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClientOptions.DefaultTimeout" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void DefaultTimeoutIsValidated()
+        {
+            Assert.That(() => new EventHubClientOptions { DefaultTimeout = TimeSpan.FromMilliseconds(-1) }, Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClientOptions.DefaultTimeout" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void DefaultTimeoutUsesDefaultValueIfNotSpecified()
+        {
+            var options = new EventHubClientOptions();
+            var defaultTimeoutValue = options.TimeoutOrDefault;
+
+            options.DefaultTimeout = TimeSpan.Zero;
+            Assert.That(options.DefaultTimeout, Is.EqualTo(TimeSpan.Zero), "The value supplied by the caller should be preserved.");
+            Assert.That(options.TimeoutOrDefault, Is.EqualTo(defaultTimeoutValue), "The timeout value should be defaulted internally.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
@@ -1,0 +1,462 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Metadata;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventHubClient" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Category(TestCategory.BuildVerification)]
+    public class EventHubClientTests
+    {
+        /// <summary>
+        ///   Provides the invalid test cases for the constructor tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ConstructorExpandedArgumentInvalidCases()
+        {
+            var credential = Mock.Of<TokenCredential>();
+
+            yield return new object[] { null, "fakePath", credential };
+            yield return new object[] { "", "fakePath", credential };
+            yield return new object[] { "FakeHost", null, credential };
+            yield return new object[] { "FakeHost", "", credential };
+            yield return new object[] { "FakeHost", "FakePath", null };
+        }
+
+        /// <summary>
+        ///   Provides the invalid test cases for the constructor tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ConstructorCreatesDefaultOptionsCases()
+        {
+            var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
+
+            yield return new object[] { new EventHubClient(fakeConnection), "simple connection string" };
+            yield return new object[] { new EventHubClient(fakeConnection), "connection string with null options" };
+            yield return new object[] { new EventHubClient("host", "path", Mock.Of<TokenCredential>()), "expanded argument" };
+        }
+
+        /// <summary>
+        ///   Provides the invalid test cases for the constructor tests.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ConstructorClonesOptionsCases()
+        {
+            var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
+
+            var options = new EventHubClientOptions
+            {
+                ConnectionType = ConnectionType.AmqpWebSockets,
+                DefaultTimeout = TimeSpan.FromHours(2),
+                Retry          = new ExponentialRetry(TimeSpan.FromMinutes(10), TimeSpan.FromHours(1), 24),
+                Proxy          = Mock.Of<IWebProxy>()
+            };
+
+            yield return new object[] { new EventHubClient(fakeConnection, options), options, "connection string" };
+            yield return new object[] { new EventHubClient("host", "path", Mock.Of<TokenCredential>(), options), options, "expanded argument" };
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorRequiresConnectionString(string connectionString)
+        {
+            Assert.That(() => new EventHubClient(connectionString), Throws.InstanceOf<ArgumentException>(), "The constructor without options should perform validation.");
+            Assert.That(() => new EventHubClient(connectionString, new EventHubClientOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should perform validation.");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorDoesNotRequireOptionsWithConnectionString()
+        {
+            var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
+            Assert.That(() => new EventHubClient(fakeConnection, null), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]")]
+        [TestCase("Endpoint=value.com;SharedAccessKey=[value];EntityPath=[value]")]
+        [TestCase("Endpoint=value.com;SharedAccessKeyName=[value];EntityPath=[value]")]
+        [TestCase("Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value]")]
+        public void ConstructorValidatesConnectionString(string connectionString)
+        {
+            Assert.That(() => new EventHubClient(connectionString), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ConstructorExpandedArgumentInvalidCases))]
+        public void ConstructorValidatesExpandedArguments(string          host,
+                                                          string          eventHubPath,
+                                                          TokenCredential credential)
+        {
+            Assert.That(() => new EventHubClient(host, eventHubPath, credential), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ConstructorCreatesDefaultOptionsCases))]
+        public void ConstructorCreatesDefaultOptions(EventHubClient client,
+                                                     string         constructorDescription)
+        {
+           var defaultOptions = new EventHubClientOptions();
+
+            var options = (EventHubClientOptions)typeof(EventHubClient)
+                .GetProperty("ClientOptions", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(client);
+
+           Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set default options.");
+           Assert.That(options, Is.Not.SameAs(defaultOptions), $"The { constructorDescription } constructor should not have the same options instance.");
+           Assert.That(options.ConnectionType, Is.EqualTo(defaultOptions.ConnectionType), $"The { constructorDescription } constructor should have the correct connection type.");
+           Assert.That(options.DefaultTimeout, Is.EqualTo(defaultOptions.DefaultTimeout), $"The { constructorDescription } constructor should have the correct default timeout.");
+           Assert.That(options.Proxy, Is.EqualTo(defaultOptions.Proxy), $"The { constructorDescription } constructor should have the correct proxy.");
+           Assert.That(options.Retry, Is.EqualTo(defaultOptions.Retry), $"The { constructorDescription } constructor should have the correct retry.");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ConstructorClonesOptionsCases))]
+        public void ConstructorClonesOptions(EventHubClient        client,
+                                             EventHubClientOptions constructorOptions,
+                                             string                constructorDescription)
+        {
+            var options = (EventHubClientOptions)typeof(EventHubClient)
+                .GetProperty("ClientOptions", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(client);
+
+           Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set the options.");
+           Assert.That(options, Is.Not.SameAs(constructorOptions), $"The { constructorDescription } constructor should have cloned the options.");
+           Assert.That(options.ConnectionType, Is.EqualTo(constructorOptions.ConnectionType), $"The { constructorDescription } constructor should have the correct connection type.");
+           Assert.That(options.DefaultTimeout, Is.EqualTo(constructorOptions.DefaultTimeout), $"The { constructorDescription } constructor should have the correct default timeout.");
+           Assert.That(options.Proxy, Is.EqualTo(constructorOptions.Proxy), $"The { constructorDescription } constructor should have the correct proxy.");
+           Assert.That(options.Retry, Is.EqualTo(constructorOptions.Retry), $"The { constructorDescription } constructor should have the correct retry.");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorWithConnectionStringInitializesProperties()
+        {
+            var entityPath = "somePath";
+            var fakeConnection = $"Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath={ entityPath }";
+            var client = new EventHubClient(fakeConnection);
+
+            Assert.That(client.EventHubPath, Is.EqualTo(entityPath));
+            Assert.That(client.Credential, Is.Null);
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorWithExpandedArgumentsInitializesProperties()
+        {
+            var host = "host.windows.servicebus.net";
+            var entityPath = "somePath";
+            var credential = Mock.Of<TokenCredential>();
+            var client = new EventHubClient(host, entityPath, credential);
+
+            Assert.That(client.EventHubPath, Is.EqualTo(entityPath));
+            Assert.That(client.Credential, Is.EqualTo(credential));
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorWithConnectionStringValidatesOptions()
+        {
+            var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
+            var invalidOptions =  new EventHubClientOptions { ConnectionType = ConnectionType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
+
+            Assert.That(() => new EventHubClient(fakeConnection, invalidOptions), Throws.InstanceOf<ArgumentException>(), "The connection string constructor should validate client options");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorWithExpandedArgumentsValidatesOptions()
+        {
+            var invalidOptions =  new EventHubClientOptions { ConnectionType = ConnectionType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
+            Assert.That(() => new EventHubClient("host", "path", Mock.Of<TokenCredential>(), invalidOptions), Throws.InstanceOf<ArgumentException>(), "The cexpanded argument onstructor should validate client options");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient.CreateSender" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateEventSenderCreatesDefaultWhenNoOptionsArePassed()
+        {
+            var clientOptions = new EventHubClientOptions
+            {
+                Retry = new ExponentialRetry(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), 5),
+                DefaultTimeout = TimeSpan.FromHours(24)
+            };
+
+            var expected = new SenderOptions
+            {
+                Retry = clientOptions.Retry,
+                Timeout = clientOptions.DefaultTimeout
+            };
+
+            var actual = default(SenderOptions);
+            var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
+
+            var mockClient = new Mock<EventHubClient>(connectionString, clientOptions)
+            {
+                CallBase = true
+            };
+
+            mockClient
+                .Protected()
+                .Setup<EventSender>("BuildEventSender", ItExpr.IsAny<ConnectionType>(), ItExpr.IsAny<string>(), ItExpr.IsAny<SenderOptions>())
+                .Returns(Mock.Of<EventSender>())
+                .Callback<ConnectionType, string, SenderOptions>((type, path, options) => actual = options);
+
+            mockClient.Object.CreateSender();
+
+            Assert.That(actual, Is.Not.Null, "The sender options should have been set.");
+            Assert.That(actual.PartitionId, Is.EqualTo(expected.PartitionId), "The partition identifiers should match.");
+            Assert.That(actual.Retry, Is.EqualTo(expected.Retry), "The retries should match.");
+            Assert.That(actual.TimeoutOrDefault, Is.EqualTo(expected.TimeoutOrDefault), "The timeouts should match.");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient.CreateSender" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateEventSenderCreatesDefaultWhenOptionsAreNotSet()
+        {
+            var clientOptions = new EventHubClientOptions
+            {
+                Retry = new ExponentialRetry(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), 5),
+                DefaultTimeout = TimeSpan.FromHours(24)
+            };
+
+            var senderOptions = new SenderOptions
+            {
+               PartitionId = "123",
+               Retry = null,
+               Timeout = TimeSpan.Zero
+            };
+
+            var expected = new SenderOptions
+            {
+                PartitionId = senderOptions.PartitionId,
+                Retry = clientOptions.Retry,
+                Timeout = clientOptions.DefaultTimeout
+            };
+
+            var actual = default(SenderOptions);
+            var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
+
+            var mockClient = new Mock<EventHubClient>(connectionString, clientOptions)
+            {
+                CallBase = true
+            };
+
+            mockClient
+                .Protected()
+                .Setup<EventSender>("BuildEventSender", ItExpr.IsAny<ConnectionType>(), ItExpr.IsAny<string>(), ItExpr.IsAny<SenderOptions>())
+                .Returns(Mock.Of<EventSender>())
+                .Callback<ConnectionType, string, SenderOptions>((type, path, options) => actual = options);
+
+            mockClient.Object.CreateSender(senderOptions);
+
+            Assert.That(actual, Is.Not.Null, "The sender options should have been set.");
+            Assert.That(actual, Is.Not.SameAs(senderOptions), "The options should have been cloned.");
+            Assert.That(actual.PartitionId, Is.EqualTo(expected.PartitionId), "The partition identifiers should match.");
+            Assert.That(actual.Retry, Is.EqualTo(expected.Retry), "The retries should match.");
+            Assert.That(actual.TimeoutOrDefault, Is.EqualTo(expected.TimeoutOrDefault), "The timeouts should match.");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient.CreatePartitionReceiver" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreatePartitionReceiverCreatesDefaultWhenNoOptionsArePassed()
+        {
+            var clientOptions = new EventHubClientOptions
+            {
+                Retry = new ExponentialRetry(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), 5),
+                DefaultTimeout = TimeSpan.FromHours(24)
+            };
+
+            var expectedOptions = new ReceiverOptions
+            {
+                Retry = clientOptions.Retry,
+                DefaultMaximumReceiveWaitTime = clientOptions.DefaultTimeout
+
+            };
+
+            var expectedPartition = "56767";
+            var actualOptions = default(ReceiverOptions);
+            var actualPartition = default(string);
+            var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
+
+            var mockClient = new Mock<EventHubClient>(connectionString, clientOptions)
+            {
+                CallBase = true
+            };
+
+            mockClient
+                .Protected()
+                .Setup<PartitionReceiver>("BuildPartitionReceiver", ItExpr.IsAny<ConnectionType>(), ItExpr.IsAny<string>(), ItExpr.IsAny<string>(), ItExpr.IsAny<ReceiverOptions>())
+                .Returns(Mock.Of<PartitionReceiver>())
+                .Callback<ConnectionType, string, string, ReceiverOptions>((type, path, partition, options) => { actualOptions = options; actualPartition = partition; });
+
+            mockClient.Object.CreatePartitionReceiver(expectedPartition);
+
+            Assert.That(actualPartition, Is.EqualTo(expectedPartition), "The partition should match.");
+            Assert.That(actualOptions, Is.Not.Null, "The receiver options should have been set.");
+            Assert.That(actualOptions.BeginReceivingAt.Offset, Is.EqualTo(expectedOptions.BeginReceivingAt.Offset), "The beginning position to receive should match.");
+            Assert.That(actualOptions.ConsumerGroup, Is.EqualTo(expectedOptions.ConsumerGroup), "The consumer groups should match.");
+            Assert.That(actualOptions.ExclusiveReceiverPriority, Is.EqualTo(expectedOptions.ExclusiveReceiverPriority), "The exclusive priorities should match.");
+            Assert.That(actualOptions.Identifier, Is.EqualTo(expectedOptions.Identifier), "The identifiers should match.");
+            Assert.That(actualOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The prefetch counts should match.");
+            Assert.That(actualOptions.Retry, Is.EqualTo(expectedOptions.Retry), "The retries should match.");
+            Assert.That(actualOptions.MaximumReceiveWaitTimeOrDefault, Is.EqualTo(expectedOptions.MaximumReceiveWaitTimeOrDefault), "The wait times should match.");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient.CreatePartitionReceiver" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreatePartitionReceiverCreatesDefaultWhenOptionsAreNotSet()
+        {
+            var clientOptions = new EventHubClientOptions
+            {
+                Retry = new ExponentialRetry(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(3), 5),
+                DefaultTimeout = TimeSpan.FromHours(24)
+            };
+
+            var expectedOptions = new ReceiverOptions
+            {
+                BeginReceivingAt = EventPosition.FromOffset(65),
+                ConsumerGroup = "SomeGroup",
+                ExclusiveReceiverPriority = 251,
+                Identifier = "Bob",
+                PrefetchCount = 600,
+                Retry = clientOptions.Retry,
+                DefaultMaximumReceiveWaitTime = clientOptions.DefaultTimeout
+
+            };
+
+            var expectedPartition = "56767";
+            var actualOptions = default(ReceiverOptions);
+            var actualPartition = default(string);
+            var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
+
+            var mockClient = new Mock<EventHubClient>(connectionString, clientOptions)
+            {
+                CallBase = true
+            };
+
+            mockClient
+                .Protected()
+                .Setup<PartitionReceiver>("BuildPartitionReceiver", ItExpr.IsAny<ConnectionType>(), ItExpr.IsAny<string>(), ItExpr.IsAny<string>(), ItExpr.IsAny<ReceiverOptions>())
+                .Returns(Mock.Of<PartitionReceiver>())
+                .Callback<ConnectionType, string, string, ReceiverOptions>((type, path, partition, options) => { actualOptions = options; actualPartition = partition; });
+
+            mockClient.Object.CreatePartitionReceiver(expectedPartition, expectedOptions);
+
+            Assert.That(actualPartition, Is.EqualTo(expectedPartition), "The partition should match.");
+            Assert.That(actualOptions, Is.Not.Null, "The receiver options should have been set.");
+            Assert.That(actualOptions, Is.Not.SameAs(expectedOptions), "A clone of the options should have been made.");
+            Assert.That(actualOptions.BeginReceivingAt.Offset, Is.EqualTo(expectedOptions.BeginReceivingAt.Offset), "The beginning position to receive should match.");
+            Assert.That(actualOptions.ConsumerGroup, Is.EqualTo(expectedOptions.ConsumerGroup), "The consumer groups should match.");
+            Assert.That(actualOptions.ExclusiveReceiverPriority, Is.EqualTo(expectedOptions.ExclusiveReceiverPriority), "The exclusive priorities should match.");
+            Assert.That(actualOptions.Identifier, Is.EqualTo(expectedOptions.Identifier), "The identifiers should match.");
+            Assert.That(actualOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The prefetch counts should match.");
+            Assert.That(actualOptions.Retry, Is.EqualTo(expectedOptions.Retry), "The retries should match.");
+            Assert.That(actualOptions.MaximumReceiveWaitTimeOrDefault, Is.EqualTo(expectedOptions.MaximumReceiveWaitTimeOrDefault), "The wait times should match.");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient.GetPartitionIdsAsync" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetPartitionIdsAsyncDelegatesToGetProperties()
+        {
+            var date = DateTimeOffset.Parse("2015-10-27T12:00:00Z").DateTime;
+            var partitionIds = new [] { "first", "second", "third" };
+            var properties = new EventHubProperties("dummy", date, partitionIds, date);
+            var mockClient = new Mock<EventHubClient> { CallBase = true };
+
+            mockClient
+                .Setup(client => client.GetPropertiesAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(properties))
+                .Verifiable("GetPropertiesAcync should have been delegated to.");
+
+            var actual = await mockClient.Object.GetPartitionIdsAsync(CancellationToken.None);
+
+            Assert.That(actual, Is.Not.Null);
+            Assert.That(actual, Is.EqualTo(partitionIds));
+
+            mockClient.VerifyAll();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventReceivers/ReceiverOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventReceivers/ReceiverOptionsTests.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="ReceiverOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Category(TestCategory.BuildVerification)]
+    public class ReceiverOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ReceiverOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var options = new ReceiverOptions
+            {
+                ConsumerGroup = "custom$consumer",
+                BeginReceivingAt = EventPosition.FromOffset(65),
+                ExclusiveReceiverPriority = 99,
+                Retry = new ExponentialRetry(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(5), 6),
+                DefaultMaximumReceiveWaitTime = TimeSpan.FromMinutes(65),
+                Identifier = "an_event_receiver"
+            };
+
+            var clone = options.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+
+            Assert.That(clone.ConsumerGroup, Is.EqualTo(options.ConsumerGroup), "The consumer group of the clone should match.");
+            Assert.That(clone.BeginReceivingAt, Is.EqualTo(options.BeginReceivingAt), "The position to begin reading events of the clone should match.");
+            Assert.That(clone.ExclusiveReceiverPriority, Is.EqualTo(options.ExclusiveReceiverPriority), "The exclusive priority of the clone should match.");
+            Assert.That(clone.DefaultMaximumReceiveWaitTime, Is.EqualTo(options.DefaultMaximumReceiveWaitTime), "The default maximum wait time of the clone should match.");
+            Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier of the clone should match.");
+
+            Assert.That(clone.Retry, Is.EqualTo(options.Retry), "The retry of the clone should be considered equal.");
+            Assert.That(clone.Retry, Is.Not.SameAs(options.Retry), "The retry of the clone should be a copy, not the same instance.");
+        }
+
+        /// <summary>
+        ///  Verifies that setting the <see cref="ReceiverOptions.PrefetchCount" /> is
+        ///  validated.
+        /// </summary>
+        ///
+        [Test]
+        public void PrefetchIsValidated()
+        {
+            var options = new MockOptions();
+            Assert.That(() => options.PrefetchCount = (options.MinPrefixCount - 1), Throws.InstanceOf<ArgumentOutOfRangeException>());
+        }
+
+        /// <summary>
+        ///  Verifies that setting the <see cref="ReceiverOptions.Identifier" /> is
+        ///  validated.
+        /// </summary>
+        ///
+        [Test]
+        public void IdentifierIsValidated()
+        {
+            var options = new MockOptions();
+            var tooLongIdentifier = new String('x', (options.MaxIdentifierLength + 1));
+
+            Assert.That(() => options.Identifier = tooLongIdentifier, Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="ReceiverOptions.DefaultMaximumReceiveWaitTime" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void DefaultMaximumReceiveWaitTimeIsValidated()
+        {
+            Assert.That(() => new ReceiverOptions { DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(-1) }, Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="SenderOptions.Timeout" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase(0)]
+        public void DefaultMaximumReceiveWaitTimeUsesNormalizesValueINotSpecified(int? noTimeoutValue)
+        {
+            var options = new ReceiverOptions();
+            var timeoutValue = (noTimeoutValue.HasValue) ? TimeSpan.Zero : (TimeSpan?)null;
+
+            options.DefaultMaximumReceiveWaitTime = timeoutValue;
+            Assert.That(options.DefaultMaximumReceiveWaitTime, Is.EqualTo(timeoutValue), "The value supplied by the caller should be preserved.");
+            Assert.That(options.MaximumReceiveWaitTimeOrDefault, Is.Null, "The maximum wait value should be normalized to null internally.");
+        }
+
+        /// <summary>
+        ///   A mock of the <see cref="ReceiverOptions" /> to allow the protected validation
+        ///   constants to be referenced.
+        /// </summary>
+        ///
+        private class MockOptions : ReceiverOptions
+        {
+            public int MinPrefixCount => ReceiverOptions.MinimumPrefetchCount;
+            public int MaxIdentifierLength => ReceiverOptions.MaximumIdentifierLength;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/SenderOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/SenderOptionsTests.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="SenderOptions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Category(TestCategory.BuildVerification)]
+    public class SenderOptionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="SenderOptions.Clone" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloneProducesACopy()
+        {
+            var options = new SenderOptions
+            {
+                PartitionId = "some_partition_id_123",
+                Retry = new ExponentialRetry(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(5), 6),
+                Timeout = TimeSpan.FromMinutes(65)
+            };
+
+            var clone = options.Clone();
+            Assert.That(clone, Is.Not.Null, "The clone should not be null.");
+
+            Assert.That(clone.PartitionId, Is.EqualTo(options.PartitionId), "The partition identifier of the clone should match.");
+            Assert.That(clone.Timeout, Is.EqualTo(options.Timeout), "The  timeout of the clone should match.");
+
+            Assert.That(clone.Retry, Is.EqualTo(options.Retry), "The retry of the clone should be considered equal.");
+            Assert.That(clone.Retry, Is.Not.SameAs(options.Retry), "The retry of the clone should be a copy, not the same instance.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="SenderOptions.Timeout" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void DefaultTimeoutIsValidated()
+        {
+            Assert.That(() => new SenderOptions { Timeout = TimeSpan.FromMilliseconds(-1) }, Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="SenderOptions.Timeout" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase(0)]
+        public void DefaultTimeoutUsesDefaultValueIfNormalizesValueINotSpecified(int? noTimeoutValue)
+        {
+            var options = new SenderOptions();
+            var timeoutValue = (noTimeoutValue.HasValue) ? TimeSpan.Zero : (TimeSpan?)null;
+
+            options.Timeout = timeoutValue;
+            Assert.That(options.Timeout, Is.EqualTo(timeoutValue), "The value supplied by the caller should be preserved.");
+            Assert.That(options.TimeoutOrDefault, Is.Null, "The timeout value should be normalized to null internally.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestCategory.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestCategory.cs
@@ -17,5 +17,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
         /// <summary>The associated test is meant to verify a scenario from end-to-end which is safe to run in isolation; it has no external dependencies</summary>
         public const string EndToEnd = "EndToEnd";
+
+        /// <summary>The associated test should not be included when Visual Studio is performing "Live Unit Testing" runs.</summary>
+        public const string DisallowVisualStudioLiveUnitTesting = "SkipWhenLiveUnitTesting";
     }
 }


### PR DESCRIPTION
# Summary

The goal of these changes to begin fleshing out the `EventHubClient` and related constructs, establishing the baseline infrastructure and operations.  This set of changes covers validation for construction, handling and validating of options for client, sender, and receiver creation, and parsing of connection strings.  

# Goals

- Ensure that consumers are provided with feedback when creating an `EventHubClient` in a way that is not legal, including malformed connection strings, invalid arguments, and invalid options.

- Ensure that consumers are provided with feedback when creating an `EventSender` in a way that is not legal, including invalid arguments and/or options.

- Ensure that consumers are provided with feedback when creating an `PartitionReceiver` in a way that is not legal, including invalid arguments and/or options.

- Allow for parsing of connection strings as they would be rendered in the Azure portal, restricting legal tokens that appear within them to that scope; parsing should be forgiving of extra spaces and delimiters.

# Non-Goals

- Providing the implementation for the compatibility layer between the track two and track one `EventHubClient`; this will happen as part of future efforts.

- Supporting validation or other authorization-related tasks with a shared access signature from the connection string; this will happen as part of future efforts.

- Import of the full test suite for the track one implementation; tests will focus on the core scenarios identified for the track two preview.

- Inclusion of the full set of supporting assets, such as README, samples, and ARM templates; these will happen as part of future efforts.

- Enabling test parallelism; this will be a stretch goal, but unlikely to occur in the time frame for the first track two preview.

# Details
    
### Event Hub Client

- Fleshed out constructors with validation, options management, and initialization.

- Added validation for options, ensuring that the combination of values is a legal, valid state.

- Added option handling for creation of senders and receivers, ensuring defaults are carried forward when needed.

- Added BVTs for construction and initialization.

###  Core
      
- Added tests for the set of primitive types, including options and retry  policies.

- Added support for cloning of options for use with creation of clients, allowing a snapshot of the options to be taken at creation.

- Added structural equality for the exponential retry to assist with change detection and compatibility shimming to the track one equivalent.

- Moved responsibility for basic validation into each set of options, reserving only the compound state validation for clients.

- Implemented a parser for Event Hubs connection strings, reducing supported tokens to the set available via copy/paste from the portal.  Though not expected to be used repeatedly on a hot path or within performance-critical sections, efforts were made to perform in-place parsing and limit allocations to the bare minimum.

# Last Upstream Rebase

Monday, June 3, 2019  10:06am (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)