### PR TITLE
Add AddPolicy method

### DIFF
--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Sample7_ConfiguringPipeline.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Sample7_ConfiguringPipeline.cs
@@ -36,10 +36,10 @@ namespace Azure.ApplicationModel.Configuration.Samples
             };
 
             // add a policy (custom behavior) that executes once per client call
-            options.PerCallPolicies.Add(new AddHeaderPolicy());
+            options.AddPolicy(HttpPipelinePolicyPosition.PerCall, new AddHeaderPolicy());
 
             // add a policy that executes once per retry
-            options.PerRetryPolicies.Add(new CustomLogPolicy());
+            options.AddPolicy(HttpPipelinePolicyPosition.PerRetry, new CustomLogPolicy());
 
             var connectionString = Environment.GetEnvironmentVariable("APP_CONFIG_CONNECTION");
             // pass the policy options to the client

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Sample7_ConfiguringPipeline.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Sample7_ConfiguringPipeline.cs
@@ -36,10 +36,10 @@ namespace Azure.ApplicationModel.Configuration.Samples
             };
 
             // add a policy (custom behavior) that executes once per client call
-            options.AddPolicy(HttpPipelinePolicyPosition.PerCall, new AddHeaderPolicy());
+            options.AddPolicy(HttpPipelinePosition.PerCall, new AddHeaderPolicy());
 
             // add a policy that executes once per retry
-            options.AddPolicy(HttpPipelinePolicyPosition.PerRetry, new CustomLogPolicy());
+            options.AddPolicy(HttpPipelinePosition.PerRetry, new CustomLogPolicy());
 
             var connectionString = Environment.GetEnvironmentVariable("APP_CONFIG_CONNECTION");
             // pass the policy options to the client

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
@@ -35,14 +35,14 @@ namespace Azure.Core.Pipeline
 
         public ResponseClassifier ResponseClassifier { get; set; } = new ResponseClassifier();
 
