### PR TITLE
Expiring set lock free

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
@@ -1008,6 +1008,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             await this.ReceiveLinkManager.CloseAsync().ConfigureAwait(false);
             await this.RequestResponseLinkManager.CloseAsync().ConfigureAwait(false);
+            this.requestResponseLockedMessages.Clear();
         }
 
         protected virtual async Task<IList<Message>> OnReceiveAsync(int maxMessageCount, TimeSpan serverWaitTime)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
@@ -1008,7 +1008,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             await this.ReceiveLinkManager.CloseAsync().ConfigureAwait(false);
             await this.RequestResponseLinkManager.CloseAsync().ConfigureAwait(false);
-            this.requestResponseLockedMessages.Clear();
+            this.requestResponseLockedMessages.Close();
         }
 
         protected virtual async Task<IList<Message>> OnReceiveAsync(int maxMessageCount, TimeSpan serverWaitTime)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Azure.ServiceBus.Primitives
 
         public void Clear()
         {
-            tokenSource.Cancel();
-            dictionary.Clear();
-            tokenSource = new CancellationTokenSource();
+            this.tokenSource.Cancel();
+            this.dictionary.Clear();
+            this.tokenSource = new CancellationTokenSource();
         }
 
         void ScheduleCleanup(CancellationToken token)

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         {
             try
             {
-                await Task.Delay(delayBetweenCleanups, token);
+                await Task.Delay(delayBetweenCleanups, token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -71,8 +71,9 @@ namespace Microsoft.Azure.ServiceBus.Primitives
                 }
             }
 
-            foreach (var key in this.dictionary.Keys)
+            foreach (var kvp in this.dictionary)
             {
+                var key = kvp.Key;
                 if (DateTime.UtcNow > this.dictionary[key])
                 {
                     this.dictionary.TryRemove(key, out _);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -71,10 +71,11 @@ namespace Microsoft.Azure.ServiceBus.Primitives
                     return;
                 }
 
+                var utcNow = DateTime.UtcNow;
                 foreach (var kvp in this.dictionary)
                 {
                     var expiration = kvp.Value;
-                    if (DateTime.UtcNow > expiration)
+                    if (utcNow > expiration)
                     {
                         this.dictionaryAsCollection.Remove(kvp);
                     }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
         readonly ICollection<KeyValuePair<TKey, DateTime>> dictionaryAsCollection;
         readonly CancellationTokenSource tokenSource = new CancellationTokenSource();
         volatile TaskCompletionSource<bool> cleanupTaskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-        volatile int closeSignaled;
+        int closeSignaled;
         bool closed;
         static readonly TimeSpan delayBetweenCleanups = TimeSpan.FromSeconds(30);
 

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.ServiceBus.Primitives
             {
                 try
                 {
-                    await cleanupTaskCompletionSource.Task.ConfigureAwait(false);
+                    await this.cleanupTaskCompletionSource.Task.ConfigureAwait(false);
                     this.cleanupTaskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     await Task.Delay(delayBetweenCleanups, token).ConfigureAwait(false);
                 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Primitives/ConcurrentExpiringSet.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Azure.ServiceBus.Primitives
                 try
                 {
                     await this.cleanupTaskCompletionSource.Task.ConfigureAwait(false);
-                    this.cleanupTaskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                     await Task.Delay(delayBetweenCleanups, token).ConfigureAwait(false);
                 }
                 catch (OperationCanceledException)
@@ -71,14 +70,21 @@ namespace Microsoft.Azure.ServiceBus.Primitives
                     return;
                 }
 
+                var isEmpty = true;
                 var utcNow = DateTime.UtcNow;
                 foreach (var kvp in this.dictionary)
                 {
+                    isEmpty = false;
                     var expiration = kvp.Value;
                     if (utcNow > expiration)
                     {
                         this.dictionaryAsCollection.Remove(kvp);
                     }
+                }
+
+                if (isEmpty)
+                {
+                    this.cleanupTaskCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
                 }
             }
         }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Primitives/ConcurrentExpiringSetTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Primitives/ConcurrentExpiringSetTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Primitives
 {
     using Microsoft.Azure.ServiceBus.Primitives;
     using System;
+    using System.Threading.Tasks;
     using Xunit;
 
     public class ConcurrentExpiringSetTests
@@ -29,25 +30,38 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Primitives
         }
 
         [Fact]
-        public void Contains_returns_false_after_clear()
+        public void Contains_throws_after_close()
         {
             var set = new ConcurrentExpiringSet<string>();
             set.AddOrUpdate("testKey", DateTime.UtcNow + TimeSpan.FromSeconds(5));
-            set.Clear();
+            set.Close();
 
-            Assert.False(set.Contains("testKey"), "The set should return false after clear.");
+            Assert.Throws<ObjectDisposedException>(() => set.Contains("testKey"));
         }
 
         [Fact]
-        public void Contains_returns_false_after_clear_for_added_expired_keys()
+        public void AddOrUpdate_throws_after_close()
         {
             var set = new ConcurrentExpiringSet<string>();
             set.AddOrUpdate("testKey1", DateTime.UtcNow + TimeSpan.FromSeconds(5));
-            set.Clear();
-            set.AddOrUpdate("testKey2", DateTime.UtcNow - TimeSpan.FromSeconds(5));
+            set.Close();
 
-            Assert.False(set.Contains("testKey1"), "The set should return false after clear.");
-            Assert.False(set.Contains("testKey2"), "The set should return false for an expired entry.");
+            Assert.Throws<ObjectDisposedException>(() => set.AddOrUpdate("testKey2", DateTime.UtcNow - TimeSpan.FromSeconds(5)));
+        }
+
+        [Fact]
+        public void Close_is_idempotent_and_thread_safe()
+        {
+            var set = new ConcurrentExpiringSet<string>();
+
+            var ex = Record.Exception(() =>
+            {
+                set.Close();
+                set.Close();
+                Parallel.Invoke(() => set.Close(), () => set.Close());
+            });
+
+            Assert.Null(ex);
         }
     }
 }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Primitives/ConcurrentExpiringSetTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/Primitives/ConcurrentExpiringSetTests.cs
