### PR TITLE
Bump to PublicApiApprover 9.1

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -69,7 +69,7 @@
     <PackageReference Update="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.5" />
-    <PackageReference Update="PublicApiGenerator" Version="9.0.0" />
+    <PackageReference Update="PublicApiGenerator" Version="9.1.0" />
     <PackageReference Update="System.Buffers" Version="4.5.0" />
     <PackageReference Update="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Update="System.Collections" Version="4.3.0" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -69,7 +69,7 @@
     <PackageReference Update="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Update="Polly" Version="7.1.0" />
     <PackageReference Update="Portable.BouncyCastle" Version="1.8.5" />
-    <PackageReference Update="PublicApiGenerator" Version="8.1.0" />
+    <PackageReference Update="PublicApiGenerator" Version="9.0.0" />
     <PackageReference Update="System.Buffers" Version="4.5.0" />
     <PackageReference Update="System.Collections.Concurrent" Version="4.3.0" />
     <PackageReference Update="System.Collections" Version="4.3.0" />

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/APIApprovals.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/APIApprovals.cs
@@ -20,11 +20,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.API
         ///   to pass.
         /// </remarks>
         ///
-        #if WINDOWS
         [Fact]
-        #else
-        [Fact(Skip ="This test is only relevant on Windows due to non-deterministic behavior of a third-party library. The ApiGenerator output differs by platform.  The generated code is semantically equivilent, but line ordering is inconsistent.  Skipping for this platform.")]
-        #endif
         public void ApproveAzureServiceBus()
         {
             var assembly = typeof(Message).Assembly;

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -37,9 +37,9 @@ namespace Microsoft.Azure.ServiceBus
         public override bool Equals(object obj) { }
         public override bool Equals(Microsoft.Azure.ServiceBus.Filter other) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
         public static bool ==(Microsoft.Azure.ServiceBus.CorrelationFilter o1, Microsoft.Azure.ServiceBus.CorrelationFilter o2) { }
         public static bool !=(Microsoft.Azure.ServiceBus.CorrelationFilter p1, Microsoft.Azure.ServiceBus.CorrelationFilter p2) { }
-        public override string ToString() { }
     }
     public class static EntityNameHelper
     {
@@ -79,9 +79,9 @@ namespace Microsoft.Azure.ServiceBus
         public override bool Equals(object obj) { }
         public override bool Equals(Microsoft.Azure.ServiceBus.Filter other) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
         public static bool ==(Microsoft.Azure.ServiceBus.FalseFilter o1, Microsoft.Azure.ServiceBus.FalseFilter o2) { }
         public static bool !=(Microsoft.Azure.ServiceBus.FalseFilter o1, Microsoft.Azure.ServiceBus.FalseFilter o2) { }
-        public override string ToString() { }
     }
     public abstract class Filter : System.IEquatable<Microsoft.Azure.ServiceBus.Filter>
     {
@@ -171,8 +171,8 @@ namespace Microsoft.Azure.ServiceBus
             public System.DateTime EnqueuedTimeUtc { get; }
             public bool IsLockTokenSet { get; }
             public bool IsReceived { get; }
-            public System.DateTime LockedUntilUtc { get; }
             public string LockToken { get; }
+            public System.DateTime LockedUntilUtc { get; }
             public long SequenceNumber { get; }
         }
     }
@@ -257,8 +257,8 @@ namespace Microsoft.Azure.ServiceBus
     {
         public RetryExponential(System.TimeSpan minimumBackoff, System.TimeSpan maximumBackoff, int maximumRetryCount) { }
         public System.TimeSpan DeltaBackoff { get; }
-        public System.TimeSpan MaximumBackoff { get; }
         public int MaxRetryCount { get; }
+        public System.TimeSpan MaximumBackoff { get; }
         public System.TimeSpan MinimalBackoff { get; }
         protected override bool OnShouldRetry(System.TimeSpan remainingTime, int currentRetryCount, out System.TimeSpan retryInterval) { }
     }
@@ -408,9 +408,9 @@ namespace Microsoft.Azure.ServiceBus
         public override bool Equals(object obj) { }
         public override bool Equals(Microsoft.Azure.ServiceBus.Filter other) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
         public static bool ==(Microsoft.Azure.ServiceBus.SqlFilter o1, Microsoft.Azure.ServiceBus.SqlFilter o2) { }
         public static bool !=(Microsoft.Azure.ServiceBus.SqlFilter o1, Microsoft.Azure.ServiceBus.SqlFilter o2) { }
-        public override string ToString() { }
     }
     public sealed class SqlRuleAction : Microsoft.Azure.ServiceBus.RuleAction
     {
@@ -420,9 +420,9 @@ namespace Microsoft.Azure.ServiceBus
         public override bool Equals(object obj) { }
         public override bool Equals(Microsoft.Azure.ServiceBus.RuleAction other) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
         public static bool ==(Microsoft.Azure.ServiceBus.SqlRuleAction o1, Microsoft.Azure.ServiceBus.SqlRuleAction o2) { }
         public static bool !=(Microsoft.Azure.ServiceBus.SqlRuleAction o1, Microsoft.Azure.ServiceBus.SqlRuleAction o2) { }
-        public override string ToString() { }
     }
     public class SubscriptionClient : Microsoft.Azure.ServiceBus.ClientEntity, Microsoft.Azure.ServiceBus.Core.IReceiverClient, Microsoft.Azure.ServiceBus.IClientEntity, Microsoft.Azure.ServiceBus.ISubscriptionClient
     {
@@ -485,9 +485,9 @@ namespace Microsoft.Azure.ServiceBus
         public override bool Equals(object obj) { }
         public override bool Equals(Microsoft.Azure.ServiceBus.Filter other) { }
         public override int GetHashCode() { }
+        public override string ToString() { }
         public static bool ==(Microsoft.Azure.ServiceBus.TrueFilter o1, Microsoft.Azure.ServiceBus.TrueFilter o2) { }
         public static bool !=(Microsoft.Azure.ServiceBus.TrueFilter o1, Microsoft.Azure.ServiceBus.TrueFilter o2) { }
-        public override string ToString() { }
     }
     public sealed class UnauthorizedException : Microsoft.Azure.ServiceBus.ServiceBusException
     {


### PR DESCRIPTION
Related to Azure Service Bus

I released today the [new major version](https://github.com/JakeGinnivan/ApiApprover/releases/tag/9.0.0) of PublicApiApprover. It uses now stable ordering that should be platform independent