### PR TITLE
[Event Hubs Client] Track Two: First Preview (Mandatory Consumer Group)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
@@ -256,13 +256,15 @@ namespace Azure.Messaging.EventHubs.Compatibility
         ///   By default, consumers are created as non-exclusive.
         /// </summary>
         ///
+        /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="consumerOptions">The set of options to apply when creating the consumer.</param>
         ///
         /// <returns>An Event Hub consumer configured in the requested manner.</returns>
         ///
-        public override EventHubConsumer CreateConsumer(string partitionId,
+        public override EventHubConsumer CreateConsumer(string consumerGroup,
+                                                        string partitionId,
                                                         EventPosition eventPosition,
                                                         EventHubConsumerOptions consumerOptions)
         {
@@ -282,11 +284,11 @@ namespace Azure.Messaging.EventHubs.Compatibility
 
                 if (consumerOptions.OwnerLevel.HasValue)
                 {
-                    consumer = TrackOneClient.CreateEpochReceiver(consumerOptions.ConsumerGroup, partitionId, position, consumerOptions.OwnerLevel.Value, trackOneOptions);
+                    consumer = TrackOneClient.CreateEpochReceiver(consumerGroup, partitionId, position, consumerOptions.OwnerLevel.Value, trackOneOptions);
                 }
                 else
                 {
-                    consumer = TrackOneClient.CreateReceiver(consumerOptions.ConsumerGroup, partitionId, position, trackOneOptions);
+                    consumer = TrackOneClient.CreateReceiver(consumerGroup, partitionId, position, trackOneOptions);
                 }
 
                 (TimeSpan minBackoff, TimeSpan maxBackoff, int maxRetries) = ((ExponentialRetry)consumerOptions.Retry).GetProperties();
@@ -300,6 +302,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
                 new TrackOneEventHubConsumer(CreateReceiverFactory),
                 TrackOneClient.EventHubName,
                 partitionId,
+                consumerGroup,
                 eventPosition,
                 consumerOptions
             );

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/Guard.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/Guard.cs
@@ -65,6 +65,29 @@ namespace Azure.Messaging.EventHubs.Core
         }
 
         /// <summary>
+        ///   Ensures that an argument's value is a string comprised of only whitespace, though
+        ///   <c>null</c> is considered a valid value.  An <see cref="ArgumentException" /> is thrown
+        ///   if that invariant is not met.
+        /// </summary>
+        ///
+        /// <param name="argumentName">The name of the argument being considered.</param>
+        /// <param name="argumentValue">The value of the argument to verify.</param>
+        ///
+        public static void ArgumentNotEmptyOrWhitespace(string argumentName,
+                                                       string argumentValue)
+        {
+            if (argumentValue == null)
+            {
+                return;
+            }
+
+            if (String.IsNullOrWhiteSpace(argumentValue))
+            {
+                throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.ArgumentEmptyOrWhiteSpace, argumentName), argumentName);
+            }
+        }
+
+        /// <summary>
         ///   Ensures that a string argument's length is below a maximum allowed threshold,
         ///   throwing an <see cref="ArgumentOutOfRangeException" /> if that invariant is not met.
         /// </summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubClient.cs
@@ -66,15 +66,17 @@ namespace Azure.Messaging.EventHubs.Core
         ///   By default, consumers are created as non-exclusive.
         /// </summary>
         ///
+        /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="consumerOptions">The set of options to apply when creating the consumer.</param>
         ///
         /// <returns>An Event Hub consumer configured in the requested manner.</returns>
         ///
-        public abstract EventHubConsumer CreateConsumer(string partitionId,
-                                                     EventPosition eventPosition,
-                                                     EventHubConsumerOptions consumerOptions);
+        public abstract EventHubConsumer CreateConsumer(string consumerGroup,
+                                                        string partitionId,
+                                                        EventPosition eventPosition,
+                                                        EventHubConsumerOptions consumerOptions);
 
         /// <summary>
         ///   Closes the connection to the transport client instance.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
@@ -300,13 +300,15 @@ namespace Azure.Messaging.EventHubs
         ///   By default, consumers are created as non-exclusive.
         /// </summary>
         ///
