### PR TITLE
Added core back into path filters.

### DIFF
--- a/sdk/appconfiguration/ci.yml
+++ b/sdk/appconfiguration/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/appconfiguration/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/appconfiguration/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/applicationinsights/ci.yml
+++ b/sdk/applicationinsights/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/applicationinsights/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/applicationinsights/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/batch/ci.yml
+++ b/sdk/batch/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/batch/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/batch/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/cognitiveservices/ci.yml
+++ b/sdk/cognitiveservices/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/cognitiveservices/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/cognitiveservices/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/containerregistry/ci.yml
+++ b/sdk/containerregistry/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/containerregistry/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/containerregistry/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/eventgrid/ci.yml
+++ b/sdk/eventgrid/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/eventgrid/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/eventgrid/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/eventhub/ci.yml
+++ b/sdk/eventhub/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/eventhub/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/eventhub/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/hdinsight/ci.yml
+++ b/sdk/hdinsight/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/hdinsight/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/hdinsight/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
+++ b/sdk/identity/Azure.Identity/src/Azure.Identity.csproj
@@ -19,7 +19,7 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Text.Json" Version="4.6.0-preview6.19226.8" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 
   <!-- Import the Azure.Base project -->

--- a/sdk/identity/ci.yml
+++ b/sdk/identity/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/identity/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/identity/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.Keyvault.Keys.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.Keyvault.Keys.csproj
@@ -21,6 +21,6 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Text.Json" Version="4.6.0-preview6.19259.10" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 </Project>

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Azure.Security.KeyVault.Secrets.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.2" />
     <PackageReference Include="System.Text.Json" Version="4.6.0-preview6.19226.8" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.1" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/keyvault/ci.yml
+++ b/sdk/keyvault/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/keyvault/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/keyvault/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/operationalinsights/ci.yml
+++ b/sdk/operationalinsights/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/operationalinsights/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/operationalinsights/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/servicebus/ci.yml
+++ b/sdk/servicebus/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/servicebus/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/servicebus/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/storage/ci.yml
+++ b/sdk/storage/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/storage/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/storage/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml

--- a/sdk/template/ci.yml
+++ b/sdk/template/ci.yml
@@ -8,6 +8,7 @@ trigger:
   paths:
     include:
     - sdk/template/
+    - sdk/core/
 
 pr:
   branches:
@@ -16,6 +17,7 @@ pr:
   paths:
     include:
     - sdk/template/
+    - sdk/core/
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml


### PR DESCRIPTION
Based on a conversation internally we are adding ```sdk/core/``` back into path filters for the various PR validation pipelines so changes in core trigger builds in libraries that depend on it. This is a temporary measure until we can find a better way to do this.