### PR TITLE
[Event Hubs Client] Track Two: First Preview (Samples)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.T
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.TrackOne", "src\TrackOneClient\Azure.Messaging.EventHubs.TrackOne.csproj", "{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventHubs.Samples", "samples\Azure.Messaging.EventHubs.Samples.csproj", "{AD33C619-AC51-4F29-937B-184B4F785F57}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|x64.Build.0 = Release|Any CPU
 		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|x86.ActiveCfg = Release|Any CPU
 		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|x86.Build.0 = Release|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|x64.Build.0 = Debug|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|x86.Build.0 = Debug|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Release|x64.ActiveCfg = Release|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Release|x64.Build.0 = Release|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Release|x86.ActiveCfg = Release|Any CPU
+		{AD33C619-AC51-4F29-937B-184B4F785F57}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/eventhub/Azure.Messaging.EventHubs/Directory.Build.props
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Directory.Build.props
@@ -1,6 +1,20 @@
-﻿<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">  
+  <!-- 
+    Identify samples as a test support project to keep the target framework synchronized, since both are 
+    based on a version of netcoreapp. 
+    
+    Because the common SDK build properties need this value in order to recognize the desired
+    target frameworks and related, this needs to be set before the common properties import.
+  -->
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Samples'))">
+    <IsTestProject>true</IsTestProject>
+    <IsTestSupportProject>true</IsTestSupportProject>
+  </PropertyGroup>
+
+  <!-- Import the common SDK build properties. -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 
+  <!-- Set any needed overrides to the decisions made within the common SDK build properties. -->
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -10,7 +24,7 @@
     <!-- Do not inherit implicit dependencies from the engineering system during build or packaging -->
     <ImportDefaultReferences>false</ImportDefaultReferences>
 
-     <!-- Disable the custom analyzer for the prototype; it's impacting development speed. -->
+     <!-- Disable the custom analyzer; it is currently in development and based against draft standards. -->
      <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
 
      <!-- If there was no override specified, assume a project reference to Azure.Core -->

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -146,18 +146,37 @@ For detailed information about these and other exceptions that may occur, please
 
 ## Next steps
 
-Beyond those discussed, the Azure Event Hubs client library offers support for many additional scenarios to help take advantage of the full feature set of the Azure Event Hubs service.  In order to help explore some of these scenarios, the following set of samples is available:
+Beyond the scenarios discussed, the Azure Event Hubs client library offers support for many additional scenarios to help take advantage of the full feature set of the Azure Event Hubs service.  In order to help explore some of these scenarios, the following set of samples is available:
 
-- Hello world
-- Create and Event Hub client with custom options
-- Inspect Event Hub and partition properties
-- Publish events to a specific Event Hub partition
-- Publish events with custom metadata
-- Consume events with as the owner of a partition/consumer group
-- Save the last read event and resume from that point
+- [Hello world](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs)  
+  An introduction to Event Hubs, illustrating how to connect and query the service.
+
+- [Create an Event Hub client with custom options](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample2_ClientWithCustomOptions.cs)  
+  An introduction to Event Hubs, exploring additional options for creating an Event Hub client.
+  
+- [Publish an event to an Event Hub](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample3_PublishAnEvent3.cs)  
+  An introduction to publishing events, using a simple Event Hub producer.
+  
+- [Publish events using a partition key](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample4_PublishEventsWithPartitionKey.cs)  
+  An introduction to publishing events, using a partition key to group them together.
+  
+- [Publish events to a specific Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample5_PublishEventsToSpecificPartitions.cs)  
+  An introduction to publishing events, using an Event Hub producer that is associated with a specific partition.
+  
+- [Publish events with custom metadata](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample6_PublishEventsWithCustomMetadata.cs)  
+  An example of publishing events, extending the event data with custom metadata.
+  
+- [Consume events from an Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs)  
+  An introduction to consuming events, using a simple Event Hub consumer.
+  
+- [Consume events from an Event Hub partition in batches](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch)  
+  An example of consuming events, using a batch approach to control throughput.
+  
+- [Consume events from a known position in the Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition)  
+  An example of consuming events, starting at a well-known position in the Event Hub partition.
 
 ## Contributing  
 
-Please refer to our [contributing guide](https://raw.githubusercontent.com/jsquire/azure-sdk-for-net/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
+Please refer to our [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
   
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs%2FFREADME.png)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Azure.Messaging.EventHubs.Samples.csproj
@@ -1,28 +1,31 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyName>Azure.Messaging.EventHubs.Tests</AssemblyName>
+    <AssemblyName>Azure.Messaging.EventHubs.Samples</AssemblyName>
     <VersionPrefix>5.0.0</VersionPrefix>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <OutputType>Exe</OutputType>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(IsTargetingNetFx)' == 'true'">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.IdentityModel" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsTargetingNetStandard)' == 'true'">
+    <PackageReference Include="System.Runtime.Serialization.Primitives" />
+  </ItemGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="System.Net.WebSockets.Client" />
     <PackageReference Include="System.ValueTuple" />
-    <PackageReference Include="NUnit" />
-    <PackageReference Include="NUnit3TestAdapter" />
-    <PackageReference Include="Moq" />
-    <PackageReference Include="Polly" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
-    <PackageReference Include="Microsoft.Azure.Management.EventHub" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\src\Azure.Messaging.EventHubs.csproj" />
-    <ProjectReference Include="..\samples\Azure.Messaging.EventHubs.Samples.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/ISample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/ISample.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+
+namespace Azure.Messaging.EventHubs.Samples.Infrastructure
+{
+    /// <summary>
+    ///   Designates a class as a sample and provides a well-known means
+    ///   of executing the sample.
+    /// </summary>
+    ///
+    ///
+    public interface ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; }
+
+        /// <summary>
+        ///   A short description of the associated sample.
+        /// </summary>
+        ///
+        public string Description { get; }
+
+        /// <summary>
+        ///   Allows for executing the sample.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that the sample should run against.</param>
+        ///
+        public Task RunAsync(string connectionString,
+                             string eventHubName);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
@@ -1,0 +1,275 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   The main entry point for executing the samples.
+    /// </summary>
+    ///
+    public static class Program
+    {
+        /// <summary>
+        ///   Serves as the main entry point of the application.
+        /// </summary>
+        ///
+        /// <param name="args">The set of command line arguments passed.</param>
+        ///
+        public static async Task Main(string[] args)
+        {
+            // Parse the command line arguments determine if help was explicitly requested or if the
+            // needed information was passed.
+
+            var parsedArgs = ParseArguments(args);
+
+            if (parsedArgs.Help)
+            {
+                DisplayHelp();
+                return;
+            }
+
+            // Display the welcome message.
+
+            Console.WriteLine();
+            Console.WriteLine("=========================================");
+            Console.WriteLine("Welcome to the Event Hubs client library!");
+            Console.WriteLine("=========================================");
+            Console.WriteLine();
+
+            // Prompt for the connection string, if it wasn't passed.
+
+            while (String.IsNullOrEmpty(parsedArgs.ConnectionString))
+            {
+                Console.Write("Please provide the connection string for the Event Hubs namespace that you'd like to use and then press Enter: ");
+                parsedArgs.ConnectionString = Console.ReadLine().Trim();
+                Console.WriteLine();
+            }
+
+            // Prompt for the Event Hub name, if it wasn't passed.
+
+            while (String.IsNullOrEmpty(parsedArgs.EventHub))
+            {
+                Console.Write("Please provide the name of the Event Hub that you'd like to use and then press Enter: ");
+                parsedArgs.EventHub = Console.ReadLine().Trim();
+                Console.WriteLine();
+            }
+
+            // Display the set of available samples and allow them to be run.
+
+            var samples = LocateSamples();
+
+            Console.WriteLine();
+            Console.WriteLine("Available Samples:");
+            Console.WriteLine();
+
+            for (var index = 0; index < samples.Count; ++index)
+            {
+                Console.WriteLine($"{ index + 1 }) { samples[index].Name }");
+                Console.WriteLine($"\t{ samples[index].Description }");
+                Console.WriteLine();
+            }
+
+            Console.WriteLine();
+            Console.Write("Please enter the number of a sample to run or press \"X\" to exit: ");
+
+            var key = ReadSelection(samples.Count);
+
+            if ((key == 'x') || (key == 'X'))
+            {
+                Console.Write(key);
+                Console.WriteLine();
+                Console.WriteLine();
+                Console.WriteLine("Quitting...");
+                Console.WriteLine();
+                return;
+            }
+            else
+            {
+                var choice = ((int)key);
+
+                Console.Write(key);
+                Console.WriteLine();
+                Console.WriteLine();
+                Console.WriteLine();
+                Console.WriteLine("-------------------------------------------------------------------------");
+                Console.WriteLine($"Running: { samples[choice].Name }");
+                Console.WriteLine("-------------------------------------------------------------------------");
+                Console.WriteLine();
+
+                await samples[choice].RunAsync(parsedArgs.ConnectionString, parsedArgs.EventHub);
+                return;
+            }
+        }
+
+        /// <summary>
+        ///   Displays the help text for running the samples to the console
+        ///   output.
+        /// </summary>
+        ///
+        private static void DisplayHelp()
+        {
+           Console.WriteLine();
+           Console.WriteLine($"{ typeof(Program).Namespace }");
+           Console.WriteLine();
+           Console.WriteLine("This executable allows for running the Azure Event Hubs client library samples.  Because");
+           Console.WriteLine("the samples run against live Azure services, they require an Event Hubs namespace and an");
+           Console.WriteLine("Event Hub under it in order to run.");
+           Console.WriteLine();
+           Console.WriteLine();
+           Console.WriteLine("Arguments:");
+           Console.WriteLine($"\t{ nameof(CommandLineArguments.Help) }:");
+           Console.WriteLine("\t\tDisplays this message.");
+           Console.WriteLine();
+           Console.WriteLine($"\t{ nameof(CommandLineArguments.ConnectionString) }:");
+           Console.WriteLine("\t\tThe connection string to the Event Hubs namespace to use for the samples.");
+           Console.WriteLine();
+           Console.WriteLine($"\t{ nameof(CommandLineArguments.EventHub) }:");
+           Console.WriteLine("\t\tThe name of the Event Hub under the namespace to use.");
+           Console.WriteLine();
+           Console.WriteLine("Usage:");
+           Console.WriteLine($"\tAzure.Messaging.EventHubs.Samples.exe { CommandLineArguments.ArgumentPrefix }{ nameof(CommandLineArguments.ConnectionString) } \"Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=NotReal;SharedAccessKey=[FAKE];\" { CommandLineArguments.ArgumentPrefix }{ nameof(CommandLineArguments.EventHub) } \"SomeHub\"");
+           Console.WriteLine();
+           Console.WriteLine("\tAzure.Messaging.EventHubs.Samples.exe \"Endpoint=sb://fake.servicebus.windows.net/;SharedAccessKeyName=NotReal;SharedAccessKey=[FAKE];\" \"SomeHub\"");
+           Console.WriteLine();
+           Console.WriteLine($"\tAzure.Messaging.EventHubs.Samples.exe { CommandLineArguments.ArgumentPrefix }{ nameof(CommandLineArguments.Help) }");
+           Console.WriteLine();
+        }
+
+        /// <summary>
+        ///   Reads the selection of the application's user from the
+        ///   console.
+        /// </summary>
+        ///
+        /// <param name="sampleCount">The count of available samples.</param>
+        ///
+        /// <returns>The validated selection that was made.</returns>
+        ///
+        private static char ReadSelection(int sampleCount)
+        {
+            while(true)
+            {
+                var key = Console.ReadKey(true);
+
+                if ((key.KeyChar == 'x') || (key.KeyChar == 'X'))
+                {
+                    return key.KeyChar;
+                }
+
+                if (Char.IsDigit(key.KeyChar))
+                {
+                    var choice = ((int)Char.GetNumericValue(key.KeyChar) - 1);
+
+                    if ((choice >= 0) && (choice < sampleCount))
+                    {
+                        return (char)choice;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Parses the set of arguments read from the command line.
+        /// </summary>
+        ///
+        /// <param name="args">The command line arguments.</param>
+        ///
+        /// <returns>The set of parsed arguments, with any values for known items captured and cleaned.</returns>
+        ///
+        private static CommandLineArguments ParseArguments(string[] args)
+        {
+
+            // If at least two arguments were passed with no argument designator, then assume they're values and
+            // accept them positionally
+            if ((args.Length >= 2) && (!args[0].StartsWith(CommandLineArguments.ArgumentPrefix)) && (!args[1].StartsWith(CommandLineArguments.ArgumentPrefix)))
+            {
+                return new CommandLineArguments { ConnectionString = args[0], EventHub = args[1] };
+            }
+
+            var parsedArgs = new CommandLineArguments();
+
+            // Enumerate the arguments that were passed, stopping one before the
+            // end, since we're scanning forward by an item to retrieve values;  if a
+            // command was passed in the last position, there was no accompanying value,
+            // so it isn't useful.
+
+            for (var index = 0; index < args.Length -1; ++index)
+            {
+                // Remove any excess spaces to comparison purposes.
+
+                args[index] = args[index].Trim();
+
+                // Help is the only flag argument supported; check for it before making
+                // assumptions about argument/value pairings that comprise the other tokens.
+
+                if (args[index].Equals($"{ CommandLineArguments.ArgumentPrefix }{ nameof(CommandLineArguments.Help) }", StringComparison.OrdinalIgnoreCase))
+                {
+                    parsedArgs.Help = true;
+                    continue;
+                }
+
+                // Since we're evaluating the next token in sequence as a value in the
+                // checks that follow, if it is an argument, we'll skip to the next iteration.
+
+                if (args[index + 1].StartsWith(CommandLineArguments.ArgumentPrefix))
+                {
+                    continue;
+                }
+
+                // If the current token is one of our known arguments, capture the next token in sequence as it's
+                // value, since we've already ruled out that it is another argument name.
+
+                if (args[index].Equals($"{ CommandLineArguments.ArgumentPrefix }{ nameof(CommandLineArguments.ConnectionString) }", StringComparison.OrdinalIgnoreCase))
+                {
+                    parsedArgs.ConnectionString = args[index + 1].Trim();
+                }
+                else if (args[index].Equals($"--{ nameof(CommandLineArguments.EventHub) }", StringComparison.OrdinalIgnoreCase))
+                {
+                    parsedArgs.EventHub = args[index + 1].Trim();
+                }
+            }
+
+            return parsedArgs;
+        }
+
+        /// <summary>
+        ///   Locates the samples within the solution and creates an instance
+        ///   that can be inspected and run.
+        /// </summary>
+        ///
+        /// <returns>The set of samples defined in the solution.</returns>
+        ///
+        private static IReadOnlyList<ISample> LocateSamples() =>
+            typeof(Program)
+              .Assembly
+              .ExportedTypes
+              .Where(type => (type.IsClass && typeof(ISample).IsAssignableFrom(type)))
+              .Select(type => (ISample)Activator.CreateInstance(type))
+              .ToList();
+
+        /// <summary>
+        ///   Provides a local means of collecting and passing
+        ///   the command line arguments received.
+        /// </summary>
+        ///
+        private class CommandLineArguments
+        {
+            /// <summary>The sequence of characters that prefix a command-line argument./summary>
+            public const string ArgumentPrefix = "--";
+
+            /// <summary>The connection string to the Azure Event Hubs namespace for samples.</summary>
+            public string ConnectionString;
+
+            /// <summary>The name of the Event Hub to use samples.</summary>
+            public string EventHub;
+
+            /// <summary>A flag indicating whether or not help was requested.</summary>
+            public bool Help;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Metadata;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An introduction to Event Hubs, illustrating how to connect and query the service.
+    /// </summary>
+    ///
+    public class Sample1_HelloWorld : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample1_HelloWorld);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An introduction to Event Hubs, illustrating how to connect and query the service.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // To interact with Event Hubs, a client is needed.  The client manages resources and should be
+            // explicitly closed or disposed, but it is not necessary to do both.  In our case, we will take
+            // advantage of the new asynchonous dispose to ensure that we clean up our client when we are
+            // done or when an exception is encountered.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            {
+                // Using the client, we will inspect the Event Hub that it is connected to, getting
+                // access to its informational properties.
+
+                EventHubProperties properties = await client.GetPropertiesAsync();
+
+                Console.WriteLine("The Event Hub has the following properties:");
+                Console.WriteLine($"\tThe path to the Event Hub from the namespace is: { properties.Path }");
+                Console.WriteLine($"\tThe Event Hub was created at: { properties.CreatedAtUtc.ToString("yyyy-MM-dd hh:mm:ss tt") }, in UTC.");
+                Console.WriteLine();
+
+                // Partitions of an Event Hub are an important concept.  Using the Event Hub properties, we'll inspect each of its partitions,
+                // getting access to partition-level properties.
+
+                foreach (string partitionId in properties.PartitionIds)
+                {
+                    PartitionProperties partitionProperties = await client.GetPartitionPropertiesAsync(partitionId);
+
+                    Console.WriteLine($"\tPartiton: { partitionProperties.Id }");
+                    Console.WriteLine($"\t\tThe partition contains no events: { partitionProperties.IsEmpty }");
+                    Console.WriteLine($"\t\tThe first sequence number of an event in the partition is: { partitionProperties.BeginningSequenceNumber }");
+                    Console.WriteLine($"\t\tThe last sequence number of an event in the partition is: { partitionProperties.LastEnqueuedSequenceNumber }");
+                    Console.WriteLine($"\t\tThe last offset of an event in the partition is: { partitionProperties.LastEnqueuedOffset }");
+                    Console.WriteLine($"\t\tThe last time that an event was enqueued in the partition is: { partitionProperties.LastEnqueuedTimeUtc.ToString("yyyy-MM-dd hh:mm:ss tt") }, in UTC.");
+                    Console.WriteLine();
+                }
+            }
+
+            // At this point, our client has passed its "using" scope and has safely been disposed of.  We have no
+            // further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample2_ClientWithCustomOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample2_ClientWithCustomOptions.cs
@@ -1,0 +1,86 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Metadata;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An introduction to Event Hubs, exploring additional options for creating an <see cref="EventHubClient" />.
+    /// </summary>
+    ///
+    public class Sample2_ClientWithCustomOptions : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample2_ClientWithCustomOptions);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An introduction to Event Hubs, exploring additional options for creating an Event Hub client.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // The Event Hub client offers additional options on creation, which allow you to control different aspects of its behavior.
+            // This is a common concept in the client library, and is extended to many of the types that you create to perform operations against
+            // an Event Hub.  If you choose not to provide these options, a set of defaults is applied.
+            //
+            // The Event Hub client allows you to customize how it interacts with the Event Hubs service on an operational level,
+            // by specifying the timeout that is used while waiting for the Event Hubs service to respond and the retry policy to
+            // apply for a failed operation.
+            //
+            // The Event Hub client also allows you to customize how it connects to the service by specifying the specific transport that it
+            // should communicate over and whether it should make use of a proxy for network communication.
+            //
+            // Please note that the proxy is only supported when using Websockets as a transport; it isn't compatibile with raw TCP or other
+            // transport channels.
+
+            var clientOptions = new EventHubClientOptions
+            {
+               DefaultTimeout = TimeSpan.FromMinutes(1),
+               Retry = new ExponentialRetry(TimeSpan.FromSeconds(0.25), TimeSpan.FromSeconds(30), 5),
+               TransportType = TransportType.AmqpWebSockets,
+               Proxy = (IWebProxy)null
+            };
+
+            await using (var client = new EventHubClient(connectionString, eventHubName, clientOptions))
+            {
+                // Using the client, we will inspect the Event Hub that it is connected to, getting
+                // access to metadata about it.
+
+                EventHubProperties properties = await client.GetPropertiesAsync();
+
+                Console.WriteLine("The Event Hub has the following properties:");
+                Console.WriteLine($"\tThe path to the Event Hub from the namespace is: { properties.Path }");
+                Console.WriteLine($"\tThe Event Hub was created at: { properties.CreatedAtUtc.ToString("yyyy-MM-dd hh:mm:ss tt") }, in UTC.");
+                Console.WriteLine("\tThe Event Hub has the following partitions:");
+
+                foreach (string partitionId in properties.PartitionIds)
+                {
+                    Console.WriteLine($"\t\tPartition Id: { partitionId }");
+                }
+            }
+
+            // At this point, our client has passed its "using" scope and has safely been disposed of.  We have no
+            // further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample3_PublishAnEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample3_PublishAnEvent.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An introduction to publishing events, using a simple <see cref="EventHubProducer" />.
+    /// </summary>
+    ///
+    public class Sample3_PublishAnEvent : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample3_PublishAnEvent);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An introduction to publishing events, using a simple Event Hub producer.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // To create an Event Hub producer, a client is needed.  We will start by creating a client with
+            // the default set of options.
+            //
+            // Using our client, we will then create a producer.  Like the client, our Event Hub producer also manages resources
+            // and should be explicitly closed or disposed, but it is not necessary to do both.  In our case, we will take
+            // advantage of the new asynchonous dispose to ensure that we clean up our client and producer when we are
+            // done or when an exception is encountered.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            await using (EventHubProducer producer = client.CreateProducer())
+            {
+                // By default, an Event Hub producer is not associated with any specific partition.  When publishing events,
+                // it will allow the Event Hubs service to route the event to an available partition.
+                //
+                // Allowing automatic routing of partitions is recommended when:
+                //  - The publishing of events needs to be highly available.
+                //  - The event data should be evenly distributed among all available partitions.
+
+
+                // An event is represented by an arbitrary collection of bytes and metadata.  Event Hubs does not make any
+                // assumptions about the data nor attempt to perform any operations on it; you are free to create the data
+                // in whatever form makes sense for your scenario.
+                //
+                // In our case, we will translate a simple sentance into bytes and send it to our Event Hub.
+
+                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!"));
+
+                // When the producer sends the event, it will receive an acknowedgement from the Event Hubs service; so
+                // long as there is no exception thrown by this call, the service is now responsible for delivery.  Your
+                // event data will be published to one of the Event Hub partitions, though there may be a (very) slight
+                // delay until it is available to be consumed.
+
+                await producer.SendAsync(eventData);
+
+                Console.WriteLine("The event has been published.");
+            }
+
+            // At this point, our client and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample4_PublishEventsWithPartitionKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample4_PublishEventsWithPartitionKey.cs
@@ -1,0 +1,82 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An introduction to publishing events, using a partition key to group them together.
+    /// </summary>
+    ///
+    public class Sample4_PublishEventsWithPartitionKey : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample4_PublishEventsWithPartitionKey);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An introduction to publishing events, using a partition key to group them together.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // We will start by creating a client and a producer, each using their default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            await using (EventHubProducer producer = client.CreateProducer())
+            {
+                // When an Event Hub producer is not associated with any specific partition, it may be desirable to request that
+                // the Event Hubs service keep different events or batches of events together on the same partition.  This can be
+                // accomplished by setting a partition key when publishing the events.
+                //
+                // The partition key is NOT the identifier of a specific partition.  Rather, it is an arbitrary piece of string data
+                // that Event Hubs uses as the basis to compute a hash value.  Event Hubs will associate the hash value with a specific
+                // partition, ensuring that any events published with the same partition key are reouted to the same partition.
+                //
+                // Note that there is no means of accurately predicting which partition will be associated with a given partition key;
+                // we can only be assured that it will be a consistent choice of partition.  If you have a need to understand which
+                // exact partition an event is published to, you will need to use an Event Hub producer associated with that partition.
+
+                // We will publish a small batch of events based on simple sentances.
+
+                var eventBatch = new EventData[]
+                {
+                    new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")),
+                    new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!"))
+                };
+
+                // To choose a partition key, you will need to create a custom set of send options.
+
+                var sendOptions = new SendOptions
+                {
+                    PartitionKey = "Any Value Will Do..."
+                };
+
+                await producer.SendAsync(eventBatch, sendOptions);
+
+                Console.WriteLine("The event batch has been published.");
+            }
+
+            // At this point, our client and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample5_PublishEventsToSpecificPartitions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample5_PublishEventsToSpecificPartitions.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An introduction to publishing events, using an <see cref="EventHubProducer" /> that is associated with a specific partition.
+    /// </summary>
+    ///
+    public class Sample5_PublishEventsToSpecificPartitions : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample5_PublishEventsToSpecificPartitions);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An introduction to publishing events, using aa Event Hub producer that is associated with a specific partition.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // We will start by creating a client using its default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            {
+                // Because partitions are owned by the Event Hubs service, it is not advised to assume that they have a stable
+                // and predictable set of identifiers.  We'll inspect the Event Hub and select the first parition to use for
+                // publishing our event batch.
+
+                string[] partitionIds = await client.GetPartitionIdsAsync();
+
+                // In order to request that a producer be associated with a specific partition, it needs to be created with a custom
+                // set of options.  Like the Event Hub client, there are options for a producer available to tune the behavior for
+                // operations that interact with the Event Hubs service.
+                //
+                // In our case, we will set the partition association but otherwise make use of the default options.
+
+                var producerOptions = new EventHubProducerOptions
+                {
+                    PartitionId = partitionIds[0]
+                };
+
+                await using (var producer = client.CreateProducer(producerOptions))
+                {
+                    // When an Event Hub producer is associated with any specific partition, it can publish events only to that partition.
+                    // The producer has no ability to ask for the service to route events, including by using a partition key.
+                    //
+                    // If you attempt to use a partition key with an Event Hub producer that is associated with a partition, an exception
+                    // will occur.  Otherwise, publishing to a specific partition is exactly the same as other publishing scenarios.
+
+                    // We will publish a small batch of events based on simple sentances.
+
+                    var eventBatch = new EventData[]
+                    {
+                        new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")),
+                        new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!"))
+                    };
+
+                    await producer.SendAsync(eventBatch);
+
+                    Console.WriteLine("The event batch has been published.");
+                }
+            }
+
+            // At this point, our client and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample6_PublishEventsWithCustomMetadata.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample6_PublishEventsWithCustomMetadata.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An example of publishing events, extending the event data with custom metadata.
+    /// </summary>
+    ///
+    public class Sample6_PublishEventsWithCustomMetadata : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample6_PublishEventsWithCustomMetadata);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An example of publishing events, extending the event data with custom metadata.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // We will start by creating a client and a producer, each using their default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            await using (EventHubProducer producer = client.CreateProducer())
+            {
+                // Because an event consists mainly of an opaque set of bytes, it may be difficult for consumers of those events to
+                // make informed decisions about how to process them.
+                //
+                // In order to allow event publishers to offer better context for consumers, event data may also contain custom metadata,
+                // in the form of a set of key/value pairs.  This metadata is not used by, or in any way meainingful to, the Event Hubs
+                // service; it exists only for coordination between event publishers and consumers.
+                //
+                // One common scenario for the inclusion of metadata is to provide a hint about the type of data contained by an event,
+                // so that consumers understand its format and can deserialize it appropriately.
+                //
+                // We will publish a small batch of events based on simple sentances, but will attach some custom metadata with
+                // pretend type names and other hints.  Note that the set of metadata is unique to an event; there is no need for every
+                // event in a batch to have the same metadata properties available nor the same data type for those properties.
+
+                var firstEvent = new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!"));
+                firstEvent.Properties.Add("EventType", "com.microsoft.samples.hello-event");
+                firstEvent.Properties.Add("priority", 1);
+                firstEvent.Properties.Add("score", 9.0);
+
+                var secondEvent = new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!"));
+                secondEvent.Properties.Add("EventType", "com.microsoft.samples.goodbye-event");
+                secondEvent.Properties.Add("priority", "17");
+                secondEvent.Properties.Add("blob", true);
+
+                await producer.SendAsync(new[] { firstEvent, secondEvent });
+
+                Console.WriteLine("The event batch has been published.");
+            }
+
+            // At this point, our client and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An introduction to consuming events, using a simple <see cref="EventHubConsumer" />.
+    /// </summary>
+    ///
+    public class Sample7_ConsumeEvents : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample7_ConsumeEvents);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An introduction to consuming events, using a simple Event Hub consumer.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // An Event Hub consumer is associated with a specific Event Hub partition and a consumer group.  The consumer group is
+            // a label that identifies one or more consumers as a set.  Often, consumer groups are named after the responsibility
+            // of the consumer in an application, such as "Telemetry" or "OrderProcessing".  When an Event Hub is created, a default
+            // consumer group is created with it, called "$Default."
+            //
+            // Each consumer has a unique view of the events in the partition, meaning that events are available to all consumers
+            // and are not removed from the partition when a consumer reads them.  This allows for different consumers to read and
+            // process events from the partition at different speeds and beginning with different events without interfering with
+            // one another.
+            //
+            // When events are published, they will continue to exist in the partition and be available for consuming until they
+            // reach an age where they are older than the retention period.
+            // (see: https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-is-the-maximum-retention-period-for-events)
+            //
+            // Because events are not removed from the partition when consuming, a consumer must specify where in the partition it
+            // would like to begin reading events.  For example, this may be starting from the very beginning of the stream, at an
+            // offset from the beginning, the next event available after a specific point in time, or at a specific event.
+
+            // We will start by creating a client using its default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            {
+                // With our client, we can now inspect the partitions and find the identifier
+                // of the first.
+
+                string firstPartition = (await client.GetPartitionIdsAsync()).First();
+
+                // In this example, we will create our consumer for the first partition in the Event Hub, using the default consumer group
+                // that is created with an Event Hub.  Our consumer will begin watching the partition at the very end, reading only new events
+                // that we will publish for it.
+
+                await using (EventHubConsumer consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, firstPartition, EventPosition.Latest))
+                await using (EventHubProducer producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = firstPartition }))
+                {
+                    // Because our consumer is reading from the latest position, it won't see events that have previously
+                    // been published.  Before we can publish the events, we will need to ask the consumer to perform an operation,
+                    // because it opens its connection only when it needs to.  The first receive that we ask of it will not see
+                    // any events, but will allow the consumer to start watching the partition.
+                    //
+                    // Because the maximum wait time is specivied as zero, this call will return immediately and will not
+                    // have consumed any events.
+
+                    await consumer.ReceiveAsync(1, TimeSpan.Zero);
+
+                    // Now that the consumer is watching the partition, let's publish the event that we would like to
+                    // receive.
+
+                    await producer.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")));
+                    Console.WriteLine("The event batch has been published.");
+
+                    // Because publishing and receving events is asynchronous, the events that we published may not
+                    // be immediately available for our consumer to see.
+                    //
+                    // Each receive specifies the maximum amount of events that we would like in the batch and the maximum
+                    // amount of time that we would like to wait for them.  If there are enough events available to meet the
+                    // requested amount, they'll be returned immediately.  If not, the consumer will wait and collect events
+                    // as they become available in an attempt to reach the requested amount.  If the maximum time that we've
+                    // allowed it to wait passes, the consumer will return the events that it has collected so far.
+                    //
+                    // Each Receive call may return between zero and the number of events that we requested, depending on the
+                    // state of events in the partition.  Likewise, it may return immediately or take up to the maximum wait
+                    // time that we've allowed.
+                    //
+                    // We will ask for just our event, but allow a fairly long wait period to ensure that we're able to receive it.
+                    // If you observe the time that the call takes, it is extremely likely that the request to recieve will complete
+                    // long before the maximum wait time.
+
+                    Stopwatch watch = Stopwatch.StartNew();
+                    IEnumerable<EventData> receivedBatch = await consumer.ReceiveAsync(1, TimeSpan.FromSeconds(2.5));
+                    watch.Stop();
+
+                    // Print out the events that we received.
+
+                    Console.WriteLine();
+                    Console.WriteLine($"The following events were consumed in { watch.ElapsedMilliseconds } milliseconds:");
+
+                    foreach (EventData eventData in receivedBatch)
+                    {
+                        // The body of our event was an encoded string; we'll recover the
+                        // message by reversing the encoding process.
+
+                        string message = Encoding.UTF8.GetString(eventData.Body.ToArray());
+                        Console.WriteLine($"\tMessage: \"{ message }\"");
+                    }
+                }
+            }
+
+            // At this point, our client, consumer, and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch.cs
@@ -1,0 +1,139 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An example of consuming events, using a batch approach to control throughput.
+    /// </summary>
+    ///
+    public class Sample8_ConsumeEventsByBatch : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample8_ConsumeEventsByBatch);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An example of consuming events, using a batch approach tocontrol throughput.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // We will start by creating a client using its default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            {
+                // With our client, we can now inspect the partitions and find the identifier
+                // of the first.
+
+                string firstPartition = (await client.GetPartitionIdsAsync()).First();
+
+                // In this example, we will create our consumer for the first partition in the Event Hub, using the default consumer group
+                // that is created with an Event Hub.  Our consumer will begin watching the partition at the very end, reading only new events
+                // that we will publish for it.
+
+                await using (EventHubConsumer consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, firstPartition, EventPosition.Latest))
+                await using (EventHubProducer producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = firstPartition }))
+                {
+                    // Because our consumer is reading from the latest position, it won't see events that have previously
+                    // been published. Before we can publish the events, we will need to ask the consumer to perform an operation,
+                    // because it opens its connection only when it needs to.  The first receive that we ask of it will not see
+                    // any events, but will allow the consumer to start watching the partition.
+                    //
+                    // Because the maximum wait time is specivied as zero, this call will return immediately and will not
+                    // have consumed any events.
+
+                    await consumer.ReceiveAsync(1, TimeSpan.Zero);
+
+                    // Now that the consumer is watching the partition, let's publish a fair sized batch of events
+                    // we would like for it to consume.
+
+                    int eventBatchSize = 100;
+                    EventData[] eventBatch = new EventData[eventBatchSize];
+
+                    for (int index = 0; index < eventBatchSize; ++index)
+                    {
+                        eventBatch[index] = new EventData(Encoding.UTF8.GetBytes($"I am event #{ index }"));
+                    }
+
+                    await producer.SendAsync(eventBatch);
+                    Console.WriteLine($"The event batch with { eventBatchSize } events has been published.");
+
+                    // To allow for throughput in our application, we will process the published events by consuming them in
+                    // small batches with a small wait time.  This will allow us to receive and process more quickly than blocking
+                    // to wait on a larger batch size.
+                    //
+                    // The values that are used in this example are intended just for illustration and not as guidance for a recommended
+                    // set of defaults.  In a real-world application, determining the right balance of batch size and wait time to achieve
+                    // the desired performance will often vary depending on the application and event data being consumed.  It is an area
+                    // where some experimentation in the application context may prove helpful.
+                    //
+                    // Our example will attempt to read about 1/5 of the batch at a time, which should result in the need for 5 batches to
+                    // be consumed.  Because publishing and receving events is asynchronous, the events that we published may not be
+                    // immediately available for our consumer to see. To compensate, we will allow for a small number of extra attempts beyond
+                    // the expected 5 to to be sure that we don't stop reading before we receive all of our events.
+
+                    var receivedEvents = new List<EventData>();
+                    int consumeBatchSize = (int)Math.Floor(eventBatchSize / 5.0f);
+                    int maximumAttempts = 15;
+                    int attempts = 0;
+
+                    while ((receivedEvents.Count < eventBatchSize) && (++attempts < maximumAttempts))
+                    {
+                        // Each receive, we ask for the maximum amount of events that we would like in the batch and
+                        // specify the maximum amount of time that we would like to wait for them.
+                        //
+                        // The batch of events will be returned to us when either we have read our maximum number of events
+                        // or when the time that we asked to wait has elapsed.  This means that a batch we receive may have
+                        // between zero and the maximum we asked for, depending on what was available in the partition.
+                        //
+                        // For this attempt, we will ask to receive our computed batch size (1/5 of published events) and wait, at most,
+                        // 25 milliseconds to receive them.  We'll then process them and if we haven't gotten all that we published, we'll
+                        // make another attempt until either we have them or we have tried for our maximum number of attempts.
+
+                        IEnumerable<EventData> receivedBatch = await consumer.ReceiveAsync(consumeBatchSize, TimeSpan.FromMilliseconds(25));
+                        receivedEvents.AddRange(receivedBatch);
+                    }
+
+                    // Print out the events that we received.
+
+                    Console.WriteLine();
+                    Console.WriteLine($"Events Consumed: { receivedEvents.Count }");
+
+                    foreach (EventData eventData in receivedEvents)
+                    {
+                        // The body of our event was an encoded string; we'll recover the
+                        // message by reversing the encoding process.
+
+                        string message = Encoding.UTF8.GetString(eventData.Body.ToArray());
+                        Console.WriteLine($"\tMessage: \"{ message }\"");
+                    }
+                }
+            }
+
+            // At this point, our client, consumer, and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition.cs
@@ -1,0 +1,175 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An example of consuming events, starting at a well-known position in the Event Hub partition.
+    /// </summary>
+    ///
+    public class Sample9_ConsumeEventsFromAKnownPosition : ISample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample9_ConsumeEventsFromAKnownPosition);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An example of consuming events, starting at a well-known position in the Event Hub partition.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // We will start by creating a client using its default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            {
+                // With our client, we can now inspect the partitions and find the identifier of the first.
+
+                string firstPartition = (await client.GetPartitionIdsAsync()).First();
+
+                // In this example, we will make use of multiple consumers for the first partition in the Event Hub, using the default consumer group
+                // that is created with an Event Hub.  Our initial consumer will begin watching the partition at the very end, reading only new events
+                // that we will publish for it.
+
+                await using (EventHubProducer producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = firstPartition }))
+                {
+                    // Each event that the initial consumer reads will have attributes set that describe the event's place in the
+                    // partition, such as it's offset, sequence number, and the date/time that it was enqueued.  These attributes can be
+                    // used to create a new consumer that begins consuming at a known position.
+                    //
+                    // With Event Hubs, it is the responsibility of an application consuming events to keep track of those that it has processed,
+                    // and to manage where in the partition the consumer begins reading events.  This is done by using the position information to track
+                    // state, commonly known as "creating a checkpoint."
+                    //
+                    // The goal is to preserve the position of an event in some form of durable state, such as writing it to a database, so that if the
+                    // consuming application crashes or is otherwise restarted, it can retrieve that checkpoint information and use it to create a consumer that
+                    // begins reading at the position where it left off.
+                    //
+                    // It is important to note that there is potential for a consumer to process an event and be unable to preserve the checkpoint.  A well-designed
+                    // consumer must be able to deal with processing the same event multiple times without it causing data corruption or otherwise creating issues.
+                    // Event Hubs, like most event streaming systems, guarantees "at least once" delivery; even in cases where the consumer does not experience a restart,
+                    // there is a small possibility that the service will return an event multiple times.
+                    //
+                    // In this example, we will publish a batch of events to be received with an initial consumer.  The third event that is consumed will be captured
+                    // and another consumer will use it's attributes to start reading the event that follows, consuming the same set of events that our initial consumer
+                    // read, skipping over the first three.
+
+                    int eventBatchSize = 50;
+
+                    EventData thirdEvent;
+
+                    await using (EventHubConsumer initialConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, firstPartition, EventPosition.Latest))
+                    {
+                        // The first receive that we ask of it will not see any events, but allows the consumer to start watching the partition.  Because
+                        // the maximum wait time is specivied as zero, this call will return immediately and will not have consumed any events.
+
+                        await initialConsumer.ReceiveAsync(1, TimeSpan.Zero);
+
+                        // Now that the consumer is watching the partition, let's publish a batch of events.
+
+                        EventData[] eventBatch = new EventData[eventBatchSize];
+
+                        for (int index = 0; index < eventBatchSize; ++index)
+                        {
+                            eventBatch[index] = new EventData(Encoding.UTF8.GetBytes($"I am event #{ index }"));
+                        }
+
+                        await producer.SendAsync(eventBatch);
+                        Console.WriteLine($"The event batch with { eventBatchSize } events has been published.");
+
+                        // We will consume the events in batches using the initial consumer until all of the published events
+                        // have been received.
+
+                        var receivedEvents = new List<EventData>();
+                        int consumeBatchSize = (int)Math.Floor(eventBatchSize / 5.0f);
+                        int maximumAttempts = 15;
+                        int attempts = 0;
+
+                        while ((receivedEvents.Count < eventBatchSize) && (++attempts < maximumAttempts))
+                        {
+                            receivedEvents.AddRange(await initialConsumer.ReceiveAsync(consumeBatchSize, TimeSpan.FromMilliseconds(25)));
+                        }
+
+                        // Print out the events that we received.
+
+                        Console.WriteLine();
+                        Console.WriteLine($"The initial consumer processed { receivedEvents.Count } events of the { eventBatchSize } that were published.");
+
+                        foreach (EventData eventData in receivedEvents)
+                        {
+                            // The body of our event was an encoded string; we'll recover the
+                            // message by reversing the encoding process.
+
+                            string message = Encoding.UTF8.GetString(eventData.Body.ToArray());
+                            Console.WriteLine($"\tMessage: \"{ message }\"");
+                        }
+
+                        // Remember the third event that was consumed.
+
+                        thirdEvent = receivedEvents[2];
+                    }
+
+                    // At this point, our initial consumer has passed its "using" scope and has been safely disposed of.
+                    //
+                    // Create a new consumer beginning using the third event as the last sequence number processed; this new consumer will begin reading at the next available
+                    // sequence number, allowing it to read the set of published events beginning with the fourth one.
+
+                    await using (EventHubConsumer newConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, firstPartition, EventPosition.FromSequenceNumber(thirdEvent.SequenceNumber)))
+                    {
+                        // We will consume the events in batches using the new consumer until all of the published events
+                        // have been received.
+
+                        var receivedEvents = new List<EventData>();
+                        int consumeBatchSize = (int)Math.Floor(eventBatchSize / 3.0f);
+                        int maximumAttempts = 10;
+                        int attempts = 0;
+
+                        while ((receivedEvents.Count < eventBatchSize) && (++attempts < maximumAttempts))
+                        {
+                            receivedEvents.AddRange(await newConsumer.ReceiveAsync(consumeBatchSize, TimeSpan.FromMilliseconds(25)));
+                        }
+
+                        // Print out the events that we received.
+
+                        Console.WriteLine();
+                        Console.WriteLine();
+                        Console.WriteLine($"The new consumer processed { receivedEvents.Count } events of the { eventBatchSize } that were published.");
+
+                        foreach (EventData eventData in receivedEvents)
+                        {
+                            // The body of our event was an encoded string; we'll recover the
+                            // message by reversing the encoding process.
+
+                            string message = Encoding.UTF8.GetString(eventData.Body.ToArray());
+                            Console.WriteLine($"\tMessage: \"{ message }\"");
+                        }
+                    }
+                }
+            }
+
+            // At this point, our client, all consumers, and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allow for both sending and receiving of events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>5.0.0</VersionPrefix>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-event-hubs-dotnet/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Azure.Messaging.EventHubs.xml</DocumentationFile>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
@@ -255,9 +255,9 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   Creates an Event Hub producer responsible for transmitting <see cref="EventData" /> to the
-        ///   Event Hub, grouped together in batches.  Depending on the <paramref name="producerOptions"/>
-        ///   specified, the producer may be created to allow event data to be automatically routed to an available
-        ///   partition or specific to a partition.
+        ///   Event Hub, either as a single item or grouped together in batches.  Depending on the
+        ///   <paramref name="producerOptions"/> specified, the producer may be created to allow event
+        ///   data to be automatically routed to an available partition or specific to a partition.
         /// </summary>
         ///
         /// <param name="producerOptions">The set of options to apply when creating the producer.</param>
