### PR TITLE
[Event Hubs Client] Track Two: First Preview (Azure.Identity Support)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/EventHubSharedKeyCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/EventHubSharedKeyCredential.cs
@@ -1,0 +1,90 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Core;
+
+namespace Azure.Messaging.EventHubs.Authorization
+{
+    /// <summary>
+    ///   Provides a credential based on a shared access signature for a given
+    ///   Event Hub instance.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Core.TokenCredential" />
+    ///
+    public sealed class EventHubSharedKeyCredential : TokenCredential
+    {
+        /// <summary>
+        ///   The name of the shared access key to be used for authorization, as
+        ///   reported by the Azure portal.
+        /// </summary>
+        ///
+        public string SharedAccessKeyName { get; }
+
+        /// <summary>
+        ///   The value of the shared access key to be used for authorization, as
+        ///   reported by the Azure portal.
+        /// </summary>
+        ///
+        private string SharedAccessKey { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubSharedKeyCredential"/> class.
+        /// </summary>
+        ///
+        /// <param name="sharedAccessKeyName">The name of the shared access key to be used for authorization, as reported by the Azure portal.</param>
+        /// <param name="sharedAccessKey">The value of the shared access key to be used for authorization, as reported by the Azure portal.</param>
+        ///
+        public EventHubSharedKeyCredential(string sharedAccessKeyName,
+                                           string sharedAccessKey)
+        {
+            Guard.ArgumentNotNullOrEmpty(nameof(sharedAccessKeyName), sharedAccessKeyName);
+            Guard.ArgumentNotNullOrEmpty(nameof(sharedAccessKey), sharedAccessKey);
+
+            SharedAccessKeyName = sharedAccessKeyName;
+            SharedAccessKey = sharedAccessKey;
+        }
+
+        /// <summary>
+        ///   Retrieves the token that represents the shared access signature credential, for
+        ///   use in authorization against an Event Hub.
+        /// </summary>
+        ///
+        /// <param name="scopes">The access scopes to request a token for.</param>
+        /// <param name="cancellationToken">The token used to request cancellation of the operation.</param>
+        ///
+        /// <returns>The token representating the shared access signature for this credential.</returns>
+        ///
+        public override AccessToken GetToken(string[] scopes, CancellationToken cancellationToken) => throw new InvalidOperationException(Resources.SharedKeyCredentialCannotGenerateTokens);
+
+        /// <summary>
+        ///   Retrieves the token that represents the shared access signature credential, for
+        ///   use in authorization against an Event Hub.
+        /// </summary>
+        ///
+        /// <param name="scopes">The access scopes to request a token for.</param>
+        /// <param name="cancellationToken">The token used to request cancellation of the operation.</param>
+        ///
+        /// <returns>The token representating the shared access signature for this credential.</returns>
+        ///
+        public override Task<AccessToken> GetTokenAsync(string[] scopes, CancellationToken cancellationToken) => throw new InvalidOperationException(Resources.SharedKeyCredentialCannotGenerateTokens);
+
+        /// <summary>
+        /// Coverts to shared access signature credential.
+        /// </summary>
+        ///
+        /// <param name="eventHubResource">The Event Hubs resource to which the token is intended to serve as authorization.</param>
+        /// <param name="signatureValidityDuration">The duration that the signature should be considered valid; if not specified, a default will be assumed.</param>
+        ///
+        /// <returns>A <see cref="SharedAccessSignatureCredential" /> based on the requested shared access key.</returns>
+        ///
+        internal SharedAccessSignatureCredential ConvertToSharedAccessSignatureCredential(string eventHubResource,
+                                                                                          TimeSpan? signatureValidityDuration = default) =>
+            new SharedAccessSignatureCredential(new SharedAccessSignature(eventHubResource, SharedAccessKeyName, SharedAccessKey, signatureValidityDuration));
+
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/EventHubTokenCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/EventHubTokenCredential.cs
@@ -1,0 +1,72 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Core;
+
+namespace Azure.Messaging.EventHubs.Authorization
+{
+    /// <summary>
+    ///   Provides a generic token-based credential for a given Event Hub instance.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Core.TokenCredential" />
+    ///
+    internal class EventHubTokenCredential : TokenCredential
+    {
+        /// <summary>
+        ///   The Event Hubs resource to which the token is intended to serve as authorization.
+        /// </summary>
+        ///
+        public string Resource { get; }
+
+        /// <summary>
+        ///   The <see cref="TokenCredential" /> that forms the basis of this security token.
+        /// </summary>
+        ///
+        private TokenCredential Credential { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="SharedAccessSignatureCredential"/> class.
+        /// </summary>
+        ///
+        /// <param name="tokenCredential">The <see cref="TokenCredential" /> on which to base the token.</param>
+        /// <param name="eventHubResource">The Event Hubs resource to which the token is intended to serve as authorization.</param>
+        ///
+        public EventHubTokenCredential(TokenCredential tokenCredential,
+                                       string eventHubResource)
+        {
+            Guard.ArgumentNotNull(nameof(tokenCredential), tokenCredential);
+            Guard.ArgumentNotNullOrEmpty(nameof(eventHubResource), eventHubResource);
+
+            Credential = tokenCredential;
+            Resource = eventHubResource;
+        }
+
+        /// <summary>
+        ///   Retrieves the token that represents the shared access signature credential, for
+        ///   use in authorization against an Event Hub.
+        /// </summary>
+        ///
+        /// <param name="scopes">The access scopes to request a token for.</param>
+        /// <param name="cancellationToken">The token used to request cancellation of the operation.</param>
+        ///
+        /// <returns>The token representating the shared access signature for this credential.</returns>
+        ///
+        public override AccessToken GetToken(string[] scopes, CancellationToken cancellationToken) => Credential.GetToken(scopes, cancellationToken);
+
+        /// <summary>
+        ///   Retrieves the token that represents the shared access signature credential, for
+        ///   use in authorization against an Event Hub.
+        /// </summary>
+        ///
+        /// <param name="scopes">The access scopes to request a token for.</param>
+        /// <param name="cancellationToken">The token used to request cancellation of the operation.</param>
+        ///
+        /// <returns>The token representating the shared access signature for this credential.</returns>
+        ///
+        public override Task<AccessToken> GetTokenAsync(string[] scopes, CancellationToken cancellationToken) => Credential.GetTokenAsync(scopes, cancellationToken);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
@@ -135,9 +135,12 @@ namespace Azure.Messaging.EventHubs.Compatibility
                     tokenProvider = new TrackOneSharedAccessTokenProvider(sasCredential.SharedAccessSignature);
                     break;
 
+                case EventHubTokenCredential eventHubCredential:
+                    tokenProvider = new TrackOneGenericTokenProvider(eventHubCredential);
+                    break;
+
                 default:
-                    throw new NotImplementedException("Only shared key credentials are currently supported.");
-                    //TODO: Revisit this once Azure.Identity is ready for managed identities.
+                    throw new ArgumentException(Resources.UnsupportedCredential, nameof(credential));
             }
 
             // Create the endpoint for the client.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneGenericToken.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneGenericToken.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Core;
+using TrackOne;
+
+namespace Azure.Messaging.EventHubs.Compatibility
+{
+    /// <summary>
+    ///   A compatibility shim allowing a token credential to be used as a
+    ///   generic JWT security token with the Track One types.
+    /// </summary>
+    ///
+    /// <seealso cref="Azure.Core.TokenCredential"/>
+    /// <seealso cref="TrackOne.SecurityToken" />
+    ///
+    internal class TrackOneGenericToken : SecurityToken
+    {
+        /// <summary>
+        ///   The <see cref="TokenCredential" /> that forms the basis of this security token.
+        /// </summary>
+        ///
+        public TokenCredential Credential { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="TrackOneGenericToken"/> class.
+        /// </summary>
+        ///
+        /// <param name="tokenCredential">The <see cref="TokenCredential" /> on which to base the token.</param>
+        /// <param name="jwtTokenString">The raw JWT token value from the <paramref name="tokenCredential" /></param>
+        /// <param name="eventHubResource">The Event Hubs resource to which the token is intended to serve as authorization.</param>
+        /// <param name="tokenExpirationUtc">The date and time that the token expires, in UTC.</param>
+        ///
+        public TrackOneGenericToken(TokenCredential tokenCredential,
+                                    string jwtTokenString,
+                                    string eventHubResource,
+                                    DateTime tokenExpirationUtc) :
+            base(jwtTokenString, tokenExpirationUtc, eventHubResource, ClientConstants.JsonWebTokenType)
+        {
+            Guard.ArgumentNotNull(nameof(tokenCredential), tokenCredential);
+            Credential = tokenCredential;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneGenericTokenProvider.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneGenericTokenProvider.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Authorization;
+using Azure.Messaging.EventHubs.Core;
+using TrackOne;
+
+namespace Azure.Messaging.EventHubs.Compatibility
+{
+    /// <summary>
+    ///   A compatibility shim allowing a shared access signature to be used as a
+    ///   renewable security token with the Track One types.
+    /// </summary>
+    ///
+    /// <seealso cref="Authorization.EventHubTokenCredential"/>
+    /// <seealso cref="TrackOne.TokenProvider" />
+    ///
+    internal sealed class TrackOneGenericTokenProvider : TokenProvider
+    {
+        /// <summary>The default scope to use for token aquisition with the Event Hubs service.</summary>
+        private static readonly string[] EventHubsDefaultScopes = new[] { "https://eventhubs.Azure.net//.default" };
+
+        /// <summary>
+        ///   The <see cref="EventHubTokenCredential" /> that forms the basis of this security token.
+        /// </summary>
+        ///
+        public EventHubTokenCredential Credential { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="TrackOneGenericTokenProvider"/> class.
+        /// </summary>
+        ///
+        /// <param name="credential">The <see cref="EventHubTokenCredential" /> on which to base the token.</param>
+        ///
+        public TrackOneGenericTokenProvider(EventHubTokenCredential credential)
+        {
+            Guard.ArgumentNotNull(nameof(credential), credential);
+            Guard.ArgumentNotNullOrEmpty(nameof(credential.Resource), credential.Resource);
+
+            Credential = credential;
+        }
+
+        /// <summary>
+        ///   Provides a security token based on a shared access signature which can be used for authorization against
+        ///   an Event Hub.
+        /// </summary>
+        ///
+        /// <param name="resource">The resource to which the token applies; this is also known as the token audience.</param>
+        /// <param name="tokenValidityDuration">The duration that the token should be considered valid.</param>
+        ///
+        /// <returns>The security token.</returns>
+        ///
+        public async override Task<SecurityToken> GetTokenAsync(string resource,
+                                                                TimeSpan tokenValidityDuration)
+        {
+            Guard.ArgumentNotNullOrEmpty(nameof(resource), resource);
+            Guard.ArgumentNotNegative(nameof(tokenValidityDuration), tokenValidityDuration);
+
+            // The resource of a token is assigned at the Event Hub level.  The resource being requested may be a child
+            // of the Event Hub, such as a partition.  Ensure that the resource being requested is the same Event Hub associated
+            // with the token or one of its children.
+            //
+            // Do not issue the token for a request that is a different Event Hub, or for a scope that is less restrictive than
+            // an Event Hub, such as a top-level namespace.
+            //
+            // For example, if the token resource is: "amqps://myeventhubs.servicebus.net/someHub"
+            //
+            //    Allow:
+            //      amqps://myeventhubs.servicebus.net/someHub
+            //      amqps://myeventhubs.servicebus.net/someHub/partitions/0
+            //
+            //    Disallow:
+            //      amqps://myeventhubs.servicebus.net
+            //      https://my.eventhubs.servicebus.net/someHub
+            //      amqps://myeventhubs.servicebus.net/otherHub
+            //      amqps://notmine.servicebus.net/SomeHub
+
+            if (resource.IndexOf(Credential.Resource, StringComparison.InvariantCultureIgnoreCase) != 0)
+            {
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.ResourceMustMatchSharedAccessSignature, resource, Credential.Resource), nameof(resource));
+            }
+
+            var accessToken = await Credential.GetTokenAsync(EventHubsDefaultScopes, CancellationToken.None);
+
+            return new TrackOneGenericToken
+            (
+                Credential,
+                accessToken.Token,
+                resource,
+                accessToken.ExpiresOn.DateTime
+            );
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -54,7 +54,7 @@ namespace Azure.Messaging.EventHubs
         /// <example>
         ///   <code>
         ///     var eventData = new EventData(serializedTelemetryData);
-        ///     eventData.Properties["eventType"] = "com.microsoft.azure.monitoring.EtlEvent";
+        ///     eventData.Properties["eventType"] = "com.microsoft.Azure.monitoring.EtlEvent";
         ///   </code>
         /// </example>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -166,13 +166,24 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to The connection string used for an Event Hub client must specify the Event Hubs namespace host, the path to an Event Hub, and a Shared Access Signature (both the name and value) to be valid..
+        ///   Looks up a localized string similar to The connection string used for an Event Hub client must specify the Event Hubs namespace host, and a Shared Access Signature (both the name and value) to be valid.  The path to an Event Hub must be included in the connection string or specified separately..
         /// </summary>
-        internal static string MalformedEventHubClientConnectionString
+        internal static string MissingConnectionInformation
         {
             get
             {
-                return ResourceManager.GetString("MalformedEventHubClientConnectionString", resourceCulture);
+                return ResourceManager.GetString("MissingConnectionInformation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The path to an Event Hub may be specified as part of the connection string or as a separate value, but not both.
+        /// </summary>
+        internal static string OnlyOneEventHubNameMayBeSpecified
+        {
+            get
+            {
+                return ResourceManager.GetString("OnlyOneEventHubNameMayBeSpecified", resourceCulture);
             }
         }
 
@@ -283,6 +294,28 @@ namespace Azure.Messaging.EventHubs
             get
             {
                 return ResourceManager.GetString("ValueOutOfRange", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The credential is not a known and supported credential type.  Please use a JWT credential or shared key credential..
+        /// </summary>
+        internal static string UnsupportedCredential
+        {
+            get
+            {
+                return ResourceManager.GetString("UnsupportedCredential", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to >A shared key credential is unable to generate a token directly.  Please use this credential when creating an Event Hub Client, for proper generation of shared key tokens..
+        /// </summary>
+        internal static string SharedKeyCredentialCannotGenerateTokens
+        {
+            get
+            {
+                return ResourceManager.GetString("SharedKeyCredentialCannotGenerateTokens", resourceCulture);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -156,8 +156,11 @@
   <data name="InvalidConnectionString" xml:space="preserve">
     <value>The connection string could not be parsed; either it was malformed or contains no well-known tokens.</value>
   </data>
-  <data name="MalformedEventHubClientConnectionString" xml:space="preserve">
-    <value>The connection string used for an Event Hub client must specify the Event Hubs namespace host, the path to an Event Hub, and a Shared Access Signature (both the name and value) to be valid.</value>
+  <data name="MissingConnectionInformation" xml:space="preserve">
+    <value>The connection string used for an Event Hub client must specify the Event Hubs namespace host, and a Shared Access Signature (both the name and value) to be valid.  The path to an Event Hub must be included in the connection string or specified separately.</value>
+  </data>
+  <data name="OnlyOneEventHubNameMayBeSpecified" xml:space="preserve">
+    <value>The path to an Event Hub may be specified as part of the connection string or as a separate value, but not both.</value>
   </data>
   <data name="UnknownConnectionType" xml:space="preserve">
     <value>The specified connection type, "{0}", is not recognized as valid in this context.</value>
@@ -176,5 +179,11 @@
   </data>
   <data name="CannotSendWithPartitionIdAndPartitionKey" xml:space="preserve">
     <value>A sender created for a specific partition cannot send events using a partition key.  This sender is associated with partition '{0}'.</value>
+  </data>
+  <data name="UnsupportedCredential" xml:space="preserve">
+    <value>The credential is not a known and supported credential type.  Please use a JWT credential or shared key credential.</value>
+  </data>
+  <data name="SharedKeyCredentialCannotGenerateTokens" xml:space="preserve">
+    <value>A shared key credential is unable to generate a token directly.  Please use this credential when creating an Event Hub Client, for proper generation of shared key tokens.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubSharedKeyCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubSharedKeyCredentialTests.cs
@@ -1,0 +1,105 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Reflection;
+using Azure.Messaging.EventHubs.Authorization;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventHubSharedKeyCredential" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventHubSharedKeyCredentialTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheKeyName(string keyName)
+        {
+            Assert.That(() => new EventHubSharedKeyCredential(keyName, "someKey"), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheKeyValue(string keyValue)
+        {
+            Assert.That(() => new EventHubSharedKeyCredential("someName", keyValue), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesInitializesProperties()
+        {
+            var name = "KeyName";
+            var value = "KeyValue";
+            var credential = new EventHubSharedKeyCredential(name, value);
+
+            var initializedValue = typeof(EventHubSharedKeyCredential)
+                .GetProperty("SharedAccessKey", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(credential, null);
+
+            Assert.That(credential.SharedAccessKeyName, Is.EqualTo(name), "The shared key name should have been set.");
+            Assert.That(initializedValue, Is.EqualTo(value), "The shared key should have been set.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void GetTokenIsNotPermitted()
+        {
+            Assert.That(() => new EventHubSharedKeyCredential("key", "value").GetToken(new[] { "test" }, default), Throws.InvalidOperationException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void GetTokenAsyncIsNotPermitted()
+        {
+            Assert.That(async () => await (new EventHubSharedKeyCredential("key", "value").GetTokenAsync(new[] { "thing" }, default)), Throws.InvalidOperationException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void CovertToSharedAccessSignatureCredentialProducesTheExpectedCredential()
+        {
+            var resource = "amqps://some.hub.com/path";
+            var keyName = "sharedKey";
+            var keyValue = "keyValue";
+            var validSpan = TimeSpan.FromHours(4);
+            var signature = new SharedAccessSignature(resource, keyName, keyValue, validSpan);
+            var keyCredential = new EventHubSharedKeyCredential(keyName, keyValue);
+            var sasCredential = keyCredential.ConvertToSharedAccessSignatureCredential(resource, validSpan);
+
+            Assert.That(sasCredential, Is.Not.Null, "A shared access signature credential should have been created.");
+            Assert.That(sasCredential.SharedAccessSignature, Is.Not.Null, "The SAS credential should contain a shared access signature.");
+            Assert.That(sasCredential.SharedAccessSignature.Resource, Is.EqualTo(signature.Resource), "The resource should match.");
+            Assert.That(sasCredential.SharedAccessSignature.SharedAccessKeyName, Is.EqualTo(signature.SharedAccessKeyName), "The shared access key name should match.");
+            Assert.That(sasCredential.SharedAccessSignature.SharedAccessKey, Is.EqualTo(signature.SharedAccessKey), "The shared access key should match.");
+            Assert.That(sasCredential.SharedAccessSignature.ExpirationUtc, Is.EqualTo(signature.ExpirationUtc).Within(TimeSpan.FromSeconds(5)), "The expiration should match.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Authorization;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventHubTokenCredential" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class EventHubTokenCredentialTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheCredential()
+        {
+            Assert.That(() => new EventHubTokenCredential(null, "anything!"), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheResource(string resource)
+        {
+            Assert.That(() => new EventHubTokenCredential(Mock.Of<TokenCredential>(), resource), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesInitializesProperties()
+        {
+            var sourceCredential = Mock.Of<TokenCredential>();
+            var resource = "the resource value";
+            var credential = new EventHubTokenCredential(sourceCredential, resource);
+
+            var credentialPropertyValue = typeof(EventHubTokenCredential)
+                .GetProperty("Credential", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(credential);
+
+            Assert.That(credential.Resource, Is.EqualTo(resource), "The resource should match.");
+            Assert.That(credentialPropertyValue, Is.SameAs(sourceCredential), "The source credential should have been retained.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void GetTokenDelegatesToTheSourceCredential()
+        {
+            var mockCredential = new Mock<TokenCredential>();
+            var accessToken = new AccessToken("token", new DateTimeOffset(2015, 10, 27, 12, 0, 0, TimeSpan.Zero));
+            var resource = "the resource value";
+            var credential = new EventHubTokenCredential(mockCredential.Object, resource);
+
+            mockCredential
+                .Setup(cred => cred.GetToken(It.Is<string[]>(value => value.FirstOrDefault() == resource), It.IsAny<CancellationToken>()))
+                .Returns(accessToken)
+                .Verifiable("The source credential GetToken method should have been called.");
+
+            var tokenResult = credential.GetToken(new[] { resource }, CancellationToken.None);
+
+            Assert.That(tokenResult, Is.EqualTo(accessToken), "The access token should match the return of the delgated call.");
+            mockCredential.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetTokenAsyncDelegatesToTheSourceCredential()
+        {
+            var mockCredential = new Mock<TokenCredential>();
+            var accessToken = new AccessToken("token", new DateTimeOffset(2015, 10, 27, 12, 0, 0, TimeSpan.Zero));
+            var resource = "the resource value";
+            var credential = new EventHubTokenCredential(mockCredential.Object, resource);
+
+            mockCredential
+                .Setup(cred => cred.GetTokenAsync(It.Is<string[]>(value => value.FirstOrDefault() == resource), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(accessToken)
+                .Verifiable("The source credential GetToken method should have been called.");
+
+            var tokenResult = await credential.GetTokenAsync(new[] { resource }, CancellationToken.None);
+
+            Assert.That(tokenResult, Is.EqualTo(accessToken), "The access token should match the return of the delgated call.");
+            mockCredential.VerifyAll();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
@@ -63,7 +63,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ConstructorRequiresThOption()
+        public void ConstructorRequiresTheOption()
         {
             Assert.That(() => new TrackOneEventHubClient("my.eventhub.com", "somePath", Mock.Of<TokenCredential>(), null), Throws.InstanceOf<ArgumentException>());
         }
@@ -83,7 +83,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var host = "my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(TransportType.AmqpTcp, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
 
             Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options), Throws.InstanceOf<ArgumentException>());
@@ -102,7 +103,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var eventHubPath = "some-path";
             var credential = Mock.Of<TokenCredential>();
 
-            Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options), Throws.InstanceOf<NotImplementedException>());
+            Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -116,7 +117,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var client = TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
 
@@ -148,7 +150,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var host = "my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
 
@@ -176,12 +179,13 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task CreateClientTranslatesTheCredential()
+        public async Task CreateClientTranslatesTheSharedKeyCredential()
         {
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
 
@@ -203,12 +207,41 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task CreateClientTranslatesTheEventHubCredential()
+        {
+            var options = new EventHubClientOptions();
+            var host = "my.eventhub.com";
+            var eventHubPath = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
+            var credential = new EventHubTokenCredential(Mock.Of<TokenCredential>(), resource);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
+
+            try
+            {
+                Assert.That(client.InternalTokenProvider, Is.InstanceOf<TrackOneGenericTokenProvider>(), "The token provider should be the track one generic adapter.");
+                Assert.That(((TrackOneGenericTokenProvider)client.InternalTokenProvider).Credential, Is.EqualTo(credential), "The source credential should match.");
+
+            }
+            finally
+            {
+                await client?.CloseAsync();
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneEventHubClient.CreateClient" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
         public async Task CreateClientFormsTheCorrectEndpoint()
         {
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
 
@@ -236,7 +269,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
 
@@ -266,7 +300,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var host = "my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options);
 
@@ -291,7 +326,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var mock = new ObservableClientMock(host, eventHubPath, credential, options);
             var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
@@ -311,7 +347,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var mock = new ObservableClientMock(host, eventHubPath, credential, options);
             var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
@@ -335,7 +372,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var mock = new ObservableClientMock(host, eventHubPath, credential, options);
             var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
@@ -362,7 +400,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var mock = new ObservableClientMock(host, eventHubPath, credential, options);
             var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
@@ -391,7 +430,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var mock = new ObservableClientMock(host, eventHubPath, credential, options);
             var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);
@@ -423,7 +463,8 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
             var eventHubPath = "some-path";
-            var signature = new SharedAccessSignature(options.TransportType, host, eventHubPath, "keyName", "KEY", TimeSpan.FromHours(1));
+            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var mock = new ObservableClientMock(host, eventHubPath, credential, options);
             var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, (host, path, credential, options) => mock);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenProviderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenProviderTests.cs
@@ -1,0 +1,211 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Authorization;
+using Azure.Messaging.EventHubs.Compatibility;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="TrackOneGenericTokenProvider" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class TrackOneGenericTokenProviderTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheCredential()
+        {
+            Assert.That(() => new TrackOneGenericTokenProvider(null), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneGenericTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void GetTokenAsyncRequiresTheResource()
+        {
+            var token = new EventHubTokenCredential(Mock.Of<TokenCredential>(), "someResource");
+            var provider = new TrackOneGenericTokenProvider(token);
+
+            Assert.That(async () => await provider.GetTokenAsync(null, TimeSpan.FromHours(4)), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneGenericTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void GetTokenAsyncValidatesTheDuration()
+        {
+            var eventHubCredential = new EventHubTokenCredential(Mock.Of<TokenCredential>(), "someResource");
+            var provider = new TrackOneGenericTokenProvider(eventHubCredential);
+
+            Assert.That(async () => await provider.GetTokenAsync(eventHubCredential.Resource, TimeSpan.FromMilliseconds(-1)), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneSharedAccessTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("amqps://my.eventhubs.com")]
+        [TestCase("amqps://my.eventhubs.com/otherHub")]
+        [TestCase("amqps://other.eventhubs.com/someHub")]
+        [TestCase("https://my.eventhubs.com/someHub")]
+        public void GetTokenAsyncDisallowsInvalideResources(string invalidResource)
+        {
+            var mockCredential = new Mock<TokenCredential>();
+            var resource = "amqps://my.eventhubs.com/someHub";
+            var jwtToken = "somevalue";
+            var expiration = DateTime.Parse("2017-10-27T12:00:00Z");
+            var accessToken = new AccessToken(jwtToken, expiration);
+            var eventHubCredential = new EventHubTokenCredential(mockCredential.Object, resource);
+            var provider = new TrackOneGenericTokenProvider(eventHubCredential);
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(accessToken);
+
+            Assert.That(async () => await provider.GetTokenAsync(invalidResource, TimeSpan.FromHours(4)), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneGenericTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("amqps://my.eventhubs.com/someHub")]
+        [TestCase("amqps://my.eventhubs.com/someHub/partition")]
+        [TestCase("amqps://my.eventhubs.com/someHub/partition/0")]
+        [TestCase("amqps://my.eventhubs.com/someHub/management")]
+        public void GetTokenAsyncAllowsValidResources(string validResource)
+        {
+            var mockCredential = new Mock<TokenCredential>();
+            var resource = "amqps://my.eventhubs.com/someHub";
+            var jwtToken = "somevalue";
+            var expiration = DateTime.Parse("2017-10-27T12:00:00Z");
+            var accessToken = new AccessToken(jwtToken, expiration);
+            var eventHubCredential = new EventHubTokenCredential(mockCredential.Object, resource);
+            var provider = new TrackOneGenericTokenProvider(eventHubCredential);
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.Is<string[]>(value => value.FirstOrDefault() == GetTokenScope()), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(accessToken);
+
+            Assert.That(async () => await provider.GetTokenAsync(validResource, TimeSpan.FromHours(4)), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneGenericTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetTokenAsyncProducesAGenericToken()
+        {
+            var mockCredential = new Mock<TokenCredential>();
+            var resource = "amqps://my.eventhubs.com/someHub";
+            var jwtToken = "somevalue";
+            var expiration = DateTime.Parse("2017-10-27T12:00:00Z");
+            var accessToken = new AccessToken(jwtToken, expiration);
+            var eventHubCredential = new EventHubTokenCredential(mockCredential.Object, resource);
+            var provider = new TrackOneGenericTokenProvider(eventHubCredential);
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.Is<string[]>(value => value.FirstOrDefault() == GetTokenScope()), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(accessToken);
+
+            var token = await provider.GetTokenAsync(resource, TimeSpan.FromHours(1));
+
+            Assert.That(token, Is.Not.Null, "A token should have been produced.");
+            Assert.That(token, Is.InstanceOf<TrackOneGenericToken>(), "The token should be a generic JWT token.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneGenericTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetTokenAsyncProducesATokenwithTheCorrectProperties()
+        {
+            var mockCredential = new Mock<TokenCredential>();
+            var resource = "amqps://my.eventhubs.com/someHub";
+            var jwtToken = "somevalue";
+            var expiration = DateTime.Parse("2017-10-27T12:00:00Z");
+            var accessToken = new AccessToken(jwtToken, expiration);
+            var eventHubCredential = new EventHubTokenCredential(mockCredential.Object, resource);
+            var provider = new TrackOneGenericTokenProvider(eventHubCredential);
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.Is<string[]>(value => value.FirstOrDefault() == GetTokenScope()), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(accessToken);
+
+            var token = await provider.GetTokenAsync(resource, TimeSpan.FromHours(1));
+
+            Assert.That(token, Is.Not.Null, "A token should have been produced.");
+            Assert.That(token.TokenValue, Is.EqualTo(jwtToken), "The JWT token should match.");
+            Assert.That(token.Audience, Is.EqualTo(resource), "The audience should match the resource.");
+            Assert.That(token.ExpiresAtUtc, Is.EqualTo(expiration), "The token expiration should match.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneGenericTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetTokenAsyncTokensChangeOnEachIssue()
+        {
+            var mockCredential = new Mock<TokenCredential>();
+            var resource = "amqps://my.eventhubs.com/someHub";
+            var jwtToken = "somevalue";
+            var expiration = DateTime.Parse("2017-10-27T12:00:00Z");
+            var accessToken = new AccessToken(jwtToken, expiration);
+            var eventHubCredential = new EventHubTokenCredential(mockCredential.Object, resource);
+            var provider = new TrackOneGenericTokenProvider(eventHubCredential);
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.Is<string[]>(value => value.FirstOrDefault() == GetTokenScope()), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(accessToken);
+
+            var first = await provider.GetTokenAsync(resource, TimeSpan.FromHours(1));
+            var second = await provider.GetTokenAsync(resource, TimeSpan.FromHours(4));
+
+            Assert.That(first, Is.Not.SameAs(second), "A new token should be created for each request.");
+            Assert.That(((TrackOneGenericToken)first).Credential, Is.SameAs(((TrackOneGenericToken)second).Credential), "The token should be based on the same source credential.");
+        }
+
+        /// <summary>
+        ///   Gets the first scope used for requesting tokens.
+        /// </summary>
+        ///
+        /// <returns>The scope used for requesting tokens.</returns>
+        ///
+        private static string GetTokenScope() =>
+            ((string[])typeof(TrackOneGenericTokenProvider)
+                .GetField("EventHubsDefaultScopes", BindingFlags.Static | BindingFlags.NonPublic)
+                .GetValue(null))
+                .First();
+
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenTests.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Compatibility;
+using Moq;
+using NUnit.Framework;
+using TrackOne;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="TrackOneGenericToken" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class TrackOneGenericTokenTokenTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheCredential()
+        {
+            Assert.That(() => new TrackOneGenericToken(null, "fakeToken", "fakeResource", DateTime.Parse("2015-10-27T12:00:00Z")), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheJwtToken(string token)
+        {
+            Assert.That(() => new TrackOneGenericToken(Mock.Of<TokenCredential>(), token, "fakeResource", DateTime.Parse("2015-10-27T12:00:00Z")), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheResource(string resource)
+        {
+            Assert.That(() => new TrackOneGenericToken(Mock.Of<TokenCredential>(), "fakeToken", resource, DateTime.Parse("2015-10-27T12:00:00Z")), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesInitializesProperties()
+        {
+            var expiration = DateTime.Parse("2015-10-27T12:00:00Z");
+            var resource = "the-audience";
+            var jwtToken = "TOkEn!";
+            var credential = Mock.Of<TokenCredential>();
+            var token = new TrackOneGenericToken(credential, jwtToken, resource, expiration);
+
+            Assert.That(token.Audience, Is.EqualTo(resource), "The audience for the token should match.");
+            Assert.That(token.TokenValue, Is.EqualTo(jwtToken), "The JWT token value should match.");
+            Assert.That(token.Credential, Is.EqualTo(credential), "The credential should match.");
+            Assert.That(token.ExpiresAtUtc, Is.EqualTo(expiration), "The expiration shoud match.");
+            Assert.That(token.TokenType, Is.EqualTo(ClientConstants.JsonWebTokenType), "The token type should identify a generic JWT.");
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The intent of these changes is to complete the end-to-end infrastructure for accepting and making use of arbitrary token credential types sourced from the `Azure.Identity` library.

### Goals

- Consider unknown `TokenCredential` types as general JWT tokens and treat them as such.

- Allow for the shared key information exposed in the Azure portal to be used for authorization with Event Hubs without having to use a connection string.

- Allow for the Event Hub namespace-level connection string to be used by sending an accompanying Event Hub path, rather than requiring navigation to deeper levels of the Azure portal to retrieve a connection string from the specific Event Hub instance.

- Review and revise the public surface area of the implementation, reducing scope as possible by internalizing constructs intended only to support project-level testing.    

# Last Upstream Rebase

Tuesday, June 18, 2019  2:43pm (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)