### PR TITLE
Cleaned up Azure.Core README

### DIFF
--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -1,16 +1,61 @@
 # Overview 
 
-Azure.Core is a reusable library used to implement .NET Azure SDK components. 
-It contains APIs that make it easy to call Azure service endpoints in a convinient, performant, and consistent manner.
+Azure.Core provides shared primitives, abstractions, and helpers for .NET Azure SDK service client libraries. 
+These shared APIs allow client libraries to expose common functionality in a consistent fashion, 
+so that once you learn how to use these APIs in one client library, you will know how to use them in other client libraries.
 
-# Installing
+The main shared concepts of Azure.Core (and so all Azure SDK libraries using Azure.Core) include:
 
-Nuget package Azure.Core avaliable on https://www.nuget.org/packages/Azure.Core/
+1. Unified APIs for configuring service clients, e.g. configuring retries, logging.
+2. Unified APIs for accessig HTTP responses.
+3. Unified APis for consuming long running operations (LROs).
+4. Unified APIs for consuming asynchronous enumerables and paging.
+5. Unified exception hierarchy for reporting errors from service requests.
+6. Abstractions for representing Azure SDK credentials.
 
-# Hello World
+The following sections will explain these shared concepts in more detail.
 
-```c#
-public async Task HelloWorld()
+# Usage Scenarios and Samples
+
+## Configuring Service Clients
+Azure SDK client libraries typically expose one or more _service client_ types that 
+are the main starting points for calling corresponding Azure services. 
+You can easily find these client types as their names end with the word _Client_. 
+For example, ```BlockBlobClient``` can be used to call storage blob services, 
+and ```KeyClient``` can be used to access KeyVault service cryptographis keys. 
+
+These client types can be instantiated by calling a relativelly simple contructor, 
+or a constructor overload that takes various configuration options. 
+These options are passed as a parameter that extends ```ClientOptions``` class exposed by Azure.Core.
+Various service specific options are usually added to its subclasses, but a set of SDK-wide options are 
+avaliable directly on ```ClientOptions```.
+
+```csharp
+public void ConfigureServiceClient()
+{
+    // BlobConnectionOptions inherits/extends ClientOptions
+    ClientOptions options = new BlobConnectionOptions();     
+    
+    // configure retries
+    options.RetryPolicy.MaxRetries = 5; // default is 3
+    options.RetryPolicy.Mode = RetryMode.Exponential; // default is fixed retry policy
+    options.RetryPolicy.Delay = TimeSpan.FromSeconds(1); // derfault is 0.8s
+
+    // finally create BlobContainerClient, but many Azure SDK clients will work similarly
+    var client = new BlobContainerClient(connectionString, "container", options);
+}
+```
+
+## Accessing HTTP Response
+Comming soon ...
+
+## Consuming Long Running Operations
+Comming soon ...
+
+## HttpPipeline
+
+```csharp
+public async Task HttpPipelineHelloWorld()
 {
     // create http pipeline
     var options = new HttpPipeline.Options();
@@ -40,6 +85,5 @@ public async Task HelloWorld()
 }
 ```
 
-# Other Samples
-
-Comming soon ...
+# Installing
+Nuget package Azure.Core avaliable on https://www.nuget.org/packages/Azure.Core/

--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -1,23 +1,33 @@
-# Overview 
+# Azure.Core shared library for .NET
 
-Azure.Core provides shared primitives, abstractions, and helpers for .NET Azure SDK service client libraries. 
-These shared APIs allow client libraries to expose common functionality in a consistent fashion, 
+Azure.Core provides shared primitives, abstractions, and helpers for modern .NET Azure SDK client libraries. 
+These libraries follow the [Azure SDK Design Guidelines for .NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html) 
+and can be easily identified by package and namespaces names starting with 'Azure', e.g. ```Azure.Storage.Blobs```. 
+A more complete list of client libraries using Azure.Core can be found [here](https://github.com/Azure/azure-sdk-for-net#core-services). 
+
+Azure.Core allows client libraries to expose common functionality in a consistent fashion, 
 so that once you learn how to use these APIs in one client library, you will know how to use them in other client libraries.
 
-The main shared concepts of Azure.Core (and so all Azure SDK libraries using Azure.Core) include:
+The main shared concepts of Azure.Core (and so Azure SDK libraries using Azure.Core) include:
 
-1. Unified APIs for configuring service clients, e.g. configuring retries, logging.
-2. Unified APIs for accessing HTTP responses.
-3. Unified APIs for consuming long running operations (LROs).
-4. Unified APIs for consuming asynchronous streams (```IAsyncEnumerable<T>```) by paging.
-5. Unified exception hierarchy for reporting errors from service requests.
-6. Abstractions for representing Azure SDK credentials.
+- Configuring service clients, e.g. configuring retries, logging.
+- Accessing HTTP response details.
+- Calling long running operations (LROs).
+- Paging and asynchronous streams (```IAsyncEnumerable<T>``) 
+- Exceptions for reporting errors from service requests in a consistent fashion.
+- Abstractions for representing Azure SDK credentials.
 
