### PR TITLE
[Event Hubs Client] Track Two: First Preview (Owner Level Rename)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
@@ -280,9 +280,9 @@ namespace Azure.Messaging.EventHubs.Compatibility
 
                 PartitionReceiver consumer;
 
-                if (consumerOptions.ExclusiveConsumerPriority.HasValue)
+                if (consumerOptions.OwnerLevel.HasValue)
                 {
-                    consumer = TrackOneClient.CreateEpochReceiver(consumerOptions.ConsumerGroup, partitionId, position, consumerOptions.ExclusiveConsumerPriority.Value, trackOneOptions);
+                    consumer = TrackOneClient.CreateEpochReceiver(consumerOptions.ConsumerGroup, partitionId, position, consumerOptions.OwnerLevel.Value, trackOneOptions);
                 }
                 else
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -43,15 +43,15 @@ namespace Azure.Messaging.EventHubs
         ///   When populated, the priority indicates that a consumer is intended to be the only reader of events for the
         ///   requested partition and an associated consumer group.  To do so, this consumer will attempt to assert ownership
         ///   over the partition; in the case where more than one exclusive consumer attempts to assert ownership for the same
-        ///   partition/consumer group pair, the one having a larger priority value will "win."
+        ///   partition/consumer group pair, the one having a larger onwership level value will "win."
         ///
-        ///   When an exclusive consumer is used, those consumers which are not exclusive or which have a lower priority will either
+        ///   When an exclusive consumer is used, those consumers which are not exclusive or which have a lower owner level will either
         ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.
         /// </summary>
         ///
         /// <value>The priority to associated with an exclusive consumer; for a non-exclusive consumer, this value will be <c>null</c>.</value>
         ///
-        public long? ExclusiveConsumerPriority { get; protected set; }
+        public long? OwnerLevel { get; protected set; }
 
         /// <summary>
         ///   The position of the event in the partition where the consumer should begin reading.
@@ -105,7 +105,7 @@ namespace Azure.Messaging.EventHubs
 
             PartitionId = partitionId;
             StartingPosition = eventPosition;
-            ExclusiveConsumerPriority = consumerOptions.ExclusiveConsumerPriority;
+            OwnerLevel = consumerOptions.OwnerLevel;
             ConsumerGroup = consumerOptions.ConsumerGroup;
             Options = consumerOptions;
             InnerConsumer = transportConsumer;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
@@ -46,15 +46,15 @@ namespace Azure.Messaging.EventHubs
         ///   When populated, the priority indicates that a consumer is intended to be the only reader of events for the
         ///   requested partition and an associated consumer group.  To do so, this consumer will attempt to assert ownership
         ///   over the partition; in the case where more than one exclusive consumer attempts to assert ownership for the same
-        ///   partition/consumer group pair, the one having a larger <see cref="ExclusiveConsumerPriority"/> value will "win."
+        ///   partition/consumer group pair, the one having a larger <see cref="OwnerLevel"/> value will "win."
         ///
-        ///   When an exclusive consumer is used, those consumers which are not exclusive or which have a lower priority will either
+        ///   When an exclusive consumer is used, other consumers which are non-exclusive or which have a lower owner level will either
         ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.
         /// </summary>
         ///
         /// <value>The priority to associated with an exclusive consumer; for a non-exclusive consumer, this value should be <c>null</c>.</value>
         ///
-        public long? ExclusiveConsumerPriority { get; set; }
+        public long? OwnerLevel { get; set; }
 
         /// <summary>
         ///   The <see cref="EventHubs.Retry" /> used to govern retry attempts when an issue
@@ -163,7 +163,7 @@ namespace Azure.Messaging.EventHubs
             new EventHubConsumerOptions
             {
                 ConsumerGroup = this.ConsumerGroup,
-                ExclusiveConsumerPriority = this.ExclusiveConsumerPriority,
+                OwnerLevel = this.OwnerLevel,
                 Retry = this.Retry?.Clone(),
 
                 _identifier = this._identifier,

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubConsumerTests.cs
@@ -54,7 +54,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(mock.ConstructedWith.ConsumerGroup, Is.EqualTo(consumerGroup), "The consumer group should match.");
             Assert.That(mock.ConstructedWith.Partition, Is.EqualTo(partition), "The partition should match.");
             Assert.That(TrackOneComparer.IsEventPositionEquivalent(mock.ConstructedWith.Position, position), Is.True, "The starting event position should match.");
-            Assert.That(mock.ConstructedWith.Priority, Is.EqualTo(priority), "The exclusive priority should match.");
+            Assert.That(mock.ConstructedWith.Priority, Is.EqualTo(priority), "The ownerlevel should match.");
             Assert.That(mock.ConstructedWith.Options.Identifier, Is.EqualTo(identifier), "The consumer identifier should match.");
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
@@ -502,7 +502,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(actualOptions, Is.Not.Null, "The consumer options should have been set.");
             Assert.That(actualOptions.ConsumerGroup, Is.EqualTo(expectedOptions.ConsumerGroup), "The consumer groups should match.");
-            Assert.That(actualOptions.ExclusiveConsumerPriority, Is.EqualTo(expectedOptions.ExclusiveConsumerPriority), "The exclusive priorities should match.");
+            Assert.That(actualOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The owner levels should match.");
             Assert.That(actualOptions.Identifier, Is.EqualTo(expectedOptions.Identifier), "The identifiers should match.");
             Assert.That(actualOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The prefetch counts should match.");
             Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)actualOptions.Retry, (ExponentialRetry)expectedOptions.Retry), "The retries should match.");
