### PR TITLE
[Event Hubs Client] Track Two: First Preview (Event Receiver)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
@@ -163,7 +163,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         ///   and their identifiers.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
         ///
@@ -186,7 +186,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         /// </summary>
         ///
         /// <param name="partitionId">The unique identifier of a partition associated with the Event Hub.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
         ///
@@ -221,11 +221,11 @@ namespace Azure.Messaging.EventHubs.Compatibility
         ///
         public override EventSender CreateSender(EventSenderOptions senderOptions)
         {
-            (TimeSpan minBackoff, TimeSpan maxBackoff, int maxRetries) = ((ExponentialRetry)senderOptions.Retry).GetProperties();
-
             TrackOne.EventDataSender CreateSenderFactory()
             {
                 var sender = TrackOneClient.CreateEventSender(senderOptions.PartitionId);
+
+                (TimeSpan minBackoff, TimeSpan maxBackoff, int maxRetries) = ((ExponentialRetry)senderOptions.Retry).GetProperties();
                 sender.RetryPolicy = new RetryExponential(minBackoff, maxBackoff, maxRetries);
 
                 return sender;
@@ -240,10 +240,72 @@ namespace Azure.Messaging.EventHubs.Compatibility
         }
 
         /// <summary>
+        ///   Creates an event receiver responsible for reading <see cref="EventData" /> from a specific Event Hub partition,
+        ///   and as a member of a specific consumer group.
+        ///
+        ///   A receiver may be exclusive, which asserts ownership over the partition for the consumer
+        ///   group to ensure that only one receiver from that group is reading the from the partition.
+        ///   These exclusive receivers are sometimes referred to as "Epoch Receivers."
+        ///
+        ///   A receiver may also be non-exclusive, allowing multiple receivers from the same consumer
+        ///   group to be actively reading events from the partition.  These non-exclusive receivers are
+        ///   sometimes referred to as "Non-epoch Receivers."
+        ///
+        ///   Designating a receiver as exclusive may be specified in the <paramref name="receiverOptions" />.
+        ///   By default, receivers are created as non-exclusive.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
+        /// <param name="receiverOptions">The set of options to apply when creating the receiver.</param>
+        ///
+        /// <returns>An event receiver configured in the requested manner.</returns>
+        ///
+        public override EventReceiver CreateReceiver(string partitionId,
+                                                     EventReceiverOptions receiverOptions)
+        {
+            TrackOne.PartitionReceiver CreateReceiverFactory()
+            {
+                var position = new TrackOne.EventPosition
+                {
+                    IsInclusive = receiverOptions.BeginReceivingAt.IsInclusive,
+                    Offset = receiverOptions.BeginReceivingAt.Offset,
+                    SequenceNumber = receiverOptions.BeginReceivingAt.SequenceNumber,
+                    EnqueuedTimeUtc = receiverOptions.BeginReceivingAt.EnqueuedTimeUtc
+                };
+
+                var trackOneOptions = new TrackOne.ReceiverOptions { Identifier = receiverOptions.Identifier };
+
+                PartitionReceiver receiver;
+
+                if (receiverOptions.ExclusiveReceiverPriority.HasValue)
+                {
+                    receiver = TrackOneClient.CreateEpochReceiver(receiverOptions.ConsumerGroup, partitionId, position, receiverOptions.ExclusiveReceiverPriority.Value, trackOneOptions);
+                }
+                else
+                {
+                    receiver = TrackOneClient.CreateReceiver(receiverOptions.ConsumerGroup, partitionId, position, trackOneOptions);
+                }
+
+                (TimeSpan minBackoff, TimeSpan maxBackoff, int maxRetries) = ((ExponentialRetry)receiverOptions.Retry).GetProperties();
+                receiver.RetryPolicy = new RetryExponential(minBackoff, maxBackoff, maxRetries);
+
+                return receiver;
+            }
+
+            return new EventReceiver
+            (
+                new TrackOneEventReceiver(CreateReceiverFactory),
+                TrackOneClient.EventHubName,
+                partitionId,
+                receiverOptions
+            );
+        }
+
+        /// <summary>
         ///   Closes the connection to the transport client instance.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventReceiver.cs
@@ -1,0 +1,104 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+
+namespace Azure.Messaging.EventHubs.Compatibility
+{
+    /// <summary>
+    ///   A transport client abstraction responsible for wrapping the track one event sender as a transport receiver for an
+    ///   AMQP-based connections.  It is intended that the public <see cref="EventReceiver" /> make use of an instance
+    ///   via containment and delegate operations to it.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Messaging.EventHubs.Core.TransportEventReceiver" />
+    ///
+    internal sealed class TrackOneEventReceiver : TransportEventReceiver
+    {
+        /// <summary>A lazy instantiation of the sender instance to delegate operation to.</summary>
+        private Lazy<TrackOne.PartitionReceiver> _trackOneReceiver;
+
+        /// <summary>
+        ///   The track one <see cref="TrackOne.PartitionReceiver" /> for use with this transport sender.
+        /// </summary>
+        ///
+        private TrackOne.PartitionReceiver TrackOneReceiver => _trackOneReceiver.Value;
+
+        /// <summary>
+        ///     Initializes a new instance of the <see cref="TrackOneEventReceiver"/> class.
+        /// </summary>
+        ///
+        /// <param name="trackOneReceiverFactory">A delegate that can be used for creation of the <see cref="TrackOne.PartitionReceiver" /> to which operations are delegated to.</param>
+        ///
+        /// <remarks>
+        ///   As an internal type, this class performs only basic sanity checks against its arguments.  It
+        ///   is assumed that callers are trusted and have performed deep validation.
+        ///
+        ///   Any parameters passed are assumed to be owned by this instance and safe to mutate or dispose;
+        ///   creation of clones or otherwise protecting the parameters is assumed to be the purview of the
+        ///   caller.
+        /// </remarks>
+        ///
+        public TrackOneEventReceiver(Func<TrackOne.PartitionReceiver> trackOneReceiverFactory)
+        {
+            Guard.ArgumentNotNull(nameof(trackOneReceiverFactory), trackOneReceiverFactory);
+            _trackOneReceiver = new Lazy<TrackOne.PartitionReceiver>(trackOneReceiverFactory, LazyThreadSafetyMode.PublicationOnly);
+        }
+
+        /// <summary>
+        ///   Receives a bach of <see cref="EventData" /> from the the Event Hub partition.
+        /// </summary>
+        ///
+        /// <param name="maximumMessageCount">The maximum number of messages to receive in this batch.</param>
+        /// <param name="maximumWaitTime">The maximum amount of time to wait to build up the requested message count for the batch; if not specified, the default wait time specified when the receiver was created will be used.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>The batch of <see cref="EventData" /> from the Event Hub partition this receiver is associated with.  If no events are present, an empty enumerable is returned.</returns>
+        ///
+        public override async Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount,
+                                                                        TimeSpan? maximumWaitTime,
+                                                                        CancellationToken cancellationToken)
+        {
+            static EventData TransformEvent(TrackOne.EventData eventData) =>
+                new EventData(eventData.Body)
+                {
+                    Properties = eventData.Properties,
+                    SystemProperties = new EventData.SystemEventProperties
+                    (
+                        eventData.SystemProperties.SequenceNumber,
+                        eventData.SystemProperties.EnqueuedTimeUtc,
+                        eventData.SystemProperties.Offset,
+                        eventData.SystemProperties.PartitionKey
+                    )
+                };
+
+            return
+                ((await TrackOneReceiver.ReceiveAsync(maximumMessageCount, maximumWaitTime).ConfigureAwait(false))
+                    ?? Enumerable.Empty<TrackOne.EventData>())
+                .Select(TransformEvent);
+        }
+
+        /// <summary>
+        ///   Closes the connection to the transport client instance.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        public override Task CloseAsync(CancellationToken cancellationToken)
+        {
+            if (!_trackOneReceiver.IsValueCreated)
+            {
+                return Task.CompletedTask;
+            }
+
+            return TrackOneReceiver.CloseAsync();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventSender.cs
@@ -57,7 +57,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         ///
         /// <param name="events">The set of event data to send.</param>
         /// <param name="batchOptions">The set of options to consider when sending this batch.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public override Task SendAsync(IEnumerable<EventData> events,
                                        EventBatchingOptions batchOptions,
@@ -69,14 +69,14 @@ namespace Azure.Messaging.EventHubs.Compatibility
                     Properties = eventData.Properties
                 };
 
-            return TrackOneSender.SendAsync(events.Select(evt => TransformEvent(evt)), batchOptions?.PartitionKey);
+            return TrackOneSender.SendAsync(events.Select(TransformEvent), batchOptions?.PartitionKey);
         }
 
         /// <summary>
         ///   Closes the connection to the transport client instance.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubClient.cs
@@ -18,7 +18,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///   and their identifiers.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
         ///
@@ -30,7 +30,7 @@ namespace Azure.Messaging.EventHubs.Core
         /// </summary>
         ///
         /// <param name="partitionId">The unique identifier of a partition associated with the Event Hub.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
         ///
@@ -48,15 +48,37 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <returns>An event sender configured in the requested manner.</returns>
         ///
-        public abstract EventSender CreateSender(EventSenderOptions senderOptions = default);
+        public abstract EventSender CreateSender(EventSenderOptions senderOptions);
+
+        /// <summary>
+        ///   Creates an event receiver responsible for reading <see cref="EventData" /> from a specific Event Hub partition,
+        ///   and as a member of a specific consumer group.
+        ///
+        ///   A receiver may be exclusive, which asserts ownership over the partition for the consumer
+        ///   group to ensure that only one receiver from that group is reading the from the partition.
+        ///   These exclusive receivers are sometimes referred to as "Epoch Receivers."
+        ///
+        ///   A receiver may also be non-exclusive, allowing multiple receivers from the same consumer
+        ///   group to be actively reading events from the partition.  These non-exclusive receivers are
+        ///   sometimes referred to as "Non-epoch Receivers."
+        ///
+        ///   Designating a receiver as exclusive may be specified in the <paramref name="receiverOptions" />.
+        ///   By default, receivers are created as non-exclusive.
+        /// </summary>
+        ///
+        /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
+        /// <param name="receiverOptions">The set of options to apply when creating the receiver.</param>
+        ///
+        /// <returns>An event receiver configured in the requested manner.</returns>
+        ///
+        public abstract EventReceiver CreateReceiver(string partitionId,
+                                                     EventReceiverOptions receiverOptions);
 
         /// <summary>
         ///   Closes the connection to the transport client instance.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
-        ///
-        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public abstract Task CloseAsync(CancellationToken cancellationToken);
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventReceiver.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Messaging.EventHubs.Core
+{
+    /// <summary>
+    ///   Provides an abstraction for generalizing an Event Receiver so that a dedicated instance may provide operations
+    ///   for a specific transport, such as AMQP or JMS.  It is intended that the public <see cref="EventReceiver" /> employ
+    ///   a transport receiver via containment and delegate operations to it rather than understanding protocol-specific details
+    ///   for different transports.
+    /// </summary>
+    ///
+    internal abstract class TransportEventReceiver
+    {
+        /// <summary>
+        ///   Receives a bach of <see cref="EventData" /> from the the Event Hub partition.
+        /// </summary>
+        ///
+        /// <param name="maximumMessageCount">The maximum number of messages to receive in this batch.</param>
+        /// <param name="maximumWaitTime">The maximum amount of time to wait to build up the requested message count for the batch; if not specified, the default wait time specified when the receiver was created will be used.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>The batch of <see cref="EventData" /> from the Event Hub partition this receiver is associated with.  If no events are present, an empty enumerable is returned.</returns>
+        ///
+        public abstract Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount,
+                                                                  TimeSpan? maximumWaitTime,
+                                                                  CancellationToken cancellationToken);
+
+        /// <summary>
+        ///   Closes the connection to the transport sender instance.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        public abstract Task CloseAsync(CancellationToken cancellationToken);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventSender.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         /// <param name="events">The set of event data to send.</param>
         /// <param name="batchOptions">The set of options to consider when sending this batch.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public abstract Task SendAsync(IEnumerable<EventData> events,
                                        EventBatchingOptions batchOptions,
@@ -32,9 +32,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///   Closes the connection to the transport sender instance.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
-        ///
-        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public abstract Task CloseAsync(CancellationToken cancellationToken);
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
@@ -168,7 +168,7 @@ namespace Azure.Messaging.EventHubs
         ///   and their identifiers.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>The set of information for the Event Hub that this client is associated with.</returns>
         ///
@@ -178,7 +178,7 @@ namespace Azure.Messaging.EventHubs
         ///   Retrieves the set of identifiers for the partitions of an Event Hub.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>The set of identifiers for the partitions within the Event Hub that this client is associated with.</returns>
         ///
@@ -197,7 +197,7 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="partitionId">The unique identifier of a partition associated with the Event Hub.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>The set of information for the requested partition under the Event Hub this client is associated with.</returns>
         ///
@@ -272,14 +272,14 @@ namespace Azure.Messaging.EventHubs
             options.Retry = options.Retry ?? ClientOptions.Retry.Clone();
             options.DefaultMaximumReceiveWaitTime = options.MaximumReceiveWaitTimeOrDefault ?? ClientOptions.DefaultTimeout;
 
-            return BuildEventReceiver(ClientOptions.TransportType, EventHubPath, partitionId, options);
+            return InnerClient.CreateReceiver(partitionId, options);
         }
 
         /// <summary>
         ///   Closes the connection to the Event Hub instance.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
@@ -289,7 +289,7 @@ namespace Azure.Messaging.EventHubs
         ///   Closes the connection to the Event Hub instance.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public virtual void Close(CancellationToken cancellationToken = default) => CloseAsync(cancellationToken).GetAwaiter().GetResult();
 
@@ -366,23 +366,6 @@ namespace Azure.Messaging.EventHubs
                     throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidTransportType, options.TransportType.ToString()), nameof(options.TransportType));
             }
         }
