### PR TITLE
[Event Hubs Client] Track Two: First Preview (Contributing Guide and Cleanup)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
@@ -1,19 +1,70 @@
 ﻿# Contributing 
 
-Coming Soon...
+Thank you for your interest in contributing to the Event Hubs client library.  As an open source effort, we're excited to welcome feedback and contributions from the community.  A great first step in sharing your thoughts and understanding where help is needed would be to take a look at the [open issues](https://github.com/Azure/azure-sdk-for-net/issues?q=is%3Aopen+is%3Aissue+label%3AClient+label%3A%22Event+Hubs%22).
 
-For more details about contributing to the Azure Event Hubs client libraries or our other .NET SDKs, please refer to: [Azure SDK for .NET Contributing Guide](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md)
+ Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use any contribution that you make. For details, visit https://cla.microsoft.com.
 
-### Live test information
-
-### Target frameworks
-
-For information about the target frameworks of the Azure Event Hubs client library, please refer to the [Target Frameworks](https://github.com/azure/azure-sdk-for-net#target-frameworks) of the Microsoft Azure SDK for .NET.  
-
-### Versioning information
-
-The Azure Event Hubs client library uses [the semantic versioning scheme.](http://semver.org/)
-
-### Code of conduct
+## Code of conduct
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+## Getting started
+
+Before working on a contribution, it would be beneficial to familiarize yourself with the process and guidelines used for the Azure SDKs so that your submission is consistent with the project standards and is ready to be accepted with fewer changes requested.   In particular, it is recommended to review:
+
+  - [Azure SDK README](https://github.com/Azure/azure-sdk), to learn more about the overall project and processes used.
+  - [Azure SDK Design Guidelines](https://azuresdkspecs.z5.web.core.windows.net/DesignGuidelines.html#general-documentation), to understand the general guidelines for the SDKs across all languages and platforms
+  - [Azure SDK Design Guidelines for .NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html), to understand the guidelines specific to the Azure SDKs for .NET.
+
+## Development environment setup
+
+### Running tests
+
+The Event Hubs client library tests may be executed using the `dotnet` CLI, or the test runner of your choice - such as Visual Studio or Visual Studio Code.  For those developers using Visual Studio, it is safe to use the Live Unit Testing feature, as any tests with external dependencies have been marked to be excluded.
+
+Tests in the Event Hubs client library are split into two categories - unit tests and integration tests.  For unit tests, there are no special considerations; these are self-contained and execute locally without any reliance on external resources.  Unit tests are considered the default test type in the Event Hubs client library and, thus, have no explicit category trait attached to them.  
+
+Integration tests, have dependencies on live Azure resources and require setting up your development environment prior to running.  Known in the Azure SDK project commonly as "Live" tests, these tests are decorated with a category trait of "Live".  Specifically, an Azure resource group, Event Hubs namespace, and Azure Service Principal with "contributor" rights to the Event Hub namespace is required.   The Live tests read information from the following environment variables:
+
+ `EVENT_HUBS_CONNECTION_STRING`  
+  The full connection string to the Event Hubs namespace, using the default shared access policy.
+    
+`EVENT_HUBS_NAMESPACE`  
+ The host name of the Event Hubs namespace, without the protocol or domain found in the connection string.
+    
+`EVENT_HUBS_RESOURCEGROUP`  
+ The name of the Azure resource group that contains the Event Hubs namespace
+   
+`EVENT_HUBS_SUBSCRIPTION`  
+ The identifier (GUID) of the Azure subscription to which the service principal belongs
+    
+`EVENT_HUBS_TENANT`  
+ The identifier (GUID) of the Azure Active Directory tenant that contains the service principal
+
+`EVENT_HUBS_CLIENT`  
+ The identifier (GUID) of the Azure Active Directory application that is associated with the service principal
+   
+`EVENT_HUBS_SECRET`  
+ The client secret (password) of the Azure Active Directory application that is associated with the service principal
+   
+To make setting up your environment easier, a [PowerShell script](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/assets/live-tests-azure-setup.ps1) is included in the repository and will create and/or configure the needed Azure resources.  To use this script, open a PowerShell instance and login to your Azure account using `Login-AzAccount`, then execute the script.   You will need to provide some information, after which the script will configure the Azure resources and then output the set of environment variables with the correct values for running tests.
+
+The simplest way to get started is to execute the script with your subscription name and then follow the prompts:
+
+```powershell
+./live-tests-azure-setup -SubscriptionName "<< YOUR SUBSCRIPTION NAME >>"
+```
+
+Help for the full set of parameters and additional information is available by specifying the `-Help` flag.
+
+```powershell
+./live-tests-azure-setup -Help
+```
+
+### Samples 
+
+In order to run the samples interactively, you'll need an Event Hubs namespace and an Event Hub with at least one partition.  Each sample will take a connection string and Event Hub name as parameters when executing, which can either be supplied directly as part of development or can be specified to the console application host in the `Samples` project, either using command line arguments or entered in response to prompts.
+
+## Development history
+
+For additional insight and context, the development, release, and issue history for the Azure Event Hubs client library is available in read-only form, in its previous location, the [Azure Event Hubs .NET repository](https://github.com/Azure/azure-event-hubs-dotnet).

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -22,7 +22,7 @@ To use Azure services, including Azure Event Hubs, you'll need a Microsoft Azure
 
 To interact with Azure Event Hubs, you'll also need to have an Event Hub available.  If you are not familiar with creating Azure resources, you may wish to follow the step-by-step guide for [creating an Event Hub using the Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create).  There, you can also find detailed instructions for using the Azure CLI, Azure PowerShell, or Azure Resource Manager (ARM) templates to create an Event Hub.
 
-To quickly create the needed Event Hubs resources in Azure and view your connection string, you can deploy our sample template by clicking:
+To quickly create the needed Event Hubs resources in Azure and to view your connection string, you can deploy our sample template by clicking:
 
 [![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Feventhub%Azure.Messaging.EventHubs%2Fassets%2Fsamples-azure-deploy.json)
 
@@ -146,7 +146,13 @@ For detailed information about these and other exceptions that may occur, please
 
 ## Next steps
 
-Beyond the scenarios discussed, the Azure Event Hubs client library offers support for many additional scenarios to help take advantage of the full feature set of the Azure Event Hubs service.  In order to help explore some of these scenarios, the following set of samples is available:
+Beyond the scenarios discussed, the Azure Event Hubs client library offers support for many additional scenarios to help take advantage of the full feature set of the Azure Event Hubs service.  In order to help explore some of these scenarios, the Event Hubs client library offers a [project of samples](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs/samples) to serve as an illustration for common scenarios.
+
+The samples are accompanied by a console application which you can use to execute and debug them interactively.  The simplest way to begin is to launch the project for debugging in Visual Studio or your preferred IDE and provide the Event Hubs connection information in response to the prompts.  
+
+Each of the samples is self-contained and focused on illustrating one specific scenario.  Each is numbered, with the lower numbers concentrating on basic scenarios and building to more complex scenarios as they increase; though each sample is independent, it will assume an understanding of the content discussed in earlier samples.
+
+The available samples are:
 
 - [Hello world](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs)  
   An introduction to Event Hubs, illustrating how to connect and query the service.
@@ -169,7 +175,7 @@ Beyond the scenarios discussed, the Azure Event Hubs client library offers suppo
 - [Consume events from an Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs)  
   An introduction to consuming events, using a simple Event Hub consumer.
   
-- [Consume events from an Event Hub partition in batches](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch)  
+- [Consume events from an Event Hub partition in batches](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch)   
   An example of consuming events, using a batch approach to control throughput.
   
 - [Consume events from a known position in the Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition)  

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample3_PublishAnEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample3_PublishAnEvent.cs
@@ -59,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // assumptions about the data nor attempt to perform any operations on it; you are free to create the data
                 // in whatever form makes sense for your scenario.
                 //
-                // In our case, we will translate a simple sentance into bytes and send it to our Event Hub.
+                // In our case, we will translate a simple sentence into bytes and send it to our Event Hub.
 
                 var eventData = new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!"));
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample4_PublishEventsWithPartitionKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample4_PublishEventsWithPartitionKey.cs
@@ -47,13 +47,13 @@ namespace Azure.Messaging.EventHubs.Samples
                 //
                 // The partition key is NOT the identifier of a specific partition.  Rather, it is an arbitrary piece of string data
                 // that Event Hubs uses as the basis to compute a hash value.  Event Hubs will associate the hash value with a specific
-                // partition, ensuring that any events published with the same partition key are reouted to the same partition.
+                // partition, ensuring that any events published with the same partition key are routed to the same partition.
                 //
                 // Note that there is no means of accurately predicting which partition will be associated with a given partition key;
                 // we can only be assured that it will be a consistent choice of partition.  If you have a need to understand which
                 // exact partition an event is published to, you will need to use an Event Hub producer associated with that partition.
 
-                // We will publish a small batch of events based on simple sentances.
+                // We will publish a small batch of events based on simple sentences.
 
                 var eventBatch = new EventData[]
                 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample5_PublishEventsToSpecificPartitions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample5_PublishEventsToSpecificPartitions.cs
@@ -65,7 +65,7 @@ namespace Azure.Messaging.EventHubs.Samples
                     // If you attempt to use a partition key with an Event Hub producer that is associated with a partition, an exception
                     // will occur.  Otherwise, publishing to a specific partition is exactly the same as other publishing scenarios.
 
-                    // We will publish a small batch of events based on simple sentances.
+                    // We will publish a small batch of events based on simple sentences.
 
                     var eventBatch = new EventData[]
                     {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample6_PublishEventsWithCustomMetadata.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample6_PublishEventsWithCustomMetadata.cs
@@ -45,13 +45,13 @@ namespace Azure.Messaging.EventHubs.Samples
                 // make informed decisions about how to process them.
                 //
                 // In order to allow event publishers to offer better context for consumers, event data may also contain custom metadata,
-                // in the form of a set of key/value pairs.  This metadata is not used by, or in any way meainingful to, the Event Hubs
+                // in the form of a set of key/value pairs.  This metadata is not used by, or in any way meaningful to, the Event Hubs
                 // service; it exists only for coordination between event publishers and consumers.
                 //
                 // One common scenario for the inclusion of metadata is to provide a hint about the type of data contained by an event,
                 // so that consumers understand its format and can deserialize it appropriately.
                 //
-                // We will publish a small batch of events based on simple sentances, but will attach some custom metadata with
+                // We will publish a small batch of events based on simple sentences, but will attach some custom metadata with
                 // pretend type names and other hints.  Note that the set of metadata is unique to an event; there is no need for every
                 // event in a batch to have the same metadata properties available nor the same data type for those properties.
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs
@@ -70,7 +70,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // that is created with an Event Hub.  Our consumer will begin watching the partition at the very end, reading only new events
                 // that we will publish for it.
 
-                await using (EventHubConsumer consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, firstPartition, EventPosition.Latest))
+                await using (EventHubConsumer consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, firstPartition, EventPosition.Latest))
                 await using (EventHubProducer producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = firstPartition }))
                 {
                     // Because our consumer is reading from the latest position, it won't see events that have previously

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch.cs
@@ -51,7 +51,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 // that is created with an Event Hub.  Our consumer will begin watching the partition at the very end, reading only new events
                 // that we will publish for it.
 
-                await using (EventHubConsumer consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, firstPartition, EventPosition.Latest))
+                await using (EventHubConsumer consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, firstPartition, EventPosition.Latest))
                 await using (EventHubProducer producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = firstPartition }))
                 {
                     // Because our consumer is reading from the latest position, it won't see events that have previously

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition.cs
@@ -77,7 +77,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
                     EventData thirdEvent;
 
-                    await using (EventHubConsumer initialConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, firstPartition, EventPosition.Latest))
+                    await using (EventHubConsumer initialConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, firstPartition, EventPosition.Latest))
                     {
                         // The first receive that we ask of it will not see any events, but allows the consumer to start watching the partition.  Because
                         // the maximum wait time is specivied as zero, this call will return immediately and will not have consumed any events.
@@ -133,7 +133,7 @@ namespace Azure.Messaging.EventHubs.Samples
                     // Create a new consumer beginning using the third event as the last sequence number processed; this new consumer will begin reading at the next available
                     // sequence number, allowing it to read the set of published events beginning with the fourth one.
 
-                    await using (EventHubConsumer newConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, firstPartition, EventPosition.FromSequenceNumber(thirdEvent.SequenceNumber)))
+                    await using (EventHubConsumer newConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, firstPartition, EventPosition.FromSequenceNumber(thirdEvent.SequenceNumber)))
                     {
                         // We will consume the events in batches using the new consumer until all of the published events
                         // have been received.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
@@ -15,7 +15,7 @@ using Azure.Messaging.EventHubs.Metadata;
 namespace Azure.Messaging.EventHubs
 {
     /// <summary>
-    ///   The main point of interaction with Azure Event Hubs, the client offers a
+    ///   The main point of interaction with the Azure Event Hubs service, the client offers a
     ///   connection to a specific Event Hub within the Event Hubs namespace and offers operations
     ///   for sending event data, receiving events, and inspecting the connected Event Hub.
     /// </summary>
@@ -254,7 +254,7 @@ namespace Azure.Messaging.EventHubs
                                                                              CancellationToken cancellationToken = default) => InnerClient.GetPartitionPropertiesAsync(partitionId, cancellationToken);
 
         /// <summary>
-        ///   Creates an Event Hub producer responsible for transmitting <see cref="EventData" /> to the
+        ///   Creates an Event Hub producer responsible for publishing <see cref="EventData" /> to the
         ///   Event Hub, either as a single item or grouped together in batches.  Depending on the
         ///   <paramref name="producerOptions"/> specified, the producer may be created to allow event
         ///   data to be automatically routed to an available partition or specific to a partition.
@@ -286,7 +286,7 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   Creates an Event Hub consumer responsible for reading <see cref="EventData" /> from a specific Event Hub partition,
-        ///   and as a member of a specific consumer group.
+        ///   in the context of a specific consumer group.
         ///
         ///   A consumer may be exclusive, which asserts ownership over the partition for the consumer
         ///   group to ensure that only one consumer from that group is reading the from the partition.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.EventHubs
     public class EventHubConsumer : IAsyncDisposable
     {
         /// <summary>The name of the default consumer group in the Event Hubs service.</summary>
-        public const string DefaultConsumerGroup = "$Default";
+        public const string DefaultConsumerGroupName = "$Default";
 
         /// <summary>
         ///   The identifier of the Event Hub partition that this consumer is associated with.  Events will be read

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs
         private string _identifier = null;
 
         /// <summary>
-        ///   When populated, the priority indicates that a consumer is intended to be the only reader of events for the
+        ///   When populated, the owner level indicates that a consumer is intended to be the only reader of events for the
         ///   requested partition and an associated consumer group.  To do so, this consumer will attempt to assert ownership
         ///   over the partition; in the case where more than one exclusive consumer attempts to assert ownership for the same
         ///   partition/consumer group pair, the one having a larger <see cref="OwnerLevel"/> value will "win."
@@ -40,7 +40,7 @@ namespace Azure.Messaging.EventHubs
         ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.
         /// </summary>
         ///
-        /// <value>The priority to associated with an exclusive consumer; for a non-exclusive consumer, this value should be <c>null</c>.</value>
+        /// <value>The relative priority to associate with an exclusive consumer; for a non-exclusive consumer, this value should be <c>null</c>.</value>
         ///
         public long? OwnerLevel { get; set; }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
@@ -492,7 +492,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             };
 
-            var expectedConsumerGroup = EventHubConsumer.DefaultConsumerGroup;
+            var expectedConsumerGroup = EventHubConsumer.DefaultConsumerGroupName;
             var expectedPartition = "56767";
             var expectedPosition = EventPosition.FromEnqueuedTime(DateTime.Parse("2015-10-27T12:00:00Z"));
             var connectionString = "Endpoint=value.com;SharedAccessKeyName=[value];SharedAccessKey=[value];EntityPath=[value]";
@@ -588,7 +588,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateConsumerRequiresEventPosition()
         {
             var client = new EventHubClient("Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real]", "fake", new EventHubClientOptions());
-            Assert.That(() => client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, "123", null), Throws.ArgumentNullException);
+            Assert.That(() => client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "123", null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -716,7 +716,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedOptions = new EventHubConsumerOptions { Retry = Retry.Default };
             var expectedPosition = EventPosition.FromOffset(65);
             var expectedPartition = "2123";
-            var expectedConsumerGroup = EventHubConsumer.DefaultConsumerGroup;
+            var expectedConsumerGroup = EventHubConsumer.DefaultConsumerGroupName;
 
             client.CreateConsumer(expectedConsumerGroup, expectedPartition, expectedPosition, expectedOptions);
             (var actualConsumerGroup, var actualPartition, var actualPosition, var actualOptions) = transportClient.CreateConsumerCalledWith;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
                     }
@@ -74,7 +74,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, options))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, options))
                     {
                         Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
                     }
