### PR TITLE
Add TryGetProperty and SetProperty to HttpPipelineMessage

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
@@ -1,12 +1,15 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Threading;
 
 namespace Azure.Core.Pipeline
 {
     public class HttpPipelineMessage
     {
+        private Dictionary<string, object> _properties;
+
         public CancellationToken CancellationToken { get; }
 
         public HttpPipelineMessage(CancellationToken cancellationToken)
@@ -19,5 +22,18 @@ namespace Azure.Core.Pipeline
         public Response Response { get; set; }
 
         public ResponseClassifier ResponseClassifier { get; set; }
+
+        public bool TryGetProperty(string name, out object value)
+        {
+            value = null;
+            return _properties?.TryGetValue(name, out value) == true;
+        }
+
+        public void SetProperty(string name, object value)
+        {
+            _properties ??= new Dictionary<string, object>();
+
+            _properties[name] = value;
+        }
     }
 }

--- a/sdk/core/Azure.Core/tests/PipelineTests.cs
+++ b/sdk/core/Azure.Core/tests/PipelineTests.cs
@@ -30,6 +30,33 @@ namespace Azure.Core.Tests
             Assert.AreEqual(1, response.Status);
         }
 
+        [Test]
+        public void TryGetPropertyReturnsFalseIfNotExist()
+        {
+            HttpPipelineMessage message = new HttpPipelineMessage(CancellationToken.None);
+
+            Assert.False(message.TryGetProperty("someName", out _));
+        }
+
+        [Test]
+        public void TryGetPropertyReturnsValueIfSet()
+        {
+            HttpPipelineMessage message = new HttpPipelineMessage(CancellationToken.None);
+            message.SetProperty("someName", "value");
+
+            Assert.True(message.TryGetProperty("someName", out object value));
+            Assert.AreEqual("value", value);
+        }
+
+        [Test]
+        public void TryGetPropertyIsCaseSensitive()
+        {
+            HttpPipelineMessage message = new HttpPipelineMessage(CancellationToken.None);
+            message.SetProperty("someName", "value");
+
+            Assert.False(message.TryGetProperty("SomeName", out object value));
+        }
+
         class CustomResponseClassifier : ResponseClassifier
         {
             public override bool IsRetriableResponse(Response response)


### PR DESCRIPTION
So the state can be stored between multiple policy invocations for the same request.