### PR TITLE
Add None backcompat option to RecordedTestMode and use it

### DIFF
--- a/eng/pipelines/templates/jobs/tests.yml
+++ b/eng/pipelines/templates/jobs/tests.yml
@@ -69,7 +69,7 @@ jobs:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
-          AZURE_TEST_MODE: "Live"
+          AZURE_TEST_MODE: "None"
           ${{ each envvar in parameters.envvars }}:
             ${{ envvar.key }}: ${{ envvar.value }}
 

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordedTestMode.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordedTestMode.cs
@@ -7,6 +7,8 @@ namespace Azure.Core.Testing
     {
         Live,
         Record,
-        Playback
+        Playback,
+        // Backcompat with Track 1
+        None = Live
     }
 }


### PR DESCRIPTION
Track 1 uses `None` to represent live tests.