@@ -106,7 +106,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -181,7 +181,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -247,7 +247,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -306,7 +306,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -367,7 +367,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -437,7 +437,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -494,7 +494,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
@@ -531,7 +531,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 await using (var client = new EventHubClient(connectionString))
                 {
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, invalidPartition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, invalidPartition, EventPosition.Latest))
                     {
                         Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ArgumentOutOfRangeException>());
                     }
@@ -567,7 +567,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -634,11 +634,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
 
                     await exclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest);
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
                 }
@@ -661,11 +661,11 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    var higherExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var higherExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
 
                     await higherExclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
-                    var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
+                    var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
 
                     Assert.That(async () => await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
                 }
@@ -688,15 +688,15 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partitionIds = await client.GetPartitionIdsAsync();
 
-                    var higherExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[0], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var higherExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
 
                     await higherExclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
-                    var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[1], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
+                    var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
 
                     Assert.That(async () => await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[2], EventPosition.Latest);
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[2], EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
                 }
@@ -733,7 +733,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     Assert.That(async () => await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest);
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
                 }
@@ -757,8 +757,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest);
+                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
 
                     await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
                     await exclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
@@ -785,8 +785,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    var higherExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
-                    var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
+                    var higherExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
 
                     await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
                     await higherExclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
