### PR TITLE
[Event Hubs Client - Track Two Preview 1] End-to-End Event Hub Client and Board Review

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -29,12 +29,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.2" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="[1.0.3, 2.0.0)" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.0.5" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="[4.5.1, 4.9.9)" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="[4.5.1, 4.9.0)" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="[5.4.0, 6.0.0)" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0-preview6.19259.10" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
@@ -1,0 +1,229 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Authorization;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Metadata;
+using TrackOne;
+
+namespace Azure.Messaging.EventHubs.Compatibility
+{
+    /// <summary>
+    ///   A transport client abstraction responsible for wrapping the track one Event Hub client as a transport client for
+    ///   AMQP-based connections.  It is intended that the public <see cref="EventHubClient" /> make use of an instance
+    ///   via containment and delegate operations to it.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Messaging.EventHubs.Core.TransportEventHubClient" />
+    ///
+    internal sealed class TrackOneEventHubClient : TransportEventHubClient
+    {
+        /// <summary>A lazy instantiation of the client instance to delegate operation to.</summary>
+        private Lazy<TrackOne.EventHubClient> _trackOneClient;
+
+        /// <summary>
+        ///   The track one <see cref="TrackOne.EventHubClient" /> for use with this transport client.
+        /// </summary>
+        ///
+        private TrackOne.EventHubClient TrackOneClient => _trackOneClient.Value;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="TrackOneEventHubClient"/> class.
+        /// </summary>
+        ///
+        /// <param name="host">The fully qualified host name for the Event Hubs namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requeseted Event Hub, depending on Azure configuration.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
+        ///
+        /// <remarks>
+        ///   As an internal type, this class performs only basic sanity checks against its arguments.  It
+        ///   is assumed that callers are trusted and have performed deep validation.
+        ///
+        ///   Any parameters passed are assumed to be owned by this instance and safe to mutate or dispose;
+        ///   creation of clones or otherwise protecting the parameters is assumed to be the purview of the
+        ///   caller.
+        /// </remarks>
+        ///
+        public TrackOneEventHubClient(string host,
+                                      string eventHubPath,
+                                      TokenCredential credential,
+                                      EventHubClientOptions clientOptions) : this(host, eventHubPath, credential, clientOptions, CreateClient)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="TrackOneEventHubClient"/> class.
+        /// </summary>
+        ///
+        /// <param name="host">The fully qualified host name for the Event Hubs namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requeseted Event Hub, depending on Azure configuration.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
+        /// <param name="eventHubClientFactory">A delegate that can be used for creation of the <see cref="TrackOne.EventHubClient" /> to which operations are delegated to.</param>
+        ///
+        /// <remarks>
+        ///   As an internal type, this class performs only basic sanity checks against its arguments.  It
+        ///   is assumed that callers are trusted and have performed deep validation.
+        ///
+        ///   Any parameters passed are assumed to be owned by this instance and safe to mutate or dispose;
+        ///   creation of clones or otherwise protecting the parameters is assumed to be the purview of the
+        ///   caller.
+        /// </remarks>
+        ///
+        internal TrackOneEventHubClient(string host,
+                                        string eventHubPath,
+                                        TokenCredential credential,
+                                        EventHubClientOptions clientOptions,
+                                        Func<string, string, TokenCredential, EventHubClientOptions, TrackOne.EventHubClient> eventHubClientFactory)
+        {
+            Guard.ArgumentNotNullOrEmpty(nameof(host), host);
+            Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
+            Guard.ArgumentNotNull(nameof(credential), credential);
+            Guard.ArgumentNotNull(nameof(clientOptions), clientOptions);
+
+            _trackOneClient = new Lazy<TrackOne.EventHubClient>(() => eventHubClientFactory(host, eventHubPath, credential, clientOptions), LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        /// <summary>
+        ///   Creates the track one Event Hub client instance for inner use, handling any necessary translation between track two
+        ///   and track one concepts/types.
+        /// </summary>
+        ///
+        /// <param name="host">The fully qualified host name for the Event Hubs namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
+        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requeseted Event Hub, depending on Azure configuration.</param>
+        /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
+        ///
+        /// <returns>The <see cref="TrackOne.EventHubClient" /> to use</returns>
+        ///
+        internal static TrackOne.EventHubClient CreateClient(string host,
+                                                             string eventHubPath,
+                                                             TokenCredential credential,
+                                                             EventHubClientOptions clientOptions)
+        {
+            // Translate the connection type into the corresponding Track One transport type.
+
+            TrackOne.TransportType transportType;
+
+            switch (clientOptions.TransportType)
+            {
+                case TransportType.AmqpTcp:
+                    transportType = TrackOne.TransportType.Amqp;
+                    break;
+
+                case TransportType.AmqpWebSockets:
+                    transportType = TrackOne.TransportType.AmqpWebSockets;
+                    break;
+
+                default:
+                    throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidTransportType, clientOptions.TransportType.ToString(), nameof(clientOptions.TransportType)));
+            }
+
+            // Translate the provided credential into a Track One token provider.
+
+            TokenProvider tokenProvider;
+
+            switch (credential)
+            {
+                case SharedAccessSignatureCredential sasCredential:
+                    tokenProvider = new TrackOneSharedAccessTokenProvider(sasCredential.SharedAccessSignature);
+                    break;
+
+                default:
+                    throw new NotImplementedException("Only shared key credentials are currently supported.");
+                    //TODO: Revisit this once Azure.Identity is ready for managed identities.
+            }
+
+            // Create the endpoint for the client.
+
+            var endpointBuilder = new UriBuilder
+            {
+                Scheme = clientOptions.TransportType.GetUriScheme(),
+                Host = host,
+                Path = eventHubPath,
+                Port = -1,
+            };
+
+            // Build and configure the client.
+
+            var client = TrackOne.EventHubClient.Create(endpointBuilder.Uri, eventHubPath, tokenProvider, clientOptions.DefaultTimeout, transportType);
+            client.WebProxy = clientOptions.Proxy;
+
+            return client;
+        }
+
+        /// <summary>
+        ///   Retrieves information about an Event Hub, including the number of partitions present
+        ///   and their identifiers.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
+        ///
+        public override async Task<EventHubProperties> GetPropertiesAsync(CancellationToken cancellationToken)
+        {
+            var runtimeInformation = await TrackOneClient.GetRuntimeInformationAsync().ConfigureAwait(false);
+
+            return new EventHubProperties
+            (
+                TrackOneClient.EventHubName,
+                runtimeInformation.CreatedAt,
+                runtimeInformation.PartitionIds,
+                DateTime.UtcNow
+            );
+        }
+
+        /// <summary>
+        ///   Retrieves information about a specific partiton for an Event Hub, including elements that describe the available
+        ///   events in the partition event stream.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The unique identifier of a partition associated with the Event Hub.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
+        ///
+        public override async Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
+                                                                                    CancellationToken cancellationToken)
+        {
+            var runtimeInformation = await TrackOneClient.GetPartitionRuntimeInformationAsync(partitionId).ConfigureAwait(false);
+
+            return new PartitionProperties
+            (
+                runtimeInformation.Path,
+                runtimeInformation.PartitionId,
+                runtimeInformation.BeginSequenceNumber,
+                runtimeInformation.LastEnqueuedSequenceNumber,
+                runtimeInformation.LastEnqueuedOffset,
+                runtimeInformation.LastEnqueuedTimeUtc,
+                runtimeInformation.IsEmpty,
+                DateTime.UtcNow
+            );
+        }
+
+        /// <summary>
+        ///   Closes the connection to the transport client instance.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        public override Task CloseAsync(CancellationToken cancellationToken)
+        {
+            if (!_trackOneClient.IsValueCreated)
+            {
+                return Task.CompletedTask;
+            }
+
+            return TrackOneClient.CloseAsync();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/MessagePropertyName.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/MessagePropertyName.cs
@@ -24,7 +24,7 @@
         /// <summary>The name of the entity that published a message.</summary>
         public const string Publisher = "x-opt-publisher";
 
-        /// <summary>The label used for grouping a bacth of events together with the intent of routing to a single partition.</summary>
-        public const string BatchLabel = "x-opt-partition-key";
+        /// <summary>The partition hashing key used for grouping a batch of events together with the intent of routing to a single partition.</summary>
+        public const string PartitionKey = "x-opt-partition-key";
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubClient.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Metadata;
+
+namespace Azure.Messaging.EventHubs.Core
+{
+    /// <summary>
+    ///   Provides an abstraction for generalizing an Event Hub client so that a dedicated instance may provide operations
+    ///   for a specific transport, such as AMQP or JMS.  It is intended that the public <see cref="EventHubClient" /> employ
+    ///   a transport client via containment and delegate operations to it rather than understanding protocol-specific details
+    ///   for different transports.
+    /// </summary>
+    ///
+    internal abstract class TransportEventHubClient
+    {
+        /// <summary>
+        ///   Retrieves information about an Event Hub, including the number of partitions present
+        ///   and their identifiers.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
+        ///
+        public abstract Task<EventHubProperties> GetPropertiesAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Retrieves information about a specific partiton for an Event Hub, including elements that describe the available
+        ///   events in the partition event stream.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The unique identifier of a partition associated with the Event Hub.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
+        ///
+        public abstract Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
+                                                                              CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Closes the connection to the transport client instance.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        public abstract Task CloseAsync(CancellationToken cancellationToken);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportTypeExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportTypeExtensions.cs
@@ -7,10 +7,10 @@ using System.Globalization;
 namespace Azure.Messaging.EventHubs.Core
 {
     /// <summary>
-    ///   The set of extension methods for the <see cref="ConnectionType" /> enumeration.
+    ///   The set of extension methods for the <see cref="TransportType" /> enumeration.
     /// </summary>
     ///
-    internal static class ConnectionTypeExtensions
+    internal static class TransportTypeExtensions
     {
         /// <summary>The URI scheme used for an AMQP-based connection.</summary>
         private const string AmqpUriScheme = "amqps";
@@ -23,16 +23,16 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <returns>The scheme that should be used for the given connection type when forming an associated URI.</returns>
         ///
-        public static string GetUriScheme(this ConnectionType instance)
+        public static string GetUriScheme(this TransportType instance)
         {
             switch (instance)
             {
-                case ConnectionType.AmqpTcp:
-                case ConnectionType.AmqpWebSockets:
+                case TransportType.AmqpTcp:
+                case TransportType.AmqpWebSockets:
                     return AmqpUriScheme;
 
                 default:
-                    throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidConnectionString, instance.ToString(), nameof(instance)));
+                    throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidTransportType, instance.ToString(), nameof(instance)));
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventBatchingOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventBatchingOptions.cs
@@ -21,35 +21,35 @@ namespace Azure.Messaging.EventHubs
         ///   an exception will be thrown and the send operation will fail.
         /// </summary>
         ///
-        public int MaximumSizeInBytes
+        private int MaximumSizeInBytes
         {
             get => _maximumSizeInBytes;
 
-            protected set
+            set
             {
-                //TODO: Expose this when splitting of batches is supported.
-
                 Guard.ArgumentInRange(nameof(MaximumSizeInBytes), value, EventSender.MinimumBatchSizeLimit, EventSender.MaximumBatchSizeLimit);
                 _maximumSizeInBytes = value;
             }
-        }
+        }  //TODO: Expose this when splitting of batches is supported.
 
         /// <summary>
-        ///   Allows a batch to be identified as part of a group, which hints to the
-        ///   Event Hubs service that reasonable efforts should be made to use the same
-        ///   partition for events belonging to that group.
+        ///   Allows a hashing key to be provided for the batch of events, which instructs the Event Hubs
+        ///   service map this key to a specific partition but allowing the service to choose an arbitrary,
+        ///   partition for this batch of events and any other batches using the same partition hashing key.
         ///
-        ///   This should be specified only when there is a need to try and group events by partition, but
-        ///   there is flexibility in allowing them to appear in other partitions at the discretion of the service,
-        ///   such as when a partition is unavailable.
+        ///   The selection of a partition is stable for a given partition hashing key.  Should any other
+        ///   batches of events be sent using the same exact partition hashing key, the Event Hubs service will
+        ///   route them all to the same partition.
         ///
-        ///   If ensuring that a batch of events is sent only to a specific partition, it is recommended that the
-        ///   identifier of the position be specified directly when sending the batch.
+        ///   This should be specified only when there is a need to group events by partition, but there is
+        ///   flexibility into which partition they are routed. If ensuring that a batch of events is sent
+        ///   only to a specific partition, it is recommended that the identifier of the position be
+        ///   specified directly when sending the batch.
         /// </summary>
         ///
-        /// <value>The label for the group to which the batch is associated; if the batch is not</value>
+        /// <value>The partition hashing key to associate with the event batch.</value>
         ///
-        public string BatchLabel { get; set; }
+        public string PartitionKey { get; set; }
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" />, is equal to this instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -58,14 +58,7 @@ namespace Azure.Messaging.EventHubs
         ///   </code>
         /// </example>
         ///
-        public IDictionary<string, object> Properties { get; protected set; } = new Dictionary<string, object>();
-
-        /// <summary>
-        ///   The set of event properties which are owned and populated by the Event Hubs service during
-        ///   operations.
-        /// </summary>
-        ///
-        public SystemEventProperties SystemProperties { get; protected internal set; }
+        public IDictionary<string, object> Properties { get; internal set; } = new Dictionary<string, object>();
 
         /// <summary>
         ///   The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.
@@ -86,10 +79,17 @@ namespace Azure.Messaging.EventHubs
         public DateTime EnqueuedTimeUtc => SystemProperties.EnqueuedTimeUtc;
 
         /// <summary>
-        ///   The date and time, in UTC, that this event data was retrieved from the Event Hub partition.
+        ///   The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.
         /// </summary>
         ///
-        public DateTime RetrievalTimeUtc { get; protected internal set; }
+        public string PartitionKey => SystemProperties.PartitionKey;
+
+        /// <summary>
+        ///   The set of event properties which are owned and populated by the Event Hubs service during
+        ///   operations.
+        /// </summary>
+        ///
+        internal SystemEventProperties SystemProperties { get; set; }
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" />, is equal to this instance.
@@ -124,7 +124,7 @@ namespace Azure.Messaging.EventHubs
         ///   The set of event properties which are owned and populated by the Event Hubs service.
         /// </summary>
         ///
-        public sealed class SystemEventProperties : Dictionary<string, object>
+        internal sealed class SystemEventProperties : Dictionary<string, object>
         {
             /// <summary>
             ///   Initializes a new instance of the <see cref="SystemEventProperties"/> class.
@@ -141,24 +141,24 @@ namespace Azure.Messaging.EventHubs
             /// <param name="sequenceNumber">The logical sequence number of the event within the partition stream of the Event Hub.</param>
             /// <param name="enqueuedTimeUtc">The date and time, in UTC, that the event was received by the partition.</param>
             /// <param name="offset">The offset of the event relative to the Event Hub partition stream.</param>
-            /// <param name="batchLabel">The label associated with the batch that the event was grouped with when sent.</param>
+            /// <param name="partitionKey">The partition hashing key associated with the batch that the event was grouped with when sent.</param>
             ///
             internal SystemEventProperties(long sequenceNumber,
                                            DateTime enqueuedTimeUtc,
                                            string offset,
-                                           string batchLabel)
+                                           string partitionKey)
             {
                 this[MessagePropertyName.SequenceNumber] = sequenceNumber;
                 this[MessagePropertyName.EnqueuedTimeUtc] = enqueuedTimeUtc;
                 this[MessagePropertyName.Offset] = offset;
-                this[MessagePropertyName.BatchLabel] = batchLabel;
+                this[MessagePropertyName.PartitionKey] = partitionKey;
             }
 
             /// <summary>
             ///   The logical sequence number of the <see cref="EventData" /> within the partition stream of the Event Hub.
             /// </summary>
             ///
-            public long SequenceNumber
+            internal long SequenceNumber
             {
                 get
                 {
@@ -175,7 +175,7 @@ namespace Azure.Messaging.EventHubs
             ///   The date and time, in UTC, that the <see cref="EventData" /> was received by the partition.
             /// </summary>
             ///
-            public DateTime EnqueuedTimeUtc
+            internal DateTime EnqueuedTimeUtc
             {
                 get
                 {
@@ -197,7 +197,7 @@ namespace Azure.Messaging.EventHubs
             ///   identifier is unique within a partition of the Event Hubs stream.
             /// </remarks>
             ///
-            public int Offset
+            internal int Offset
             {
                 get
                 {
@@ -219,14 +219,14 @@ namespace Azure.Messaging.EventHubs
             }
 
             /// <summary>
-            ///   The label applied to the batch that the associated <see cref="EventData"/>, was sent with.
+            ///   The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.
             /// </summary>
             ///
-            public string BatchLabel
+            internal string PartitionKey
             {
                 get
                 {
-                    if (this.TryGetValue(MessagePropertyName.BatchLabel, out var value))
+                    if (this.TryGetValue(MessagePropertyName.PartitionKey, out var value))
                     {
                         return (string)value;
                     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClientOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClientOptions.cs
@@ -15,7 +15,7 @@ namespace Azure.Messaging.EventHubs
     public class EventHubClientOptions
     {
         /// <summary>The value to use as the default for the <see cref="DefaultTimeout" /> property.</summary>
-        protected static readonly TimeSpan DefaultTimeoutValue = TimeSpan.FromMinutes(1);
+        private static readonly TimeSpan DefaultTimeoutValue = TimeSpan.FromMinutes(1);
 
         /// <summary>The retry policy to apply to operations.</summary>
         private Retry _retry = Retry.Default;
@@ -24,11 +24,11 @@ namespace Azure.Messaging.EventHubs
         private TimeSpan _defaultTimeout = DefaultTimeoutValue;
 
         /// <summary>
-        ///   The type of connection that will be used for communicating with the Event Hubs
+        ///   The type of protocol and transport that will be used for communicating with the Event Hubs
         ///   service.
         /// </summary>
         ///
-        public ConnectionType ConnectionType { get; set; } = ConnectionType.AmqpTcp;
+        public TransportType TransportType { get; set; } = TransportType.AmqpTcp;
 
         /// <summary>
         ///   The proxy to use for communication over web sockets.  If not specified,
@@ -120,7 +120,7 @@ namespace Azure.Messaging.EventHubs
             new EventHubClientOptions
             {
                 Retry = this.Retry.Clone(),
-                ConnectionType = this.ConnectionType,
+                TransportType = this.TransportType,
                 DefaultTimeout = this.DefaultTimeout,
                 Proxy = this.Proxy
             };
@@ -132,7 +132,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="timeout">The time period to validate.</param>
         ///
-        protected virtual void ValidateDefaultTimeout(TimeSpan timeout)
+        private void ValidateDefaultTimeout(TimeSpan timeout)
         {
             if (timeout < TimeSpan.Zero)
             {
@@ -146,7 +146,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="retry">The time period to validae.</param>
         ///
-        protected virtual void ValidateRetry(Retry retry)
+        private void ValidateRetry(Retry retry)
         {
             if (retry == null)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
@@ -12,13 +12,13 @@ namespace Azure.Messaging.EventHubs
     ///   an <see cref="EventSender" />.
     /// </summary>
     ///
-    public class EventPosition
+    public sealed class EventPosition
     {
         /// <summary>The token that represents the beginning event in the stream of a partition.</summary>
-        protected const string StartOfStreamOffset = "-1";
+        private const string StartOfStreamOffset = "-1";
 
         /// <summary>The token that represents the last event in the stream of a partition.</summary>
-        protected const string EndOfStreamOffset = "@latest";
+        private const string EndOfStreamOffset = "@latest";
 
         /// <summary>
         ///   Corresponds to the location of the the first event present in the partition.  Use
@@ -30,7 +30,7 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   Corresponds to the end of the partition, where no more events are currently enqueued.  Use this
-        ///   position to begin receiving from the next event to be enqueued in the partion after an <see cref="PartitionReceiver"/>
+        ///   position to begin receiving from the next event to be enqueued in the partion after an <see cref="EventReceiver"/>
         ///   is created with this position.
         /// </summary>
         ///
@@ -74,20 +74,6 @@ namespace Azure.Messaging.EventHubs
         /// <value>Excpected to be <c>null</c> if the event position represents an offset or enqueue time.</value>
         ///
         internal long? SequenceNumber { get; set; }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="EventPosition"/> class.
-        /// </summary>
-        ///
-        /// <remarks>
-        ///   Limit construction to only derrived classes, as the rules for legal value combinations
-        ///   would be intimidating for consumers; the factory methods provide a more intuitive means of
-        ///   creation.
-        /// </remarks>
-        ///
-        protected EventPosition()
-        {
-        }
 
         /// <summary>
         ///   Corresponds to the event in the partition at the provided offset, inclusive of that event.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventSender.cs
@@ -27,7 +27,7 @@ namespace Azure.Messaging.EventHubs
     ///   <para>2) If a partition becomes unavailable, the Event Hubs service will automatically detect it and forward the message to another available partition.</para>
     /// </remarks>
     ///
-    public class EventSender
+    public class EventSender : IAsyncDisposable
     {
         /// <summary>The maximum allowable size, in bytes, for a batch to be sent.</summary>
         internal const int MinimumBatchSizeLimit = 24;
@@ -51,13 +51,13 @@ namespace Azure.Messaging.EventHubs
         ///   The set of options used for creation of this sender.
         /// </summary>
         ///
-        protected SenderOptions Options { get; }
+        protected SenderOptions Options { get; set; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventSender"/> class.
         /// </summary>
         ///
-        /// <param name="connectionType">The type of connection used for communicating with the Event Hubs service.</param>
+        /// <param name="transportType">The type of protocol and transport used for communicating with the Event Hubs service.</param>
         /// <param name="eventHubPath">The path of the Event Hub to which events will be sent.</param>
         /// <param name="senderOptions">The set of options to use for this receiver.</param>
         ///
@@ -67,9 +67,9 @@ namespace Azure.Messaging.EventHubs
         ///   caller to ensure that any needed cloning of options is performed.
         /// </remarks>
         ///
-        protected internal EventSender(ConnectionType connectionType,
-                                       string eventHubPath,
-                                       SenderOptions senderOptions)
+        internal EventSender(TransportType transportType,
+                             string eventHubPath,
+                             SenderOptions senderOptions)
         {
             Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
             Guard.ArgumentNotNull(nameof(senderOptions), senderOptions);
@@ -137,6 +137,15 @@ namespace Azure.Messaging.EventHubs
         /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
         ///
         public virtual void Close(CancellationToken cancellationToken = default) => CloseAsync(cancellationToken).GetAwaiter().GetResult();
+
+        /// <summary>
+        ///   Performs the task needed to clean up resources used by the <see cref="EventHubClient" />,
+        ///   including ensuring that the client itself has been closed.
+        /// </summary>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        public virtual async ValueTask DisposeAsync() => await CloseAsync().ConfigureAwait(false);
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" />, is equal to this instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/PartitionProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/PartitionProperties.cs
@@ -76,7 +76,7 @@ namespace Azure.Messaging.EventHubs.Metadata
         /// </summary>
         ///
         /// <param name="path">The path of the Event Hub that contains the partitions.</param>
-        /// <param name="key">The identifier of the partition.</param>
+        /// <param name="partitionId">The identifier of the partition.</param>
         /// <param name="beginningSequenceNumber">The first sequence number available for events in the partition.</param>
         /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
         /// <param name="lastOffset">The offset of the last event to be enqueued in the partition.</param>
@@ -85,7 +85,7 @@ namespace Azure.Messaging.EventHubs.Metadata
         /// <param name="retrievalTimeUtc">the date and time, in UTC, that the information was retrieved from the service; if not provided, the current date/time will be used.</param>
         ///
         internal PartitionProperties(string path,
-                                      string key,
+                                      string partitionId,
                                       long beginningSequenceNumber,
                                       long lastSequenceNumber,
                                       string lastOffset,
@@ -94,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Metadata
                                       DateTime? retrievalTimeUtc = null)
         {
             EventHubPath = path;
-            Id = key;
+            Id = partitionId;
             BeginningSequenceNumber = beginningSequenceNumber;
             LastEnqueuedSequenceNumber = lastSequenceNumber;
             LastEnqueuedOffset = lastOffset;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/ReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/ReceiverOptions.cs
@@ -9,7 +9,7 @@ using Azure.Messaging.EventHubs.Core;
 namespace Azure.Messaging.EventHubs
 {
     /// <summary>
-    ///   The baseline set of options that can be specified when creating a <see cref="PartitionReceiver" />
+    ///   The baseline set of options that can be specified when creating a <see cref="EventReceiver" />
     ///   to configure its behavior.
     /// </summary>
     ///
@@ -19,10 +19,10 @@ namespace Azure.Messaging.EventHubs
         public const string DefaultConsumerGroup = "$Default";
 
         /// <summary>The minimum value allowed for the prefetch count of the receiver.</summary>
-        protected const int MinimumPrefetchCount = 10;
+        internal const int MinimumPrefetchCount = 10;
 
         /// <summary>The maximum length, in characters, for the identifier assigned to a receiver.</summary>
-        protected const int MaximumIdentifierLength = 64;
+        internal const int MaximumIdentifierLength = 64;
 
         /// <summary>The amount of time to wait for messages when receiving.</summary>
         private TimeSpan? _maximumReceiveWaitTime = TimeSpan.FromMinutes(1);
@@ -85,7 +85,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <value>If not specified, the operation timeout requested for the associated <see cref="EventHubClient" /> will be used.</value>
         ///
-        public TimeSpan? DefaultMaximumReceiveWaitTime
+        internal TimeSpan? DefaultMaximumReceiveWaitTime
         {
             get => _maximumReceiveWaitTime;
 
@@ -104,7 +104,7 @@ namespace Azure.Messaging.EventHubs
         internal TimeSpan? MaximumReceiveWaitTimeOrDefault => (_maximumReceiveWaitTime == TimeSpan.Zero) ? null : _maximumReceiveWaitTime;
 
         /// <summary>
-        ///     An optional text-based identifierlabel to assign to an event receiver.
+        ///     An optional text-based identifier label to assign to an event receiver.
         /// </summary>
         ///
         /// <value>The identifier is used for informational purposes only.  If not specified, the reaciever will have no assigned identifier label.</value>
@@ -191,7 +191,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="identifier">The identifier to validae.</param>
         ///
-        protected virtual void ValidateIdentifier(string identifier)
+        private void ValidateIdentifier(string identifier)
         {
             if ((!String.IsNullOrEmpty(identifier)) && (identifier.Length > MaximumIdentifierLength))
             {
@@ -206,7 +206,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="maximumWaitTime">The time period to validae.</param>
         ///
-        protected virtual void ValidateMaximumReceiveWaitTime(TimeSpan? maximumWaitTime)
+        private void ValidateMaximumReceiveWaitTime(TimeSpan? maximumWaitTime)
         {
             if (maximumWaitTime < TimeSpan.Zero)
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -8,8 +8,10 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Azure.Messaging.EventHubs
-{
+namespace Azure.Messaging.EventHubs {
+    using System;
+    
+    
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -20,246 +22,211 @@ namespace Azure.Messaging.EventHubs
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources
-    {
-
+    internal class Resources {
+        
         private static global::System.Resources.ResourceManager resourceMan;
-
+        
         private static global::System.Globalization.CultureInfo resourceCulture;
-
+        
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources()
-        {
+        internal Resources() {
         }
-
+        
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager
-        {
-            get
-            {
-                if (object.ReferenceEquals(resourceMan, null))
-                {
+        internal static global::System.Resources.ResourceManager ResourceManager {
+            get {
+                if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Azure.Messaging.EventHubs.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-
+        
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture
-        {
-            get
-            {
+        internal static global::System.Globalization.CultureInfo Culture {
+            get {
                 return resourceCulture;
             }
-            set
-            {
+            set {
                 resourceCulture = value;
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; may not be null or empty..
         /// </summary>
-        internal static string ArgumentNullOrEmpty
-        {
-            get
-            {
+        internal static string ArgumentNullOrEmpty {
+            get {
                 return ResourceManager.GetString("ArgumentNullOrEmpty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; may not be null or white space..
         /// </summary>
-        internal static string ArgumentNullOrWhiteSpace
-        {
-            get
-            {
+        internal static string ArgumentNullOrWhiteSpace {
+            get {
                 return ResourceManager.GetString("ArgumentNullOrWhiteSpace", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; cannot exceed {1} characters..
         /// </summary>
-        internal static string ArgumentStringTooLong
-        {
-            get
-            {
+        internal static string ArgumentStringTooLong {
+            get {
                 return ResourceManager.GetString("ArgumentStringTooLong", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The connection string could not be parsed; either it was malformed or contains no well-known tokens..
         /// </summary>
-        internal static string InvalidConnectionString
-        {
-            get
-            {
+        internal static string InvalidConnectionString {
+            get {
                 return ResourceManager.GetString("InvalidConnectionString", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The string has an invalid encoding format..
         /// </summary>
-        internal static string InvalidEncoding
-        {
-            get
-            {
+        internal static string InvalidEncoding {
+            get {
                 return ResourceManager.GetString("InvalidEncoding", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The shared access signature could not be parsed; it was either malformed or incorrectly encoded..
         /// </summary>
-        internal static string InvalidSharedAccessSignature
-        {
-            get
-            {
+        internal static string InvalidSharedAccessSignature {
+            get {
                 return ResourceManager.GetString("InvalidSharedAccessSignature", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The time period may not be Zero or Infinite..
         /// </summary>
-        internal static string InvalidTimePeriod
-        {
-            get
-            {
+        internal static string InvalidTimePeriod {
+            get {
                 return ResourceManager.GetString("InvalidTimePeriod", resourceCulture);
             }
         }
-
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The requested transport type, &apos;{0}&apos; is not supported..
+        /// </summary>
+        internal static string InvalidTransportType {
+            get {
+                return ResourceManager.GetString("InvalidTransportType", resourceCulture);
+            }
+        }
+        
         /// <summary>
         ///   Looks up a localized string similar to The connection string used for an Event Hub client must specify the Event Hubs namespace host, the path to an Event Hub, and a Shared Access Signature (both the name and value) to be valid..
         /// </summary>
-        internal static string MalformedEventHubClientConnectionString
-        {
-            get
-            {
+        internal static string MalformedEventHubClientConnectionString {
+            get {
                 return ResourceManager.GetString("MalformedEventHubClientConnectionString", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to System property &apos;{0}&apos; is missing in the event..
         /// </summary>
-        internal static string MissingSystemProperty
-        {
-            get
-            {
+        internal static string MissingSystemProperty {
+            get {
                 return ResourceManager.GetString("MissingSystemProperty", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A proxy may only be used for a websockets connection..
         /// </summary>
-        internal static string ProxyMustUseWebsockets
-        {
-            get
-            {
+        internal static string ProxyMustUseWebsockets {
+            get {
                 return ResourceManager.GetString("ProxyMustUseWebsockets", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The &apos;identifier&apos; parameter exceeds the maximum allowed size of {0} characters..
         /// </summary>
-        internal static string ReceiverIdentifierOverMaxValue
-        {
-            get
-            {
+        internal static string ReceiverIdentifierOverMaxValue {
+            get {
                 return ResourceManager.GetString("ReceiverIdentifierOverMaxValue", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The reqested resource, &apos;{0}&apos;, does not match the resource of the shared access signature, &apos;{1}&apos;.   A token cannot be issued..
         /// </summary>
-        internal static string ResourceMustMatchSharedAccessSignature
-        {
-            get
-            {
+        internal static string ResourceMustMatchSharedAccessSignature {
+            get {
                 return ResourceManager.GetString("ResourceMustMatchSharedAccessSignature", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A retry must be set for the options; if no retry is desired, please set the value to Retry.NoRetry.
         /// </summary>
-        internal static string RetryMustBeSet
-        {
-            get
-            {
+        internal static string RetryMustBeSet {
+            get {
                 return ResourceManager.GetString("RetryMustBeSet", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to In order to update the signature, a shared access key must have been provided when the shared access signature was created..
         /// </summary>
-        internal static string SharedAccessKeyIsRequired
-        {
-            get
-            {
+        internal static string SharedAccessKeyIsRequired {
+            get {
                 return ResourceManager.GetString("SharedAccessKeyIsRequired", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to A timeout value must be positive.  To request using the default timeout, please use TimeSpan.Zero or null..
         /// </summary>
-        internal static string TimeoutMustBePositive
-        {
-            get
-            {
+        internal static string TimeoutMustBePositive {
+            get {
                 return ResourceManager.GetString("TimeoutMustBePositive", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Argument {0} must be a non-negative timespan value. The provided value was {1}..
         /// </summary>
-        internal static string TimeSpanMustBeNonNegative
-        {
-            get
-            {
+        internal static string TimeSpanMustBeNonNegative {
+            get {
                 return ResourceManager.GetString("TimeSpanMustBeNonNegative", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The specified connection type, &quot;{0}&quot;, is not recognized as valid in this context..
         /// </summary>
-        internal static string UnknownConnectionType
-        {
-            get
-            {
+        internal static string UnknownConnectionType {
+            get {
                 return ResourceManager.GetString("UnknownConnectionType", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to The value supplied must be between {0} and {1}..
         /// </summary>
-        internal static string ValueOutOfRange
-        {
-            get
-            {
+        internal static string ValueOutOfRange {
+            get {
                 return ResourceManager.GetString("ValueOutOfRange", resourceCulture);
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -171,4 +171,7 @@
   <data name="ResourceMustMatchSharedAccessSignature" xml:space="preserve">
     <value>The reqested resource, '{0}', does not match the resource of the shared access signature, '{1}'.   A token cannot be issued.</value>
   </data>
+  <data name="InvalidTransportType" xml:space="preserve">
+    <value>The requested transport type, '{0}' is not supported.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TransportType.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TransportType.cs
@@ -4,11 +4,11 @@
 namespace Azure.Messaging.EventHubs
 {
     /// <summary>
-    ///   Specifies the type of connection what will be used for communicating with
+    ///   Specifies the type of protocol and transport that will be used for communicating with
     ///   Azure Event Hubs.
     /// </summary>
     ///
-    public enum ConnectionType
+    public enum TransportType
     {
         /// <summary>The connection uses the AMQP prototcol over TCP.</summary>
         AmqpTcp,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureCredentialTests.cs
@@ -34,10 +34,8 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesInitializesProperties()
         {
-            var expiration = DateTime.UtcNow;
-            var audience = "the-audience";
             var value = "TOkEn!";
-            var signature = new SettablePropertiesMock("keyName", "key", expiration, audience, value);
+            var signature = new SharedAccessSignature(String.Empty, "keyName", "key", value, DateTime.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
 
             Assert.That(credential.SharedAccessSignature, Is.SameAs(signature), "The credential should allow the signature to be accessed.");
@@ -51,7 +49,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void GetTokenReturnsTheSignatureValue()
         {
             var value = "TOkEn!";
-            var signature = new SettablePropertiesMock(value: value);
+            var signature = new SharedAccessSignature(String.Empty, "keyName", "key", value, DateTime.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
 
             Assert.That(credential.GetToken(null, default), Is.SameAs(signature.Value), "The credential should return the signature as the token.");
@@ -65,7 +63,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void GetTokenIgnoresScopeAndCancellationToken()
         {
             var value = "TOkEn!";
-            var signature = new SettablePropertiesMock(value: value);
+            var signature = new SharedAccessSignature(String.Empty, "keyName", "key", value, DateTime.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
 
             Assert.That(credential.GetToken(new[] { "test", "this" }, CancellationToken.None), Is.SameAs(signature.Value), "The credential should return the signature as the token.");
@@ -79,7 +77,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetTokenAsyncReturnsTheSignatureValue()
         {
             var value = "TOkEn!";
-            var signature = new SettablePropertiesMock(value: value);
+            var signature = new SharedAccessSignature(String.Empty, "keyName", "key", value, DateTime.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
             var cancellation = new CancellationTokenSource();
             var token = await credential.GetTokenAsync(null, cancellation.Token);
@@ -95,33 +93,12 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task GetTokenAsyncIgnoresScopeAndCancellationToken()
         {
             var value = "TOkEn!";
-            var signature = new SettablePropertiesMock(value: value);
+            var signature = new SharedAccessSignature(String.Empty, "keyName", "key", value, DateTime.UtcNow.AddHours(4));
             var credential = new SharedAccessSignatureCredential(signature);
             var cancellation = new CancellationTokenSource();
             var token = await credential.GetTokenAsync(new string[0], cancellation.Token);
 
             Assert.That(token, Is.SameAs(signature.Value), "The credential should return the signature as the token.");
-        }
-
-        /// <summary>
-        ///   Allows for the properties of the shared access signature to be manually set for
-        ///   testing purposes.
-        /// </summary>
-        ///
-        private class SettablePropertiesMock : SharedAccessSignature
-        {
-            public SettablePropertiesMock(string sharedAccessKeyName = default,
-                                          string sharedAccessKey = default,
-                                          DateTime expirationUtc = default,
-                                          string resource = default,
-                                          string value = default) : base()
-            {
-                SharedAccessKeyName = sharedAccessKeyName;
-                SharedAccessKey = sharedAccessKey;
-                ExpirationUtc = expirationUtc;
-                Resource = resource;
-                Value = value;
-            }
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -13,8 +13,9 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Moq" Version="4.11.0" />
-    <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.2.1" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.5.2" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0-preview6.19259.10" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
@@ -1,0 +1,438 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Authorization;
+using Azure.Messaging.EventHubs.Compatibility;
+using Azure.Messaging.EventHubs.Core;
+using Moq;
+using NUnit.Framework;
+using TrackOne;
+using TrackOne.Amqp;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="TrackOneEventHubClient" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class TrackOneEventHubClientTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorRequiresTheHost(string host)
+        {
+            Assert.That(() => new TrackOneEventHubClient(host, "test-path", Mock.Of<TokenCredential>(), new EventHubClientOptions()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorRequiresTheEventHubPath(string path)
+        {
+            Assert.That(() => new TrackOneEventHubClient("my.eventhub.com", path, Mock.Of<TokenCredential>(), new EventHubClientOptions()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorRequiresTheCredential()
+        {
+            Assert.That(() => new TrackOneEventHubClient("my.eventhub.com", "somePath", null, new EventHubClientOptions()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorRequiresThOption()
+        {
+            Assert.That(() => new TrackOneEventHubClient("my.eventhub.com", "somePath", Mock.Of<TokenCredential>(), null), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateFailsOnUnknownConnectionType()
+        {
+            var options = new EventHubClientOptions
+            {
+                TransportType = (TransportType)Int32.MinValue
+            };
+
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(TransportType.AmqpTcp, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+
+            Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CreateFailsForUnknownCredentialType()
+        {
+            var options = new EventHubClientOptions();
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var credential = Mock.Of<TokenCredential>();
+
+            Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options), Throws.InstanceOf<NotImplementedException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateClienCreatesTheProperClientType()
+        {
+            var options = new EventHubClientOptions();
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var client = TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
+
+            try
+            {
+                Assert.That(client, Is.Not.Null, "The client should have been returned.");
+                Assert.That(client, Is.InstanceOf<AmqpEventHubClient>(), "The client should be specific to the AMQP protocol.");
+            }
+            finally
+            {
+                await client?.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(TransportType.AmqpTcp)]
+        [TestCase(TransportType.AmqpWebSockets)]
+        public async Task CreateClientTranslatesTheTransportType(TransportType connectionType)
+        {
+            var options = new EventHubClientOptions
+            {
+                TransportType = connectionType
+            };
+
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
+
+            try
+            {
+                if (connectionType.ToString().ToLower().Contains("websockets"))
+                {
+                    Assert.That(client.ConnectionStringBuilder.TransportType.ToString().ToLower(), Contains.Substring("websockets"), "The transport type should be based on WebSockets.");
+                }
+                else
+                {
+                    Assert.That(client.ConnectionStringBuilder.TransportType.ToString().ToLower(), Does.Not.Contain("websockets"), "The transport type should be based on TCP.");
+                }
+
+            }
+            finally
+            {
+                await client?.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateClientTranslatesTheCredential()
+        {
+            var options = new EventHubClientOptions();
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
+
+            try
+            {
+                Assert.That(client.InternalTokenProvider, Is.InstanceOf<TrackOneSharedAccessTokenProvider>(), "The token provider should be the track one SAS adapter.");
+                Assert.That(((TrackOneSharedAccessTokenProvider)client.InternalTokenProvider).SharedAccessSignature.Value, Is.EqualTo(signature.Value), "The SAS should match.");
+
+            }
+            finally
+            {
+                await client?.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateClientFormsTheCorrectEndpoint()
+        {
+            var options = new EventHubClientOptions();
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
+
+            try
+            {
+                var endpoint = client.ConnectionStringBuilder.Endpoint;
+                Assert.That(endpoint.Scheme.ToLowerInvariant(), Contains.Substring(options.TransportType.GetUriScheme().ToLowerInvariant()), "The scheme should be part of the endpoint.");
+                Assert.That(endpoint.Host.ToLowerInvariant(), Contains.Substring(host.ToLowerInvariant()), "The host should be part of the endpoint.");
+                Assert.That(endpoint.AbsolutePath.ToLowerInvariant(), Contains.Substring(eventHubPath.ToLowerInvariant()), "The host should be part of the endpoint.");
+            }
+            finally
+            {
+                await client?.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateClientPopulatesTheEventHubPath()
+        {
+            var options = new EventHubClientOptions();
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
+
+            try
+            {
+                Assert.That(client.EventHubName, Is.EqualTo(eventHubPath), "The client should recognize the Event Hub path.");
+            }
+            finally
+            {
+                await client?.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CreateClientPopulatesTheProxy()
+        {
+            var options = new EventHubClientOptions
+            {
+                TransportType = TransportType.AmqpWebSockets,
+                Proxy = Mock.Of<IWebProxy>()
+            };
+
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
+
+            try
+            {
+                Assert.That(client.WebProxy, Is.SameAs(options.Proxy), "The client should honor the proxy.");
+            }
+            finally
+            {
+                await client?.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncDoesNotDelegateIfTheClientWasNotCreated()
+        {
+            var options = new EventHubClientOptions();
+            var host = "http://my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
+
+            await client.CloseAsync(default);
+            Assert.That(mock.WasCloseAsyncInvoked, Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncDelegatesToTheClient()
+        {
+            var options = new EventHubClientOptions();
+            var host = "http://my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
+
+            // Invoke an operation to force the client to be lazily instantiated.  Otherwise,
+            // Close does not delegate the call.
+
+            await client.GetPropertiesAsync(default);
+            await client.CloseAsync(default);
+            Assert.That(mock.WasCloseAsyncInvoked, Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetPropertiesAsyncDelegatesToTheClient()
+        {
+            var options = new EventHubClientOptions();
+            var host = "http://my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
+
+            try
+            {
+                await client.GetPropertiesAsync(default);
+                Assert.That(mock.WasGetRuntimeInvoked, Is.True);
+            }
+            finally
+            {
+                await client?.CloseAsync(default);
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.GetPartitionPropertiesAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetPartitionPropertiesAsyncDelegatesToTheClient()
+        {
+            var options = new EventHubClientOptions();
+            var host = "http://my.eventhub.com";
+            var eventHubPath = "some-path";
+            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new SharedAccessSignatureCredential(signature);
+            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
+
+            try
+            {
+                var partitionId = "0123";
+
+                await client.GetPartitionPropertiesAsync(partitionId, CancellationToken.None);
+                Assert.That(mock.GetPartitionRuntimePartitionInvokedWith, Is.EqualTo(partitionId));
+            }
+            finally
+            {
+                await client?.CloseAsync(default);
+            }
+        }
+
+        private class ObservableClientMock : TrackOne.EventHubClient
+        {
+            public bool WasCloseAsyncInvoked;
+            public bool WasGetRuntimeInvoked;
+            public string GetPartitionRuntimePartitionInvokedWith;
+            public string CreateSenderInvokedWith;
+            public (string ConsumerGroup, string Partition, TrackOne.EventPosition startingPosition, long? priority, TrackOne.ReceiverOptions Options) CreateReiverInvokedWith;
+
+
+            public ObservableClientMock(string host,
+                                        string path,
+                                        TokenCredential credential,
+                                        EventHubClientOptions options) : base(new TrackOne.EventHubsConnectionStringBuilder(new Uri(host), path, "keyName", "KEY!"))
+            {
+            }
+
+            protected override Task OnCloseAsync()
+            {
+                WasCloseAsyncInvoked = true;
+                return Task.CompletedTask;
+            }
+
+            protected override PartitionReceiver OnCreateReceiver(string consumerGroupName, string partitionId, TrackOne.EventPosition eventPosition, long? epoch, TrackOne.ReceiverOptions receiverOptions)
+            {
+                CreateReiverInvokedWith =
+                (
+                   consumerGroupName,
+                   partitionId,
+                   eventPosition,
+                   epoch,
+                   receiverOptions
+                );
+
+                return Mock.Of<PartitionReceiver>();
+            }
+
+            protected override Task<EventHubPartitionRuntimeInformation> OnGetPartitionRuntimeInformationAsync(string partitionId)
+            {
+                GetPartitionRuntimePartitionInvokedWith = partitionId;
+                return Task.FromResult(new EventHubPartitionRuntimeInformation());
+            }
+
+            protected override Task<EventHubRuntimeInformation> OnGetRuntimeInformationAsync()
+            {
+                WasGetRuntimeInvoked = true;
+                return Task.FromResult(new EventHubRuntimeInformation());
+            }
+
+            internal override EventDataSender OnCreateEventSender(string partitionId)
+            {
+                CreateSenderInvokedWith = partitionId;
+                return Mock.Of<EventDataSender>();
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneSharedAccessTokenTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneSharedAccessTokenTests.cs
@@ -34,7 +34,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheSignatureValue()
         {
-            var signature = new SettablePropertiesMock("keyName", "key", DateTime.UtcNow, "audience", null);
+            var signature = new SharedAccessSignature("audience", "keyName", "key", null, DateTime.UtcNow);
             Assert.That(() => new TrackOneSharedAccessSignatureToken(signature), Throws.InstanceOf<ArgumentException>());
         }
 
@@ -45,7 +45,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheSignatureResource()
         {
-            var signature = new SettablePropertiesMock("keyName", "key", DateTime.UtcNow, "", "token!");
+            var signature = new SharedAccessSignature(String.Empty, "keyName", "key", String.Empty, DateTime.UtcNow);
             Assert.That(() => new TrackOneSharedAccessSignatureToken(signature), Throws.InstanceOf<ArgumentException>());
         }
 
@@ -59,34 +59,13 @@ namespace Azure.Messaging.EventHubs.Tests
             var expiration = DateTime.UtcNow;
             var audience = "the-audience";
             var value = "TOkEn!";
-            var signature = new SettablePropertiesMock("keyName", "key", expiration, audience, value);
+            var signature = new SharedAccessSignature(audience, "keyName", "key", value, expiration);
             var token = new TrackOneSharedAccessSignatureToken(signature);
 
             Assert.That(token.Audience, Is.EqualTo(audience), "The audience for the token should match the signature resource.");
             Assert.That(token.TokenValue, Is.EqualTo(value), "The value for the token should match the signature value.");
             Assert.That(token.ExpiresAtUtc, Is.EqualTo(expiration), "The expiration for the token should match the signature expiration.");
             Assert.That(token.TokenType, Is.EqualTo(ClientConstants.SasTokenType), "The type for the token should match the expected constant.");
-        }
-
-        /// <summary>
-        ///   Allows for the properties of the shared access signature to be manually set for
-        ///   testing purposes.
-        /// </summary>
-        ///
-        private class SettablePropertiesMock : SharedAccessSignature
-        {
-            public SettablePropertiesMock(string sharedAccessKeyName = default,
-                                          string sharedAccessKey = default,
-                                          DateTime expirationUtc = default,
-                                          string resource = default,
-                                          string value = default) : base()
-            {
-                SharedAccessKeyName = sharedAccessKeyName;
-                SharedAccessKey = sharedAccessKey;
-                ExpirationUtc = expirationUtc;
-                Resource = resource;
-                Value = value;
-            }
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionTypeExtensionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionTypeExtensionTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="ConnectionTypeExtensions" />
+    ///   The suite of tests for the <see cref="TransportTypeExtensions" />
     ///   class.
     /// </summary>
     ///
@@ -16,14 +16,14 @@ namespace Azure.Messaging.EventHubs.Tests
     public class ConnectionTypeExtensionTests
     {
         /// <summary>
-        ///   Verifies functionality of the <see cref="ConnectionTypeExtensions.GetUriScheme" />
+        ///   Verifies functionality of the <see cref="TransportTypeExtensions.GetUriScheme" />
         ///   method;
         /// </summary>
         ///
         [Test]
-        [TestCase(ConnectionType.AmqpTcp)]
-        [TestCase(ConnectionType.AmqpWebSockets)]
-        public void GetUriSchemeUnderstandsAmqpConnectionTypes(ConnectionType connectionType)
+        [TestCase(TransportType.AmqpTcp)]
+        [TestCase(TransportType.AmqpWebSockets)]
+        public void GetUriSchemeUnderstandsAmqpConnectionTypes(TransportType connectionType)
         {
             var scheme = connectionType.GetUriScheme();
 
@@ -32,14 +32,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="ConnectionTypeExtensions.GetUriScheme" />
+        ///   Verifies functionality of the <see cref="TransportTypeExtensions.GetUriScheme" />
         ///   method;
         /// </summary>
         ///
         [Test]
         public void GetUriSchemeUDisallowsUnknownConnectionTypes()
         {
-            var invalidConnectionType = (ConnectionType)Int32.MinValue;
+            var invalidConnectionType = (TransportType)Int32.MinValue;
             Assert.That(() => invalidConnectionType.GetUriScheme(), Throws.ArgumentException);
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/GuardTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/GuardTests.cs
@@ -61,7 +61,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("  ")]
         [TestCase(3)]
         [TestCase(typeof(Guard))]
-        [TestCase(ConnectionType.AmqpTcp)]
+        [TestCase(TransportType.AmqpTcp)]
         [TestCase(new[] { 1, 3, 4 })]
         public void ArgumentNotNullAllowsValidValues(object value)
         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Authorization;
+using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Tests.Infrastructure;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of live tests for the <see cref="EventHubClient" />
+    ///   class.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   These tests have a depenency on live Azure services and may
+    ///   incur costs for the assocaied Azure subscription.
+    /// </remarks>
+    ///
+    [TestFixture]
+    [Category(TestCategory.Live)]
+    [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    public class EventHubClientLiveTests
+    {
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClientCanConnectToEventHubsUsingConnectionString()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(1))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    Assert.That(() => client.GetPropertiesAsync(), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClientCanConnectToEventHubsUsingArguments()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(1))
+            {
+                var clientOptions = new EventHubClientOptions();
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var connectionProperties = ConnectionStringParser.Parse(connectionString);
+
+                var credential = new SharedAccessSignatureCredential
+                (
+                    new SharedAccessSignature
+                    (
+                        clientOptions.TransportType,
+                        connectionProperties.Endpoint.Host,
+                        connectionProperties.EventHubPath,
+                        connectionProperties.SharedAccessKeyName,
+                        connectionProperties.SharedAccessKey,
+                        TimeSpan.FromHours(4)
+                    )
+                );
+
+                await using (var client = new EventHubClient(connectionProperties.Endpoint.Host, connectionProperties.EventHubPath, credential))
+                {
+                    Assert.That(() => client.GetPropertiesAsync(), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClientCanRetrieveProperties()
+        {
+            var partitionCount = 4;
+
+            await using (var scope = await EventHubScope.CreateAsync(partitionCount))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var properties = await client.GetPropertiesAsync();
+
+                    Assert.That(properties, Is.Not.Null, "A set of properties should have been returned.");
+                    Assert.That(properties.Path, Is.EqualTo(scope.EventHubName), "The property Event Hub name should match the scope.");
+                    Assert.That(properties.PartitionIds.Length, Is.EqualTo(partitionCount), "The properties should have the requested number of partitions.");
+                    Assert.That(properties.CreatedAtUtc, Is.LessThanOrEqualTo(DateTime.UtcNow), "The Event Hub should have been created prior to now.");
+                    Assert.That(properties.PropertyRetrievalTimeUtc, Is.EqualTo(DateTime.UtcNow).Within(TimeSpan.FromSeconds(30)), "The property retrieval time should denote the current time.");
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClientCanRetrievePartitionProperties()
+        {
+            var partitionCount = 4;
+
+            await using (var scope = await EventHubScope.CreateAsync(partitionCount))
+            {
+                var clientOptions = new EventHubClientOptions();
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var connectionProperties = ConnectionStringParser.Parse(connectionString);
+
+                var credential = new SharedAccessSignatureCredential
+                (
+                    new SharedAccessSignature
+                    (
+                        clientOptions.TransportType,
+                        connectionProperties.Endpoint.Host,
+                        connectionProperties.EventHubPath,
+                        connectionProperties.SharedAccessKeyName,
+                        connectionProperties.SharedAccessKey,
+                        TimeSpan.FromHours(4)
+                    )
+                );
+
+                await using (var client = new EventHubClient(connectionProperties.Endpoint.Host, connectionProperties.EventHubPath, credential))
+                {
+                    var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+                    var properties = await client.GetPropertiesAsync();
+                    var partition = properties.PartitionIds.First();
+                    var partitionProperties = await client.GetPartitionPropertiesAsync(partition, cancellation.Token);
+
+                    Assert.That(partitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
+                    Assert.That(partitionProperties.Id, Is.EqualTo(partition), "The partition identifier should match.");
+                    Assert.That(partitionProperties.EventHubPath, Is.EqualTo(connectionProperties.EventHubPath).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
+                    Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(Int64)), "The beginning sequence number should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(Int64)), "The last sequance number should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.Null.Or.Empty, "The last offset should have been populated.");
+                    Assert.That(partitionProperties.PropertyRetrievalTimeUtc, Is.EqualTo(DateTime.UtcNow).Within(TimeSpan.FromSeconds(30)), "The property retrieval time should denote the current time.");
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ClientPartitionIdsMatchPartitionProperties()
+        {
+            var partitionCount = 4;
+
+            await using (var scope = await EventHubScope.CreateAsync(partitionCount))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var properties = await client.GetPropertiesAsync();
+                    var partitions = await client.GetPartitionIdsAsync();
+
+                    Assert.That(properties, Is.Not.Null, "A set of properties should have been returned.");
+                    Assert.That(properties.PartitionIds, Is.Not.Null, "A set of partition identifiers for the properties should have been returned.");
+                    Assert.That(partitions, Is.Not.Null, "A set of partition identifiers should have been returned.");
+                    Assert.That(partitions, Is.EquivalentTo(properties.PartitionIds), "The partition identifiers returned directly should match those returned with properties.");
+                }
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientOptionsTests.cs
@@ -24,7 +24,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions
             {
                 Retry = new ExponentialRetry(TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2), 3),
-                ConnectionType = ConnectionType.AmqpWebSockets,
+                TransportType = TransportType.AmqpWebSockets,
                 DefaultTimeout = TimeSpan.FromDays(1),
                 Proxy = Mock.Of<IWebProxy>()
             };
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
-            Assert.That(clone.ConnectionType, Is.EqualTo(options.ConnectionType), "The connection type of the clone should match.");
+            Assert.That(clone.TransportType, Is.EqualTo(options.TransportType), "The connection type of the clone should match.");
             Assert.That(clone.DefaultTimeout, Is.EqualTo(options.DefaultTimeout), "The default timeout of the clone should match.");
             Assert.That(clone.Proxy, Is.EqualTo(options.Proxy), "The proxy of the clone should match.");
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
@@ -4,13 +4,13 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;
+using Azure.Messaging.EventHubs.Authorization;
+using Azure.Messaging.EventHubs.Core;
 using Azure.Messaging.EventHubs.Metadata;
 using Moq;
-using Moq.Protected;
 using NUnit.Framework;
 
 namespace Azure.Messaging.EventHubs.Tests
@@ -46,9 +46,9 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
 
-            yield return new object[] { new EventHubClient(fakeConnection), "simple connection string" };
-            yield return new object[] { new EventHubClient(fakeConnection), "connection string with null options" };
-            yield return new object[] { new EventHubClient("host", "path", Mock.Of<TokenCredential>()), "expanded argument" };
+            yield return new object[] { new ReadableOptionsMock(fakeConnection), "simple connection string" };
+            yield return new object[] { new ReadableOptionsMock(fakeConnection), "connection string with null options" };
+            yield return new object[] { new ReadableOptionsMock("host", "path", Mock.Of<TokenCredential>()), "expanded argument" };
         }
 
         /// <summary>
@@ -61,14 +61,24 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var options = new EventHubClientOptions
             {
-                ConnectionType = ConnectionType.AmqpWebSockets,
+                TransportType = TransportType.AmqpWebSockets,
                 DefaultTimeout = TimeSpan.FromHours(2),
                 Retry = new ExponentialRetry(TimeSpan.FromMinutes(10), TimeSpan.FromHours(1), 24),
                 Proxy = Mock.Of<IWebProxy>()
             };
 
-            yield return new object[] { new EventHubClient(fakeConnection, options), options, "connection string" };
-            yield return new object[] { new EventHubClient("host", "path", Mock.Of<TokenCredential>(), options), options, "expanded argument" };
+            yield return new object[] { new ReadableOptionsMock(fakeConnection, options), options, "connection string" };
+            yield return new object[] { new ReadableOptionsMock("host", "path", Mock.Of<TokenCredential>(), options), options, "expanded argument" };
+        }
+
+        /// <summary>
+        ///   Provides the test cases for valid connection types.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ValidConnectionTypeCases()
+        {
+            yield return new object[] { TransportType.AmqpTcp };
+            yield return new object[] { TransportType.AmqpWebSockets };
         }
 
         /// <summary>
@@ -133,18 +143,15 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(ConstructorCreatesDefaultOptionsCases))]
-        public void ConstructorCreatesDefaultOptions(EventHubClient client,
+        public void ConstructorCreatesDefaultOptions(ReadableOptionsMock client,
                                                      string constructorDescription)
         {
             var defaultOptions = new EventHubClientOptions();
-
-            var options = (EventHubClientOptions)typeof(EventHubClient)
-                .GetProperty("ClientOptions", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(client);
+            var options = client.Options;
 
             Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set default options.");
             Assert.That(options, Is.Not.SameAs(defaultOptions), $"The { constructorDescription } constructor should not have the same options instance.");
-            Assert.That(options.ConnectionType, Is.EqualTo(defaultOptions.ConnectionType), $"The { constructorDescription } constructor should have the correct connection type.");
+            Assert.That(options.TransportType, Is.EqualTo(defaultOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
             Assert.That(options.DefaultTimeout, Is.EqualTo(defaultOptions.DefaultTimeout), $"The { constructorDescription } constructor should have the correct default timeout.");
             Assert.That(options.Proxy, Is.EqualTo(defaultOptions.Proxy), $"The { constructorDescription } constructor should have the correct proxy.");
             Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)options.Retry, (ExponentialRetry)defaultOptions.Retry), $"The { constructorDescription } constructor should have the correct retry.");
@@ -157,17 +164,15 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         [Test]
         [TestCaseSource(nameof(ConstructorClonesOptionsCases))]
-        public void ConstructorClonesOptions(EventHubClient client,
+        public void ConstructorClonesOptions(ReadableOptionsMock client,
                                              EventHubClientOptions constructorOptions,
                                              string constructorDescription)
         {
-            var options = (EventHubClientOptions)typeof(EventHubClient)
-                .GetProperty("ClientOptions", BindingFlags.Instance | BindingFlags.NonPublic)
-                .GetValue(client);
+            var options = client.Options;
 
             Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set the options.");
             Assert.That(options, Is.Not.SameAs(constructorOptions), $"The { constructorDescription } constructor should have cloned the options.");
-            Assert.That(options.ConnectionType, Is.EqualTo(constructorOptions.ConnectionType), $"The { constructorDescription } constructor should have the correct connection type.");
+            Assert.That(options.TransportType, Is.EqualTo(constructorOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
             Assert.That(options.DefaultTimeout, Is.EqualTo(constructorOptions.DefaultTimeout), $"The { constructorDescription } constructor should have the correct default timeout.");
             Assert.That(options.Proxy, Is.EqualTo(constructorOptions.Proxy), $"The { constructorDescription } constructor should have the correct proxy.");
             Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)options.Retry, (ExponentialRetry)constructorOptions.Retry), $"The { constructorDescription } constructor should have the correct retry.");
@@ -215,7 +220,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorWithConnectionStringValidatesOptions()
         {
             var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
-            var invalidOptions = new EventHubClientOptions { ConnectionType = ConnectionType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
+            var invalidOptions = new EventHubClientOptions { TransportType = TransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
 
             Assert.That(() => new EventHubClient(fakeConnection, invalidOptions), Throws.ArgumentException, "The connection string constructor should validate client options");
         }
@@ -228,8 +233,124 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorWithExpandedArgumentsValidatesOptions()
         {
-            var invalidOptions = new EventHubClientOptions { ConnectionType = ConnectionType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
+            var invalidOptions = new EventHubClientOptions { TransportType = TransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
             Assert.That(() => new EventHubClient("host", "path", Mock.Of<TokenCredential>(), invalidOptions), Throws.ArgumentException, "The cexpanded argument onstructor should validate client options");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ContructorWithConnectionStringCreatesTheTransportClient()
+        {
+
+            var client = new EventHubClient("Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
+            Assert.That(client.InnerClient, Is.Not.Null);
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ContructorWithExpandedArgumentsCreatesTheTransportClient()
+        {
+            var host = "my.eventhubs.com";
+            var path = "some-hub";
+            var keyName = "aWonderfulKey";
+            var key = "ABC4223";
+            var options = new EventHubClientOptions { TransportType = TransportType.AmqpTcp };
+            var signature = new SharedAccessSignature(options.TransportType, host, path, keyName, key);
+            var client = new EventHubClient(host, path, new SharedAccessSignatureCredential(signature), options);
+
+            Assert.That(client.InnerClient, Is.Not.Null);
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient.BuildTransportClient" />
+        ///    method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ConstructorCreatesDefaultOptionsCases))]
+        public void TransportClientReceivesDefaultOptions(ReadableOptionsMock client,
+                                                          string constructorDescription)
+        {
+            var defaultOptions = new EventHubClientOptions();
+            var options = client.TransportClientOptions;
+
+            Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set default options.");
+            Assert.That(options, Is.Not.SameAs(defaultOptions), $"The { constructorDescription } constructor should not have the same options instance.");
+            Assert.That(options.TransportType, Is.EqualTo(defaultOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
+            Assert.That(options.DefaultTimeout, Is.EqualTo(defaultOptions.DefaultTimeout), $"The { constructorDescription } constructor should have the correct default timeout.");
+            Assert.That(options.Proxy, Is.EqualTo(defaultOptions.Proxy), $"The { constructorDescription } constructor should have the correct proxy.");
+            Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)options.Retry, (ExponentialRetry)defaultOptions.Retry), $"The { constructorDescription } constructor should have the correct retry.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.BuildTransportClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ConstructorClonesOptionsCases))]
+        public void TransportClientReceivesClonesOptions(ReadableOptionsMock client,
+                                                         EventHubClientOptions constructorOptions,
+                                                         string constructorDescription)
+        {
+            var options = client.TransportClientOptions;
+
+            Assert.That(options, Is.Not.Null, $"The { constructorDescription } constructor should have set the options.");
+            Assert.That(options, Is.Not.SameAs(constructorOptions), $"The { constructorDescription } constructor should have cloned the options.");
+            Assert.That(options.TransportType, Is.EqualTo(constructorOptions.TransportType), $"The { constructorDescription } constructor should have the correct connection type.");
+            Assert.That(options.DefaultTimeout, Is.EqualTo(constructorOptions.DefaultTimeout), $"The { constructorDescription } constructor should have the correct default timeout.");
+            Assert.That(options.Proxy, Is.EqualTo(constructorOptions.Proxy), $"The { constructorDescription } constructor should have the correct proxy.");
+            Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)options.Retry, (ExponentialRetry)constructorOptions.Retry), $"The { constructorDescription } constructor should have the correct retry.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.BuildTransportClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ValidConnectionTypeCases))]
+        public void BuildTransportClientAllowsLegalConnectionTypes(TransportType connectionType)
+        {
+            var host = "my.eventhubs.com";
+            var path = "some-hub";
+            var keyName = "aWonderfulKey";
+            var key = "ABC4223";
+            var options = new EventHubClientOptions { TransportType = connectionType };
+            var signature = new SharedAccessSignature(connectionType, host, path, keyName, key);
+            var credential = new SharedAccessSignatureCredential(signature);
+            var client = new EventHubClient(host, path, credential);
+
+            Assert.That(() => client.BuildTransportClient(host, path, credential, options), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.BuildTransportClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void BuildTransportClientRejectsInvalidConnectionTypes()
+        {
+            var host = "my.eventhubs.com";
+            var path = "some-hub";
+            var keyName = "aWonderfulKey";
+            var key = "ABC4223";
+            var connectionType = (TransportType)Int32.MinValue;
+            var options = new EventHubClientOptions { TransportType = connectionType };
+            var signature = new SharedAccessSignature(TransportType.AmqpTcp, host, path, keyName, key);
+            var credential = new SharedAccessSignatureCredential(signature);
+            var client = new EventHubClient(host, path, credential);
+
+            Assert.That(() => client.BuildTransportClient(host, path, credential, options), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -252,26 +373,15 @@ namespace Azure.Messaging.EventHubs.Tests
                 Timeout = clientOptions.DefaultTimeout
             };
 
-            var actual = default(SenderOptions);
             var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
+            var mockClient = new ReadableOptionsMock(connectionString, clientOptions);
 
-            var mockClient = new Mock<EventHubClient>(connectionString, clientOptions)
-            {
-                CallBase = true
-            };
+            mockClient.CreateSender();
 
-            mockClient
-                .Protected()
-                .Setup<EventSender>("BuildEventSender", ItExpr.IsAny<ConnectionType>(), ItExpr.IsAny<string>(), ItExpr.IsAny<SenderOptions>())
-                .Returns(Mock.Of<EventSender>())
-                .Callback<ConnectionType, string, SenderOptions>((type, path, options) => actual = options);
-
-            mockClient.Object.CreateSender();
-
-            Assert.That(actual, Is.Not.Null, "The sender options should have been set.");
-            Assert.That(actual.PartitionId, Is.EqualTo(expected.PartitionId), "The partition identifiers should match.");
-            Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)actual.Retry, (ExponentialRetry)expected.Retry), "The retries should match.");
-            Assert.That(actual.TimeoutOrDefault, Is.EqualTo(expected.TimeoutOrDefault), "The timeouts should match.");
+            Assert.That(mockClient.SenderOptions, Is.Not.Null, "The sender options should have been set.");
+            Assert.That(mockClient.SenderOptions.PartitionId, Is.EqualTo(expected.PartitionId), "The partition identifiers should match.");
+            Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)mockClient.SenderOptions.Retry, (ExponentialRetry)expected.Retry), "The retries should match.");
+            Assert.That(mockClient.SenderOptions.TimeoutOrDefault, Is.EqualTo(expected.TimeoutOrDefault), "The timeouts should match.");
         }
 
         /// <summary>
@@ -302,27 +412,16 @@ namespace Azure.Messaging.EventHubs.Tests
                 Timeout = clientOptions.DefaultTimeout
             };
 
-            var actual = default(SenderOptions);
             var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
+            var mockClient = new ReadableOptionsMock(connectionString, clientOptions);
 
-            var mockClient = new Mock<EventHubClient>(connectionString, clientOptions)
-            {
-                CallBase = true
-            };
+            mockClient.CreateSender(senderOptions);
 
-            mockClient
-                .Protected()
-                .Setup<EventSender>("BuildEventSender", ItExpr.IsAny<ConnectionType>(), ItExpr.IsAny<string>(), ItExpr.IsAny<SenderOptions>())
-                .Returns(Mock.Of<EventSender>())
-                .Callback<ConnectionType, string, SenderOptions>((type, path, options) => actual = options);
-
-            mockClient.Object.CreateSender(senderOptions);
-
-            Assert.That(actual, Is.Not.Null, "The sender options should have been set.");
-            Assert.That(actual, Is.Not.SameAs(senderOptions), "The options should have been cloned.");
-            Assert.That(actual.PartitionId, Is.EqualTo(expected.PartitionId), "The partition identifiers should match.");
-            Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)actual.Retry, (ExponentialRetry)expected.Retry), "The retries should match.");
-            Assert.That(actual.TimeoutOrDefault, Is.EqualTo(expected.TimeoutOrDefault), "The timeouts should match.");
+            Assert.That(mockClient.SenderOptions, Is.Not.Null, "The sender options should have been set.");
+            Assert.That(mockClient.SenderOptions, Is.Not.SameAs(senderOptions), "The options should have been cloned.");
+            Assert.That(mockClient.SenderOptions.PartitionId, Is.EqualTo(expected.PartitionId), "The partition identifiers should match.");
+            Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)mockClient.SenderOptions.Retry, (ExponentialRetry)expected.Retry), "The retries should match.");
+            Assert.That(mockClient.SenderOptions.TimeoutOrDefault, Is.EqualTo(expected.TimeoutOrDefault), "The timeouts should match.");
         }
 
         /// <summary>
@@ -347,24 +446,12 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var expectedPartition = "56767";
-            var actualOptions = default(ReceiverOptions);
-            var actualPartition = default(string);
             var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
+            var mockClient = new ReadableOptionsMock(connectionString, clientOptions);
+            var receiver = mockClient.CreateReceiver(expectedPartition);
+            var actualOptions = mockClient.ReceiverOptions;
 
-            var mockClient = new Mock<EventHubClient>(connectionString, clientOptions)
-            {
-                CallBase = true
-            };
-
-            mockClient
-                .Protected()
-                .Setup<PartitionReceiver>("BuildPartitionReceiver", ItExpr.IsAny<ConnectionType>(), ItExpr.IsAny<string>(), ItExpr.IsAny<string>(), ItExpr.IsAny<ReceiverOptions>())
-                .Returns(Mock.Of<PartitionReceiver>())
-                .Callback<ConnectionType, string, string, ReceiverOptions>((type, path, partition, options) => { actualOptions = options; actualPartition = partition; });
-
-            mockClient.Object.CreatePartitionReceiver(expectedPartition);
-
-            Assert.That(actualPartition, Is.EqualTo(expectedPartition), "The partition should match.");
+            Assert.That(receiver.PartitionId, Is.EqualTo(expectedPartition), "The partition should match.");
             Assert.That(actualOptions, Is.Not.Null, "The receiver options should have been set.");
             Assert.That(actualOptions.BeginReceivingAt.Offset, Is.EqualTo(expectedOptions.BeginReceivingAt.Offset), "The beginning position to receive should match.");
             Assert.That(actualOptions.ConsumerGroup, Is.EqualTo(expectedOptions.ConsumerGroup), "The consumer groups should match.");
@@ -402,24 +489,12 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var expectedPartition = "56767";
-            var actualOptions = default(ReceiverOptions);
-            var actualPartition = default(string);
             var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
+            var mockClient = new ReadableOptionsMock(connectionString, clientOptions);
+            var receiver = mockClient.CreateReceiver(expectedPartition, expectedOptions);
+            var actualOptions = mockClient.ReceiverOptions;
 
-            var mockClient = new Mock<EventHubClient>(connectionString, clientOptions)
-            {
-                CallBase = true
-            };
-
-            mockClient
-                .Protected()
-                .Setup<PartitionReceiver>("BuildPartitionReceiver", ItExpr.IsAny<ConnectionType>(), ItExpr.IsAny<string>(), ItExpr.IsAny<string>(), ItExpr.IsAny<ReceiverOptions>())
-                .Returns(Mock.Of<PartitionReceiver>())
-                .Callback<ConnectionType, string, string, ReceiverOptions>((type, path, partition, options) => { actualOptions = options; actualPartition = partition; });
-
-            mockClient.Object.CreatePartitionReceiver(expectedPartition, expectedOptions);
-
-            Assert.That(actualPartition, Is.EqualTo(expectedPartition), "The partition should match.");
+            Assert.That(receiver.PartitionId, Is.EqualTo(expectedPartition), "The partition should match.");
             Assert.That(actualOptions, Is.Not.Null, "The receiver options should have been set.");
             Assert.That(actualOptions, Is.Not.SameAs(expectedOptions), "A clone of the options should have been made.");
             Assert.That(actualOptions.BeginReceivingAt.Offset, Is.EqualTo(expectedOptions.BeginReceivingAt.Offset), "The beginning position to receive should match.");
@@ -429,6 +504,39 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(actualOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The prefetch counts should match.");
             Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)actualOptions.Retry, (ExponentialRetry)expectedOptions.Retry), "The retries should match.");
             Assert.That(actualOptions.MaximumReceiveWaitTimeOrDefault, Is.EqualTo(expectedOptions.MaximumReceiveWaitTimeOrDefault), "The wait times should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloseDelegatesToCloseAsync()
+        {
+            var client = new ObservableOperationsMock("Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
+
+            client.Close();
+
+            Assert.That(client.WasCloseAsyncCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.DisposeAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task DisposeAsyncDelegatesToCloseAsync()
+        {
+            ObservableOperationsMock capturedClient;
+
+            await using (var client = new ObservableOperationsMock("Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake"))
+            {
+                capturedClient = client;
+            }
+
+            Assert.That(capturedClient.WasCloseAsyncCalled, Is.True);
         }
 
         /// <summary>
@@ -455,6 +563,201 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(actual, Is.EqualTo(partitionIds));
 
             mockClient.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.GetPropertiesAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetPropertiesAsyncInvokesTheTransportClient()
+        {
+            var transportClient = new ObservableTransportClientMock();
+            var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
+
+            await client.GetPropertiesAsync(CancellationToken.None);
+
+            Assert.That(transportClient.WasGetPropertiesCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.GetPartitionPropertiesAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetPartitionPropertiesAsyncInvokesTheTransportClient()
+        {
+            var transportClient = new ObservableTransportClientMock();
+            var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
+            var expectedId = "BB33";
+
+            await client.GetPartitionPropertiesAsync(expectedId);
+
+            Assert.That(transportClient.GetPartitionPropertiesCalledForId, Is.EqualTo(expectedId));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncClosesTheTransportClient()
+        {
+            var transportClient = new ObservableTransportClientMock();
+            var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
+
+            await client.CloseAsync();
+
+            Assert.That(transportClient.WasCloseCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloseClosesTheTransportClient()
+        {
+            var transportClient = new ObservableTransportClientMock();
+            var client = new InjectableTransportClientMock(transportClient, "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake");
+
+            client.Close();
+
+            Assert.That(transportClient.WasCloseCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Allows for the options used by the client to be exposed for testing purposes.
+        /// </summary>
+        ///
+        public class ReadableOptionsMock : EventHubClient
+        {
+            public EventHubClientOptions Options => base.ClientOptions;
+
+            public EventHubClientOptions TransportClientOptions;
+            public SenderOptions SenderOptions;
+            public ReceiverOptions ReceiverOptions;
+
+            public ReadableOptionsMock(string connectionString,
+                                       EventHubClientOptions clientOptions = default) : base(connectionString, clientOptions)
+            {
+            }
+
+            public ReadableOptionsMock(string host,
+                                       string eventHubPath,
+                                       TokenCredential credential,
+                                       EventHubClientOptions clientOptions = default) : base(host, eventHubPath, credential, clientOptions)
+            {
+            }
+
+            internal override TransportEventHubClient BuildTransportClient(string host, string eventHubPath, TokenCredential credential, EventHubClientOptions options)
+            {
+                TransportClientOptions = options;
+                return base.BuildTransportClient(host, eventHubPath, credential, options);
+            }
+
+            internal override EventSender BuildEventSender(TransportType connectionType, string eventHubPath, SenderOptions options)
+            {
+                SenderOptions = options;
+                return base.BuildEventSender(connectionType, eventHubPath, options);
+            }
+
+            internal override EventReceiver BuildEventReceiver(TransportType connectionType, string eventHubPath, string partitionId, ReceiverOptions options)
+            {
+                ReceiverOptions = options;
+                return base.BuildEventReceiver(connectionType, eventHubPath, partitionId, options);
+            }
+        }
+
+        /// <summary>
+        ///   Allows for the operations performed by the client to be observed for testing purposes.
+        /// </summary>
+        ///
+        public class ObservableOperationsMock : EventHubClient
+        {
+            public bool WasCloseAsyncCalled = false;
+
+            public ObservableOperationsMock(string connectionString,
+                                       EventHubClientOptions clientOptions = default) : base(connectionString, clientOptions)
+            {
+            }
+
+            public ObservableOperationsMock(string host,
+                                       string eventHubPath,
+                                       TokenCredential credential,
+                                       EventHubClientOptions clientOptions = default) : base(host, eventHubPath, credential, clientOptions)
+            {
+            }
+
+            public override Task CloseAsync(CancellationToken cancellationToken = default)
+            {
+                WasCloseAsyncCalled = true;
+                return base.CloseAsync(cancellationToken);
+            }
+
+        }
+
+        /// <summary>
+        ///   Allows for the transport client created the client to be injected for testing purposes.
+        /// </summary>
+        ///
+        private class InjectableTransportClientMock : EventHubClient
+        {
+            public TransportEventHubClient TransportClient;
+
+            public InjectableTransportClientMock(TransportEventHubClient transportClient,
+                                                 string connectionString,
+                                                 EventHubClientOptions clientOptions = default) : base(connectionString, clientOptions)
+            {
+                TransportClient = transportClient;
+                InnerClient = transportClient;
+            }
+
+            public InjectableTransportClientMock(TransportEventHubClient transportClient,
+                                                 string host,
+                                                 string eventHubPath,
+                                                 TokenCredential credential,
+                                                 EventHubClientOptions clientOptions = default) : base(host, eventHubPath, credential, clientOptions)
+            {
+                TransportClient = transportClient;
+                InnerClient = transportClient;
+            }
+
+            internal override TransportEventHubClient BuildTransportClient(string host, string eventHubPath, TokenCredential credential, EventHubClientOptions options) => TransportClient;
+        }
+
+        /// <summary>
+        ///   Allows for observation of operations performed by the client for testing purposes.
+        /// </summary>
+        ///
+        private class ObservableTransportClientMock : TransportEventHubClient
+        {
+            public string GetPartitionPropertiesCalledForId = default;
+            public bool WasGetPropertiesCalled = false;
+            public bool WasCloseCalled = false;
+
+            public override Task<EventHubProperties> GetPropertiesAsync(CancellationToken cancellationToken = default)
+            {
+                WasGetPropertiesCalled = true;
+                return Task.FromResult(default(EventHubProperties));
+            }
+
+            public override Task<PartitionProperties> GetPartitionPropertiesAsync(string partitionId,
+                                                                                  CancellationToken cancellationToken = default)
+            {
+                GetPartitionPropertiesCalledForId = partitionId;
+                return Task.FromResult(default(PartitionProperties));
+            }
+
+            public override Task CloseAsync(CancellationToken cancellationToken)
+            {
+                WasCloseCalled = true;
+                return Task.CompletedTask;
+            }
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+
+namespace Azure.Messaging.EventHubs.Tests.Infrastructure
+{
+    /// <summary>
+    ///  Provides a dynamically created Event Hub instance which exists only in the context
+    ///  of the scope; disposal removes the instance.
+    /// </summary>
+    ///
+    /// <seealso cref="System.IAsyncDisposable" />
+    ///
+    public sealed class EventHubScope : IAsyncDisposable
+    {
+        /// <summary>Serves as a sentinal flag to denote when the instance has been disposed.</summary>
+        private bool _disposed = false;
+
+        /// <summary>
+        ///  The name of the Event Hub that was created.
+        /// </summary>
+        ///
+        public string EventHubName { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubScope"/> class.
+        /// </summary>
+        ///
+        /// <param name="partitionCount">The number of partitions that the Event Hub should be configured with.</param>
+        /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
+        ///
+        private EventHubScope(string eventHubHame)
+        {
+            //TODO: Constructor needs to take the state needed to tear down the Event Hub.
+            EventHubName = eventHubHame;
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to remove the dynamically created
+        ///   Event Hub.
+        /// </summary>
+        ///
+        public ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return new ValueTask();
+            }
+
+            //TODO: Perform the needed actions to tear down the Event Hub.
+            _disposed = true;
+            return new ValueTask();
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to create a new Event Hub instance with the requested
+        ///   partition count and a dynamically assigned unique name.
+        /// </summary>
+        ///
+        /// <param name="partitionCount">The number of partitions that the Event Hub should be configured with.</param>
+        /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
+        ///
+        public static Task<EventHubScope> CreateAsync(int partitionCount,
+                                                      [CallerMemberName] string caller = "")
+        {
+            var name = $"{ caller }-{ Guid.NewGuid().ToString("D").Substring(0, 8) }";
+
+            //TODO: This is temporary until the actual dynamic creation is in place.
+            name = "eventhubs-sdk-test-hub";
+
+            //TODO: Create/Invoke a management client to dynamically create the Event Hub.  There should be some minimal retries on this; consider Polly if we have nothing in Core to help.
+            //TODO: Set state as appropriate for cleaning things up and pass to the constructor.
+            return Task.FromResult(new EventHubScope(name));
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestEnvironment.cs
@@ -28,6 +28,15 @@ namespace Azure.Messaging.EventHubs.Tests
         public static string EventHubsConnectionString => EventHubsConnectionStringInstance.Value;
 
         /// <summary>
+        ///   Builds a connection string for a specific Event Hub instance under the Event Hubs namespace used for
+        ///   Live tests.
+        /// </summary>
+        ///
+        /// <value>The namepsace connection string is read from the "EVENT_HUBS_CONNECTION_STRING" environment variable.</value>
+        ///
+        public static string BuildConnectionStringForEventHub(string eventHubName) => $"{ EventHubsConnectionString };EntityPath={eventHubName}";
+
+        /// <summary>
         ///   Reads an environment variable, ensuring that it is populated.
         /// </summary>
         ///


### PR DESCRIPTION
# Summary

The intent of these changes is to complete the end-to-end infrastructure of an `EventHubClient`, from the API surface through the compatibility shim for the track one implementation.  At this point, the client-level functionality such as querying Event Hub metadata is in-place and testable via the included live tests.  Also a core focus of these changes is incorporating the latest round of feedback from architectural board reviews, primarily aimed at tuning the public API surface.

# Goals

- Ensure that an `EventHubClient` creates a transport-aware client for containment to which it delegates operations.  This is currently used as a `TrackOneEventHubClient` and is intended to allow for concepts such as `AmqpEventHubClient` and `ReplayTestEventHubClient` to be used post-preview.

- Broker the compatibility between the track two API and the track one `EventHubClient` implementation, mapping types as needed.

- Allow for creation of an `EventHubClient` that is capable of interacting with the Event Hubs service for client-level operations, such as querying metadata.

- Address feedback  from the Azure Developer Platform Team architecture board.

- Review and revise the public surface area of the implementation, reducing scope as possible by internalizing constructs intended only to support project-level testing.

# Non-Goals

- Providing the implementation for the compatibility layer between the track two and track one `EventSender`; this will happen as part of future efforts.

- Providing the implementation for the compatibility layer between the track two and track one `EventReceiver`; this will happen as part of future efforts.

- Supporting validation or other authorization-related tasks for non-SAS credential types; this will happen as part of future efforts.

- Cover the identified set of end-to-end live tests needed to fully exercise the target scenarios; this will happen as part of future efforts.

- Inclusion of the full set of supporting assets, such as README, samples, and ARM templates; these will happen as part of future efforts.

- Enabling test parallelism; this will be a stretch goal, but unlikely to occur in the time frame for the first track two preview.

# Details  
  
### General
        
- Ongoing review and updates to member visibility to reduce public scope and limit protected members.

- Removal of some package references carried over from track one that have been determined to be unnecessary.

- Inclusion of the BCL interfaces preview package and supporting dependencies to allow for IAsyncDisposable use.

###   Architecture Board Review Feedback

- Hide `MaximumSizeInBytes` from the `EventBatchingOptions`, it is associated with a feature no longer in scope for the first preview.

- Rename of `ConnectionType` to `TransportType` to clarify semantics.

- Remove `RetrievalTimeUtc` from `EventData` to align members cross-language.

- Hide `SystemProperties` on `EventData` in order to present a more clear surface.  Properties from the system set have been hoisted to first class members of `EventData`.   At this time, it is believed that there are no additional metadata items sent by the service that we wish to expose to callers.

- Hide `Credential` and `ClientOptions` on `EventHubClient`; these are internal state tracking members used by the class and were not intended to be exposed to consumers.

- Rename `PartitionReceiver` to `EventReceiver` to better align terminology between senders and receivers.  The associated `CreatePartitionReceiver` member on `EventHubClient` was updated to `CreateReceiver` to reflect this change.

- Refactor to rename "BatchLabel" to "PartitionKey" in all contexts, along with documentation updates to try and add clarity to the meaning and semantics of it.

- Marked the `ReceiverOptions` member `DefaultMaximumReceiveWaitTime` as internal, allowing it to be hidden from consumers without causing churn and instability in the current flow of options.   _(This will be revisited post-preview to better understand if it is needed at all and, if so, whether there is benefit to exposing it to consumers.)_

###  Event Hub Client

- Refactoring to tighten access modifier scopes; testing approach has been adjusted to make greater use of custom mock objects and rely less on mocking via Moq to help limit the need for `protected` members exposed only to allow internal testing.

- Added support for IAsyncDisposable, delegating to `CloseAsync` to allow for more consise and representative usage patterns rather than requiring an explicit try/finally wrapper to ensure proper closure.

- Implemented construction of an inner transport client to use via containment as a delegate for performing the operations requested by consumers.

- Wired up delegation to the active transport client to service operations requested of the `EventHubClient`.

- Introduced Live tests for basic operations directly on the `EventHubClient`, absent creating senders and receivers.

###  Transport Client

 - Introduced as an abstraction to allow for a generalized Event Hub client interface specific to a protocol/transport to be used for delegation of operations.  It is intended that the public-facing `EventHubClient` create a dedicated transport client based on the active set of client options and make use if it via containment to avoid having protocol/transport concerns exposed.

- Created a transport client shim to serve as a bridge and adapter between the track two API and the track one implementation, allowing the preview to delegate operations to the track one types.

###  Authorization

- Added a default duration for shared key credentials in support of connection string use.

###  Test Infrastructure

- Added an abstraction for running Live tests in an `EventHubScope`, which is intended to allow for dynamic creation of an Event Hub with a given number of partitions, uniquely named.  This will allow Live tests to run strictly sandboxed, with a single test running against a give Hub.

    **NOTE:** _This has not been fully implemented yet; currently, the structure is in place to allow for creating Live tests in the form that will be needed to avoid a large and sweeping refactoring when the management functionality is added._

# Last Upstream Rebase

Monday, June 10, 2019  11:06am (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)