-
-        /// <summary>
-        ///   Builds a partition receiver instance using the provided options.
-        /// </summary>
-        ///
-        /// <param name="connectionType">The type of connection being used for communication with the EventHubs servcie.</param>
-        /// <param name="eventHubPath">The path to a specific Event Hub.</param>
-        /// <param name="partitionId">The identifier of the partition to receive from.</param>
-        /// <param name="options">The set of options to use for the receiver.</param>
-        ///
-        /// <returns>The fully constructed receiver.</returns>
-        ///
-        internal virtual EventReceiver BuildEventReceiver(TransportType connectionType,
-                                                          string eventHubPath,
-                                                          string partitionId,
-                                                          EventReceiverOptions options) =>
-            new EventReceiver(connectionType, eventHubPath, partitionId, options);
 
         /// <summary>
         ///   Performs the actions needed to validate the <see cref="ConnectionStringProperties" /> associated

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.EventHubs
         ///   which has not expired due to the retention policy.
         /// </summary>
         ///
-        public static EventPosition FirstAvailableEvent => FromOffset(StartOfStreamOffset, true);
+        public static EventPosition FirstAvailableEvent => FromOffset(StartOfStreamOffset, false);
 
         /// <summary>
         ///   Corresponds to the end of the partition, where no more events are currently enqueued.  Use this

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventSender.cs
@@ -74,7 +74,7 @@ namespace Azure.Messaging.EventHubs
         ///   Initializes a new instance of the <see cref="EventSender"/> class.
         /// </summary>
         ///