@@ -812,9 +812,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partitionIds = await client.GetPartitionIdsAsync();
 
-                    var higherExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[0], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
-                    var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[1], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[2], EventPosition.Latest);
+                    var higherExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[2], EventPosition.Latest);
 
                     await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
                     await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
@@ -850,7 +850,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var higherExclusiveConsumer = client.CreateConsumer(consumerGroups[0], partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
                     var lowerExclusiveConsumer = client.CreateConsumer(consumerGroups[1], partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest);
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
 
                     await higherExclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
@@ -877,8 +877,8 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partitionIds = await client.GetPartitionIdsAsync();
 
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[0], EventPosition.Latest);
-                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[0], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest);
+                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
 
                     await exclusiveConsumer.ReceiveAsync(1, TimeSpan.FromSeconds(2));
 
@@ -888,8 +888,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // It should be possible to create new valid consumers.
 
-                    var newExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[0], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
-                    var anotherPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[1], EventPosition.Latest);
+                    var newExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[0], EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
+                    var anotherPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest);
                     var anotherConsumerGroupConsumer = client.CreateConsumer("anotherConsumerGroup", partitionIds[0], EventPosition.Latest);
 
                     Assert.That(async () => await newExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
@@ -898,7 +898,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Proper exceptions should be thrown as well.
 
-                    var invalidPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, "XYZ", EventPosition.Latest);
+                    var invalidPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "XYZ", EventPosition.Latest);
                     var invalidConsumerGroupConsumer = client.CreateConsumer("imNotAConsumerGroup", partitionIds[0], EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
@@ -925,7 +925,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    var invalidPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, "XYZ", EventPosition.Latest);
+                    var invalidPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "XYZ", EventPosition.Latest);
 
                     // Failing at consumer creation should not compromise future ReceiveAsync calls.
 
