### PR TITLE
Update mgmt and service projs

### DIFF
--- a/eng/mgmt.proj
+++ b/eng/mgmt.proj
@@ -9,4 +9,7 @@
     <Error Condition="!Exists('$(ScopePath)')" Text="Scope [$(Scope)] does not exists please specify a path relative to the sdk root directory (i.e. compute, keyvault, etc)" />
     <Error Condition="'$(Scope)' == '' and '$(ForPublishing)' == 'true'" Text="Scope cannot be empty you are intending to automatically publish the build output. Please set a Scope and retry." />
   </Target>
+  
+  <Target Name="Pack" DependsOnTargets="CreateNugetPackage" />
+  <Target Name="VSTest" DependsOnTargets="RunTests" />
 </Project>

--- a/eng/service.proj
+++ b/eng/service.proj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <PropertyGroup>
+    <ServiceDirectory Condition="'$(ServiceDirectory)' == '' and '$(Scope)' != ''">$(Scope)</ServiceDirectory>
     <ServiceDirectory Condition="'$(ServiceDirectory)' == ''">*</ServiceDirectory>
   </PropertyGroup>
 


### PR DESCRIPTION
mgmt - now supports common pack and test targets
service - supports scope property

This should enable use to run commands like:

dotnet build
dotnet pack
dotnet test

on the root build.proj and scope via /p:Scope=<service folder>