-The following sections will explain these shared concepts in more detail.
+Below, you will find sections explaining these shared concepts in more detail.
 
-# Usage Scenarios and Samples
+## Installing
+Typically, you will not need to install Azure.Core; 
+it will be installed for you when you install one of the client libraries using it. 
+In case you want to install it explicitly (to implement your own client library, for example), 
+you can find the NuGet package [here](https://www.nuget.org/packages/Azure.Core).
 
-## Configuring Service Clients Using ```ClientOptions```
+## Usage Scenarios and Samples
+
+### Configuring Service Clients Using ```ClientOptions```
 Azure SDK client libraries typically expose one or more _service client_ types that 
 are the main starting points for calling corresponding Azure services. 
 You can easily find these client types as their names end with the word _Client_. 
@@ -39,17 +49,20 @@ public void ConfigureServiceClient()
     // configure retries
     options.RetryPolicy.MaxRetries = 5; // default is 3
     options.RetryPolicy.Mode = RetryMode.Exponential; // default is fixed retry policy
-    options.RetryPolicy.Delay = TimeSpan.FromSeconds(1); // derfault is 0.8s
+    options.RetryPolicy.Delay = TimeSpan.FromSeconds(1); // default is 0.8s
 
     // finally create BlobContainerClient, but many Azure SDK clients will work similarly
     var client = new BlobContainerClient(connectionString, "container", options);
+
+    // if you don't specify the options, default options will be used, e.g.
+    var clientWithDefaultOptions = new BlobContainerClient(connectionString, "container");
 }
 ```
 
-## Accessing HTTP Response Details Using ```Response<T>```
+### Accessing HTTP Response Details Using ```Response<T>```
 _Service clients_ have methods that can be used to call Azure services. 
 We refer to these client methods _service methods_.
-_Service methods_ return a shared Azure.Core type ```Response<T>``` (in rare cases its non-generic sibling ```Response```).
+_Service methods_ return a shared Azure.Core type ```Response<T>``` (in rare cases its non-generic sibling, a raw ```Response```).
 This type provides access to both the deserialized result of the service call, 
 and to the details of the HTTP response returned from the server.
 
@@ -87,14 +100,14 @@ public async Task UsingResponseOfT()
 }
 ```
 
-## Consuming Service Methods Returning ```IAsyncEnumerable<T>```
+### Reporting Errors ```RequestFailedException```
 Coming soon ...
 
-## Consuming Long Running Operations Using ```OperationT<T>```
+### Consuming Service Methods Returning ```IAsyncEnumerable<T>```
+Coming soon ...
+
+### Consuming Long Running Operations Using ```OperationT<T>```
 Comming soon ...
 
-# Installing
-Typically, you will not need to install Azure.Core; 
-it will be installed for you when you install one of the client libraries using it. 
-In case you want to install it explicitly (to implement your own client library, for example), 
-you can find the NuGet package [here](https://www.nuget.org/packages/Azure.Core).
+### Mocking
+Comming soon ...


### PR DESCRIPTION
Changed the README to be more for Azure SDK users, as opposed to for implementers of client libraries.

The two sections with "coming soon" are not finished as we are yet to add client APIs that do what the sections will explain. The Operation<T> section will be updated soon as we are in the process of adding LRO APIs to storage. 

This README layout/format is a bit unusual, as the layout that we settled on for client libraries does not really work well for Azure.Core. For example, I had a hard time thinking about a "hello world" sample for Azure.Core.