### PR TITLE
Publishing to public feeds

### DIFF
--- a/eng/pipelines/templates/jobs/archetype-sdk-client.yml
+++ b/eng/pipelines/templates/jobs/archetype-sdk-client.yml
@@ -9,8 +9,15 @@ jobs:
         displayName: "Use .NET Core sdk $(DotNetCoreSDKVersion)"
         inputs:
           version: "$(DotNetCoreSDKVersion)"
-      - script: "dotnet pack eng/service.proj -o $(Build.ArtifactStagingDirectory) -warnaserror /p:ServiceDirectory=${{parameters.ServiceDirectory}} /p:PublicSign=false ${{ parameters.VersioningProperties }}"
-        displayName: "Build and Package"
+      - script: "dotnet build eng/service.proj -o $(Build.ArtifactStagingDirectory) -warnaserror /p:ServiceDirectory=${{parameters.ServiceDirectory}} /p:PublicSign=false ${{ parameters.VersioningProperties }}"
+        displayName: "Build"
+        env:
+          DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+          DOTNET_CLI_TELEMETRY_OPTOUT: 1
+          DOTNET_MULTILEVEL_LOOKUP: 0
+      - script: |
+          dotnet pack eng/service.proj --no-build -o $(Build.ArtifactStagingDirectory) -warnaserror /p:ServiceDirectory=${{parameters.ServiceDirectory}} /p:PublicSign=false ${{ parameters.VersioningProperties }} /p:VersionSuffix=run.$(Build.BuildID)"
+        displayName: "Package"
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/sdk/core/ci.yml
+++ b/sdk/core/ci.yml
@@ -17,6 +17,7 @@ pr:
     include:
     - sdk/core/
 
+
 jobs:
 - template: ../../eng/pipelines/templates/jobs/archetype-sdk-client.yml
   parameters:


### PR DESCRIPTION
This PR adds support for publishing packages to an Azure Artifacts public feed. The pipeline is modified to produce three different package versions.

* ```x.y.z``` (no suffix)
* ```x.y.z-run.12345``` (package specific to this run)
* ```x.y.z-preview.abc``` (the preview package)

The idea is that upfront in the build we create our packages up front and carry them through the pipeline and publish them at the right time (unpacking and signing where appropriate). This assumes a pipeline that goes from PR through CI and all the way to publishing.