@@ -266,12 +266,12 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <remarks>
         ///   Allowing automatic routing of partitions is recommended when:
-        ///   <para>- The sending of events needs to be highly available.</para>
+        ///   <para>- The publishing of events needs to be highly available.</para>
         ///   <para>- The event data should be evenly distributed among all available partitions.</para>
         ///
         ///   If no partition is specified, the following rules are used for automatically selecting one:
-        ///   <para>1) Distribute the events equally amongst all available partitions using a round-robin approach.</para>
-        ///   <para>2) If a partition becomes unavailable, the Event Hubs service will automatically detect it and forward the message to another available partition.</para>
+        ///   <para>- Distribute the events equally amongst all available partitions using a round-robin approach.</para>
+        ///   <para>- If a partition becomes unavailable, the Event Hubs service will automatically detect it and forward the message to another available partition.</para>
         /// </remarks>
         ///
         public virtual EventHubProducer CreateProducer(EventHubProducerOptions producerOptions = default)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Properties/AssemblyInfo.cs
@@ -5,6 +5,6 @@
 using System.Runtime.CompilerServices;
 using Azure.Core;
 
-[assembly: AzureSdkClientLibraryAttribute("eventhubs")]
+[assembly: AzureSdkClientLibraryAttribute("Messaging.EventHubs")]
 [assembly: InternalsVisibleTo("Azure.Messaging.EventHubs.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100d15ddcb29688295338af4b7686603fe614abd555e09efba8fb88ee09e1f7b1ccaeed2e8f823fa9eef3fdd60217fc012ea67d2479751a0b8c087a4185541b851bd8b16f8d91b840e51b1cb0ba6fe647997e57429265e85ef62d565db50a69ae1647d54d7bd855e4db3d8a91510e5bcbd0edfbbecaa20a7bd9ae74593daa7b11b4")]
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
@@ -202,9 +202,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task ClientPartitionIdsMatchPartitionProperties()
         {
-            var partitionCount = 4;
-
-            await using (var scope = await EventHubScope.CreateAsync(partitionCount))
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -73,7 +73,6 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         private EventHubScope(string eventHubHame,
                               IReadOnlyList<string> consumerGroups)
         {
-            //TODO: Constructor needs to take the state needed to tear down the Event Hub.
             EventHubName = eventHubHame;
             ConsumerGroups = consumerGroups;
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+using Azure.Messaging.EventHubs.Tests.Infrastructure;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of live tests for the samples associated with the
+    ///   client library.
+    /// </summary>
+    ///
+    /// <remarks>
+    ///   These tests have a depenency on live Azure services and may
+    ///   incur costs for the assocaied Azure subscription.
+    /// </remarks>
+    ///
+    [TestFixture]
+    [Category(TestCategory.Live)]
+    [Category(TestCategory.DisallowVisualStudioLiveUnitTesting)]
+    public class SamplesLiveTests
+    {
+        /// <summary>
+        ///   Provides a set of test cases for each available sample.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> SampleTestCases() =>
+            typeof(Samples.Program)
+              .Assembly
+              .ExportedTypes
+              .Where(type => (type.IsClass && typeof(ISample).IsAssignableFrom(type)))
+              .Select(type => new object[] { (ISample)Activator.CreateInstance(type) });
+
+        /// <summary>
+        ///   Verifies that the specified <see cref="ISample" /> is able to
+        ///   be run without encountering an exception.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(SampleTestCases))]
+        public async Task SmokeTestASample(ISample sample)
+        {
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestEnvironment.EventHubsConnectionString;
+                Assert.That(async () => await sample.RunAsync(connectionString, scope.EventHubName), Throws.Nothing);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The intent of these changes is to build the initial set of documentation for the preview, focusing on the samples.

### Goals

- Create a set of samples for common target scenarios to help developers onboard to the Event Hubs client library.

- Update the README with content for the samples.

- Ensure that the samples are included in nightly builds and test runs.

# Last Upstream Rebase

Monday, June 24, 2019  12:50pm (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)