### PR TITLE
Build all services when we change core

### DIFF
--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -20,4 +20,4 @@ pr:
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:
-    ServiceDirectory: core
+    ServiceDirectory: '*'


### PR DESCRIPTION
For now we will build all libraries when core changes but eventually
we can rescope this once we stop using the project references and
instead use package reference to azure.core.