### PR TITLE
Add nameof() to thrown ArgumentNull exceptions so that errors specify which arguments are null

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/QueueClient.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.ServiceBus
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw Fx.Exception.ArgumentNullOrWhiteSpace(connectionString);
+                throw Fx.Exception.ArgumentNullOrWhiteSpace(nameof(connectionString));
             }
             
             this.OwnsConnection = true;
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.ServiceBus
 
             if (string.IsNullOrWhiteSpace(entityPath))
             {
-                throw Fx.Exception.ArgumentNullOrWhiteSpace(entityPath);
+                throw Fx.Exception.ArgumentNullOrWhiteSpace(nameof(entityPath));
             }
 
             this.ServiceBusConnection = serviceBusConnection ?? throw new ArgumentNullException(nameof(serviceBusConnection));


### PR DESCRIPTION
Added nameof() to connectionString and entityPath variables when throwing exceptions.
Previously if these were null or whitespace the error message would say: "System.ArgumentException: The argument  is null or white space."

Now it will state which argument it is referring to.