### PR TITLE
[Event Hubs Client - Track Two Preview 1] Event Sender

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignature.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignature.cs
@@ -66,7 +66,7 @@ namespace Azure.Messaging.EventHubs.Authorization
         ///   or the Event Hub.
         /// </summary>
         ///
-        public string SharedAccessKey { get; private set;}
+        public string SharedAccessKey { get; private set; }
 
         /// <summary>
         ///   The date and time that the shared access signature expires, in UTC.
@@ -144,6 +144,16 @@ namespace Azure.Messaging.EventHubs.Authorization
         }
 
         /// <summary>
+        ///   Initializes a new instance of the <see cref="SharedAccessSignature"/> class.
+        /// </summary>
+        ///
+        /// <param name="sharedAccessSignature">The shared access signature that will be parsed as the basis of this instance.</param>
+        ///
+        public SharedAccessSignature(string sharedAccessSignature) : this(sharedAccessSignature, null)
+        {
+        }
+
+        /// <summary>
         ///   nitializes a new instance of the <see cref="SharedAccessSignature" /> class.
         /// </summary>
         ///
@@ -169,16 +179,6 @@ namespace Azure.Messaging.EventHubs.Authorization
             SharedAccessKey = sharedAccessKey;
             Value = value;
             ExpirationUtc = expirationUtc;
-        }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="SharedAccessSignature"/> class.
-        /// </summary>
-        ///
-        /// <param name="sharedAccessSignature">The shared access signature that will be parsed as the basis of this instance.</param>
-        ///
-        public SharedAccessSignature(string sharedAccessSignature) : this(sharedAccessSignature, null)
-        {
         }
 
         /// <summary>
@@ -241,7 +241,6 @@ namespace Azure.Messaging.EventHubs.Authorization
         internal SharedAccessSignature Clone() =>
             new SharedAccessSignature(Resource, SharedAccessKeyName, SharedAccessKey, Value, ExpirationUtc);
 
-
         /// <summary>
         ///   Parses a shared access signature into its component parts.
         /// </summary>
@@ -250,7 +249,7 @@ namespace Azure.Messaging.EventHubs.Authorization
         ///
         /// <returns>The set of composite properties parsed from the signature.</returns>
         ///
-        internal static (string KeyName, string Resource, DateTime ExpirationUtc) ParseSignature(string sharedAccessSignature)
+        private static (string KeyName, string Resource, DateTime ExpirationUtc) ParseSignature(string sharedAccessSignature)
         {
             int tokenPositionModifier = (sharedAccessSignature[0] == TokenValuePairDelimiter) ? 0 : 1;
             int lastPosition = 0;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignatureCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignatureCredential.cs
@@ -44,7 +44,7 @@ namespace Azure.Messaging.EventHubs.Authorization
         /// <param name="scopes">The access scopes to request a token for.</param>
         /// <param name="cancellationToken">The token used to request cancellation of the operation.</param>
         ///
-        /// <returns>The token representating the shared access signatuer for this credential.</returns>
+        /// <returns>The token representating the shared access signature for this credential.</returns>
         ///
         public override AccessToken GetToken(string[] scopes, CancellationToken cancellationToken) => new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.ExpirationUtc);
 
@@ -56,8 +56,8 @@ namespace Azure.Messaging.EventHubs.Authorization
         /// <param name="scopes">The access scopes to request a token for.</param>
         /// <param name="cancellationToken">The token used to request cancellation of the operation.</param>
         ///
-        /// <returns>The token representating the shared access signatuer for this credential.</returns>
+        /// <returns>The token representating the shared access signature for this credential.</returns>
         ///
