### PR TITLE
Fixes session pump stop when auto-renew lock task expires

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SessionReceivePump.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/SessionReceivePump.cs
@@ -54,17 +54,18 @@ namespace Microsoft.Azure.ServiceBus
             }
         }
 
-        static void CancelAndDisposeCancellationTokenSource(CancellationTokenSource renewLockCancellationTokenSource)
-        {
-            renewLockCancellationTokenSource?.Cancel();
-            renewLockCancellationTokenSource?.Dispose();
-        }
-
-        static void OnUserCallBackTimeout(object state)
+        static void CancelAutoRenewLock(object state)
         {
             var renewCancellationTokenSource = (CancellationTokenSource)state;
-            renewCancellationTokenSource?.Cancel();
-            renewCancellationTokenSource?.Dispose();
+
+            try
+            {
+                renewCancellationTokenSource.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Ignore this race.
+            }
         }
 
         bool ShouldRenewSessionLock()
@@ -179,8 +180,8 @@ namespace Microsoft.Azure.ServiceBus
                 TaskExtensionHelper.Schedule(() => this.RenewSessionLockTaskAsync(session, renewLockCancellationTokenSource.Token));
             }
 
-            var userCallbackTimer = new Timer(
-                OnUserCallBackTimeout,
+            var autoRenewLockCancellationTimer = new Timer(
+                CancelAutoRenewLock,
                 renewLockCancellationTokenSource,
                 Timeout.Infinite,
                 Timeout.Infinite);
@@ -223,7 +224,7 @@ namespace Microsoft.Azure.ServiceBus
                     try
                     {
                         // Set the timer
-                        userCallbackTimer.Change(this.sessionHandlerOptions.MaxAutoRenewDuration,
+                        autoRenewLockCancellationTimer.Change(this.sessionHandlerOptions.MaxAutoRenewDuration,
                             TimeSpan.FromMilliseconds(-1));
                         var callbackExceptionOccurred = false;
                         try
@@ -248,7 +249,7 @@ namespace Microsoft.Azure.ServiceBus
                         }
                         finally
                         {
-                            userCallbackTimer.Change(Timeout.Infinite, Timeout.Infinite);
+                            autoRenewLockCancellationTimer.Change(Timeout.Infinite, Timeout.Infinite);
                         }
 
                         if (!callbackExceptionOccurred)
@@ -269,8 +270,10 @@ namespace Microsoft.Azure.ServiceBus
             }
             finally
             {
-                userCallbackTimer.Dispose();
-                CancelAndDisposeCancellationTokenSource(renewLockCancellationTokenSource);
+                renewLockCancellationTokenSource.Cancel();
+                renewLockCancellationTokenSource.Dispose();
+                autoRenewLockCancellationTimer.Dispose();
+
                 await this.CloseSessionIfNeededAsync(session).ConfigureAwait(false);
                 this.maxConcurrentSessionsSemaphoreSlim.Release();
             }


### PR DESCRIPTION
Fixes the bug when the session handler stops processing messages if renew lock duration is less than it takes to process a message in user callback.

The code flow in `SessionReceivePump.cs` which leads to a problem looks like this:
1. When a new session is accepted, the `MessagePumpTaskAsync` starts a renew lock task in background and a timer to cancel this task in 1 second (the value specified in `MaxAutoRenewDuration`).
2. 1 second has passed and `OnUserCallBackTimeout` is executed which cancels and **disposes** `renewLockCancellationTokenSource`.
3. After ~30 seconds `MessagePumpTaskAsync` is getting some exception and pops out to a `finally` block which should release a semaphore. But it couldn't do it because of exception `ObjectDisposedException` when trying to cancel already disposed (in step 2) `renewLockCancellationTokenSource`.

**Reproduction program**
It sends a few messages in different sessions and then tries to receive them. The gotcha here is that processing a message takes longer than LockDuration and AutorenewLockDuration.
_Expected:_ session pump indefinitely tries to process messages without stopping.
_Actual:_ after the first message the pump is stuck and don't try to process new messages.

```cs
using System;
using System.Linq;
using System.Threading;
using System.Threading.Tasks;
using HangReproduction.SessionClient;
using Microsoft.Azure.ServiceBus;
using Microsoft.Azure.ServiceBus.Core;

namespace HangReproduction
{
    internal class Program
    {
        private static async Task Main()
        {
            // Set your connection string to a queue with sessions enabled and LockDuration set to 10 seconds
            const string connectionString = "...secret...";

            // Send some messages
            //const int messageCount = 50;
            //Console.WriteLine("Sending test messages...");
            //await SendSomeMessages(connectionString, messageCount);
            //Console.WriteLine($"{messageCount} messages have been sent.");

            // Start receiving messages
            StartReceiveHandler(connectionString);

            Console.WriteLine("Press any key to exit...");
            Console.ReadKey();
        }

        private static void StartReceiveHandler(string connectionString)
        {
            var sessionClient = new Microsoft.Azure.ServiceBus.QueueClient(new ServiceBusConnectionStringBuilder(connectionString));
            sessionClient.RegisterSessionHandler(MessageHandler, new SessionHandlerOptions(ExceptionReceivedHandler)
            {
                // Set only 1 concurrent session to faster reveal the bug with pumps
                MaxConcurrentSessions = 1,
                MaxAutoRenewDuration = TimeSpan.FromSeconds(1) // Should be less than the time to process a message and LockDuration
            });
        }

        private static async Task MessageHandler(IMessageSession session, Message message, CancellationToken cancellationToken)
        {
            Console.WriteLine($"{DateTime.Now} Session {session.SessionId} message processing begin...");

            // Wait longer than MaxAutoRenewDuration
            await Task.Delay(TimeSpan.FromSeconds(20), cancellationToken);

            Console.WriteLine($"{DateTime.Now} Session {session.SessionId} message processing end");
        }

        private static Task ExceptionReceivedHandler(ExceptionReceivedEventArgs arg)
        {
            Console.WriteLine($"{DateTime.Now} Exception in handler: {arg.Exception.Message}");
            return Task.CompletedTask;
        }

        private static async Task SendSomeMessages(string connectionString, int count)
        {
            var messageSender = new MessageSender(new ServiceBusConnectionStringBuilder(connectionString));

            for (var i = 0; i < count; i++)
            {
                var message = new Message(new byte[20])
                {
                    SessionId = Guid.NewGuid().ToString()
                };
                await messageSender.SendAsync(message);
            }
        }
    }
}
```

P.S. this problem is already fixed in [MessageReceivePump.cs#L190](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessageReceivePump.cs#L190) but in SessionReceivePump it was overlooked.