### PR TITLE
Remove explicit offloading in TaskExtensionHelper

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/TaskExtensionHelper.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/TaskExtensionHelper.cs
@@ -10,17 +10,20 @@ namespace Microsoft.Azure.ServiceBus.Primitives
     {
         public static void Schedule(Func<Task> func)
         {
-            Task.Run(async () =>
-            {
-                try
-                {
-                    await func().ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    MessagingEventSource.Log.ScheduleTaskFailed(func, ex);
-                }
-            });
+            _ = ScheduleInternal(func);
         }
+
+        static async Task ScheduleInternal(Func<Task> func)
+        {
+            try
+            {
+                await func().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                MessagingEventSource.Log.ScheduleTaskFailed(func, ex);
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Related to Azure Service Bus

TaskExtensionHelper used `Task.Run` to offload `Func<Task>` to the worker thread pool. I checked and all the method that are passed as funcs to that helper are pure async functions and therefore explicitly scheduling with `Task.Run` is not needed because the acquired worker thread will be immediately released after the async operation reached its first await. One could argue that it is even harmful especially when doing transactional sends because then every single phase commit async will increase the pressure on the default task scheduler. 

Old but still good

https://blogs.msdn.microsoft.com/lucian/2013/11/22/talk-async-best-practices/
https://blog.stephencleary.com/2013/11/taskrun-etiquette-examples-dont-use.html