### PR TITLE
Fix assembly info for cogservices.luis.authoring

### DIFF
--- a/sdk/cognitiveservices/Language.LUIS.Authoring/src/Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.csproj
+++ b/sdk/cognitiveservices/Language.LUIS.Authoring/src/Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring.csproj
@@ -17,7 +17,6 @@
     5. Fix some spelling mistakes in the API documentation.
     ]]>
     </PackageReleaseNotes>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
The Microsoft.Azure.CognitiveServices.Language.LUIS.Authoring
project incorrectly had disabled GenerateAssemblyInfo and as a
result the version and copyright information was not correctly
embedded into the assembly.

cc @chidozieononiwu 