-        /// <param name="transportSender">The type of protocol and transport used for communicating with the Event Hubs service.</param>
+        /// <param name="transportSender">An abstracted Event Sender specific to the active protocol and transport intended to perform delegated operations.</param>
         /// <param name="eventHubPath">The path of the Event Hub to which events will be sent.</param>
         /// <param name="senderOptions">The set of options to use for this receiver.</param>
         ///
@@ -112,7 +112,7 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="events">The set of event data to send.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
@@ -128,7 +128,7 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="events">The set of event data to send.</param>
         /// <param name="batchOptions">The set of options to consider when sending this batch.</param>
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
@@ -154,7 +154,7 @@ namespace Azure.Messaging.EventHubs
         ///   Closes the sender.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         /// <returns>A task to be resolved on when the operation has completed.</returns>
         ///
@@ -164,7 +164,7 @@ namespace Azure.Messaging.EventHubs
         ///   Closes the sender.
         /// </summary>
         ///
-        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request for cancelling the operation.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
         ///
         public virtual void Close(CancellationToken cancellationToken = default) => CloseAsync(cancellationToken).GetAwaiter().GetResult();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/EventPosition.cs
@@ -10,7 +10,7 @@ namespace TrackOne
 
     /// <summary>
     /// Represents options can be set during the creation of a event hub receiver.
-    /// </summary> 
+    /// </summary>
     /// <summary>
     /// Defines a position of an <see cref="EventData" /> in the event hub partition.
     /// The position can be one of <see cref="EventData.SystemPropertiesCollection.Offset"/>, <see cref="EventData.SystemPropertiesCollection.SequenceNumber"/>
@@ -21,7 +21,7 @@ namespace TrackOne
         const string StartOfStream = "-1";
         const string EndOfStream = "@latest";
 
-        EventPosition() { }
+        internal EventPosition() { }
 
         /// <summary>
         /// Returns the position for the start of a stream. Provide this position in receiver creation