@@ -933,13 +933,13 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // It should be possible to create new valid consumers.
 
-                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
 
                     Assert.That(async () => await exclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
                     // Proper exceptions should be thrown as well.
 
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest);
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
                     var invalidConsumerGroupConsumer = client.CreateConsumer("imNotAConsumerGroup", partition, EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
@@ -974,14 +974,14 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // It should be possible to create new valid consumers.
 
-                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
+                    var exclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 20 });
 
                     Assert.That(async () => await exclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.Nothing);
 
                     // Proper exceptions should be thrown as well.
 
-                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest);
-                    var invalidPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, "XYZ", EventPosition.Latest);
+                    var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
+                    var invalidPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "XYZ", EventPosition.Latest);
 
                     Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
                     Assert.That(async () => await invalidPartitionConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ArgumentOutOfRangeException>());
@@ -1007,7 +1007,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         client.Close();
 
@@ -1041,7 +1041,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partitionIds = await client.GetPartitionIdsAsync();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partitionIds[0] }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[1], EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[1], EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumer to connect and set its position at the
                         // end of the event stream.
@@ -1099,7 +1099,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     await using (var anotherConsumer = client.CreateConsumer("anotherConsumerGroup", partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumers to connect and set their positions at the
@@ -1160,7 +1160,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var partition = (await client.GetPartitionIdsAsync()).First();
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest))
                     {
                         // Initiate an operation to force the consumers to connect and set their positions at the
                         // end of the event stream.
@@ -1206,7 +1206,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     };
 
                     await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Latest, consumerOptions))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, consumerOptions))
                     {
                         var maximumWaitTimeInSecs = 10;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheConsumer()
         {
-            Assert.That(() => new EventHubConsumer(null, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions()), Throws.ArgumentNullException);
+            Assert.That(() => new EventHubConsumer(null, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions()), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesTheEventHub(string eventHub)
         {
-            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), eventHub, EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), eventHub, EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -50,7 +50,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("")]
         public void ConstructorValidatesThePartition(string partition)
         {
-            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Earliest, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheEventPosition()
         {
-            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroup, "1234", null, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroupName, "1234", null, new EventHubConsumerOptions()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void ConstructorValidatesTheOptions()
         {
-            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, null), Throws.ArgumentNullException);
+            Assert.That(() => new EventHubConsumer(new ObservableTransportConsumerMock(), "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, null), Throws.ArgumentNullException);
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var partition = "aPartition";
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, partition, EventPosition.FromSequenceNumber(1), new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.FromSequenceNumber(1), new EventHubConsumerOptions());
 
             Assert.That(consumer.PartitionId, Is.EqualTo(partition));
         }
@@ -115,7 +115,7 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.FromOffset(65), options);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.FromOffset(65), options);
 
             Assert.That(consumer.OwnerLevel, Is.EqualTo(priority));
         }
