### PR TITLE
[Azure Search] Fix broken Search tests

### DIFF
--- a/src/AzSdk.test.reference.props
+++ b/src/AzSdk.test.reference.props
@@ -12,4 +12,7 @@
 		<DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.1" PrivateAssets="All" />
   </ItemGroup>
+  <ItemGroup> 
+    <Compile Include="$(RepoEngPath)\mgmt\DisableTestRunParallel.cs" Link="DisableTestRunParallel.cs" /> 
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
FYI @shahabhijeet @chidozieononiwu @weshaggard 

This is just to unblock Search tests until the source tree migration is done.