+        /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="consumerOptions">The set of options to apply when creating the consumer.</param>
         ///
         /// <returns>An Event Hub consumer configured in the requested manner.</returns>
         ///
-        public virtual EventHubConsumer CreateConsumer(string partitionId,
+        public virtual EventHubConsumer CreateConsumer(string consumerGroup,
+                                                       string partitionId,
                                                        EventPosition eventPosition,
                                                        EventHubConsumerOptions consumerOptions = default)
         {
@@ -318,7 +320,7 @@ namespace Azure.Messaging.EventHubs
             options.Retry = options.Retry ?? ClientOptions.Retry.Clone();
             options.DefaultMaximumReceiveWaitTime = options.MaximumReceiveWaitTimeOrDefault ?? ClientOptions.DefaultTimeout;
 
-            return InnerClient.CreateConsumer(partitionId, eventPosition, options);
+            return InnerClient.CreateConsumer(consumerGroup, partitionId, eventPosition, options);
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -25,6 +25,9 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventHubConsumer : IAsyncDisposable
     {
+        /// <summary>The name of the default consumer group in the Event Hubs service.</summary>
+        public const string DefaultConsumerGroup = "$Default";
+
         /// <summary>
         ///   The identifier of the Event Hub partition that this consumer is associated with.  Events will be read
         ///   only from this partition.
@@ -78,6 +81,7 @@ namespace Azure.Messaging.EventHubs
         /// <param name="transportConsumer">An abstracted Event Consumer specific to the active protocol and transport intended to perform delegated operations.</param>
         /// <param name="eventHubPath">The path of the Event Hub from which events will be received.</param>
         /// <param name="partitionId">The identifier of the Event Hub partition from which events will be received.</param>
+        /// <param name="consumerGroup">The name of the consumer group this consumer is associated with.  Events are read in the context of this group.</param>
         /// <param name="eventPosition">The position within the partition where the consumer should begin reading events.</param>
         /// <param name="consumerOptions">The set of options to use for this consumer.</param>
         ///
@@ -92,13 +96,15 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         internal EventHubConsumer(TransportEventHubConsumer transportConsumer,
-                               string eventHubPath,
-                               string partitionId,
-                               EventPosition eventPosition,
-                               EventHubConsumerOptions consumerOptions)
+                                   string eventHubPath,
+                                   string consumerGroup,
+                                   string partitionId,
+                                   EventPosition eventPosition,
+                                   EventHubConsumerOptions consumerOptions)
         {
             Guard.ArgumentNotNull(nameof(transportConsumer), transportConsumer);
             Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
+            Guard.ArgumentNotNullOrEmpty(nameof(consumerGroup), consumerGroup);
             Guard.ArgumentNotNullOrEmpty(nameof(partitionId), partitionId);
             Guard.ArgumentNotNull(nameof(eventPosition), eventPosition);
             Guard.ArgumentNotNull(nameof(consumerOptions), consumerOptions);
@@ -106,7 +112,7 @@ namespace Azure.Messaging.EventHubs
             PartitionId = partitionId;
             StartingPosition = eventPosition;
             OwnerLevel = consumerOptions.OwnerLevel;
-            ConsumerGroup = consumerOptions.ConsumerGroup;
+            ConsumerGroup = consumerGroup;
             Options = consumerOptions;
             InnerConsumer = transportConsumer;
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
@@ -15,9 +15,6 @@ namespace Azure.Messaging.EventHubs
     ///
     public class EventHubConsumerOptions
     {
-        /// <summary>The name of the default consumer group in the Event Hubs service.</summary>
-        public const string DefaultConsumerGroup = "$Default";
-
         /// <summary>The minimum value allowed for the prefetch count of the consumer.</summary>
         internal const int MinimumPrefetchCount = 10;
 
@@ -32,15 +29,6 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>The identifier to use for the consumer.</summary>
         private string _identifier = null;
-
-        /// <summary>
-        ///   The name of the consumer group that an Event Hub consumer should be associated with.  Events read
-        ///   by the consumer will be performed in the context of this group.
-        /// </summary>
-        ///
-        /// <value>If not specified, the default consumer group will be assumed.</value>
-        ///
-        public string ConsumerGroup { get; set; } = DefaultConsumerGroup;
 
         /// <summary>
         ///   When populated, the priority indicates that a consumer is intended to be the only reader of events for the
@@ -162,7 +150,6 @@ namespace Azure.Messaging.EventHubs
         internal EventHubConsumerOptions Clone() =>
             new EventHubConsumerOptions
             {
-                ConsumerGroup = this.ConsumerGroup,
                 OwnerLevel = this.OwnerLevel,
                 Retry = this.Retry?.Clone(),
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducerOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.ComponentModel;
+using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -16,11 +17,14 @@ namespace Azure.Messaging.EventHubs
         /// <summary>The timeout that will be used by default for sending events.</summary>
         private TimeSpan? _timeout = TimeSpan.FromMinutes(1);
 
+        /// <summary>The identifier of the partition that the producer will be bound to.</summary>
+        private string _partitionId = null;
+
         /// <summary>
         ///   The identifier of the Event Hub partition that the <see cref="EventHubProducer" /> will be bound to,
         ///   limiting it to sending events to only that partition.
         ///
-        ///   If the identifier is not spedified, the Event Hubs service will be responsible for routing events that
+        ///   If the identifier is not specified, the Event Hubs service will be responsible for routing events that
         ///   are sent to an available partition.
         /// </summary>
         ///
@@ -36,7 +40,15 @@ namespace Azure.Messaging.EventHubs
         ///   <para>2) If a partition becomes unavailable, the Event Hubs service will automatically detect it and forward the message to another available partition.</para>
         /// </remarks>
         ///
-        public string PartitionId { get; set; }
+        public string PartitionId
+        {
+            get => _partitionId;
+            set
+            {
+                Guard.ArgumentNotEmptyOrWhitespace(nameof(PartitionId), value);
+                _partitionId = value;
+            }
+        }
 
         /// <summary>
         ///   The <see cref="EventHubs.Retry" /> used to govern retry attempts when an issue is
@@ -49,7 +61,7 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   The default timeout to apply when sending events.  If the timeout is reached, before the Event Hub
-        ///   acknowledges receipt of the event data being sent, the attempt will be conisdered failed and considered
+        ///   acknowledges receipt of the event data being sent, the attempt will be classified as failed and considered
         ///   to be retried.
         /// </summary>
         ///
@@ -111,7 +123,7 @@ namespace Azure.Messaging.EventHubs
         internal EventHubProducerOptions Clone() =>
             new EventHubProducerOptions
             {
-                PartitionId = this.PartitionId,
+                _partitionId = this.PartitionId,
                 Retry = this.Retry?.Clone(),
                 Timeout = this.Timeout
             };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -89,6 +89,17 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The argument &apos;{0}&apos; may not be empty or white space, though it may be null.
+        /// </summary>
+        internal static string ArgumentEmptyOrWhiteSpace
+        {
+            get
+            {
+                return ResourceManager.GetString("ArgumentEmptyOrWhiteSpace", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; cannot exceed {1} characters..
         /// </summary>
         internal static string ArgumentStringTooLong

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -123,6 +123,9 @@
   <data name="ArgumentNullOrWhiteSpace" xml:space="preserve">
     <value>The argument '{0}' may not be null or white space.</value>
   </data>
+  <data name="ArgumentEmptyOrWhiteSpace" xml:space="preserve">
+    <value>The argument '{0}' may not be empty or white space, though it may be null.</value>
+  </data>
   <data name="ArgumentStringTooLong" xml:space="preserve">
     <value>The argument '{0}' cannot exceed {1} characters.</value>
   </data>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
@@ -473,17 +473,18 @@ namespace Azure.Messaging.EventHubs.Tests
             try
             {
                 var partitionId = "32234";
+                var consumerGroup = "AGroup";
                 var eventPosition = EventPosition.FromOffset(34);
-                var consumerOptions = new EventHubConsumerOptions { ConsumerGroup = "Test" };
+                var consumerOptions = new EventHubConsumerOptions { Identifier = "Test" };
 
                 // Because the consumer is lazily instantiated, an operation needs to be requested to force creation.  Because we are returning a null
                 // consumer from within the mock client, that operation will fail with a null reference exception.
 
-                Assert.That(async () => await client.CreateConsumer(partitionId, eventPosition, consumerOptions).ReceiveAsync(10), Throws.InstanceOf<NullReferenceException>(), "because the PartitionReceiver was not populated.");
+                Assert.That(async () => await client.CreateConsumer(consumerGroup, partitionId, eventPosition, consumerOptions).ReceiveAsync(10), Throws.InstanceOf<NullReferenceException>(), "because the PartitionReceiver was not populated.");
 
                 (var calledConsumerGroup, var calledPartition, var calledPosition, var calledPriority, var calledOptions) = mock.CreateReiverInvokedWith;
 
-                Assert.That(calledConsumerGroup, Is.EqualTo(consumerOptions.ConsumerGroup), "The consumer group should match.");
+                Assert.That(calledConsumerGroup, Is.EqualTo(consumerGroup), "The consumer group should match.");
                 Assert.That(calledPartition, Is.EqualTo(partitionId), "The partition should match.");
                 Assert.That(calledPosition.Offset, Is.EqualTo(eventPosition.Offset), "The event position offset should match.");
                 Assert.That(calledOptions.Identifier, Is.EqualTo(consumerOptions.Identifier), "The options should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/GuardTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/GuardTests.cs
@@ -121,6 +121,32 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="Guard.ArgumentNotEmptyOrWhitespace" /> method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("")]
+        [TestCase(" ")]
+        [TestCase("         ")]
+        public void ArgumentNotEmptyOrWhitespaceEnforcesInvariants(string value)
+        {
+            Assert.That(() => Guard.ArgumentNotEmptyOrWhitespace(nameof(value), value), Throws.ArgumentException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="Guard.ArgumentNotEmptyOrWhitespace" /> method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("1")]
+        [TestCase("This is a thing")]
+        public void ArgumentNotEmptyOrWhitespaceAllowsValidValues(string value)
+        {
+            Assert.That(() => Guard.ArgumentNotEmptyOrWhitespace(nameof(value), value), Throws.Nothing);
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="Guard.ArgumentNotNegative" /> method.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    await using (var consumer = client.CreateConsumer(partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
                     {
                         Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
                     }
@@ -61,14 +61,13 @@ namespace Azure.Messaging.EventHubs.Tests
             await using (var scope = await EventHubScope.CreateAsync(4))
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
-
-                var options = new EventHubConsumerOptions { ConsumerGroup = "$Default" };
+                var options = new EventHubConsumerOptions { Identifier = "FakeIdentifier" };
 
                 await using (var client = new EventHubClient(connectionString))
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    await using (var consumer = client.CreateConsumer(partition, EventPosition.Latest, options))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, options))
                     {
                         Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
                     }
@@ -100,7 +99,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -175,7 +174,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerOptionsTests.cs
@@ -22,7 +22,6 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubConsumerOptions
             {
-                ConsumerGroup = "custom$consumer",
                 OwnerLevel = 99,
                 Retry = new ExponentialRetry(TimeSpan.FromSeconds(4), TimeSpan.FromSeconds(5), 6),
                 DefaultMaximumReceiveWaitTime = TimeSpan.FromMinutes(65),
@@ -32,7 +31,6 @@ namespace Azure.Messaging.EventHubs.Tests
             var clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
-            Assert.That(clone.ConsumerGroup, Is.EqualTo(options.ConsumerGroup), "The consumer group of the clone should match.");
             Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The ownerlevel of the clone should match.");
             Assert.That(clone.DefaultMaximumReceiveWaitTime, Is.EqualTo(options.DefaultMaximumReceiveWaitTime), "The default maximum wait time of the clone should match.");
             Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier of the clone should match.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheConsumer()
         {
-            Assert.That(() => new EventHubConsumer(null, "dummy", "0", EventPosition.Latest, new EventHubConsumerOptions()), Throws.ArgumentNullException);
+            Assert.That(() => new EventHubConsumer(null, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheEventHub(string eventHub)
         {
-            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), eventHub, "0", EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), eventHub, EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -50,7 +50,19 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesThePartition(string partition)
         {
-            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", partition, EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void ConstructorValidatesTheConsumerGroup(string consumerGroup)
+        {
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", consumerGroup, "1332", EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -60,7 +72,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheEventPosition()
         {
-            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", "1234", null, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroup, "1234", null, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -70,7 +82,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheOptions()
         {
-            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", "0", EventPosition.Latest, null), Throws.ArgumentNullException);
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -82,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var partition = "aPartition";
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", partition, EventPosition.FromSequenceNumber(1), new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.FromSequenceNumber(1), new EventHubConsumerOptions());
 
             Assert.That(consumer.PartitionId, Is.EqualTo(partition));
         }
@@ -103,7 +115,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", EventPosition.FromOffset(65), options);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.FromOffset(65), options);
 
             Assert.That(consumer.OwnerLevel, Is.EqualTo(priority));
         }
@@ -117,7 +129,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedPosition = EventPosition.FromSequenceNumber(5641);
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", expectedPosition, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", expectedPosition, new EventHubConsumerOptions());
 
             Assert.That(consumer.StartingPosition, Is.EqualTo(expectedPosition));
         }
@@ -129,15 +141,11 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorSetsTheConsumerGroup()
         {
-            var options = new EventHubConsumerOptions
-            {
-                ConsumerGroup = "SomeGroup"
-            };
-
+            var consumerGroup = "SomeGroup";
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", EventPosition.Latest, options);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", consumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
 
-            Assert.That(consumer.ConsumerGroup, Is.EqualTo(options.ConsumerGroup));
+            Assert.That(consumer.ConsumerGroup, Is.EqualTo(consumerGroup));
         }
 
         /// <summary>
@@ -152,7 +160,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ReceiveAsyncValidatesTheMaximumCount(int maximumMessageCount)
         {
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", EventPosition.Latest, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
             var cancellation = new CancellationTokenSource();
             var expectedWaitTime = TimeSpan.FromDays(1);
 
@@ -172,7 +180,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ReceiveAsyncValidatesTheMaximumWaitTime(int timeSpanDelta)
         {
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", EventPosition.Latest, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
             var cancellation = new CancellationTokenSource();
             var expectedWaitTime = TimeSpan.FromMilliseconds(timeSpanDelta);
 
@@ -189,7 +197,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubConsumerOptions { DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(8) };
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", EventPosition.Latest, options);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, options);
             var cancellation = new CancellationTokenSource();
             var expectedMessageCount = 45;
 
@@ -210,7 +218,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncClosesTheTransportConsumer()
         {
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", EventPosition.Latest, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
 
             await consumer.CloseAsync();
 
@@ -226,7 +234,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CloseClosesTheTransportConsumer()
         {
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", "0", EventPosition.Latest, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
 
             consumer.Close();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerOptionsTests.cs
@@ -49,6 +49,31 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerOptions.PartitionId" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase("    ")]
+        [TestCase(" ")]
+        [TestCase("")]
+        public void PartitionIdIsValidated(string partition)
+        {
+            Assert.That(() => new EventHubProducerOptions { PartitionId = partition }, Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubProducerOptions.PartitionId" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void PartitionIdAllowsNull()
+        {
+            Assert.That(() => new EventHubProducerOptions { PartitionId = null }, Throws.Nothing);
+        }
+
+        /// <summary>
         ///   Verifies functionality of the <see cref="EventHubProducerOptions.Timeout" />
         ///   property.
         /// </summary>


### PR DESCRIPTION
# Summary

The intent of these changes is to incorporate feedback from the Event Hubs service team and force the consumer group to be specified when creating an `EventHubConsumer`; the default is no
longer assumed, though it is still a valid value.

# Last Upstream Rebase

Wednesday, June 19, 2019  3:07pm (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)