@@ -27,5 +27,27 @@ namespace Microsoft.Azure.ServiceBus.UnitTests.Primitives
             set.AddOrUpdate("testKey", DateTime.UtcNow - TimeSpan.FromSeconds(5));
             Assert.False(set.Contains("testKey"), "The set should return false for an expired entry.");
         }
+
+        [Fact]
+        public void Contains_returns_false_after_clear()
+        {
+            var set = new ConcurrentExpiringSet<string>();
+            set.AddOrUpdate("testKey", DateTime.UtcNow + TimeSpan.FromSeconds(5));
+            set.Clear();
+
+            Assert.False(set.Contains("testKey"), "The set should return false after clear.");
+        }
+
+        [Fact]
+        public void Contains_returns_false_after_clear_for_added_expired_keys()
+        {
+            var set = new ConcurrentExpiringSet<string>();
+            set.AddOrUpdate("testKey1", DateTime.UtcNow + TimeSpan.FromSeconds(5));
+            set.Clear();
+            set.AddOrUpdate("testKey2", DateTime.UtcNow - TimeSpan.FromSeconds(5));
+
+            Assert.False(set.Contains("testKey1"), "The set should return false after clear.");
+            Assert.False(set.Contains("testKey2"), "The set should return false for an expired entry.");
+        }
     }
 }


### PR DESCRIPTION
Related to Azure Service Bus

Lock-free alternative to https://github.com/Azure/azure-sdk-for-net/pull/6576

- Properly cancels the `Task.Delay` if cleanup was scheduled to not leak the task for the duration of the timeout
- Removes the `.Keys` access that locks the whole concurrent dictionary
- Makes sure to remove the key only if the snapshot matches by using collection remove

Caveat (but highly unlikely):

- Due to the field exchange, we might miss a TrySetResult on the old TCS and therefore would not run the cleanup again until the next add or update comes. This spinning solution in the second latest commit might decrease that change even more but I let it to the team reviewing the PR to decide what they want to take

```
        [Benchmark(Baseline = true)]
        public void Old()
        {
            Parallel.For(0, 1000, i => { oldSet.AddOrUpdate(i, DateTime.UtcNow.AddSeconds(5)); });
        }

        [Benchmark]
        public void New()
        {
            Parallel.For(0, 1000, i => { newSet.AddOrUpdate(i, DateTime.UtcNow.AddSeconds(5)); });
        }
```

### With spinning

![image](https://user-images.githubusercontent.com/174258/59501895-cdc82880-8e9c-11e9-87ae-16893c102be1.png)


### Without

TBD
![image](https://user-images.githubusercontent.com/174258/59501745-77f38080-8e9c-11e9-8106-8c2d28eb64c7.png)

