### PR TITLE
CloudTask.CopyNodeFileContentTo* methods don't work

### DIFF
--- a/sdk/batch/Microsoft.Azure.Batch/src/CloudTask.cs
+++ b/sdk/batch/Microsoft.Azure.Batch/src/CloudTask.cs
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.Batch
         {
             // create the behavior manager
             BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
-            Task asyncTask = this.parentBatchClient.PoolOperations.CopyNodeFileContentToStreamAsyncImpl(
+            Task asyncTask = this.parentBatchClient.JobOperations.CopyNodeFileContentToStreamAsyncImpl(
                 this.parentJobId,
                 this.Id,
                 filePath,
@@ -423,7 +423,7 @@ namespace Microsoft.Azure.Batch
         {
             // create the behavior manager
             BehaviorManager bhMgr = new BehaviorManager(this.CustomBehaviors, additionalBehaviors);
-            return this.parentBatchClient.PoolOperations.CopyNodeFileContentToStringAsyncImpl(
+            return this.parentBatchClient.JobOperations.CopyNodeFileContentToStringAsyncImpl(
                 this.parentJobId,
                 this.Id,
                 filePath,


### PR DESCRIPTION
PoolOperations and JobOperations both define CopyNodeFileContentToStreamAsyncImpl and CopyNodeFileContentToStringAsyncImpl methods with the same number of arguments and the same types but different meaning. As a result, the wrong REST API is invoked when using CloudTask.CopyNodeFileContentTo* methods.