### PR TITLE
Add net461 and netstandard2.0 to default target frameworks

### DIFF
--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -27,7 +27,7 @@
     <SupportsNetStandard20 Condition="'$(SupportsNetStandard20)' == '' and '$(IsClientLibrary)' == 'true'">true</SupportsNetStandard20>
     <SupportsNetStandard20 Condition="'$(SupportsNetStandard20)' == ''">false</SupportsNetStandard20>
 
-    <RequiredTargetFrameworks>net452;netstandard1.4</RequiredTargetFrameworks>
+    <RequiredTargetFrameworks>net452;netstandard1.4;net461;netstandard2.0</RequiredTargetFrameworks>
     <RequiredTargetFrameworks Condition="'$(SupportsNetStandard20)' == 'true'">net461;netstandard2.0</RequiredTargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
For the older track 1 data-plane libraries they used to only
support net452 and netstandard1.4 but in order to align the packages
with the newer platforms we are adding net461 and netstandard2.0
to the list of target frameworks.

Fixes https://github.com/Azure/azure-sdk-for-net/issues/5959

PTAL @shahabhijeet @AlexGhiondea @chidozieononiwu 