### PR TITLE
Renaming some Azure.Identity classes for cross-language consistency

### DIFF
--- a/sdk/identity/Azure.Identity/src/ChainedTokenCredential.cs
+++ b/sdk/identity/Azure.Identity/src/ChainedTokenCredential.cs
@@ -9,11 +9,11 @@ using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
-    public class AggregateCredential : TokenCredential
+    public class ChainedTokenCredential : TokenCredential
     {
         private TokenCredential[] _sources;
 
-        public AggregateCredential(params TokenCredential[] sources)
+        public ChainedTokenCredential(params TokenCredential[] sources)
         {
             if (sources == null) throw new ArgumentNullException(nameof(sources));
 

--- a/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
+++ b/sdk/identity/Azure.Identity/src/DefaultAzureCredential.cs
@@ -8,15 +8,15 @@ using System.Threading.Tasks;
 
 namespace Azure.Identity
 {
-    public class SystemCredential : AggregateCredential
+    public class DefaultAzureCredential : ChainedTokenCredential
     {
-        public SystemCredential()
+        public DefaultAzureCredential()
             :this(null)
         {
 
         }
 
-        public SystemCredential(IdentityClientOptions options)
+        public DefaultAzureCredential(IdentityClientOptions options)
             : base(new EnvironmentCredential(options), new ManagedIdentityCredential(options: options))
         {
 

--- a/sdk/identity/Azure.Identity/tests/TokenCredentialProviderTests.cs
+++ b/sdk/identity/Azure.Identity/tests/TokenCredentialProviderTests.cs
@@ -56,13 +56,13 @@ namespace Azure.Identity.Tests
         [Test]
         public void CtorInvalidInput()
         {
-            Assert.Throws<ArgumentNullException>(() => new AggregateCredential(null));
+            Assert.Throws<ArgumentNullException>(() => new ChainedTokenCredential(null));
 
-            Assert.Throws<ArgumentException>(() => new AggregateCredential((TokenCredential)null));
+            Assert.Throws<ArgumentException>(() => new ChainedTokenCredential((TokenCredential)null));
 
-            Assert.Throws<ArgumentException>(() => new AggregateCredential());
+            Assert.Throws<ArgumentException>(() => new ChainedTokenCredential());
 
-            Assert.Throws<ArgumentException>(() => new AggregateCredential(new TokenCredential[] { }));
+            Assert.Throws<ArgumentException>(() => new ChainedTokenCredential(new TokenCredential[] { }));
         }
 
         [Test]
@@ -72,7 +72,7 @@ namespace Azure.Identity.Tests
             var cred2 = new SimpleMockTokenCredential("scopeB", "tokenB");
             var cred3 = new SimpleMockTokenCredential("scopeB", "NotToBeReturned");
             var cred4 = new SimpleMockTokenCredential("scopeC", "tokenC");
-            var provider = new AggregateCredential(cred1, cred2, cred3, cred4);
+            var provider = new ChainedTokenCredential(cred1, cred2, cred3, cred4);
 
             Assert.AreEqual("tokenA", (await provider.GetTokenAsync(new string[] { "scopeA" })).Token);
             Assert.AreEqual("tokenB", (await provider.GetTokenAsync(new string[] { "scopeB" })).Token);
@@ -86,7 +86,7 @@ namespace Azure.Identity.Tests
             var cred1 = new SimpleMockTokenCredential("scopeA", "tokenA");
             var cred2 = new ExceptionalMockTokenCredential();
             var cred3 = new SimpleMockTokenCredential("scopeB", "tokenB");
-            var provider = new AggregateCredential(cred1, cred2, cred3);
+            var provider = new ChainedTokenCredential(cred1, cred2, cred3);
 
             Assert.AreEqual("tokenA", (await provider.GetTokenAsync(new string[] { "scopeA" })).Token);
             Assert.ThrowsAsync<MockException>(async () => await provider.GetTokenAsync(new string[] { "ScopeB" }));

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientTests.cs
@@ -13,7 +13,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
     {
         public KeyClientTests(bool isAsync) : base(isAsync)
         {
-            Client = InstrumentClient(new KeyClient(new Uri("http://localhost"), new SystemCredential()));
+            Client = InstrumentClient(new KeyClient(new Uri("http://localhost"), new DefaultAzureCredential()));
         }
 
         public KeyClient Client { get; set; }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeysTestBase.cs
@@ -31,7 +31,7 @@ namespace Azure.Security.KeyVault.Keys.Tests
             return InstrumentClient
                 (new KeyClient(
                     new Uri(recording.GetVariableFromEnvironment(AzureKeyVaultUrlEnvironmentVariable)),
-                    recording.GetCredential(new SystemCredential()),
+                    recording.GetCredential(new DefaultAzureCredential()),
                     recording.InstrumentClientOptions(new KeyClientOptions())));
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/KeyVaultTestBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/KeyVaultTestBase.cs
@@ -32,7 +32,7 @@ namespace Azure.Security.KeyVault.Test
             return InstrumentClient
                 (new SecretClient(
                     new Uri(recording.GetVariableFromEnvironment(AzureKeyVaultUrlEnvironmentVariable)),
-                    recording.GetCredential(new SystemCredential()),
+                    recording.GetCredential(new DefaultAzureCredential()),
                     recording.InstrumentClientOptions(new SecretClientOptions())));
         }
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientTests.cs
@@ -13,7 +13,7 @@ namespace Azure.Security.KeyVault.Test
     {
         public SecretClientTests(bool isAsync) : base(isAsync)
         {
-            Client = InstrumentClient(new SecretClient(new Uri("http://localhost"), new SystemCredential()));
+            Client = InstrumentClient(new SecretClient(new Uri("http://localhost"), new DefaultAzureCredential()));
         }
 
         public SecretClient Client { get; set; }


### PR DESCRIPTION
Renaming the following classes so identity classes / concepts are consistent across all languages:

SystemCredential -> DefaultAzureCredential
AggregateCredential -> ChainedTokenCredential

Updated the classes as well as the tests referencing them.