-        public void AddPolicy(HttpPipelinePolicyPosition position, HttpPipelinePolicy policy)
+        public void AddPolicy(HttpPipelinePosition position, HttpPipelinePolicy policy)
         {
             switch (position)
             {
-                case HttpPipelinePolicyPosition.PerCall:
+                case HttpPipelinePosition.PerCall:
                     PerCallPolicies.Add(policy);
                     break;
-                case HttpPipelinePolicyPosition.PerRetry:
+                case HttpPipelinePosition.PerRetry:
                     PerRetryPolicies.Add(policy);
                     break;
                 default:

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineOptions.cs
@@ -35,9 +35,24 @@ namespace Azure.Core.Pipeline
 
         public ResponseClassifier ResponseClassifier { get; set; } = new ResponseClassifier();
 
-        public IList<HttpPipelinePolicy> PerCallPolicies { get; } = new List<HttpPipelinePolicy>();
+        public void AddPolicy(HttpPipelinePolicyPosition position, HttpPipelinePolicy policy)
+        {
+            switch (position)
+            {
+                case HttpPipelinePolicyPosition.PerCall:
+                    PerCallPolicies.Add(policy);
+                    break;
+                case HttpPipelinePolicyPosition.PerRetry:
+                    PerRetryPolicies.Add(policy);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(position), position, null);
+            }
+        }
 
-        public IList<HttpPipelinePolicy> PerRetryPolicies { get; } = new List<HttpPipelinePolicy>();
+        internal IList<HttpPipelinePolicy> PerCallPolicies { get; } = new List<HttpPipelinePolicy>();
+
+        internal IList<HttpPipelinePolicy> PerRetryPolicies { get; } = new List<HttpPipelinePolicy>();
 
         private (string ComponentName, string ComponentVersion) GetComponentNameAndVersion()
         {

--- a/sdk/core/Azure.Core/src/Pipeline/PolicyLocation.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/PolicyLocation.cs
@@ -3,7 +3,7 @@
 
 namespace Azure.Core.Pipeline
 {
-    public enum HttpPipelinePolicyPosition
+    public enum HttpPipelinePosition
     {
         PerCall,
         PerRetry

--- a/sdk/core/Azure.Core/src/Pipeline/PolicyLocation.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/PolicyLocation.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Azure.Core.Pipeline
+{
+    public enum HttpPipelinePolicyPosition
+    {
+        PerCall,
+        PerRetry
+    }
+}

--- a/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Pipeline;
+using Azure.Core.Testing;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class HttpPipelineBuilderTest: PolicyTestBase
+    {
+        [Theory]
+        [TestCase(HttpPipelinePolicyPosition.PerCall, 1)]
+        [TestCase(HttpPipelinePolicyPosition.PerRetry, 2)]
+        public async Task CanAddCustomPolicy(HttpPipelinePolicyPosition position, int expectedCount)
+        {
+            var policy = new CounterPolicy();
+            var transport = new MockTransport(new MockResponse(503), new MockResponse(200));
+
+            var options = new TestOptions();
+            options.AddPolicy(position, policy);
+            options.Transport = transport;
+
+            HttpPipeline pipeline = HttpPipelineBuilder.Build(options, false);
+
+            using Request request = transport.CreateRequest();
+            request.Method = HttpPipelineMethod.Get;
+            request.UriBuilder.Uri = new Uri("http://example.com");
+
+            Response response = await pipeline.SendRequestAsync(request, CancellationToken.None);
+
+            Assert.AreEqual(200, response.Status);
+            Assert.AreEqual(expectedCount, policy.ExecutionCount);
+        }
+
+        private class TestOptions : ClientOptions
+        {
+            public TestOptions()
+            {
+                RetryPolicy.Delay = TimeSpan.Zero;
+            }
+        }
+
+        private class CounterPolicy : SynchronousHttpPipelinePolicy
+        {
+            public override void OnSendingRequest(HttpPipelineMessage message)
+            {
+                ExecutionCount++;
+            }
+
+            public int ExecutionCount { get; set; }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineBuilderTest.cs
@@ -13,9 +13,9 @@ namespace Azure.Core.Tests
     public class HttpPipelineBuilderTest: PolicyTestBase
     {
         [Theory]
-        [TestCase(HttpPipelinePolicyPosition.PerCall, 1)]
-        [TestCase(HttpPipelinePolicyPosition.PerRetry, 2)]
-        public async Task CanAddCustomPolicy(HttpPipelinePolicyPosition position, int expectedCount)
+        [TestCase(HttpPipelinePosition.PerCall, 1)]
+        [TestCase(HttpPipelinePosition.PerRetry, 2)]
+        public async Task CanAddCustomPolicy(HttpPipelinePosition position, int expectedCount)
         {
             var policy = new CounterPolicy();
             var transport = new MockTransport(new MockResponse(503), new MockResponse(200));

--- a/sdk/storage/Azure.Storage.Blobs/tests/TestHelper.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/TestHelper.cs
@@ -36,7 +36,7 @@ namespace Azure.Storage.Test
         {
             raise = raise ?? new Exception("Simulated connection fault");
             var options = GetOptions<BlobConnectionOptions>(credentials);
-            options.AddPolicy(HttpPipelinePolicyPosition.PerCall, new FaultyDownloadPipelinePolicy(raiseAt, raise));
+            options.AddPolicy(HttpPipelinePosition.PerCall, new FaultyDownloadPipelinePolicy(raiseAt, raise));
             return options;
         }
         

--- a/sdk/storage/Azure.Storage.Blobs/tests/TestHelper.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/TestHelper.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Core.Pipeline;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs.Specialized;
@@ -35,7 +36,7 @@ namespace Azure.Storage.Test
         {
             raise = raise ?? new Exception("Simulated connection fault");
             var options = GetOptions<BlobConnectionOptions>(credentials);
-            options.PerCallPolicies.Add(new FaultyDownloadPipelinePolicy(raiseAt, raise));
+            options.AddPolicy(HttpPipelinePolicyPosition.PerCall, new FaultyDownloadPipelinePolicy(raiseAt, raise));
             return options;
         }
         

--- a/sdk/storage/Azure.Storage.Files/tests/TestHelper.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/TestHelper.cs
@@ -54,7 +54,7 @@ namespace Azure.Storage.Test
         {
             raise = raise ?? new IOException("Simulated connection fault");
             var options = GetOptions<FileConnectionOptions>(credentials);
-            options.PerCallPolicies.Add(new FaultyDownloadPipelinePolicy(raiseAt, raise));
+            options.AddPolicy(HttpPipelinePolicyPosition.PerCall, new FaultyDownloadPipelinePolicy(raiseAt, raise));
             return options;
         }
 

--- a/sdk/storage/Azure.Storage.Files/tests/TestHelper.cs
+++ b/sdk/storage/Azure.Storage.Files/tests/TestHelper.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using Azure.Core.Pipeline;
 using Azure.Storage.Common;
 using Azure.Storage.Files;
 using Azure.Storage.Files.Models;
@@ -54,7 +55,7 @@ namespace Azure.Storage.Test
         {
             raise = raise ?? new IOException("Simulated connection fault");
             var options = GetOptions<FileConnectionOptions>(credentials);
-            options.AddPolicy(HttpPipelinePolicyPosition.PerCall, new FaultyDownloadPipelinePolicy(raiseAt, raise));
+            options.AddPolicy(HttpPipelinePosition.PerCall, new FaultyDownloadPipelinePolicy(raiseAt, raise));
             return options;
         }
 


### PR DESCRIPTION
As per discussion with @KrzysztofCwalina adding AddPolicy method.

Making PerCallPolicies\PerRetryPolicies internal.

## Breaking change

Before:
```
options.PerCallPolicies.Add(policy);
```
After:
```
options.AddPolicy(HttpPipelinePolicyPosition.PerCall, policy);
```
