### PR TITLE
Move RetryPolicy to the base ClientOptions

### DIFF
--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClient.cs
@@ -52,11 +52,8 @@ namespace Azure.ApplicationModel.Configuration
             ParseConnectionString(connectionString, out _baseUri, out var credential, out var secret);
 
             _pipeline = HttpPipelineBuilder.Build(options,
-                    options.RetryPolicy,
-                    ClientRequestIdPolicy.Shared,
-                    new AuthenticationPolicy(credential, secret),
-                    options.LoggingPolicy,
-                    BufferResponsePolicy.Shared);
+                    bufferResponse: true,
+                    new AuthenticationPolicy(credential, secret));
         }
 
         /// <summary>

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientOptions.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientOptions.cs
@@ -1,25 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using Azure.Core.Pipeline;
-using Azure.Core.Pipeline.Policies;
 
 namespace Azure.ApplicationModel.Configuration
 {
     public class ConfigurationClientOptions: ClientOptions
     {
-        public RetryPolicy RetryPolicy { get; set; }
-
-        public ConfigurationClientOptions()
-        {
-            RetryPolicy = new RetryPolicy()
-            {
-                Mode = RetryMode.Fixed,
-                Delay =  TimeSpan.Zero,
-                MaxRetries = 3
-            };
-        }
-
     }
 }

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
@@ -2,16 +2,19 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
+using Azure.Core.Pipeline.Policies;
 
 namespace Azure.Core.Pipeline
 {
     public static class HttpPipelineBuilder
     {
-        public static HttpPipeline Build(ClientOptions options, params HttpPipelinePolicy[] clientPolicies)
+        public static HttpPipeline Build(ClientOptions options, bool bufferResponse = true, params HttpPipelinePolicy[] clientPolicies)
         {
             var policies = new List<HttpPipelinePolicy>();
 
             policies.AddRange(options.PerCallPolicies);
+
+            policies.Add(ClientRequestIdPolicy.Shared);
 
             policies.Add(options.TelemetryPolicy);
 
@@ -20,6 +23,11 @@ namespace Azure.Core.Pipeline
             policies.AddRange(options.PerRetryPolicies);
 
             policies.Add(options.LoggingPolicy);
+
+            if (bufferResponse)
+            {
+                policies.Add(BufferResponsePolicy.Shared);
+            }
 
             policies.RemoveAll(policy => policy == null);
 

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineBuilder.cs
@@ -18,6 +18,8 @@ namespace Azure.Core.Pipeline
 
             policies.Add(options.TelemetryPolicy);
 
+            policies.Add(options.RetryPolicy);
+
             policies.AddRange(clientPolicies);
 
             policies.AddRange(options.PerRetryPolicies);

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
@@ -30,6 +30,8 @@ namespace Azure.Core.Pipeline
 
         public LoggingPolicy LoggingPolicy { get; set; }
 
+        public RetryPolicy RetryPolicy { get; set; }
+
         public ResponseClassifier ResponseClassifier { get; set; } = new ResponseClassifier();
 
         public IList<HttpPipelinePolicy> PerCallPolicies { get; } = new List<HttpPipelinePolicy>();

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
@@ -19,6 +19,7 @@ namespace Azure.Core.Pipeline
 
             TelemetryPolicy = new TelemetryPolicy(name, version);
             LoggingPolicy = LoggingPolicy.Shared;
+            RetryPolicy = new RetryPolicy();
         }
 
         public HttpPipelineTransport Transport {

--- a/sdk/identity/Azure.Identity/src/IdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/IdentityClient.cs
@@ -18,7 +18,7 @@ namespace Azure.Identity
 {
     internal class IdentityClient
     {
-        private static Lazy<IdentityClient> s_sharedClient = new Lazy<IdentityClient>(() => new IdentityClient()); 
+        private static Lazy<IdentityClient> s_sharedClient = new Lazy<IdentityClient>(() => new IdentityClient());
 
         private readonly IdentityClientOptions _options;
         private readonly HttpPipeline _pipeline;
@@ -29,10 +29,7 @@ namespace Azure.Identity
         {
             _options = options ?? new IdentityClientOptions();
 
-            _pipeline = HttpPipelineBuilder.Build(_options,
-                    _options.RetryPolicy,
-                    ClientRequestIdPolicy.Shared,
-                    BufferResponsePolicy.Shared);
+            _pipeline = HttpPipelineBuilder.Build(_options, bufferResponse: true);
         }
 
         public static IdentityClient SharedClient { get { return s_sharedClient.Value; } }

--- a/sdk/identity/Azure.Identity/src/IdentityClientOptions.cs
+++ b/sdk/identity/Azure.Identity/src/IdentityClientOptions.cs
@@ -12,19 +12,11 @@ namespace Azure.Identity
         private readonly static Uri DefaultAuthorityHost = new Uri("https://login.microsoftonline.com/");
         private readonly static TimeSpan DefaultRefreshBuffer = TimeSpan.FromMinutes(2);
 
-        public RetryPolicy RetryPolicy { get; set; }
-
         public Uri AuthorityHost { get; set; }
 
         public IdentityClientOptions()
         {
             AuthorityHost = DefaultAuthorityHost;
-            RetryPolicy = new RetryPolicy()
-            {
-                Mode = RetryMode.Exponential,
-                Delay = TimeSpan.FromMilliseconds(800),
-                MaxRetries = 3
-            };
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -33,11 +33,8 @@ namespace Azure.Security.KeyVault.Keys
             options = options ?? new KeyClientOptions();
 
             _pipeline = HttpPipelineBuilder.Build(options,
-                    options.RetryPolicy,
-                    ClientRequestIdPolicy.Shared,
-                    new BearerTokenAuthenticationPolicy(credential, "https://vault.azure.net//.default"),
-                    options.LoggingPolicy,
-                    BufferResponsePolicy.Shared);
+                    bufferResponse: true,
+                    new BearerTokenAuthenticationPolicy(credential, "https://vault.azure.net//.default"));
         }
 
         public virtual Response<Key> CreateKey(string name, KeyType keyType, KeyCreateOptions keyOptions = default, CancellationToken cancellationToken = default)
@@ -149,7 +146,7 @@ namespace Azure.Security.KeyVault.Keys
             if (string.IsNullOrEmpty(name)) throw new ArgumentException($"{nameof(name)} can't be empty or null");
 
             Uri firstPageUri = CreateFirstPageUri($"{KeysPath}{name}/versions");
-            
+
             return PageResponseEnumerator.CreateEnumerable(nextLink => GetPage(firstPageUri, nextLink, () => new KeyBase(), cancellationToken));
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
@@ -3,23 +3,10 @@
 // license information.
 
 using Azure.Core.Pipeline;
-using Azure.Core.Pipeline.Policies;
-using System;
 
 namespace Azure.Security.KeyVault.Keys
 {
     public class KeyClientOptions : ClientOptions
     {
-        public RetryPolicy RetryPolicy { get; set; }
-
-        public KeyClientOptions()
-        {
-            RetryPolicy = new RetryPolicy()
-            {
-                Mode = RetryMode.Exponential,
-                Delay = TimeSpan.FromMilliseconds(800),
-                MaxRetries = 3
-            };
-        }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -37,11 +37,8 @@ namespace Azure.Security.KeyVault.Secrets
             options = options ?? new SecretClientOptions();
 
             _pipeline = HttpPipelineBuilder.Build(options,
-                    options.RetryPolicy,
-                    ClientRequestIdPolicy.Shared,
-                    new BearerTokenAuthenticationPolicy(credential, "https://vault.azure.net/.default"),
-                    options.LoggingPolicy,
-                    BufferResponsePolicy.Shared);
+                    bufferResponse: true,
+                    new BearerTokenAuthenticationPolicy(credential, "https://vault.azure.net/.default"));
         }
 
         public virtual async Task<Response<Secret>> GetAsync(string name, string version = null, CancellationToken cancellationToken = default)

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
@@ -2,24 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
-using System;
 using Azure.Core.Pipeline;
-using Azure.Core.Pipeline.Policies;
 
 namespace Azure.Security.KeyVault.Secrets
 {
     public class SecretClientOptions : ClientOptions
     {
-        public RetryPolicy RetryPolicy { get; set; }
-
-        public SecretClientOptions()
-        {
-            RetryPolicy = new RetryPolicy()
-            {
-                Mode = RetryMode.Exponential,
-                Delay = TimeSpan.FromMilliseconds(800),
-                MaxRetries = 3
-            };
-        }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/src/StorageConnectionOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageConnectionOptions.cs
@@ -20,11 +20,6 @@ namespace Azure.Storage
         public IStorageCredentials Credentials { get; set; }
 
         /// <summary>
-        /// HttpPipelinePolicy for automatically retrying failed requests
-        /// </summary>
-        public RetryPolicy RetryPolicy { get; set; }
-
-        /// <summary>
         /// Construct the default options for making service requests that
         /// don't require authentication.
         /// </summary>
@@ -78,13 +73,11 @@ namespace Azure.Storage
         internal virtual HttpPipeline Build()
             => HttpPipelineBuilder.Build(
                 this,
-                ClientRequestIdPolicy.Shared,
-                this.RetryPolicy,
-                this.GetAuthenticationPipelinePolicy(this.Credentials),
                 // TODO: PageBlob's UploadPagesAsync test currently fails
                 // without buffered responses, so I'm leaving this on for now.
                 // It'd be a great perf win to remove it soon.
-                BufferResponsePolicy.Shared);
+                bufferResponse: true,
+                this.GetAuthenticationPipelinePolicy(this.Credentials));
 
         /// <summary>
         /// Create an authentication HttpPipelinePolicy to sign requests


### PR DESCRIPTION
1. Move RetryPolicy to the base ClientOptions
2. Move default policies to HttpPipelineBuilder.Build

### Breaking change

1. Don't pass default policies, use `bufferResponse: true` instead of `BufferResponsePolicy.Shared`

Before
![image](https://user-images.githubusercontent.com/1697911/59302914-e68cd000-8c49-11e9-85b7-88df2ba17d55.png)

After

![image](https://user-images.githubusercontent.com/1697911/59302926-ed1b4780-8c49-11e9-8b53-dabb99dd8e4d.png)

2. Remove RetryPolicy from client options type

``` diff
-         public RetryPolicy RetryPolicy { get; set; } 
```