@@ -526,7 +526,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedOptions = new EventHubConsumerOptions
             {
                 ConsumerGroup = "SomeGroup",
-                ExclusiveConsumerPriority = 251,
+                OwnerLevel = 251,
                 Identifier = "Bob",
                 PrefetchCount = 600,
                 Retry = clientOptions.Retry,
@@ -545,7 +545,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(actualOptions, Is.Not.Null, "The consumer options should have been set.");
             Assert.That(actualOptions, Is.Not.SameAs(expectedOptions), "A clone of the options should have been made.");
             Assert.That(actualOptions.ConsumerGroup, Is.EqualTo(expectedOptions.ConsumerGroup), "The consumer groups should match.");
-            Assert.That(actualOptions.ExclusiveConsumerPriority, Is.EqualTo(expectedOptions.ExclusiveConsumerPriority), "The exclusive priorities should match.");
+            Assert.That(actualOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The owner levels should match.");
             Assert.That(actualOptions.Identifier, Is.EqualTo(expectedOptions.Identifier), "The identifiers should match.");
             Assert.That(actualOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The prefetch counts should match.");
             Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)actualOptions.Retry, (ExponentialRetry)expectedOptions.Retry), "The retries should match.");
@@ -712,7 +712,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(actualOptions, Is.Not.Null, "The consumer options should have been set.");
             Assert.That(actualPosition.Offset, Is.EqualTo(expectedPosition.Offset), "The event position to receive should match.");
             Assert.That(actualOptions.ConsumerGroup, Is.EqualTo(expectedOptions.ConsumerGroup), "The consumer groups should match.");
-            Assert.That(actualOptions.ExclusiveConsumerPriority, Is.EqualTo(expectedOptions.ExclusiveConsumerPriority), "The exclusive priorities should match.");
+            Assert.That(actualOptions.OwnerLevel, Is.EqualTo(expectedOptions.OwnerLevel), "The owner levels should match.");
             Assert.That(actualOptions.Identifier, Is.EqualTo(expectedOptions.Identifier), "The identifiers should match.");
             Assert.That(actualOptions.PrefetchCount, Is.EqualTo(expectedOptions.PrefetchCount), "The prefetch counts should match.");
             Assert.That(ExponentialRetry.HaveSameConfiguration((ExponentialRetry)actualOptions.Retry, (ExponentialRetry)expectedOptions.Retry), "The retries should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerOptionsTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var options = new EventHubConsumerOptions
             {
                 ConsumerGroup = "custom$consumer",
-                ExclusiveConsumerPriority = 99,
+                OwnerLevel = 99,
                 Retry = new ExponentialRetry(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(5), 6),
                 DefaultMaximumReceiveWaitTime = TimeSpan.FromMinutes(65),
                 Identifier = "an_event_consumer"
@@ -33,7 +33,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
             Assert.That(clone.ConsumerGroup, Is.EqualTo(options.ConsumerGroup), "The consumer group of the clone should match.");
-            Assert.That(clone.ExclusiveConsumerPriority, Is.EqualTo(options.ExclusiveConsumerPriority), "The exclusive priority of the clone should match.");
+            Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The ownerlevel of the clone should match.");
             Assert.That(clone.DefaultMaximumReceiveWaitTime, Is.EqualTo(options.DefaultMaximumReceiveWaitTime), "The default maximum wait time of the clone should match.");
             Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier of the clone should match.");
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -99,13 +99,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubConsumerOptions
             {
-                ExclusiveConsumerPriority = priority
+                OwnerLevel = priority
             };
 
             var transportConsumer = new ObservableTransportConsumerMock();
             var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", EventPosition.FromOffset(65), options);
 
-            Assert.That(consumer.ExclusiveConsumerPriority, Is.EqualTo(priority));
+            Assert.That(consumer.OwnerLevel, Is.EqualTo(priority));
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The intent of these changes is to incorporate feedback from the Event Hubs service team and rename the `ExclusiveConsumerPriority` to `OwnerLevel`.

# Last Upstream Rebase

Wednesday, June 19, 2019  10:48am (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)