-        public override Task<AccessToken> GetTokenAsync(string[] scopes, CancellationToken cancellationToken) => Task<AccessToken>.FromResult(new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.ExpirationUtc));
+        public override Task<AccessToken> GetTokenAsync(string[] scopes, CancellationToken cancellationToken) => Task.FromResult(new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.ExpirationUtc));
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventSender.cs
@@ -1,0 +1,93 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+
+namespace Azure.Messaging.EventHubs.Compatibility
+{
+    /// <summary>
+    ///   A transport client abstraction responsible for wrapping the track one event sender as a transport sender for
+    ///   AMQP-based connections.  It is intended that the public <see cref="EventSender" /> make use of an instance
+    ///   via containment and delegate operations to it.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Messaging.EventHubs.Core.TransportEventSender" />
+    ///
+    internal sealed class TrackOneEventSender : TransportEventSender
+    {
+        /// <summary>A lazy instantiation of the sender instance to delegate operation to.</summary>
+        private Lazy<TrackOne.EventDataSender> _trackOneSender;
+
+        /// <summary>
+        ///   The track one <see cref="TrackOne.EventDataSender" /> for use with this transport sender.
+        /// </summary>
+        ///
+        private TrackOne.EventDataSender TrackOneSender => _trackOneSender.Value;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="TrackOneEventSender"/> class.
+        /// </summary>
+        ///
+        /// <param name="trackOneSenderFactory">A delegate that can be used for creation of the <see cref="TrackOne.EventDataSender" /> to which operations are delegated to.</param>
+        ///
+        /// <remarks>
+        ///   As an internal type, this class performs only basic sanity checks against its arguments.  It
+        ///   is assumed that callers are trusted and have performed deep validation.
+        ///
+        ///   Any parameters passed are assumed to be owned by this instance and safe to mutate or dispose;
+        ///   creation of clones or otherwise protecting the parameters is assumed to be the purview of the
+        ///   caller.
+        /// </remarks>
+        ///
+        public TrackOneEventSender(Func<TrackOne.EventDataSender> trackOneSenderFactory)
+        {
+            Guard.ArgumentNotNull(nameof(trackOneSenderFactory), trackOneSenderFactory);
+            _trackOneSender = new Lazy<TrackOne.EventDataSender>(trackOneSenderFactory, LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        /// <summary>
+        ///   Sends a set of events to the associated Event Hub using a batched approach.  If the size of events exceed the
+        ///   maximum size of a single batch, an exception will be triggered and the send will fail.
+        /// </summary>
+        ///
+        /// <param name="events">The set of event data to send.</param>
+        /// <param name="batchOptions">The set of options to consider when sending this batch.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        public override Task SendAsync(IEnumerable<EventData> events,
+                                       EventBatchingOptions batchOptions,
+                                       CancellationToken cancellationToken)
+        {
+            static TrackOne.EventData TransformEvent(EventData eventData) =>
+                new TrackOne.EventData(eventData.Body.ToArray())
+                {
+                    Properties = eventData.Properties
+                };
+
+            return TrackOneSender.SendAsync(events.Select(evt => TransformEvent(evt)), batchOptions?.PartitionKey);
+        }
+
+        /// <summary>
+        ///   Closes the connection to the transport client instance.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        public override Task CloseAsync(CancellationToken cancellationToken)
+        {
+            if (!_trackOneSender.IsValueCreated)
+            {
+                return Task.CompletedTask;
+            }
+
+            return TrackOneSender.CloseAsync();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubClient.cs
@@ -38,6 +38,19 @@ namespace Azure.Messaging.EventHubs.Core
                                                                               CancellationToken cancellationToken);
 
         /// <summary>
+        ///   Creates an event sender responsible for transmitting <see cref="EventData" /> to the
+        ///   Event Hub, grouped together in batches.  Depending on the <paramref name="senderOptions"/>
+        ///   specified, the sender may be created to allow event data to be automatically routed to an available
+        ///   partition or specific to a partition.
+        /// </summary>
+        ///
+        /// <param name="senderOptions">The set of options to apply when creating the sender.</param>
+        ///
+        /// <returns>An event sender configured in the requested manner.</returns>
+        ///
+        public abstract EventSender CreateSender(EventSenderOptions senderOptions = default);
+
+        /// <summary>
         ///   Closes the connection to the transport client instance.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventSender.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Messaging.EventHubs.Core
+{
+    /// <summary>
+    ///   Provides an abstraction for generalizing an Event Sender so that a dedicated instance may provide operations
+    ///   for a specific transport, such as AMQP or JMS.  It is intended that the public <see cref="EventSender" /> employ
+    ///   a transport sender via containment and delegate operations to it rather than understanding protocol-specific details
+    ///   for different transports.
+    /// </summary>
+    ///
+    internal abstract class TransportEventSender
+    {
+        /// <summary>
+        ///   Sends a set of events to the associated Event Hub using a batched approach.  If the size of events exceed the
+        ///   maximum size of a single batch, an exception will be triggered and the send will fail.
+        /// </summary>
+        ///
+        /// <param name="events">The set of event data to send.</param>
+        /// <param name="batchOptions">The set of options to consider when sending this batch.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        public abstract Task SendAsync(IEnumerable<EventData> events,
+                                       EventBatchingOptions batchOptions,
+                                       CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Closes the connection to the transport sender instance.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        public abstract Task CloseAsync(CancellationToken cancellationToken);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventReceiver.cs
@@ -63,7 +63,7 @@ namespace Azure.Messaging.EventHubs
         ///   The set of event receiver options used for creation of this receiver.
         /// </summary>
         ///
-        protected ReceiverOptions Options { get; set; }
+        protected EventReceiverOptions Options { get; set; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventReceiver"/> class.
@@ -87,7 +87,7 @@ namespace Azure.Messaging.EventHubs
         internal EventReceiver(TransportType connectionType,
                                string eventHubPath,
                                string partitionId,
-                               ReceiverOptions receiverOptions)
+                               EventReceiverOptions receiverOptions)
         {
             Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
             Guard.ArgumentNotNullOrEmpty(nameof(partitionId), partitionId);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventReceiverOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventReceiverOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.Messaging.EventHubs
     ///   to configure its behavior.
     /// </summary>
     ///
-    public class ReceiverOptions
+    public class EventReceiverOptions
     {
         /// <summary>The name of the default consumer group in the Event Hubs service.</summary>
         public const string DefaultConsumerGroup = "$Default";
@@ -166,13 +166,13 @@ namespace Azure.Messaging.EventHubs
         public override string ToString() => base.ToString();
 
         /// <summary>
-        ///   Creates a new copy of the current <see cref="ReceiverOptions" />, cloning its attributes into a new instance.
+        ///   Creates a new copy of the current <see cref="EventReceiverOptions" />, cloning its attributes into a new instance.
         /// </summary>
         ///
-        /// <returns>A new copy of <see cref="ReceiverOptions" />.</returns>
+        /// <returns>A new copy of <see cref="EventReceiverOptions" />.</returns>
         ///
-        internal ReceiverOptions Clone() =>
-            new ReceiverOptions
+        internal EventReceiverOptions Clone() =>
+            new EventReceiverOptions
             {
                 ConsumerGroup = this.ConsumerGroup,
                 BeginReceivingAt = this.BeginReceivingAt,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventSenderOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventSenderOptions.cs
@@ -11,7 +11,7 @@ namespace Azure.Messaging.EventHubs
     ///   to configure its behavior.
     /// </summary>
     ///
-    public class SenderOptions
+    public class EventSenderOptions
     {
         /// <summary>The timeout that will be used by default for sending events.</summary>
         private TimeSpan? _timeout = TimeSpan.FromMinutes(1);
@@ -103,13 +103,13 @@ namespace Azure.Messaging.EventHubs
         public override string ToString() => base.ToString();
 
         /// <summary>
-        ///   Creates a new copy of the current <see cref="SenderOptions" />, cloning its attributes into a new instance.
+        ///   Creates a new copy of the current <see cref="EventSenderOptions" />, cloning its attributes into a new instance.
         /// </summary>
         ///
-        /// <returns>A new copy of <see cref="SenderOptions" />.</returns>
+        /// <returns>A new copy of <see cref="EventSenderOptions" />.</returns>
         ///
-        internal SenderOptions Clone() =>
-            new SenderOptions
+        internal EventSenderOptions Clone() =>
+            new EventSenderOptions
             {
                 PartitionId = this.PartitionId,
                 Retry = this.Retry?.Clone(),

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/ExponentialRetry.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/ExponentialRetry.cs
@@ -88,6 +88,20 @@ namespace Azure.Messaging.EventHubs
             new ExponentialRetry(_minimumBackoff, _maximumBackoff, _maximumRetryCount);
 
         /// <summary>
+        ///   Allows internal access to the retry properties for compatibility shims.
+        /// </summary>
+        ///
+        /// <returns>The set of properties for the retry policy.</returns>
+        ///
+        /// <remarks>
+        ///   This method is intended to allow for compatibility shims to create the equivilent retry
+        ///   policy within the track one code;  it will be removed after the first preview and should
+        ///   not be depended upon outside of that context.
+        /// </remarks>
+        ///
+        internal (TimeSpan minimumBackOff, TimeSpan maximumBackoff, int maximumRetryCount) GetProperties() => (_minimumBackoff, _maximumBackoff, _maximumRetryCount); //TODO: Remove after preview
+
+        /// <summary>
         ///   Determines whether the specified <see cref="ExponentialRetry" />, is equal to this instance.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/PartitionProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/PartitionProperties.cs
@@ -16,25 +16,25 @@ namespace Azure.Messaging.EventHubs.Metadata
         ///   that contains it.
         /// </summary>
         ///
-        public string EventHubPath { get; private set; }
+        public string EventHubPath { get; }
 
         /// <summary>
         ///   The identifier of the partition, unique to the Event Hub which contains it.
         /// </summary>
         ///
-        public string Id { get; private set; }
+        public string Id { get; }
 
         /// <summary>
         ///   The first sequence number available for events in the partition.
         /// </summary>
         ///
-        public long BeginningSequenceNumber { get; private set; }
+        public long BeginningSequenceNumber { get; }
 
         /// <summary>
         ///   The sequence number observed the last event to be enqueued in the partition.
         /// </summary>
         ///
-        public long LastEnqueuedSequenceNumber { get; private set; }
+        public long LastEnqueuedSequenceNumber { get; }
 
         /// <summary>
         ///   The offset of the last event to be enqueued in the partition.
@@ -46,13 +46,13 @@ namespace Azure.Messaging.EventHubs.Metadata
         ///   as events reach the age limit for retention and are no longer visible within the stream.
         /// </remarks>
         ///
-        public string LastEnqueuedOffset { get; private set; }
+        public string LastEnqueuedOffset { get; }
 
         /// <summary>
         ///   The date and time, in UTC, that the last event was enqueued in the partition.
         /// </summary>
         ///
-        public DateTime LastEnqueuedTimeUtc { get; private set; }
+        public DateTime LastEnqueuedTimeUtc { get; }
 
         /// <summary>
         ///   Indicates whether or not the partition is currently empty.
@@ -62,14 +62,14 @@ namespace Azure.Messaging.EventHubs.Metadata
         ///   <c>true</c> if the partition is empty; otherwise, <c>false</c>.
         /// </value>
         ///
-        public bool IsEmpty { get; private set; }
+        public bool IsEmpty { get; }
 
         /// <summary>
         ///   The date and time, in UTC, that the information was retrieved from the
         ///   Event Hub.
         /// </summary>
         ///
-        public DateTime PropertyRetrievalTimeUtc { get; private set; }
+        public DateTime PropertyRetrievalTimeUtc { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="PartitionProperties"/> class.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -8,10 +8,8 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace Azure.Messaging.EventHubs {
-    using System;
-    
-    
+namespace Azure.Messaging.EventHubs
+{
     /// <summary>
     ///   A strongly-typed resource class, for looking up localized strings, etc.
     /// </summary>
@@ -22,211 +20,268 @@ namespace Azure.Messaging.EventHubs {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Resources {
-        
+    internal class Resources
+    {
+
         private static global::System.Resources.ResourceManager resourceMan;
-        
+
         private static global::System.Globalization.CultureInfo resourceCulture;
-        
+
         [global::System.Diagnostics.CodeAnalysis.SuppressMessageAttribute("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        internal Resources() {
+        internal Resources()
+        {
         }
-        
+
         /// <summary>
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
-            get {
-                if (object.ReferenceEquals(resourceMan, null)) {
+        internal static global::System.Resources.ResourceManager ResourceManager
+        {
+            get
+            {
+                if (object.ReferenceEquals(resourceMan, null))
+                {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Azure.Messaging.EventHubs.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
             }
         }
-        
+
         /// <summary>
         ///   Overrides the current thread's CurrentUICulture property for all
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
-            get {
+        internal static global::System.Globalization.CultureInfo Culture
+        {
+            get
+            {
                 return resourceCulture;
             }
-            set {
+            set
+            {
                 resourceCulture = value;
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; may not be null or empty..
         /// </summary>
-        internal static string ArgumentNullOrEmpty {
-            get {
+        internal static string ArgumentNullOrEmpty
+        {
+            get
+            {
                 return ResourceManager.GetString("ArgumentNullOrEmpty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; may not be null or white space..
         /// </summary>
-        internal static string ArgumentNullOrWhiteSpace {
-            get {
+        internal static string ArgumentNullOrWhiteSpace
+        {
+            get
+            {
                 return ResourceManager.GetString("ArgumentNullOrWhiteSpace", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; cannot exceed {1} characters..
         /// </summary>
-        internal static string ArgumentStringTooLong {
-            get {
+        internal static string ArgumentStringTooLong
+        {
+            get
+            {
                 return ResourceManager.GetString("ArgumentStringTooLong", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to A sender created for a specific partition cannot send events using a partition key.  This sender is associated with partition &apos;{0}&apos;..
+        /// </summary>
+        internal static string CannotSendWithPartitionIdAndPartitionKey
+        {
+            get
+            {
+                return ResourceManager.GetString("CannotSendWithPartitionIdAndPartitionKey", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The connection string could not be parsed; either it was malformed or contains no well-known tokens..
         /// </summary>
-        internal static string InvalidConnectionString {
-            get {
+        internal static string InvalidConnectionString
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidConnectionString", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The string has an invalid encoding format..
         /// </summary>
-        internal static string InvalidEncoding {
-            get {
+        internal static string InvalidEncoding
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidEncoding", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The shared access signature could not be parsed; it was either malformed or incorrectly encoded..
         /// </summary>
-        internal static string InvalidSharedAccessSignature {
-            get {
+        internal static string InvalidSharedAccessSignature
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidSharedAccessSignature", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The time period may not be Zero or Infinite..
         /// </summary>
-        internal static string InvalidTimePeriod {
-            get {
+        internal static string InvalidTimePeriod
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTimePeriod", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The requested transport type, &apos;{0}&apos; is not supported..
         /// </summary>
-        internal static string InvalidTransportType {
-            get {
+        internal static string InvalidTransportType
+        {
+            get
+            {
                 return ResourceManager.GetString("InvalidTransportType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The connection string used for an Event Hub client must specify the Event Hubs namespace host, the path to an Event Hub, and a Shared Access Signature (both the name and value) to be valid..
         /// </summary>
-        internal static string MalformedEventHubClientConnectionString {
-            get {
+        internal static string MalformedEventHubClientConnectionString
+        {
+            get
+            {
                 return ResourceManager.GetString("MalformedEventHubClientConnectionString", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to System property &apos;{0}&apos; is missing in the event..
         /// </summary>
-        internal static string MissingSystemProperty {
-            get {
+        internal static string MissingSystemProperty
+        {
+            get
+            {
                 return ResourceManager.GetString("MissingSystemProperty", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A proxy may only be used for a websockets connection..
         /// </summary>
-        internal static string ProxyMustUseWebsockets {
-            get {
+        internal static string ProxyMustUseWebsockets
+        {
+            get
+            {
                 return ResourceManager.GetString("ProxyMustUseWebsockets", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The &apos;identifier&apos; parameter exceeds the maximum allowed size of {0} characters..
         /// </summary>
-        internal static string ReceiverIdentifierOverMaxValue {
-            get {
+        internal static string ReceiverIdentifierOverMaxValue
+        {
+            get
+            {
                 return ResourceManager.GetString("ReceiverIdentifierOverMaxValue", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The reqested resource, &apos;{0}&apos;, does not match the resource of the shared access signature, &apos;{1}&apos;.   A token cannot be issued..
         /// </summary>
-        internal static string ResourceMustMatchSharedAccessSignature {
-            get {
+        internal static string ResourceMustMatchSharedAccessSignature
+        {
+            get
+            {
                 return ResourceManager.GetString("ResourceMustMatchSharedAccessSignature", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A retry must be set for the options; if no retry is desired, please set the value to Retry.NoRetry.
         /// </summary>
-        internal static string RetryMustBeSet {
-            get {
+        internal static string RetryMustBeSet
+        {
+            get
+            {
                 return ResourceManager.GetString("RetryMustBeSet", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to In order to update the signature, a shared access key must have been provided when the shared access signature was created..
         /// </summary>
-        internal static string SharedAccessKeyIsRequired {
-            get {
+        internal static string SharedAccessKeyIsRequired
+        {
+            get
+            {
                 return ResourceManager.GetString("SharedAccessKeyIsRequired", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to A timeout value must be positive.  To request using the default timeout, please use TimeSpan.Zero or null..
         /// </summary>
-        internal static string TimeoutMustBePositive {
-            get {
+        internal static string TimeoutMustBePositive
+        {
+            get
+            {
                 return ResourceManager.GetString("TimeoutMustBePositive", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to Argument {0} must be a non-negative timespan value. The provided value was {1}..
         /// </summary>
-        internal static string TimeSpanMustBeNonNegative {
-            get {
+        internal static string TimeSpanMustBeNonNegative
+        {
+            get
+            {
                 return ResourceManager.GetString("TimeSpanMustBeNonNegative", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The specified connection type, &quot;{0}&quot;, is not recognized as valid in this context..
         /// </summary>
-        internal static string UnknownConnectionType {
-            get {
+        internal static string UnknownConnectionType
+        {
+            get
+            {
                 return ResourceManager.GetString("UnknownConnectionType", resourceCulture);
             }
         }
-        
+
         /// <summary>
         ///   Looks up a localized string similar to The value supplied must be between {0} and {1}..
         /// </summary>
-        internal static string ValueOutOfRange {
-            get {
+        internal static string ValueOutOfRange
+        {
+            get
+            {
                 return ResourceManager.GetString("ValueOutOfRange", resourceCulture);
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -174,4 +174,7 @@
   <data name="InvalidTransportType" xml:space="preserve">
     <value>The requested transport type, '{0}' is not supported.</value>
   </data>
+  <data name="CannotSendWithPartitionIdAndPartitionKey" xml:space="preserve">
+    <value>A sender created for a specific partition cannot send events using a partition key.  This sender is associated with partition '{0}'.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/EventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/EventHubClient.cs
@@ -341,29 +341,7 @@ namespace TrackOne
         /// <see cref="PartitionSender.SendAsync(EventData)"/>
         public async Task SendAsync(IEnumerable<EventData> eventDatas, string partitionKey)
         {
-            // eventDatas null check is inside ValidateEvents
-            int count = EventDataSender.ValidateEvents(eventDatas);
-
-            EventHubsEventSource.Log.EventSendStart(this.ClientId, count, partitionKey);
-            Activity activity = EventHubsDiagnosticSource.StartSendActivity(this.ClientId, this.ConnectionStringBuilder, partitionKey, eventDatas, count);
-
-            Task sendTask = null;
-            try
-            {
-                sendTask = this.InnerSender.SendAsync(eventDatas, partitionKey);
-                await sendTask.ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                EventHubsEventSource.Log.EventSendException(this.ClientId, exception.ToString());
-                EventHubsDiagnosticSource.FailSendActivity(activity, this.ConnectionStringBuilder, partitionKey, eventDatas, exception);
-                throw;
-            }
-            finally
-            {
-                EventHubsEventSource.Log.EventSendStop(this.ClientId);
-                EventHubsDiagnosticSource.StopSendActivity(activity, this.ConnectionStringBuilder, partitionKey, eventDatas, sendTask);
-            }
+            await this.InnerSender.SendAsync(eventDatas, partitionKey).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/PartitionSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/PartitionSender.cs
@@ -96,7 +96,7 @@ namespace TrackOne
         /// <code>
         /// EventHubClient client = EventHubClient.Create("__connectionString__");
         /// PartitionSender senderToPartitionOne = client.CreatePartitionSender("1");
-        ///         
+        ///
         /// while (true)
         /// {
         ///     var events = new List&lt;EventData&gt;();
@@ -110,10 +110,10 @@ namespace TrackOne
         ///         sendEvent.Properties = applicationProperties;
         ///         events.Add(sendEvent);
         ///     }
-        ///         
+        ///
         ///     await senderToPartitionOne.SendAsync(events);
         ///     Console.WriteLine("Sent Batch... Size: {0}", events.Count);
-        ///     
+        ///
         /// }
         /// </code>
         /// </example>
@@ -130,27 +130,7 @@ namespace TrackOne
                 throw Fx.Exception.InvalidOperation(Resources.PartitionSenderInvalidWithPartitionKeyOnBatch);
             }
 
-            int count = EventDataSender.ValidateEvents(eventDatas);
-            EventHubsEventSource.Log.EventSendStart(this.ClientId, count, null);
-            Activity activity = EventHubsDiagnosticSource.StartSendActivity(this.ClientId, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDatas, count);
-
-            Task sendTask = null;
-            try
-            {
-                sendTask = this.InnerSender.SendAsync(eventDatas, null);
-                await sendTask.ConfigureAwait(false);
-            }
-            catch (Exception exception)
-            {
-                EventHubsEventSource.Log.EventSendException(this.ClientId, exception.ToString());
-                EventHubsDiagnosticSource.FailSendActivity(activity, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDatas, exception);
-                throw;
-            }
-            finally
-            {
-                EventHubsEventSource.Log.EventSendStop(this.ClientId);
-                EventHubsDiagnosticSource.StopSendActivity(activity, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, eventDatas, sendTask);
-            }
+            await  this.InnerSender.SendAsync(eventDatas, null).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureTests.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using Azure.Messaging.EventHubs.Authorization;
 using NUnit.Framework;
 
@@ -299,7 +300,7 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SharedAccessSignature.ParseSignature" />
+        ///   Verifies functionality of the <see cref="ParseSignature" />
         ///   method.
         /// </summary>
         ///
@@ -309,11 +310,11 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&")]
         public void ParseSignatureFailsWhenComponentsAreMissing(string signature)
         {
-            Assert.That(() => SharedAccessSignature.ParseSignature(signature), Throws.ArgumentException);
+            Assert.That(() => ParseSignature(signature), Throws.ArgumentException);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SharedAccessSignature.ParseSignature" />
+        ///   Verifies functionality of the <see cref="ParseSignature" />
         ///   method.
         /// </summary>
         ///
@@ -325,11 +326,11 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn")]
         public void ParseSignatureFailsWhenValuesAreMissing(string signature)
         {
-            Assert.That(() => SharedAccessSignature.ParseSignature(signature), Throws.ArgumentException);
+            Assert.That(() => ParseSignature(signature), Throws.ArgumentException);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SharedAccessSignature.ParseSignature" />
+        ///   Verifies functionality of the <see cref="ParseSignature" />
         ///   method.
         /// </summary>
         ///
@@ -339,11 +340,11 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=hello&skn=keykeykey")]
         public void ParseSignatureFailsWhenExpirationIsInvalid(string signature)
         {
-            Assert.That(() => SharedAccessSignature.ParseSignature(signature), Throws.ArgumentException);
+            Assert.That(() => ParseSignature(signature), Throws.ArgumentException);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SharedAccessSignature.ParseSignature" />
+        ///   Verifies functionality of the <see cref="ParseSignature" />
         ///   method.
         /// </summary>
         ///
@@ -355,11 +356,11 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F  &sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D& se=1562258488&skn=keykeykey")]
         public void ParseToleratesExtraSpacing(string signature)
         {
-            Assert.That(() => SharedAccessSignature.ParseSignature(signature), Throws.Nothing);
+            Assert.That(() => ParseSignature(signature), Throws.Nothing);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SharedAccessSignature.ParseSignature" />
+        ///   Verifies functionality of the <see cref="ParseSignature" />
         ///   method.
         /// </summary>
         ///
@@ -368,11 +369,11 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey")]
         public void ParseToleratesTrailingDelimiters(string signature)
         {
-            Assert.That(() => SharedAccessSignature.ParseSignature(signature), Throws.Nothing);
+            Assert.That(() => ParseSignature(signature), Throws.Nothing);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SharedAccessSignature.ParseSignature" />
+        ///   Verifies functionality of the <see cref="ParseSignature" />
         ///   method.
         /// </summary>
         ///
@@ -381,11 +382,11 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&fale=test&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey")]
         public void ParseToleratesExtraTokens(string signature)
         {
-            Assert.That(() => SharedAccessSignature.ParseSignature(signature), Throws.Nothing);
+            Assert.That(() => ParseSignature(signature), Throws.Nothing);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SharedAccessSignature.ParseSignature" />
+        ///   Verifies functionality of the <see cref="ParseSignature" />
         ///   method.
         /// </summary>
         ///
@@ -393,7 +394,7 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         public void ParseExtractsValues()
         {
             var signature = "SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey";
-            var parsed = SharedAccessSignature.ParseSignature(signature);
+            var parsed = ParseSignature(signature);
 
             Assert.That(parsed, Is.Not.Null, "There should have been a result returned.");
             Assert.That(parsed.Resource, Is.Not.Null.Or.Empty, "The resource should have been parsed.");
@@ -465,7 +466,7 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SharedAccessSignature.ParseSignature" />
+        ///   Verifies functionality of the <see cref="ParseSignature" />
         ///   method.
         /// </summary>
         ///
@@ -479,7 +480,7 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
             var validFor = TimeSpan.FromMinutes(30);
             var expiration = DateTime.UtcNow.Add(validFor);
             var signature = new SharedAccessSignature(TransportType.AmqpTcp, host, path, keyName, key, validFor);
-            var parsed = SharedAccessSignature.ParseSignature(signature.ToString());
+            var parsed = ParseSignature(signature.ToString());
 
             Assert.That(parsed, Is.Not.Null, "There should have been a result returned.");
             Assert.That(parsed.Resource, Contains.Substring(host.ToLower()), "The resource should contain the host.");
@@ -510,6 +511,30 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
             Assert.That(clone.SharedAccessKeyName, Is.EqualTo(signature.SharedAccessKeyName), "The key name should match.");
             Assert.That(clone.SharedAccessKey, Is.EqualTo(signature.SharedAccessKey), "The key should match.");
             Assert.That(clone.ExpirationUtc, Is.EqualTo(signature.ExpirationUtc), "The expiration should match.");
+        }
+
+        /// <summary>
+        ///  A test shim to allow direct access to the implementation of signature parsing
+        ///  within the <see cref="SharedAccessSignature" />.
+        /// </summary>
+        ///
+        /// <param name="sharedAccessSignature">The shared access signature to parse.</param>
+        ///
+        /// <returns>The set of composite properties parsed from the signature.</returns>
+        ///
+        private static (string KeyName, string Resource, DateTime ExpirationUtc) ParseSignature(string sharedAccessSignature)
+        {
+            try
+            {
+                return ((string KeyName, string Resource, DateTime ExpirationUtc))
+                    typeof(SharedAccessSignature)
+                        .GetMethod(nameof(ParseSignature), BindingFlags.Static | BindingFlags.NonPublic)
+                        .Invoke(null, new object[] { sharedAccessSignature });
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
+            {
+                throw ex.InnerException;
+            }
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
@@ -380,6 +380,10 @@ namespace Azure.Messaging.EventHubs.Tests
             }
         }
 
+        /// <summary>
+        ///   Allows for observation of operations performed by the client for testing purposes.
+        /// </summary>
+        ///
         private class ObservableClientMock : TrackOne.EventHubClient
         {
             public bool WasCloseAsyncInvoked;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventSenderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventSenderTests.cs
@@ -1,0 +1,314 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Compatibility;
+using NUnit.Framework;
+using TrackOne;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="TrackOneEventSender" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class TrackOneEventSenderTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheSenderFactory()
+        {
+            Assert.That(() => new TrackOneEventSender(null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventSender.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        [TestCase("someValue")]
+        [TestCase(" ")]
+        public async Task SendAsyncForwardsThePartitionHashKey(string expectedHashKey)
+        {
+            var options = new EventBatchingOptions { PartitionKey = expectedHashKey };
+            var mock = new ObservableSenderMock(new ClientMock(), null);
+            var sender = new TrackOneEventSender(() => mock);
+
+            await sender.SendAsync(new[] { new EventData(new byte[] { 0x43 }) }, options, CancellationToken.None);
+            Assert.That(mock.SendCalledWithParameters, Is.Not.Null, "The Send request should have been delegated.");
+
+            (_, var actualHashKey) = mock.SendCalledWithParameters;
+            Assert.That(actualHashKey, Is.EqualTo(expectedHashKey), "The partition hash key should have been forwarded.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventSender.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendAsyncTransformsSimpleEvents()
+        {
+            var sourceEvents = new[]
+            {
+                new EventData(Encoding.UTF8.GetBytes("FirstValue")),
+                new EventData(Encoding.UTF8.GetBytes("Second")),
+                new EventData(new byte[] { 0x11, 0x22, 0x33 })
+            };
+
+            var options = new EventBatchingOptions();
+            var mock = new ObservableSenderMock(new ClientMock(), null);
+            var sender = new TrackOneEventSender(() => mock);
+
+            await sender.SendAsync(sourceEvents, options, CancellationToken.None);
+            Assert.That(mock.SendCalledWithParameters, Is.Not.Null, "The Send request should have been delegated.");
+
+            var sentEvents = mock.SendCalledWithParameters.Events.ToArray();
+            Assert.That(sentEvents.Length, Is.EqualTo(sourceEvents.Length), "The number of events sent should match the number of source events.");
+
+            // The events should not only be structurally equivilent, the ordering of them should be preserved.  Compare the
+            // sequence in order and validate that the events in each position are equivilent.
+
+            for (var index = 0; index < sentEvents.Length; ++index)
+            {
+                Assert.That(CompareEventData(sentEvents[index], sourceEvents[index]), Is.True, $"The sequence of events sent should match; they differ at index: { index }");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventSender.SendAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendAsyncTransformsComplexEvents()
+        {
+            var sourceEvents = new[]
+            {
+                new EventData(Encoding.UTF8.GetBytes("FirstValue")),
+                new EventData(Encoding.UTF8.GetBytes("Second")),
+                new EventData(new byte[] { 0x11, 0x22, 0x33 })
+            };
+
+            for (var index = 0; index < sourceEvents.Length; ++index)
+            {
+                sourceEvents[index].Properties["type"] = typeof(TrackOneEventSender).Name;
+                sourceEvents[index].Properties["arbitrary"] = index;
+            }
+
+            var options = new EventBatchingOptions();
+            var mock = new ObservableSenderMock(new ClientMock(), null);
+            var sender = new TrackOneEventSender(() => mock);
+
+            await sender.SendAsync(sourceEvents, options, CancellationToken.None);
+            Assert.That(mock.SendCalledWithParameters, Is.Not.Null, "The Send request should have been delegated.");
+
+            var sentEvents = mock.SendCalledWithParameters.Events.ToArray();
+            Assert.That(sentEvents.Length, Is.EqualTo(sourceEvents.Length), "The number of events sent should match the number of source events.");
+
+            // The events should not only be structurally equivilent, the ordering of them should be preserved.  Compare the
+            // sequence in order and validate that the events in each position are equivilent.
+
+            for (var index = 0; index < sentEvents.Length; ++index)
+            {
+                Assert.That(CompareEventData(sentEvents[index], sourceEvents[index]), Is.True, $"The sequence of events sent should match; they differ at index: { index }");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventSender.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncDoesNotDelegateIfTheSenderWasNotCreated()
+        {
+            var mock = new ObservableSenderMock(new ClientMock(), null);
+            var sender = new TrackOneEventSender(() => mock);
+
+            await sender.CloseAsync(default);
+            Assert.That(mock.WasCloseAsyncInvoked, Is.False);
+        }
+
+        /// <summaryTrackOneEventSender
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncDelegatesToTheSender()
+        {
+            var mock = new ObservableSenderMock(new ClientMock(), null);
+            var sender = new TrackOneEventSender(() => mock);
+
+            // Invoke an operation to force the sender to be lazily instantiated.  Otherwise,
+            // Close does not delegate the call.
+
+            await sender.SendAsync(new[] { new EventData(new byte[] { 0x12, 0x22 }) }, new EventBatchingOptions(), default);
+            await sender.CloseAsync(default);
+            Assert.That(mock.WasCloseAsyncInvoked, Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CompareEventData" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void CompareEventDataDetectsDifferentBodies()
+        {
+            var trackOneEvent = new TrackOne.EventData(new byte[] { 0x22, 0x44 });
+            var trackTwoEvent = new EventData(new byte[] { 0x11, 0x33 });
+
+            Assert.That(CompareEventData(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CompareEventData" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void CompareEventDataDetectsDifferentProperties()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            var trackTwoEvent = new EventData((byte[])body.Clone());
+
+            trackOneEvent.Properties["test"] = "trackOne";
+            trackTwoEvent.Properties["test"] = "trackTwo";
+
+            Assert.That(CompareEventData(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Compares event data between its representations in track one and
+        ///   track two to determine if the instances represent the same event.
+        /// </summary>
+        ///
+        /// <param name="trackOneEvent">The track one event to consider.</param>
+        /// <param name="trackTwoEvent">The track two event to consider.</param>
+        ///
+        /// <returns><c>true</c>, if the two events are structurally equivilent; otherwise, <c>false</c>.</returns>
+        ///
+        private bool CompareEventData(TrackOne.EventData trackOneEvent,
+                                      EventData trackTwoEvent)
+        {
+            // If the events are the same instance, they're equal.  This should only happen
+            // if both are null, since the types differ.
+
+            if (Object.ReferenceEquals(trackOneEvent, trackTwoEvent))
+            {
+                return true;
+            }
+
+            // If one or the other is null, then they cannot be equal, since we know that
+            // they are not both null.
+
+            if ((trackOneEvent == null) || (trackTwoEvent == null))
+            {
+                return false;
+            }
+
+            // If the contents of each body is not equal, the events are not
+            // equal.
+
+            var trackOneBody = trackOneEvent.Body.ToArray();
+            var trackTwoBody = trackTwoEvent.Body.ToArray();
+
+            if (trackOneBody.Length != trackTwoBody.Length)
+            {
+                return false;
+            }
+
+            if (!Enumerable.SequenceEqual(trackOneBody, trackTwoBody))
+            {
+                return false;
+            }
+
+            // Since we know that the event bodies are equal, if the property sets are the same instance,
+            // then we know that the events are equal.  This should only happen if both are null.
+
+            if (Object.ReferenceEquals(trackOneEvent.Properties, trackTwoEvent.Properties))
+            {
+                return true;
+            }
+
+            // If either property is null, then the events are not equal, since we know that they are
+            // not both null.
+
+            if ((trackOneEvent.Properties == null) || (trackTwoEvent.Properties == null))
+            {
+                return false;
+            }
+
+            // The only meaningful comparison left is to ensure that the property sets are equivilent,
+            // the outcome of this check is the final word on equality.
+
+            if (trackOneEvent.Properties.Count != trackTwoEvent.Properties.Count)
+            {
+                return false;
+            }
+
+            return trackOneEvent.Properties.OrderBy(kvp => kvp.Key).SequenceEqual(trackTwoEvent.Properties.OrderBy(kvp => kvp.Key));
+        }
+
+        /// <summary>
+        ///   Allows for observation of operations performed by the sender for testing purposes.
+        /// </summary>
+        ///
+        private class ObservableSenderMock : TrackOne.EventDataSender
+        {
+            public bool WasCloseAsyncInvoked;
+            public string ConstructedWithPartition;
+            public (IEnumerable<TrackOne.EventData> Events, string PartitionKey) SendCalledWithParameters;
+
+            public ObservableSenderMock(TrackOne.EventHubClient eventHubClient, string partitionId) : base(eventHubClient, partitionId)
+            {
+                ConstructedWithPartition = partitionId;
+            }
+
+            public override Task CloseAsync()
+            {
+                WasCloseAsyncInvoked = true;
+                return Task.CompletedTask;
+            }
+
+            protected override Task OnSendAsync(IEnumerable<TrackOne.EventData> eventDatas, string partitionKey)
+            {
+                SendCalledWithParameters = (eventDatas, partitionKey);
+                return Task.CompletedTask;
+            }
+        }
+
+        /// <summary>
+        ///   Allows easy creation of a non-functioning client for testing purposes.
+        /// </summary>
+        ///
+        private class ClientMock : TrackOne.EventHubClient
+        {
+            public ClientMock() : base(new TrackOne.EventHubsConnectionStringBuilder(new Uri("http://my.hub.com"), "aPath", "keyName", "KEY!"))
+            {
+            }
+
+            protected override Task OnCloseAsync() => Task.CompletedTask;
+            protected override PartitionReceiver OnCreateReceiver(string consumerGroupName, string partitionId, TrackOne.EventPosition eventPosition, long? epoch, ReceiverOptions receiverOptions) => default;
+            protected override Task<EventHubPartitionRuntimeInformation> OnGetPartitionRuntimeInformationAsync(string partitionId) => Task.FromResult(default(EventHubPartitionRuntimeInformation));
+            protected override Task<EventHubRuntimeInformation> OnGetRuntimeInformationAsync() => Task.FromResult(default(EventHubRuntimeInformation));
+            internal override EventDataSender OnCreateEventSender(string partitionId) => default;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneSharedAccessSignatureTokenProviderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneSharedAccessSignatureTokenProviderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Authorization;
 using Azure.Messaging.EventHubs.Compatibility;
@@ -91,13 +92,36 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void GetTokenAsyncValidatesTheResource()
+        [TestCase("amqps://my.eventhubs.com")]
+        [TestCase("amqps://my.eventhubs.com/otherHub")]
+        [TestCase("amqps://other.eventhubs.com/someHub")]
+        [TestCase("https://my.eventhubs.com/someHub")]
+        public void GetTokenAsyncDisallowsInvalideResources(string invalidResource)
         {
-            var signature = new SharedAccessSignature("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey", "ABC123");
-            var wrongResource = signature.Resource + "DOES_NOT-MATCH";
+            var resource = WebUtility.UrlEncode("amqps://my.eventhubs.com/someHub");
+            var signature = new SharedAccessSignature($"SharedAccessSignature sr={ resource }&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey", "ABC123");
             var provider = new TrackOneSharedAccessTokenProvider(signature);
 
-            Assert.That(async () => await provider.GetTokenAsync(wrongResource, TimeSpan.FromHours(4)), Throws.InstanceOf<ArgumentException>());
+            Assert.That(async () => await provider.GetTokenAsync(invalidResource, TimeSpan.FromHours(4)), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneSharedAccessTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("amqps://my.eventhubs.com/someHub")]
+        [TestCase("amqps://my.eventhubs.com/someHub/partition")]
+        [TestCase("amqps://my.eventhubs.com/someHub/partition/0")]
+        [TestCase("amqps://my.eventhubs.com/someHub/management")]
+        public void GetTokenAsyncAllowsValidResources(string validResource)
+        {
+            var resource = WebUtility.UrlEncode("amqps://my.eventhubs.com/someHub");
+            var signature = new SharedAccessSignature($"SharedAccessSignature sr={ resource }&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey", "ABC123");
+            var provider = new TrackOneSharedAccessTokenProvider(signature);
+
+            Assert.That(async () => await provider.GetTokenAsync(validResource, TimeSpan.FromHours(4)), Throws.Nothing);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventReceivers/ReceiverOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventReceivers/ReceiverOptionsTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="ReceiverOptions" />
+    ///   The suite of tests for the <see cref="EventReceiverOptions" />
     ///   class.
     /// </summary>
     ///
@@ -12,14 +12,14 @@ namespace Azure.Messaging.EventHubs.Tests
     public class ReceiverOptionsTests
     {
         /// <summary>
-        ///   Verifies functionality of the <see cref="ReceiverOptions.Clone" />
+        ///   Verifies functionality of the <see cref="EventReceiverOptions.Clone" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void CloneProducesACopy()
         {
-            var options = new ReceiverOptions
+            var options = new EventReceiverOptions
             {
                 ConsumerGroup = "custom$consumer",
                 BeginReceivingAt = EventPosition.FromOffset(65),
@@ -43,7 +43,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///  Verifies that setting the <see cref="ReceiverOptions.PrefetchCount" /> is
+        ///  Verifies that setting the <see cref="EventReceiverOptions.PrefetchCount" /> is
         ///  validated.
         /// </summary>
         ///
@@ -55,7 +55,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///  Verifies that setting the <see cref="ReceiverOptions.Identifier" /> is
+        ///  Verifies that setting the <see cref="EventReceiverOptions.Identifier" /> is
         ///  validated.
         /// </summary>
         ///
@@ -69,18 +69,18 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="ReceiverOptions.DefaultMaximumReceiveWaitTime" />
+        ///   Verifies functionality of the <see cref="EventReceiverOptions.DefaultMaximumReceiveWaitTime" />
         ///   property.
         /// </summary>
         ///
         [Test]
         public void DefaultMaximumReceiveWaitTimeIsValidated()
         {
-            Assert.That(() => new ReceiverOptions { DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(-1) }, Throws.ArgumentException);
+            Assert.That(() => new EventReceiverOptions { DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(-1) }, Throws.ArgumentException);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SenderOptions.Timeout" />
+        ///   Verifies functionality of the <see cref="EventSenderOptions.Timeout" />
         ///   property.
         /// </summary>
         ///
@@ -89,7 +89,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(0)]
         public void DefaultMaximumReceiveWaitTimeUsesNormalizesValueINotSpecified(int? noTimeoutValue)
         {
-            var options = new ReceiverOptions();
+            var options = new EventReceiverOptions();
             var timeoutValue = (noTimeoutValue.HasValue) ? TimeSpan.Zero : (TimeSpan?)null;
 
             options.DefaultMaximumReceiveWaitTime = timeoutValue;
@@ -98,14 +98,14 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   A mock of the <see cref="ReceiverOptions" /> to allow the protected validation
+        ///   A mock of the <see cref="EventReceiverOptions" /> to allow the protected validation
         ///   constants to be referenced.
         /// </summary>
         ///
-        private class MockOptions : ReceiverOptions
+        private class MockOptions : EventReceiverOptions
         {
-            public int MinPrefixCount => ReceiverOptions.MinimumPrefetchCount;
-            public int MaxIdentifierLength => ReceiverOptions.MaximumIdentifierLength;
+            public int MinPrefixCount => EventReceiverOptions.MinimumPrefetchCount;
+            public int MaxIdentifierLength => EventReceiverOptions.MaximumIdentifierLength;
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/EventSenderLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/EventSenderLiveTests.cs
@@ -1,0 +1,185 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Tests.Infrastructure;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of live tests for the <see cref="EventSender" />
+    ///   class.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   These tests have a depenency on live Azure services and may
+    ///   incur costs for the assocaied Azure subscription.
+    /// </remarks>
+    ///
+    [TestFixture]
+    [Category(TestCategory.Live)]
+    [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    public class EventSenderLiveTests
+    {
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SenderWithNoOptionsCanSend()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString))
+                await using (var sender = client.CreateSender())
+                {
+                    var events = new[] { new EventData(Encoding.UTF8.GetBytes("AWord")) };
+                    Assert.That(async () => await sender.SendAsync(events), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SenderWithOptionsCanSend()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+                var senderOptions = new EventSenderOptions { Retry = new ExponentialRetry(TimeSpan.FromSeconds(0.25), TimeSpan.FromSeconds(45), 5) };
+
+                await using (var client = new EventHubClient(connectionString))
+                await using (var sender = client.CreateSender(senderOptions))
+                {
+                    var events = new[] { new EventData(Encoding.UTF8.GetBytes("AWord")) };
+                    Assert.That(async () => await sender.SendAsync(events), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SenderCanSendToASpecificPartition()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var partition = (await client.GetPartitionIdsAsync()).First();
+                    var senderOptions = new EventSenderOptions { PartitionId = partition };
+
+                    await using (var sender = client.CreateSender(senderOptions))
+                    {
+                        var events = new[] { new EventData(Encoding.UTF8.GetBytes("AWord")) };
+                        Assert.That(async () => await sender.SendAsync(events), Throws.Nothing);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SenderCanSendEventsWithCustomProperties()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var events = new[]
+                {
+                    new EventData(new byte[] { 0x22, 0x33 }),
+                    new EventData(Encoding.UTF8.GetBytes("This is a really long string of stuff that I wanted to type because I like to")),
+                    new EventData(Encoding.UTF8.GetBytes("I wanted to type because I like to")),
+                    new EventData(Encoding.UTF8.GetBytes("If you are reading this, you really like test cases"))
+                };
+
+                for (var index = 0; index < events.Length; ++index)
+                {
+                    events[index].Properties[index.ToString()] = "some value";
+                    events[index].Properties["Type"] = $"com.microsoft.test.Type{ index }";
+                }
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString))
+                await using (var sender = client.CreateSender())
+                {
+                    Assert.That(async () => await sender.SendAsync(events), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SenderCanSendEventsUsingAPartitionHashHey()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var events = Enumerable
+                    .Range(0, 25)
+                    .Select(index => new EventData(Encoding.UTF8.GetBytes(new String('X', index + 5))));
+
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString))
+                await using (var sender = client.CreateSender())
+                {
+                    var batchOptions = new EventBatchingOptions { PartitionKey = "some123key-!d" };
+                    Assert.That(async () => await sender.SendAsync(events, batchOptions), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubClient" /> is able to
+        ///   connect to the Event Hubs service.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SenderCanSendMultipleBatchesOfEventsUsingAPartitionHashHey()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var batchOptions = new EventBatchingOptions { PartitionKey = "some123key-!d" };
+
+                for (var index = 0; index < 5; ++index)
+                {
+                    var events = Enumerable
+                        .Range(0, 25)
+                        .Select(index => new EventData(Encoding.UTF8.GetBytes(new String((char)(65 + index), index + 5))));
+
+                    var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                    await using (var client = new EventHubClient(connectionString))
+                    await using (var sender = client.CreateSender())
+                    {
+                        Assert.That(async () => await sender.SendAsync(events, batchOptions), Throws.Nothing, $"Batch { index } should not have thrown an exception.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/EventSenderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/EventSenderTests.cs
@@ -1,0 +1,219 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventSender" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventSenderTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheSender()
+        {
+            Assert.That(() => new EventSender(null, "dummy", new EventSenderOptions()), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheEventHubPath(string eventHubPath)
+        {
+            Assert.That(() => new EventSender(new ObservableTransportSenderMock(), eventHubPath, new EventSenderOptions()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheOptions()
+        {
+            Assert.That(() => new EventSender(new ObservableTransportSenderMock(), "dummy", null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("123")]
+        [TestCase(" ")]
+        [TestCase("someValue")]
+        public void ConstructorSetsTheEventHubPath(string eventHubPath)
+        {
+            var sender = new EventSender(new ObservableTransportSenderMock(), eventHubPath, new EventSenderOptions());
+            Assert.That(sender.EventHubPath, Is.EqualTo(eventHubPath));
+        }
+
+        /// <summary>
+        ///   Verifies finctionality of the <see cref="EventSender.SendAsync"/>
+        /// </summary>
+        ///
+        [Test]
+        public void SendWithoutOptionsRequiresEvents()
+        {
+            var transportSender = new ObservableTransportSenderMock();
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions());
+
+            Assert.That(async () => await sender.SendAsync(null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies finctionality of the <see cref="EventSender.SendAsync"/>
+        /// </summary>
+        ///
+        [Test]
+        public void SendRequiresEvents()
+        {
+            var transportSender = new ObservableTransportSenderMock();
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions());
+
+            Assert.That(async () => await sender.SendAsync(null, new EventBatchingOptions()), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies finctionality of the <see cref="EventSender.SendAsync"/>
+        /// </summary>
+        ///
+        [Test]
+        public void SendAllowsAPartitionHashKey()
+        {
+            var batchingOptions = new EventBatchingOptions { PartitionKey = "testKey" };
+            var events = new[] { new EventData(new byte[] { 0x44, 0x66, 0x88 }) };
+            var transportSender = new ObservableTransportSenderMock();
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions());
+
+            Assert.That(async () => await sender.SendAsync(events, batchingOptions), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Verifies finctionality of the <see cref="EventSender.SendAsync"/>
+        /// </summary>
+        ///
+        [Test]
+        public void SendForASpecificPartitionDoesNotAllowAPartitionHashKey()
+        {
+            var batchingOptions = new EventBatchingOptions { PartitionKey = "testKey" };
+            var events = new[] { new EventData(new byte[] { 0x44, 0x66, 0x88 }) };
+            var transportSender = new ObservableTransportSenderMock();
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions{ PartitionId = "1" });
+
+            Assert.That(async () => await sender.SendAsync(events, batchingOptions), Throws.InvalidOperationException);
+        }
+
+        /// <summary>
+        ///   Verifies finctionality of the <see cref="EventSender.SendAsync"/>
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendWithoutOptionsInvokesTheTransportSender()
+        {
+            var events = Mock.Of<IEnumerable<EventData>>();
+            var transportSender = new ObservableTransportSenderMock();
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions());
+
+            await sender.SendAsync(events);
+
+            (var calledWithEvents, var calledWithOptions) = transportSender.SendCalledWithParameters;
+
+            Assert.That(calledWithEvents, Is.SameAs(events), "The events should be the same instance.");
+            Assert.That(calledWithOptions, Is.Not.Null, "A default set of options should be used.");
+        }
+
+        /// <summary>
+        ///   Verifies finctionality of the <see cref="EventSender.SendAsync"/>
+        /// </summary>
+        ///
+        [Test]
+        public async Task SendInvokesTheTransportSender()
+        {
+            var events = Mock.Of<IEnumerable<EventData>>();
+            var options = new EventBatchingOptions();
+            var transportSender = new ObservableTransportSenderMock();
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions());
+
+            await sender.SendAsync(events, options);
+
+            (var calledWithEvents, var calledWithOptions) = transportSender.SendCalledWithParameters;
+
+            Assert.That(calledWithEvents, Is.SameAs(events), "The events should be the same instance.");
+            Assert.That(calledWithOptions, Is.SameAs(options), "The options should be the same instance");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventSender.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncClosesTheTransportSender()
+        {
+            var transportSender = new ObservableTransportSenderMock();
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions());
+
+            await sender.CloseAsync();
+
+            Assert.That(transportSender.WasCloseCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventSender.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloseClosesTheTransportSender()
+        {
+            var transportSender = new ObservableTransportSenderMock();
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions());
+
+            sender.Close();
+
+            Assert.That(transportSender.WasCloseCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Allows for observation of operations performed by the sender for testing purposes.
+        /// </summary>
+        ///
+        private class ObservableTransportSenderMock : TransportEventSender
+        {
+            public bool WasCloseCalled = false;
+            public (IEnumerable<EventData>, EventBatchingOptions) SendCalledWithParameters;
+
+            public override Task SendAsync(IEnumerable<EventData> events,
+                                           EventBatchingOptions batchOptions,
+                                           CancellationToken cancellationToken)
+            {
+                SendCalledWithParameters = (events, batchOptions);
+                return Task.CompletedTask;
+            }
+
+            public override Task CloseAsync(CancellationToken cancellationToken)
+            {
+                WasCloseCalled = true;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/SenderOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/SenderOptionsTests.cs
@@ -4,7 +4,7 @@ using NUnit.Framework;
 namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
-    ///   The suite of tests for the <see cref="SenderOptions" />
+    ///   The suite of tests for the <see cref="EventSenderOptions" />
     ///   class.
     /// </summary>
     ///
@@ -12,14 +12,14 @@ namespace Azure.Messaging.EventHubs.Tests
     public class SenderOptionsTests
     {
         /// <summary>
-        ///   Verifies functionality of the <see cref="SenderOptions.Clone" />
+        ///   Verifies functionality of the <see cref="EventSenderOptions.Clone" />
         ///   method.
         /// </summary>
         ///
         [Test]
         public void CloneProducesACopy()
         {
-            var options = new SenderOptions
+            var options = new EventSenderOptions
             {
                 PartitionId = "some_partition_id_123",
                 Retry = new ExponentialRetry(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(5), 6),
@@ -37,18 +37,18 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SenderOptions.Timeout" />
+        ///   Verifies functionality of the <see cref="EventSenderOptions.Timeout" />
         ///   property.
         /// </summary>
         ///
         [Test]
         public void DefaultTimeoutIsValidated()
         {
-            Assert.That(() => new SenderOptions { Timeout = TimeSpan.FromMilliseconds(-1) }, Throws.ArgumentException);
+            Assert.That(() => new EventSenderOptions { Timeout = TimeSpan.FromMilliseconds(-1) }, Throws.ArgumentException);
         }
 
         /// <summary>
-        ///   Verifies functionality of the <see cref="SenderOptions.Timeout" />
+        ///   Verifies functionality of the <see cref="EventSenderOptions.Timeout" />
         ///   property.
         /// </summary>
         ///
@@ -57,7 +57,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(0)]
         public void DefaultTimeoutUsesDefaultValueIfNormalizesValueINotSpecified(int? noTimeoutValue)
         {
-            var options = new SenderOptions();
+            var options = new EventSenderOptions();
             var timeoutValue = (noTimeoutValue.HasValue) ? TimeSpan.Zero : (TimeSpan?)null;
 
             options.Timeout = timeoutValue;


### PR DESCRIPTION
# Summary

The intent of these changes is to complete the end-to-end infrastructure for sending events via the `EventSender`, from the API surface through the compatibility shim for the track one implementation.  Client operations have been validated at the unit level and basic sending scenarios have been smoke tested through Live tests.  

# Goals

- Ensure that an `EventSender` creates a transport-aware sender for containment to which it delegates operations.  This is based on an abstraction to isolate transport-level concerns from the core class, allowing different protocols, transports, compatibility shims, and test infrastructure to be used for delegation.

- Broker the compatibility between the track two API and the track one `EventDataSender` implementation, mapping types as needed.  Chief among them is mapping of the `EventData` model between the track one and track two incarnations.

- Allow for creation of an `EventSender` that is capable of interacting with the Event Hubs service for sending of events to either a specific partition or to the general Event Hub gateway for automatic partition routing.

- Review and revise the public surface area of the implementation, reducing scope as possible by internalizing constructs intended only to support project-level testing.

# Non-Goals

- Providing the implementation for the compatibility layer between the track two and track one `EventReceiver`; this will happen as part of future efforts.

- Supporting validation or other authorization-related tasks for non-SAS credential types; this will happen as part of future efforts.

- Cover the identified set of end-to-end live tests needed to fully exercise the target scenarios; this will happen as part of future efforts.

- Inclusion of the full set of supporting assets, such as README, samples, and ARM templates; these will happen as part of future efforts.

- Enabling test parallelism; this will be a stretch goal, but unlikely to occur in the time frame for the first track two preview.

# Details       

### General

- Ongoing review and updates to member visibility to reduce public scope and limit protected members.

- Shifting to a reflection-based approach over `internal` members for areas where the testing is focused in a tight scope.

###  Track One Token Provider

- Allowed for sub-paths of an event hub instance to be considered valid, which is needed for support of partition-based senders and receivers.

###  Event Sender

- Fleshed out the prototype skeleton to complete functionality using an abstraction for the transport-level concerns, making use of a compatibility shim to bridge to the track one `EventDataSender`.

###   Event Data Sender (Track One)

- Moved diagnostics and logging functionality into the core `EventDataSender` and out of the consuming classes (`PartitionSender` and `EventHubClient`) to remove duplication and allow the track two implementation to make use of the functionality implicitly.

###  Live Tests

- Added basic scenarios around the sending of events to smoke test the end-to-end scenarios; these will be extended with more complete coverage in a future workstream.

# Last Upstream Rebase

Tuesday, June 11, 2019  3:08pm (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)