### PR TITLE
Enable Signing for mgmt plane libraries

### DIFF
--- a/.azure-pipelines/mgmt.yml
+++ b/.azure-pipelines/mgmt.yml
@@ -7,7 +7,6 @@ pr:
   paths:
     exclude:
     - sdk/
-    - eng/
 
 variables:
   DotNetCoreVersion: '2.1.503'

--- a/eng/mgmt/Directory.Build.Mgmt.props
+++ b/eng/mgmt/Directory.Build.Mgmt.props
@@ -1,4 +1,10 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(RepoRoot)\tools\bootstrapTools\bootstrap.targets" />
   <Import Project="CI.Bootstrap.targets" Sdk="Microsoft.Internal.NetSdkBuild.Mgmt.Tools" Version="0.10.0" />
+
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>$(pkg_root_RepoToolsDir)\MSSharedLibKey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
cc @shahabhijeet @chidozieononiwu 

@shahabhijeet for some reason the signing properties were disabled in the new toolset  (https://github.com/Azure/azure-sdk-tools/pull/46/files#r292544719)