@@ -129,7 +129,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var expectedPosition = EventPosition.FromSequenceNumber(5641);
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", expectedPosition, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", expectedPosition, new EventHubConsumerOptions());
 
             Assert.That(consumer.StartingPosition, Is.EqualTo(expectedPosition));
         }
@@ -160,7 +160,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ReceiveAsyncValidatesTheMaximumCount(int maximumMessageCount)
         {
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions());
             var cancellation = new CancellationTokenSource();
             var expectedWaitTime = TimeSpan.FromDays(1);
 
@@ -180,7 +180,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ReceiveAsyncValidatesTheMaximumWaitTime(int timeSpanDelta)
         {
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions());
             var cancellation = new CancellationTokenSource();
             var expectedWaitTime = TimeSpan.FromMilliseconds(timeSpanDelta);
 
@@ -197,7 +197,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubConsumerOptions { DefaultMaximumReceiveWaitTime = TimeSpan.FromMilliseconds(8) };
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, options);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, options);
             var cancellation = new CancellationTokenSource();
             var expectedMessageCount = 45;
 
@@ -218,7 +218,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public async Task CloseAsyncClosesTheTransportConsumer()
         {
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions());
 
             await consumer.CloseAsync();
 
@@ -234,7 +234,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CloseClosesTheTransportConsumer()
         {
             var transportConsumer = new ObservableTransportConsumerMock();
-            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroup, "0", EventPosition.Latest, new EventHubConsumerOptions());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions());
 
             consumer.Close();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -623,7 +623,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             for (var index = 0; index < partitions; index++)
                             {
-                                consumers.Add(client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[index], EventPosition.Latest));
+                                consumers.Add(client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[index], EventPosition.Latest));
 
                                 // Initiate an operation to force the consumer to connect and set its position at the
                                 // end of the event stream.
@@ -700,7 +700,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         for (var index = 0; index < partitions; index++)
                         {
-                            consumers.Add(client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[index], EventPosition.Latest));
+                            consumers.Add(client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[index], EventPosition.Latest));
 
                             // Initiate an operation to force the consumer to connect and set its position at the
                             // end of the event stream.
@@ -775,7 +775,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     {
                         for (var index = 0; index < partitions; index++)
                         {
-                            consumers.Add(client.CreateConsumer(EventHubConsumer.DefaultConsumerGroup, partitionIds[index], EventPosition.Latest));
+                            consumers.Add(client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partitionIds[index], EventPosition.Latest));
 
                             // Initiate an operation to force the consumer to connect and set its position at the
                             // end of the event stream.


### PR DESCRIPTION
# Summary

The intent of these changes is to continue to revise and improve the set of documentation for the first preview.

### Goals

- Create the initial version of the Event Hubs client library contributing guide.

- Fix typos and improve readability of the README, docstrings, and code samples.

# Last Upstream Rebase

Tuesday, June 25, 2019  10:52am (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)