### PR TITLE
Make ConcurrentExpiringSet not leak the cleanup task for the period of delayBetweenCleanups

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
@@ -1008,6 +1008,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             await this.ReceiveLinkManager.CloseAsync().ConfigureAwait(false);
             await this.RequestResponseLinkManager.CloseAsync().ConfigureAwait(false);
+            this.requestResponseLockedMessages.Clear();
         }
 
         protected virtual async Task<IList<Message>> OnReceiveAsync(int maxMessageCount, TimeSpan serverWaitTime)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 
         public void Clear()
         {
-            tokenSource.Cancel();
-            dictionary.Clear();
-            tokenSource = new CancellationTokenSource();
+            this.tokenSource.Cancel();
+            this.dictionary.Clear();
+            this.tokenSource = new CancellationTokenSource();
         }
 
         void ScheduleCleanup(CancellationToken token)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         {
             try
             {
-                await Task.Delay(delayBetweenCleanups, token);
+                await Task.Delay(delayBetweenCleanups, token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -71,8 +71,9 @@ namespace Microsoft.Azure.ServiceBus.Primitives
                 }
             }
 
-            foreach (var key in this.dictionary.Keys)
+            foreach (var kvp in this.dictionary)
             {
+                var key = kvp.Key;
                 if (DateTime.UtcNow > this.dictionary[key])
                 {
                     this.dictionary.TryRemove(key, out _);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Primitives/ConcurrentExpiringSetTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Primitives/ConcurrentExpiringSetTests.cs
@@ -27,5 +27,27 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Primitives
             set.AddOrUpdate("testKey", DateTime.UtcNow - TimeSpan.FromSeconds(5));
             Assert.False(set.Contains("testKey"), "The set should return false for an expired entry.");
         }
+
+        [Fact]
+        public void Contains_returns_false_after_clear()
+        {
+            var set = new ConcurrentExpiringSet<string>();
+            set.AddOrUpdate("testKey", DateTime.UtcNow + TimeSpan.FromSeconds(5));
+            set.Clear();
+
+            Assert.False(set.Contains("testKey"), "The set should return false after clear.");
+        }
+
+        [Fact]
+        public void Contains_returns_false_after_clear_for_added_expired_keys()
+        {
+            var set = new ConcurrentExpiringSet<string>();
+            set.AddOrUpdate("testKey1", DateTime.UtcNow + TimeSpan.FromSeconds(5));
+            set.Clear();
+            set.AddOrUpdate("testKey2", DateTime.UtcNow - TimeSpan.FromSeconds(5));
+
+            Assert.False(set.Contains("testKey1"), "The set should return false after clear.");
+            Assert.False(set.Contains("testKey2"), "The set should return false for an expired entry.");
+        }
     }
 }


### PR DESCRIPTION
Related to Azure Service Bus

- Properly cancels the `Task.Delay` if cleanup was scheduled to not leak the task for the duration of the timeout
- Removes the `.Keys` access that locks the whole concurrent dictionary
- Makes sure to remove the key only if the snapshot matches by using collection remove