### PR TITLE
Fix ResponseExceptionExtensions type name

### DIFF
--- a/sdk/core/Azure.Core/src/ResponseExceptionExtensions.cs
+++ b/sdk/core/Azure.Core/src/ResponseExceptionExtensions.cs
@@ -10,7 +10,7 @@ using Azure.Core.Pipeline.Policies;
 
 namespace Azure.Core
 {
-    public static class ResponseExceptionExtensionsExtensions
+    public static class ResponseExceptionExtensions
     {
         private const string DefaultMessage = "Service request failed.";
 

--- a/sdk/storage/Azure.Storage.Common/src/StorageRequestFailedException.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageRequestFailedException.cs
@@ -70,7 +70,7 @@ namespace Azure.Storage
         /// <returns>A new StorageRequestFailedException.</returns>
         public static async Task<StorageRequestFailedException> CreateAsync(Response response, string message)
         {
-            message = await ResponseExceptionExtensionsExtensions.CreateRequestFailedMessageAsync(message, response, true).ConfigureAwait(false);
+            message = await ResponseExceptionExtensions.CreateRequestFailedMessageAsync(message, response, true).ConfigureAwait(false);
             return new StorageRequestFailedException(response.Status, message, GetRequestId(response));
         }
 
@@ -81,7 +81,7 @@ namespace Azure.Storage
         /// <param name="message">Summary of the failure.</param>
         /// <returns>The request failure message.</returns>
         private static string CreateMessage(Response response, string message)
-            => ResponseExceptionExtensionsExtensions.CreateRequestFailedMessageAsync(message, response, false).GetAwaiter().GetResult();
+            => ResponseExceptionExtensions.CreateRequestFailedMessageAsync(message, response, false).GetAwaiter().GetResult();
 
         /// <summary>
         /// Gets the x-ms-request-id header that uniquely identifies the


### PR DESCRIPTION
Duplicated word extensions in the type name.

### Breaking change (if not used as extensions method)

Before:
```
ResponseExceptionExtensionsExtensions.CreateRequestFailedMessageAsync
```

After:

```
ResponseExceptionExtensions.CreateRequestFailedMessageAsync
```