@@ -50,7 +50,7 @@ namespace TrackOne
         public static EventPosition FromOffset(string offset, bool inclusive = false)
         {
             Guard.ArgumentNotNullOrWhiteSpace(nameof(offset), offset);
-          
+
             return new EventPosition { Offset = offset, IsInclusive = inclusive };
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/PartitionReceiver.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/PartitionReceiver.cs
@@ -15,7 +15,7 @@ namespace TrackOne
     /// <para>
     /// A PartitionReceiver is tied to a ConsumerGroup + Partition combination. If you are creating an epoch based
     /// PartitionReceiver (i.e. PartitionReceiver.Epoch != 0) you cannot have more than one active receiver per
-    /// ConsumerGroup + Partition combo. You can have multiple receivers per ConsumerGroup + Partition combination with 
+    /// ConsumerGroup + Partition combo. You can have multiple receivers per ConsumerGroup + Partition combination with
     /// non-epoch receivers.
     /// </para>
     /// </summary>
@@ -117,7 +117,7 @@ namespace TrackOne
         /// <summary></summary>
         protected EventPosition EventPosition { get; set; }
 
-        /// <summary>Gets the identifier of a receiver which was set during the creation of the receiver.</summary> 
+        /// <summary>Gets the identifier of a receiver which was set during the creation of the receiver.</summary>
         /// <value>A string representing the identifier of a receiver. It will return null if the identifier is not set.</value>
         public string Identifier { get; private set; }
 
@@ -130,7 +130,7 @@ namespace TrackOne
         /// EventHubClient client = EventHubClient.Create("__connectionString__");
         /// PartitionReceiver receiver = client.CreateReceiver("ConsumerGroup1", "1");
         /// IEnumerable&lt;EventData&gt; receivedEvents = await receiver.ReceiveAsync(BatchSize);
-        ///      
+        ///
         /// while (true)
         /// {
         ///     int batchSize = 0;
@@ -139,14 +139,14 @@ namespace TrackOne
         ///         foreach (EventData receivedEvent in receivedEvents)
         ///         {
         ///             Console.WriteLine("Message Payload: {0}", Encoding.UTF8.GetString(receivedEvent.Body));
-        ///             Console.WriteLine("Offset: {0}, SeqNo: {1}, EnqueueTime: {2}", 
-        ///                 receivedEvent.SystemProperties.Offset, 
-        ///                 receivedEvent.SystemProperties.SequenceNumber, 
+        ///             Console.WriteLine("Offset: {0}, SeqNo: {1}, EnqueueTime: {2}",
+        ///                 receivedEvent.SystemProperties.Offset,
+        ///                 receivedEvent.SystemProperties.SequenceNumber,
         ///                 receivedEvent.SystemProperties.EnqueuedTime);
         ///             batchSize++;
         ///         }
         ///     }
-        ///          
+        ///
         ///     Console.WriteLine("ReceivedBatch Size: {0}", batchSize);
         ///     receivedEvents = await receiver.ReceiveAsync();
         /// }
@@ -162,8 +162,10 @@ namespace TrackOne
         /// Receive a batch of <see cref="EventData"/>'s from an EventHub partition by allowing wait time on each individual call.
         /// </summary>
         /// <returns>A Task that will yield a batch of <see cref="EventData"/> from the partition on which this receiver is created. Returns 'null' if no EventData is present.</returns>
-        public async Task<IEnumerable<EventData>> ReceiveAsync(int maxMessageCount, TimeSpan waitTime)
+        public async Task<IEnumerable<EventData>> ReceiveAsync(int maxMessageCount, TimeSpan? waitTime = default)
         {
+            waitTime = waitTime ?? this.EventHubClient.ConnectionStringBuilder.OperationTimeout;
+
             EventHubsEventSource.Log.EventReceiveStart(this.ClientId);
             Activity activity = EventHubsDiagnosticSource.StartReceiveActivity(this.ClientId, this.EventHubClient.ConnectionStringBuilder, this.PartitionId, this.ConsumerGroupName, this.EventPosition);
 
@@ -173,7 +175,7 @@ namespace TrackOne
 
             try
             {
-                receiveTask = this.OnReceiveAsync(maxMessageCount, waitTime);
+                receiveTask = this.OnReceiveAsync(maxMessageCount, waitTime.Value);
                 events = await receiveTask.ConfigureAwait(false);
                 count = events?.Count ?? 0;
                 EventData lastEvent = events?[count - 1];

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparer.cs
@@ -1,0 +1,151 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   Provides a means of comparing the track one and track two representations
+    ///   of types.
+    /// </summary>
+    ///
+    internal static class TrackOneComparer
+    {
+        /// <summary>
+        ///   Compares event data between its representations in track one and
+        ///   track two to determine if the instances represent the same event.
+        /// </summary>
+        ///
+        /// <param name="trackOneEvent">The track one event to consider.</param>
+        /// <param name="trackTwoEvent">The track two event to consider.</param>
+        ///
+        /// <returns><c>true</c>, if the two events are structurally equivilent; otherwise, <c>false</c>.</returns>
+        ///
+        public static bool IsEventDataEquivalent(TrackOne.EventData trackOneEvent,
+                                                EventData trackTwoEvent)
+        {
+            // If the events are the same instance, they're equal.  This should only happen
+            // if both are null, since the types differ.
+
+            if (Object.ReferenceEquals(trackOneEvent, trackTwoEvent))
+            {
+                return true;
+            }
+
+            // If one or the other is null, then they cannot be equal, since we know that
+            // they are not both null.
+
+            if ((trackOneEvent == null) || (trackTwoEvent == null))
+            {
+                return false;
+            }
+
+            // If the contents of each body is not equal, the events are not
+            // equal.
+
+            var trackOneBody = trackOneEvent.Body.ToArray();
+            var trackTwoBody = trackTwoEvent.Body.ToArray();
+
+            if (trackOneBody.Length != trackTwoBody.Length)
+            {
+                return false;
+            }
+
+            if (!Enumerable.SequenceEqual(trackOneBody, trackTwoBody))
+            {
+                return false;
+            }
+
+            // Verify the system properties are equivilent, unless they're the same reference.
+
+            if (!Object.ReferenceEquals(trackOneEvent.SystemProperties, trackTwoEvent.SystemProperties))
+            {
+
+                if ((trackOneEvent.SystemProperties == null) || (trackTwoEvent.SystemProperties == null))
+                {
+                    return false;
+                }
+
+                // Verify that the system properties contain the same elements, assuming they are non-null.
+
+                if (trackOneEvent.SystemProperties?.Count != trackTwoEvent.SystemProperties?.Count)
+                {
+                    return false;
+                }
+
+                if (!trackOneEvent.SystemProperties.OrderBy(kvp => kvp.Key).SequenceEqual(trackTwoEvent.SystemProperties.OrderBy(kvp => kvp.Key)))
+                {
+                    return false;
+                }
+            }
+
+            // Since we know that the event bodies and system properties are equal, if the property sets are the
+            // same instance, then we know that the events are equal.  This should only happen if both are null.
+
+            if (Object.ReferenceEquals(trackOneEvent.Properties, trackTwoEvent.Properties))
+            {
+                return true;
+            }
+
+            // If either property is null, then the events are not equal, since we know that they are
+            // not both null.
+
+            if ((trackOneEvent.Properties == null) || (trackTwoEvent.Properties == null))
+            {
+                return false;
+            }
+
+            // The only meaningful comparison left is to ensure that the property sets are equivilent,
+            // the outcome of this check is the final word on equality.
+
+            if (trackOneEvent.Properties.Count != trackTwoEvent.Properties.Count)
+            {
+                return false;
+            }
+
+            return trackOneEvent.Properties.OrderBy(kvp => kvp.Key).SequenceEqual(trackTwoEvent.Properties.OrderBy(kvp => kvp.Key));
+        }
+
+        /// <summary>
+        ///   Compares event position between its representations in track one and
+        ///   track two to determine if the instances represent the same event.
+        /// </summary>
+        ///
+        /// <param name="trackOnePosition">The track one event position to consider.</param>
+        /// <param name="trackTwoPosition">The track two event position to consider.</param>
+        ///
+        /// <returns><c>true</c>, if the two events are structurally equivilent; otherwise, <c>false</c>.</returns>
+        ///
+        public static bool IsEventPositionEquivalent(TrackOne.EventPosition trackOnePosition,
+                                                    EventPosition trackTwoPosition)
+        {
+            // If the positions are the same instance, they're equal.  This should only happen
+            // if both are null, since the types differ.
+
+            if (Object.ReferenceEquals(trackOnePosition, trackTwoPosition))
+            {
+                return true;
+            }
+
+            // If one or the other is null, then they cannot be equal, since we know that
+            // they are not both null.
+
+            if ((trackOnePosition == null) || (trackTwoPosition == null))
+            {
+                return false;
+            }
+
+            // Compare the properties and ensure that they're equal.
+
+            return
+            (
+                (String.Equals(trackOnePosition.Offset, trackTwoPosition.Offset, StringComparison.Ordinal))
+                 && (trackOnePosition.SequenceNumber == trackTwoPosition.SequenceNumber)
+                 && (trackOnePosition.IsInclusive == trackTwoPosition.IsInclusive)
+                 && (trackOnePosition.EnqueuedTimeUtc == trackTwoPosition.EnqueuedTimeUtc)
+            );
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparerTests.cs
@@ -1,0 +1,247 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Messaging.EventHubs.Compatibility;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="TrackOneEventSender" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class TrackOneComparerTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsDifferentBodies()
+        {
+            var trackOneEvent = new TrackOne.EventData(new byte[] { 0x22, 0x44 });
+            var trackTwoEvent = new EventData(new byte[] { 0x11, 0x33 });
+
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsDifferentProperties()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            var trackTwoEvent = new EventData((byte[])body.Clone());
+
+            trackOneEvent.Properties["test"] = "trackOne";
+            trackTwoEvent.Properties["test"] = "trackTwo";
+
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsWhenOnePropertySetIsNull()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            var trackTwoEvent = new EventData((byte[])body.Clone());
+
+            trackOneEvent.Properties = null;
+            trackTwoEvent.Properties["test"] = "trackTwo";
+
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsDifferentSystemProperties()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            var trackTwoEvent = new EventData((byte[])body.Clone());
+
+            trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
+            trackOneEvent.SystemProperties["something"] = "trackOne";
+
+            trackTwoEvent.SystemProperties = new EventData.SystemEventProperties();
+            trackTwoEvent.SystemProperties["something"] = "trackTwo";
+
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsWhenOneSystemPropertySetIsNull()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            var trackTwoEvent = new EventData((byte[])body.Clone());
+
+            trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
+            trackOneEvent.SystemProperties["something"] = "trackOne";
+
+            trackTwoEvent.SystemProperties = null;
+
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsEqualEvents()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            var trackTwoEvent = new EventData((byte[])body.Clone());
+
+            trackOneEvent.Properties["test"] = "same";
+            trackTwoEvent.Properties["test"] = "same";
+
+            trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
+            trackOneEvent.SystemProperties["something"] = "otherSame";
+
+            trackTwoEvent.SystemProperties = new EventData.SystemEventProperties();
+            trackTwoEvent.SystemProperties["something"] = "otherSame";
+
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventPositionEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventPositionEquivalentDetectsDifferentOffsets()
+        {
+            var trackOnePosition = TrackOne.EventPosition.FromOffset("12", false);
+            var trackTwoPosition = EventPosition.FromOffset(12);
+
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(trackOnePosition, trackTwoPosition), Is.False, "The offset for track two is inclusive; even the same base offset with non-inclusive is not equivilent.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventPositionEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventPositionEquivalentRecognizesSameOffsets()
+        {
+            var trackOnePosition = TrackOne.EventPosition.FromOffset("12", true);
+            var trackTwoPosition = EventPosition.FromOffset(12);
+
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(trackOnePosition, trackTwoPosition), Is.True, "The offset for track two is inclusive; the equivilent offset set as inclusive should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventPositionEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventPositionEquivalentDetectsDifferentSequence()
+        {
+            var trackOnePosition = TrackOne.EventPosition.FromSequenceNumber(54123);
+            var trackTwoPosition = EventPosition.FromSequenceNumber(2);
+
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(trackOnePosition, trackTwoPosition), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventPositionEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventPositionEquivalentRecognizesSameSequence()
+        {
+            var trackOnePosition = TrackOne.EventPosition.FromSequenceNumber(54123);
+            var trackTwoPosition = EventPosition.FromSequenceNumber(54123);
+
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(trackOnePosition, trackTwoPosition), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventPositionEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventPositionEquivalentDetectsDifferentEnqueueTime()
+        {
+            var enqueueTime = DateTime.Parse("2015-10-27T12:00:00Z");
+            var trackOnePosition = TrackOne.EventPosition.FromEnqueuedTime(enqueueTime);
+            var trackTwoPosition = EventPosition.FromEnqueuedTime(enqueueTime.AddDays(1));
+
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(trackOnePosition, trackTwoPosition), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventPositionEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventPositionEquivalentRecognizesSameEnqueueTime()
+        {
+            var enqueueTime = DateTime.Parse("2015-10-27T12:00:00Z");
+            var trackOnePosition = TrackOne.EventPosition.FromEnqueuedTime(enqueueTime);
+            var trackTwoPosition = EventPosition.FromEnqueuedTime(enqueueTime);
+
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(trackOnePosition, trackTwoPosition), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventPositionEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventPositionEquivalentRecognizesSameBeginning()
+        {
+            var trackOnePosition = TrackOne.EventPosition.FromStart();
+            var trackTwoPosition = EventPosition.FirstAvailableEvent;
+
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(trackOnePosition, trackTwoPosition), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventPositionEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventPositionEquivalentRecognizesSameEnding()
+        {
+            var trackOnePosition = TrackOne.EventPosition.FromEnd();
+            var trackTwoPosition = EventPosition.NewEventsOnly;
+
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(trackOnePosition, trackTwoPosition), Is.True);
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventReceiverTests.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Compatibility;
+using NUnit.Framework;
+using TrackOne;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="TrackOneEventReceiver" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class TrackOneEventReceiverTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheSenderFactory()
+        {
+            Assert.That(() => new TrackOneEventReceiver(null), Throws.ArgumentNullException);
+        }
+
+        /// <summary
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiverIsConstructedCorrectly()
+        {
+            var consumerGroup = "$TestThing";
+            var partition = "123";
+            var position = EventPosition.FromEnqueuedTime(DateTime.Parse("2015-10-25T12:00:00Z"));
+            var priority = 8765;
+            var identifier = "ThisIsAnAwesomeReceiver!";
+            var mock = new ObservableReceiverMock(new ClientMock(), consumerGroup, partition, TrackOne.EventPosition.FromEnqueuedTime(position.EnqueuedTimeUtc.Value), priority, new ReceiverOptions { Identifier = identifier });
+            var receiver = new TrackOneEventReceiver(() => mock);
+
+            // Invoke an operation to force the sender to be lazily instantiated.  Otherwise,
+            // construction does not happen.
+
+            await receiver.ReceiveAsync(0, TimeSpan.Zero, default);
+
+            Assert.That(mock.ConstructedWith.ConsumerGroup, Is.EqualTo(consumerGroup), "The consumer group should match.");
+            Assert.That(mock.ConstructedWith.Partition, Is.EqualTo(partition), "The partition should match.");
+            Assert.That(TrackOneComparer.IsEventPositionEquivalent(mock.ConstructedWith.Position, position), Is.True, "The starting event position should match.");
+            Assert.That(mock.ConstructedWith.Priority, Is.EqualTo(priority), "The exclusive priority should match.");
+            Assert.That(mock.ConstructedWith.Options.Identifier, Is.EqualTo(identifier), "The receiver identifier should match.");
+        }
+
+        /// <summary
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveAsyncForwardsParameters()
+        {
+            var maximumEventCount = 666;
+            var maximumWaitTime = TimeSpan.FromMilliseconds(17);
+            var mock = new ObservableReceiverMock(new ClientMock(), "$Default", "0", TrackOne.EventPosition.FromEnd(), null, new ReceiverOptions());
+            var receiver = new TrackOneEventReceiver(() => mock);
+
+            await receiver.ReceiveAsync(maximumEventCount, maximumWaitTime, CancellationToken.None);
+
+            Assert.That(mock.ReceiveInvokeWith.MaxCount, Is.EqualTo(maximumEventCount), "The maximum event count should match.");
+            Assert.That(mock.ReceiveInvokeWith.WaitTime, Is.EqualTo(maximumWaitTime), "The maximum wait time should match.");
+        }
+
+        /// <summary
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveAsyncSendsAnEmptyEnumerableWhenThereAreNoEvents()
+        {
+            var mock = new ObservableReceiverMock(new ClientMock(), "$Default", "0", TrackOne.EventPosition.FromEnd(), null, new ReceiverOptions());
+            var receiver = new TrackOneEventReceiver(() => mock);
+            var results = await receiver.ReceiveAsync(10, default, default);
+
+            Assert.That(results, Is.Not.Null, "There should have been an enumerable returned.");
+            Assert.That(results.Any(), Is.False, "The result enumerable should have been empty.");
+        }
+
+        /// <summary
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveAsyncTransformsResults()
+        {
+            var mock = new ObservableReceiverMock(new ClientMock(), "$Default", "0", TrackOne.EventPosition.FromEnd(), null, new ReceiverOptions());
+            var receiver = new TrackOneEventReceiver(() => mock);
+
+            mock.ReceiveResult = new List<TrackOne.EventData>
+            {
+                new TrackOne.EventData(new byte[] { 0x33, 0x66 }),
+                new TrackOne.EventData(Encoding.UTF8.GetBytes("Oh! Hello, there!"))
+            };
+
+            mock.ReceiveResult[0].SystemProperties = new TrackOne.EventData.SystemPropertiesCollection(1234, DateTime.Parse("2015-10-27T12:00:00Z"), "6", "key");
+            mock.ReceiveResult[1].SystemProperties = new TrackOne.EventData.SystemPropertiesCollection(6666, DateTime.Parse("1974-12-09T20:00:00Z"), "24", null);
+            mock.ReceiveResult[1].Properties["test"] = "this is a test!";
+
+            var results = await receiver.ReceiveAsync(10, default, default);
+            var index = 0;
+
+            foreach (var result in results)
+            {
+                Assert.That(TrackOneComparer.IsEventDataEquivalent(mock.ReceiveResult[index], result), Is.True, $"The transformed result at index { index } did not match the source result.");
+                ++index;
+            }
+
+            Assert.That(index, Is.EqualTo(mock.ReceiveResult.Count), "There should have been the same number of translated results as there were source results.");
+
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventReceiver.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncDoesNotDelegateIfTheSenderWasNotCreated()
+        {
+            var mock = new ObservableReceiverMock(new ClientMock(), "$Default", "0", TrackOne.EventPosition.FromEnd(), null, new ReceiverOptions());
+            var receiver = new TrackOneEventReceiver(() => mock);
+
+            await receiver.CloseAsync(default);
+            Assert.That(mock.WasCloseAsyncInvoked, Is.False);
+        }
+
+        /// <summary
+        ///   Verifies functionality of the <see cref="TrackOneEventReceiver.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncDelegatesToTheSender()
+        {
+            var mock = new ObservableReceiverMock(new ClientMock(), "$Default", "0", TrackOne.EventPosition.FromEnd(), null, new ReceiverOptions());
+            var receiver = new TrackOneEventReceiver(() => mock);
+
+            // Invoke an operation to force the receiver to be lazily instantiated.  Otherwise,
+            // Close does not delegate the call.
+
+            await receiver.ReceiveAsync(0, TimeSpan.Zero, default);
+            await receiver.CloseAsync(default);
+            Assert.That(mock.WasCloseAsyncInvoked, Is.True);
+        }
+
+        /// <summary>
+        ///   Allows for observation of operations performed by the receiver for testing purposes.
+        /// </summary>
+        ///
+        private class ObservableReceiverMock : TrackOne.PartitionReceiver
+        {
+            public bool WasCloseAsyncInvoked;
+            public (int MaxCount, TimeSpan WaitTime) ReceiveInvokeWith;
+            public (string ConsumerGroup, string Partition, TrackOne.EventPosition Position, long? Priority, TrackOne.ReceiverOptions Options) ConstructedWith;
+
+            public IList<TrackOne.EventData> ReceiveResult = null;
+
+            public ObservableReceiverMock(TrackOne.EventHubClient eventHubClient,
+                                          string consumerGroupName,
+                                          string partitionId,
+                                          TrackOne.EventPosition eventPosition,
+                                          long? priority,
+                                          TrackOne.ReceiverOptions options) : base(eventHubClient, consumerGroupName, partitionId, eventPosition, priority, options)
+            {
+                ConstructedWith = (consumerGroupName, partitionId, eventPosition, priority, options);
+            }
+
+            protected override Task OnCloseAsync()
+            {
+                WasCloseAsyncInvoked = true;
+                return Task.CompletedTask;
+            }
+
+            protected override Task<IList<TrackOne.EventData>> OnReceiveAsync(int maxMessageCount, TimeSpan waitTime)
+            {
+                ReceiveInvokeWith = (maxMessageCount, waitTime);
+                return Task.FromResult(ReceiveResult);
+            }
+
+            protected override void OnSetReceiveHandler(IPartitionReceiveHandler receiveHandler, bool invokeWhenNoEvents) => throw new NotImplementedException();
+        }
+
+        /// <summary>
+        ///   Allows easy creation of a non-functioning client for testing purposes.
+        /// </summary>
+        ///
+        private class ClientMock : TrackOne.EventHubClient
+        {
+            public ClientMock() : base(new TrackOne.EventHubsConnectionStringBuilder(new Uri("http://my.hub.com"), "aPath", "keyName", "KEY!"))
+            {
+            }
+
+            protected override Task OnCloseAsync() => Task.CompletedTask;
+            protected override PartitionReceiver OnCreateReceiver(string consumerGroupName, string partitionId, TrackOne.EventPosition eventPosition, long? epoch, ReceiverOptions receiverOptions) => default;
+            protected override Task<EventHubPartitionRuntimeInformation> OnGetPartitionRuntimeInformationAsync(string partitionId) => Task.FromResult(default(EventHubPartitionRuntimeInformation));
+            protected override Task<EventHubRuntimeInformation> OnGetRuntimeInformationAsync() => Task.FromResult(default(EventHubRuntimeInformation));
+            internal override EventDataSender OnCreateEventSender(string partitionId) => default;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventReceivers/EventReceiverLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventReceivers/EventReceiverLiveTests.cs
@@ -1,0 +1,237 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Tests.Infrastructure;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of live tests for the <see cref="EventReceiver" />
+    ///   class.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   These tests have a depenency on live Azure services and may
+    ///   incur costs for the assocaied Azure subscription.
+    /// </remarks>
+    ///
+    [TestFixture]
+    [NonParallelizable]
+    [Category(TestCategory.Live)]
+    [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    public class EventReceiverLiveTests
+    {
+        /// <summary>
+        ///   Verifies that the <see cref="EventReceiver" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiverWithNoOptionsCanReceive()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var partition = (await client.GetPartitionIdsAsync()).First();
+
+                    await using (var receiver = client.CreateReceiver(partition))
+                    {
+                        Assert.That(async () => await receiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventReceiver" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiverWithOptionsCanReceive()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                var options = new EventReceiverOptions
+                {
+                    ConsumerGroup = "$Default",
+                    BeginReceivingAt = EventPosition.NewEventsOnly
+                };
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var partition = (await client.GetPartitionIdsAsync()).First();
+
+                    await using (var receiver = client.CreateReceiver(partition, options))
+                    {
+                        Assert.That(async () => await receiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventReceiver" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveCanReadOneEventBatch()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                var eventBatch = new[]
+                {
+                    new EventData(Encoding.UTF8.GetBytes("One")),
+                    new EventData(Encoding.UTF8.GetBytes("Two")),
+                    new EventData(Encoding.UTF8.GetBytes("Three"))
+                };
+
+                var receiverOptions = new EventReceiverOptions
+                {
+                    BeginReceivingAt = EventPosition.NewEventsOnly
+                };
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var partition = (await client.GetPartitionIdsAsync()).First();
+
+                    await using (var sender = client.CreateSender(new EventSenderOptions { PartitionId = partition }))
+                    await using (var receiver = client.CreateReceiver(partition, receiverOptions))
+                    {
+                        // Initiate an operation to force the receiver to connect and set its position at the
+                        // end of the event stream.
+
+                        Assert.That(async () => await receiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
+
+                        // Send the batch of events.
+
+                        await sender.SendAsync(eventBatch);
+
+                        // Recieve and validate the events; because there is some non-determinism in the messaging flow, the
+                        // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
+                        // to account for availability delays.
+
+                        var receivedEvents = new List<EventData>();
+                        var index = 0;
+
+                        while ((receivedEvents.Count < eventBatch.Length) && (++index < 3))
+                        {
+                            receivedEvents.AddRange(await receiver.ReceiveAsync(eventBatch.Length + 10, TimeSpan.FromMilliseconds(25)));
+                        }
+
+                        index = 0;
+
+                        Assert.That(receivedEvents, Is.Not.Empty, "There should have been a set of events received.");
+
+                        foreach (var receivedEvent in receivedEvents)
+                        {
+                            Assert.That(receivedEvent.IsEquivalentTo(eventBatch[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
+                            ++index;
+                        }
+
+                        Assert.That(index, Is.EqualTo(eventBatch.Length), "The number of received events did not match the batch size.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventReceiver" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveCanReadMultipleEventBatches()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                var eventBatch = new[]
+                {
+                    new EventData(Encoding.UTF8.GetBytes("One")),
+                    new EventData(Encoding.UTF8.GetBytes("Two")),
+                    new EventData(Encoding.UTF8.GetBytes("Three")),
+                    new EventData(Encoding.UTF8.GetBytes("Four")),
+                    new EventData(Encoding.UTF8.GetBytes("Five")),
+                    new EventData(Encoding.UTF8.GetBytes("Six")),
+                    new EventData(Encoding.UTF8.GetBytes("Seven")),
+                    new EventData(Encoding.UTF8.GetBytes("Eight")),
+                    new EventData(Encoding.UTF8.GetBytes("Nine")),
+                    new EventData(Encoding.UTF8.GetBytes("Ten")),
+                    new EventData(Encoding.UTF8.GetBytes("Eleven")),
+                    new EventData(Encoding.UTF8.GetBytes("Twelve")),
+                    new EventData(Encoding.UTF8.GetBytes("Thirteen")),
+                    new EventData(Encoding.UTF8.GetBytes("Fourteen")),
+                    new EventData(Encoding.UTF8.GetBytes("Fifteen"))
+                };
+
+                var receiverOptions = new EventReceiverOptions
+                {
+                    BeginReceivingAt = EventPosition.NewEventsOnly
+                };
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var partition = (await client.GetPartitionIdsAsync()).First();
+
+                    await using (var sender = client.CreateSender(new EventSenderOptions { PartitionId = partition }))
+                    await using (var receiver = client.CreateReceiver(partition, receiverOptions))
+                    {
+                        // Initiate an operation to force the receiver to connect and set its position at the
+                        // end of the event stream.
+
+                        Assert.That(async () => await receiver.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
+
+                        // Send the batch of events, receive and validate them.
+
+                        await sender.SendAsync(eventBatch);
+
+                        // Recieve and validate the events; because there is some non-determinism in the messaging flow, the
+                        // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
+                        // to account for availability delays.
+
+                        var receivedEvents = new List<EventData>();
+                        var index = 0;
+                        var batchNumber = 1;
+                        var batchSize = (eventBatch.Length / 3);
+
+                        while ((receivedEvents.Count < eventBatch.Length) && (++index < eventBatch.Length + 3))
+                        {
+                            var currentReceiveBatch = await receiver.ReceiveAsync(batchSize, TimeSpan.FromMilliseconds(25));
+                            receivedEvents.AddRange(currentReceiveBatch);
+
+                            Assert.That(currentReceiveBatch, Is.Not.Empty, $"There should have been a set of events received for batch number: { batchNumber }.");
+
+                            ++batchNumber;
+                        }
+
+                        index = 0;
+
+                        foreach (var receivedEvent in receivedEvents)
+                        {
+                            Assert.That(receivedEvent.IsEquivalentTo(eventBatch[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
+                            ++index;
+                        }
+
+                        Assert.That(index, Is.EqualTo(eventBatch.Length), "The number of received events did not match the batch size.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventReceivers/EventReceiverTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventReceivers/EventReceiverTests.cs
@@ -1,0 +1,253 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventReceiver" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventReceiverTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheReceiver()
+        {
+            Assert.That(() => new EventReceiver(null, "dummy", "0", new EventReceiverOptions()), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheEventHub(string eventHub)
+        {
+            Assert.That(() => new EventReceiver(new ObservableTransportReceiverMock(), eventHub, "0", new EventReceiverOptions()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesThePartition(string partition)
+        {
+            Assert.That(() => new EventReceiver(new ObservableTransportReceiverMock(), "dummy", partition, new EventReceiverOptions()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheOptions()
+        {
+            Assert.That(() => new EventReceiver(new ObservableTransportReceiverMock(), "dummy", "0", null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorSetsThePartition()
+        {
+            var partition = "aPartition";
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", partition, new EventReceiverOptions());
+
+            Assert.That(receiver.PartitionId, Is.EqualTo(partition));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase(1)]
+        [TestCase(32769)]
+        public void ConstructorSetsThePriority(long? priority)
+        {
+            var options = new EventReceiverOptions
+            {
+                ExclusiveReceiverPriority = priority
+            };
+
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", "0", options);
+
+            Assert.That(receiver.ExclusiveReceiverPriority, Is.EqualTo(priority));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorSetsTheStartingPosition()
+        {
+            var options = new EventReceiverOptions
+            {
+                BeginReceivingAt = EventPosition.FromSequenceNumber(12345, true)
+            };
+
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", "0", options);
+
+            Assert.That(receiver.StartingPosition, Is.EqualTo(options.BeginReceivingAt));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorSetsTheConsumerGroup()
+        {
+            var options = new EventReceiverOptions
+            {
+                ConsumerGroup = "SomeGroup"
+            };
+
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", "0", options);
+
+            Assert.That(receiver.ConsumerGroup, Is.EqualTo(options.ConsumerGroup));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventReceiver.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-32767)]
+        [TestCase(-1)]
+        [TestCase(0)]
+        public void ReceiveAsyncValidatesTheMaximumCount(int maximumMessageCount)
+        {
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", "0", new EventReceiverOptions());
+            var cancellation = new CancellationTokenSource();
+            var expectedWaitTime = TimeSpan.FromDays(1);
+
+            Assert.That(async () => await receiver.ReceiveAsync(maximumMessageCount, expectedWaitTime, cancellation.Token), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventReceiver.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(-1)]
+        [TestCase(-100)]
+        [TestCase(-1000)]
+        [TestCase(-10000)]
+        public void ReceiveAsyncValidatesTheMaximumWaitTime(int timeSpanDelta)
+        {
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", "0", new EventReceiverOptions());
+            var cancellation = new CancellationTokenSource();
+            var expectedWaitTime = TimeSpan.FromMilliseconds(timeSpanDelta);
+
+            Assert.That(async () => await receiver.ReceiveAsync(32, expectedWaitTime, cancellation.Token), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventReceiver.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ReceiveAsyncInvokesTheTransportReceiver()
+        {
+            var options = new EventReceiverOptions { DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(8) };
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", "0", options);
+            var cancellation = new CancellationTokenSource();
+            var expectedMessageCount = 45;
+
+            await receiver.ReceiveAsync(expectedMessageCount, null, cancellation.Token);
+
+            (var actualMessageCount, var actualWaitTime) = transportReceiver.ReceiveCalledWithParameters;
+
+            Assert.That(actualMessageCount, Is.EqualTo(expectedMessageCount), "The message counts should match.");
+            Assert.That(actualWaitTime, Is.EqualTo(options.DefaultMaximumReceiveWaitTime), "The wait time should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventReceiver.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task CloseAsyncClosesTheTransportReceiver()
+        {
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", "0", new EventReceiverOptions());
+
+            await receiver.CloseAsync();
+
+            Assert.That(transportReceiver.WasCloseCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventReceiver.CloseAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void CloseClosesTheTransportReceiver()
+        {
+            var transportReceiver = new ObservableTransportReceiverMock();
+            var receiver = new EventReceiver(transportReceiver, "dummy", "0", new EventReceiverOptions());
+
+            receiver.Close();
+
+            Assert.That(transportReceiver.WasCloseCalled, Is.True);
+        }
+
+        /// <summary>
+        ///   Allows for observation of operations performed by the receiver for testing purposes.
+        /// </summary>
+        ///
+        private class ObservableTransportReceiverMock : TransportEventReceiver
+        {
+            public bool WasCloseCalled = false;
+            public (int, TimeSpan?) ReceiveCalledWithParameters;
+
+            public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount,
+                                                                      TimeSpan? maximumWaitTime,
+                                                                      CancellationToken cancellationToken)
+            {
+                ReceiveCalledWithParameters = (maximumMessageCount, maximumWaitTime);
+                return Task.FromResult(default(IEnumerable<EventData>));
+            }
+
+            public override Task CloseAsync(CancellationToken cancellationToken)
+            {
+                WasCloseCalled = true;
+                return Task.CompletedTask;
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/EventSenderLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/EventSenderLiveTests.cs
@@ -26,8 +26,8 @@ namespace Azure.Messaging.EventHubs.Tests
     public class EventSenderLiveTests
     {
         /// <summary>
-        ///   Verifies that the <see cref="EventHubClient" /> is able to
-        ///   connect to the Event Hubs service.
+        ///   Verifies that the <see cref="EventSender" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
         /// </summary>
         ///
         [Test]
@@ -47,8 +47,8 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies that the <see cref="EventHubClient" /> is able to
-        ///   connect to the Event Hubs service.
+        ///   Verifies that the <see cref="EventSender" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
         /// </summary>
         ///
         [Test]
@@ -69,8 +69,8 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies that the <see cref="EventHubClient" /> is able to
-        ///   connect to the Event Hubs service.
+        ///   Verifies that the <see cref="EventSender" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
         /// </summary>
         ///
         [Test]
@@ -95,8 +95,8 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies that the <see cref="EventHubClient" /> is able to
-        ///   connect to the Event Hubs service.
+        ///   Verifies that the <see cref="EventSender" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
         /// </summary>
         ///
         [Test]
@@ -129,8 +129,8 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies that the <see cref="EventHubClient" /> is able to
-        ///   connect to the Event Hubs service.
+        ///   Verifies that the <see cref="EventSender" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
         /// </summary>
         ///
         [Test]
@@ -154,8 +154,8 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies that the <see cref="EventHubClient" /> is able to
-        ///   connect to the Event Hubs service.
+        ///   Verifies that the <see cref="EventSender" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
         /// </summary>
         ///
         [Test]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/EventSenderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventSenders/EventSenderTests.cs
@@ -116,7 +116,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var batchingOptions = new EventBatchingOptions { PartitionKey = "testKey" };
             var events = new[] { new EventData(new byte[] { 0x44, 0x66, 0x88 }) };
             var transportSender = new ObservableTransportSenderMock();
-            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions{ PartitionId = "1" });
+            var sender = new EventSender(transportSender, "dummy", new EventSenderOptions { PartitionId = "1" });
 
             Assert.That(async () => await sender.SendAsync(events, batchingOptions), Throws.InvalidOperationException);
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensionTests.cs
@@ -1,0 +1,208 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventDataExtensions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventDataExtensionsTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsDifferentBodies()
+        {
+            var firstEvent = new EventData(new byte[] { 0x22, 0x44 });
+            var secondEvent = new EventData(new byte[] { 0x11, 0x33 });
+
+            Assert.That(firstEvent.IsEquivalentTo(secondEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsDifferentProperties()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var firstEvent = new EventData((byte[])body.Clone());
+            var secondEvent = new EventData((byte[])body.Clone());
+
+            firstEvent.Properties["test"] = "trackOne";
+            secondEvent.Properties["test"] = "trackTwo";
+
+            Assert.That(firstEvent.IsEquivalentTo(secondEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsWhenOnePropertySetIsNull()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var firstEvent = new EventData((byte[])body.Clone());
+            var secondEvent = new EventData((byte[])body.Clone());
+
+            firstEvent.Properties = null;
+            secondEvent.Properties["test"] = "trackTwo";
+
+            Assert.That(firstEvent.IsEquivalentTo(secondEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToIgnoresSystemPropertiesByDefault()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var firstEvent = new EventData((byte[])body.Clone());
+            var secondEvent = new EventData((byte[])body.Clone());
+
+            firstEvent.SystemProperties = new EventData.SystemEventProperties();
+            firstEvent.SystemProperties["something"] = "trackOne";
+
+            secondEvent.SystemProperties = new EventData.SystemEventProperties();
+            secondEvent.SystemProperties["something"] = "trackTwo";
+
+            Assert.That(firstEvent.IsEquivalentTo(secondEvent), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsDifferentSystemProperties()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var firstEvent = new EventData((byte[])body.Clone());
+            var secondEvent = new EventData((byte[])body.Clone());
+
+            firstEvent.SystemProperties = new EventData.SystemEventProperties();
+            firstEvent.SystemProperties["something"] = "trackOne";
+
+            secondEvent.SystemProperties = new EventData.SystemEventProperties();
+            secondEvent.SystemProperties["something"] = "trackTwo";
+
+            Assert.That(firstEvent.IsEquivalentTo(secondEvent, true), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsWhenOneSystemPropertySetIsNull()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var firstEvent = new EventData((byte[])body.Clone());
+            var secondEvent = new EventData((byte[])body.Clone());
+
+            firstEvent.SystemProperties = new EventData.SystemEventProperties();
+            firstEvent.SystemProperties["something"] = "trackOne";
+
+            secondEvent.SystemProperties = null;
+
+            Assert.That(firstEvent.IsEquivalentTo(secondEvent, true), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsEqualEvents()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var firstEvent = new EventData((byte[])body.Clone());
+            var secondEvent = new EventData((byte[])body.Clone());
+
+            firstEvent.Properties["test"] = "same";
+            secondEvent.Properties["test"] = "same";
+
+            firstEvent.SystemProperties = new EventData.SystemEventProperties();
+            firstEvent.SystemProperties["something"] = "otherSame";
+
+            secondEvent.SystemProperties = new EventData.SystemEventProperties();
+            secondEvent.SystemProperties["something"] = "otherSame";
+
+            Assert.That(firstEvent.IsEquivalentTo(secondEvent), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsSameInstance()
+        {
+            var firstEvent = new EventData(new byte[] { 0x22, 0x44, 0x88 });
+            firstEvent.SystemProperties = new EventData.SystemEventProperties();
+            firstEvent.SystemProperties["something"] = "otherSame";
+
+            Assert.That(firstEvent.IsEquivalentTo(firstEvent), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsTwoNulls()
+        {
+            Assert.That(((EventData)null).IsEquivalentTo(null), Is.True);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsNullInstance()
+        {
+            var firstEvent = new EventData(new byte[] { 0x22, 0x44, 0x88 });
+            firstEvent.SystemProperties = new EventData.SystemEventProperties();
+            firstEvent.SystemProperties["something"] = "otherSame";
+
+            Assert.That(((EventData)null).IsEquivalentTo(firstEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventDataExtensions.IsEquivalentTo" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEquivalentToDetectsNullArgument()
+        {
+            var firstEvent = new EventData(new byte[] { 0x22, 0x44, 0x88 });
+            firstEvent.SystemProperties = new EventData.SystemEventProperties();
+            firstEvent.SystemProperties["something"] = "otherSame";
+
+            Assert.That(firstEvent.IsEquivalentTo((EventData)null), Is.False);
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensions.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The set of extension methods for the <see cref="EventData" />
+    ///   class.
+    /// </summary>
+    ///
+    internal static class EventDataExtensions
+    {
+        /// <summary>
+        ///   Compares event data between two instances to determine if the
+        ///   instances represent the same event.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        /// <param name="other">The other event to consider.</param>
+        /// <param name="considerSystemProperties">If <c>true</c>, the <see cref="EventData.SystemProperties" /> will be considered; otherwise, differences will be ignored.</param>
+        ///
+        /// <returns><c>true</c>, if the two events are structurally equivilent; otherwise, <c>false</c>.</returns>
+        ///
+        public static bool IsEquivalentTo(this EventData instance,
+                                          EventData other,
+                                          bool considerSystemProperties = false)
+        {
+            // If the events are the same instance, they're equal.  This should only happen
+            // if both are null or they are the exact same instance.
+
+            if (Object.ReferenceEquals(instance, other))
+            {
+                return true;
+            }
+
+            // If one or the other is null, then they cannot be equal, since we know that
+            // they are not both null.
+
+            if ((instance == null) || (other == null))
+            {
+                return false;
+            }
+
+            // If the contents of each body is not equal, the events are not
+            // equal.
+
+            var instanceBody = instance.Body.ToArray();
+            var otherBody = other.Body.ToArray();
+
+            if (instanceBody.Length != otherBody.Length)
+            {
+                return false;
+            }
+
+            if (!Enumerable.SequenceEqual(instanceBody, otherBody))
+            {
+                return false;
+            }
+
+            // Verify the system properties are equivilent, unless they're the same reference.
+
+            if ((considerSystemProperties) && (!Object.ReferenceEquals(instance.SystemProperties, other.SystemProperties)))
+            {
+
+                if ((instance.SystemProperties == null) || (other.SystemProperties == null))
+                {
+                    return false;
+                }
+
+                // Verify that the system properties contain the same elements, assuming they are non-null.
+
+                if (instance.SystemProperties?.Count != other.SystemProperties?.Count)
+                {
+                    return false;
+                }
+
+                if (!instance.SystemProperties.OrderBy(kvp => kvp.Key).SequenceEqual(other.SystemProperties.OrderBy(kvp => kvp.Key)))
+                {
+                    return false;
+                }
+            }
+
+            // Since we know that the event bodies and system properties are equal, if the property sets are the
+            // same instance, then we know that the events are equal.  This should only happen if both are null.
+
+            if (Object.ReferenceEquals(instance.Properties, other.Properties))
+            {
+                return true;
+            }
+
+            // If either property is null, then the events are not equal, since we know that they are
+            // not both null.
+
+            if ((instance.Properties == null) || (other.Properties == null))
+            {
+                return false;
+            }
+
+            // The only meaningful comparison left is to ensure that the property sets are equivilent,
+            // the outcome of this check is the final word on equality.
+
+            if (instance.Properties.Count != other.Properties.Count)
+            {
+                return false;
+            }
+
+            return instance.Properties.OrderBy(kvp => kvp.Key).SequenceEqual(other.Properties.OrderBy(kvp => kvp.Key));
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The intent of these changes is to complete the end-to-end infrastructure for receiving events via the `EventReceiver`, from the API surface through the compatibility shim for the track one implementation.  Client operations have been validated at the unit level and basic sending scenarios have been smoke tested through Live tests.  

# Goals

- Ensure that an `EventReceiver` creates a transport-aware receiver for containment to which it delegates operations.  This is based on an abstraction to isolate transport-level concerns from the core class, allowing different protocols, transports, compatibility shims, and test infrastructure to be used for delegation.

- Broker the compatibility between the track two API and the track one `PartitionReceiver` implementation, mapping types as needed.  Chief among them is mapping of the `EventData` model between the track one and track two incarnations.

- Allow for creation of an `EventReceiver` that is capable of interacting with the Event Hubs service for receiving of events as either a shared or exclusive resource for a given partition/consumer group pairing.

- Review and revise the public surface area of the implementation, reducing scope as possible by internalizing constructs intended only to support project-level testing.

# Last Upstream Rebase

Thursday, June 13, 2019  12:58pm (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)