### PR TITLE
Use ServiceDirectory for tests builds

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -7,8 +7,8 @@
 # EventHubsStorageConnectionString - The connection string to the storage account used for testing the Event Hubs service.  This is set in the pipeline web ui and needs different values for public vs internal.
 
 parameters:
-  presteps: []
-  envvars: []
+  PreSteps: []
+  EnvVars: {}
 
 jobs:
 
@@ -37,8 +37,8 @@ jobs:
       vmImage: '$(OSVmImage)'
 
     steps:
-      - ${{ each step in parameters.presteps }}:
-        - ${{ step }}
+      - ${{ parameters.PreSteps }}
+
       - powershell: |
           Invoke-WebRequest -Uri "https://github.com/Azure/azure-sdk-tools/releases/download/sdk-tools_14793/sdk-tools.zip" `
           -OutFile "sdk-tools.zip" | Wait-Process; Expand-Archive -Path "sdk-tools.zip" -DestinationPath "./sdk-tools/"
@@ -70,8 +70,8 @@ jobs:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
           AZURE_TEST_MODE: "None"
-          ${{ each envvar in parameters.envvars }}:
-            ${{ envvar.key }}: ${{ envvar.value }}
+          ${{ each var in parameters.EnvVars }}:
+            ${{ insert }}: ${{ var }}
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -9,6 +9,7 @@
 parameters:
   PreSteps: []
   EnvVars: {}
+  MaxParallel: 0
 
 jobs:
 
@@ -21,7 +22,7 @@ jobs:
     timeoutInMinutes: 175
 
     strategy:
-      maxParallel: $[ variables['MaxParallelTestJobs'] ]
+      maxParallel: ${{ parameters.MaxParallel }}
       matrix:
         Linux:
           OSName: 'Linux'
@@ -63,15 +64,14 @@ jobs:
           packageType: sdk
           version: "$(DotNetCoreSDKVersion)"
 
-      - script: 'dotnet test $(ProjectFile) --logger trx'
+      - script: "dotnet test eng/service.proj --logger trx /p:ServiceDirectory=${{ parameters.ServiceDirectory }}"
         displayName: 'Build & Test (all tests)'
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
           AZURE_TEST_MODE: "None"
-          ${{ each var in parameters.EnvVars }}:
-            ${{ insert }}: ${{ var }}
+          ${{ insert }}: ${{  parameters.EnvVars }}
 
       - task: PublishTestResults@2
         condition: succeededOrFailed()

--- a/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-tests.yml
@@ -1,11 +1,3 @@
-# External variables:
-# ProjectFile - The project to build and test. This variable is defined in pipeline web ui because we want to be able to provide it at queue time and that isn't supported in yaml yet.
-# MaxParallelTestJobs - Maximum number of parallel test jobs
-# AzConfigConnectionString - The connection string used for testing the AzConfig service. This is set in the pipeline web ui as it needs different values for public vs internal.
-# ServiceBusConnectionString - The connection string used for testing the Service Bus service. This is set in the pipeline web ui as it needs different values for public vs internal.
-# EventHubsConnectionString - The connection string to the namespace used for testing the Event Hubs service.  This is set in the pipeline web ui and needs different values for public vs internal.
-# EventHubsStorageConnectionString - The connection string to the storage account used for testing the Event Hubs service.  This is set in the pipeline web ui and needs different values for public vs internal.
-
 parameters:
   PreSteps: []
   EnvVars: {}

--- a/sdk/appconfiguration/tests.yml
+++ b/sdk/appconfiguration/tests.yml
@@ -4,7 +4,7 @@ variables:
   ProjectFile: sdk/appconfiguration/Azure.ApplicationModel.Configuration/Azure.ApplicationModel.Configuration.sln
 
 jobs:
-- template: ../../eng/pipelines/templates/jobs/tests.yml
+- template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
-    envvars:
+    EnvVars:
       APP_CONFIG_CONNECTION: $(net-azconfig-test-connection-string)

--- a/sdk/appconfiguration/tests.yml
+++ b/sdk/appconfiguration/tests.yml
@@ -1,10 +1,9 @@
 trigger: none
 
-variables:
-  ProjectFile: sdk/appconfiguration/Azure.ApplicationModel.Configuration/Azure.ApplicationModel.Configuration.sln
-
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
+    MaxParallel: 1
+    ServiceDirectory: appconfiguration
     EnvVars:
       APP_CONFIG_CONNECTION: $(net-azconfig-test-connection-string)

--- a/sdk/core/tests.yml
+++ b/sdk/core/tests.yml
@@ -4,4 +4,4 @@ variables:
   ProjectFile: sdk/core/Azure.Core/Azure.Core.sln
 
 jobs:
-- template: ../../eng/pipelines/templates/jobs/tests.yml
+- template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml

--- a/sdk/core/tests.yml
+++ b/sdk/core/tests.yml
@@ -1,7 +1,7 @@
 trigger: none
 
-variables:
-  ProjectFile: sdk/core/Azure.Core/Azure.Core.sln
-
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+  parameters:
+    ServiceDirectory: core
+    

--- a/sdk/core/tests.yml
+++ b/sdk/core/tests.yml
@@ -1,7 +1,6 @@
 trigger: none
 
 jobs:
-- template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
-  parameters:
-    ServiceDirectory: core
-    
+  - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+    parameters:
+      ServiceDirectory: core

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -1,11 +1,10 @@
 trigger: none
 
-variables:
-  ProjectFile: sdk/eventhub/Microsoft.Azure.EventHubs.sln
-
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
+    MaxParallel: 1
+    ServiceDirectory: eventhub
     EnvVars:
       EVENT_HUBS_CONNECTION_STRING: $(net-eventhubs-internal-namespace-connection-string)
       EVENT_HUBS_STORAGE_CONNECTION_STRING: $(net-eventhubs-internal-storage-connection-string)

--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -4,8 +4,8 @@ variables:
   ProjectFile: sdk/eventhub/Microsoft.Azure.EventHubs.sln
 
 jobs:
-- template: ../../eng/pipelines/templates/jobs/tests.yml
+- template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
-    envvars:
+    EnvVars:
       EVENT_HUBS_CONNECTION_STRING: $(net-eventhubs-internal-namespace-connection-string)
       EVENT_HUBS_STORAGE_CONNECTION_STRING: $(net-eventhubs-internal-storage-connection-string)

--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -2,4 +2,4 @@ variables:
   ProjectFile: sdk/keyvault/Microsoft.Azure.KeyVault.sln
 
 jobs:
-- template: ../../eng/pipelines/templates/jobs/tests.yml
+- template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml

--- a/sdk/keyvault/tests.yml
+++ b/sdk/keyvault/tests.yml
@@ -1,5 +1,7 @@
-variables:
-  ProjectFile: sdk/keyvault/Microsoft.Azure.KeyVault.sln
+trigger: none
 
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
+  parameters:
+    MaxParallel: 1
+    ServiceDirectory: keyvault

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -1,10 +1,9 @@
 trigger: none
 
-variables:
-  ProjectFile: sdk/servicebus/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.sln
-
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
+    MaxParallel: 1
+    ServiceDirectory: servicebus
     EnvVars:
       SERVICE_BUS_CONNECTION_STRING: $(net-service-bus-test-connection-string)

--- a/sdk/servicebus/tests.yml
+++ b/sdk/servicebus/tests.yml
@@ -4,7 +4,7 @@ variables:
   ProjectFile: sdk/servicebus/Microsoft.Azure.ServiceBus/Microsoft.Azure.ServiceBus.sln
 
 jobs:
-- template: ../../eng/pipelines/templates/jobs/tests.yml
+- template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
-    envvars:
+    EnvVars:
       SERVICE_BUS_CONNECTION_STRING: $(net-service-bus-test-connection-string)

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -1,11 +1,9 @@
 trigger: none
 
-variables:
-  ProjectFile: sdk/storage/Azure.Storage.sln
-
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
+    ServiceDirectory: storage
     PreSteps:
       - powershell: |
           $TestConfigurationPath = "$(Build.ArtifactStagingDirectory)/TestConfiguration.xml"

--- a/sdk/storage/tests.yml
+++ b/sdk/storage/tests.yml
@@ -4,13 +4,13 @@ variables:
   ProjectFile: sdk/storage/Azure.Storage.sln
 
 jobs:
-- template: ../../eng/pipelines/templates/jobs/tests.yml
+- template: ../../eng/pipelines/templates/jobs/archetype-sdk-tests.yml
   parameters:
-    presteps:
+    PreSteps:
       - powershell: |
           $TestConfigurationPath = "$(Build.ArtifactStagingDirectory)/TestConfiguration.xml"
           '$(net-storage-test-configuration)' | Out-File -Encoding Utf8 $TestConfigurationPath
           Write-Host "##vso[task.setvariable variable=TestConfigurationPath]$TestConfigurationPath"
 
-    envvars:
+    EnvVars:
       AZ_STORAGE_CONFIG_PATH: $(TestConfigurationPath)


### PR DESCRIPTION
Uses the `ServiceDirectory` traversal project in tests.yml. 

@Azure/azure-sdk-eng 

@maririos -- This change uses a traversal project that will include all tests projects for KeyVault