### PR TITLE
[Event Hubs Client] Track Two: First Preview (Content Tweaks)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to the Event Hubs client library.  As an open source effort, we're excited to welcome feedback and contributions from the community.  A great first step in sharing your thoughts and understanding where help is needed would be to take a look at the [open issues](https://github.com/Azure/azure-sdk-for-net/issues?q=is%3Aopen+is%3Aissue+label%3AClient+label%3A%22Event+Hubs%22).
 
- Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use any contribution that you make. For details, visit https://cla.microsoft.com.
+Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use any contribution that you make. For details, visit https://cla.microsoft.com.
 
 ## Code of conduct
 
@@ -10,11 +10,11 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 
 ## Getting started
 
-Before working on a contribution, it would be beneficial to familiarize yourself with the process and guidelines used for the Azure SDKs so that your submission is consistent with the project standards and is ready to be accepted with fewer changes requested.   In particular, it is recommended to review:
+Before working on a contribution, it would be beneficial to familiarize yourself with the process and guidelines used for the Azure SDKs so that your submission is consistent with the project standards and is ready to be accepted with fewer changes requested.  In particular, it is recommended to review:
 
   - [Azure SDK README](https://github.com/Azure/azure-sdk), to learn more about the overall project and processes used.
-  - [Azure SDK Design Guidelines](https://azuresdkspecs.z5.web.core.windows.net/DesignGuidelines.html#general-documentation), to understand the general guidelines for the SDKs across all languages and platforms
-  - [Azure SDK Design Guidelines for .NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html), to understand the guidelines specific to the Azure SDKs for .NET.
+  - [Azure SDK Design Guidelines](https://azuresdkspecs.z5.web.core.windows.net/DesignGuidelines.html#general-documentation), to understand the general guidelines for the Azure SDK across all languages and platforms.
+  - [Azure SDK Design Guidelines for .NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html), to understand the guidelines specific to the Azure SDK for .NET.
 
 ## Development environment setup
 
@@ -22,11 +22,13 @@ Before working on a contribution, it would be beneficial to familiarize yourself
 
 The Event Hubs client library tests may be executed using the `dotnet` CLI, or the test runner of your choice - such as Visual Studio or Visual Studio Code.  For those developers using Visual Studio, it is safe to use the Live Unit Testing feature, as any tests with external dependencies have been marked to be excluded.
 
-Tests in the Event Hubs client library are split into two categories - unit tests and integration tests.  For unit tests, there are no special considerations; these are self-contained and execute locally without any reliance on external resources.  Unit tests are considered the default test type in the Event Hubs client library and, thus, have no explicit category trait attached to them.  
+Tests in the Event Hubs client library are split into two categories:
 
-Integration tests, have dependencies on live Azure resources and require setting up your development environment prior to running.  Known in the Azure SDK project commonly as "Live" tests, these tests are decorated with a category trait of "Live".  Specifically, an Azure resource group, Event Hubs namespace, and Azure Service Principal with "contributor" rights to the Event Hub namespace is required.   The Live tests read information from the following environment variables:
+- **Unit tests** have no special considerations; these are self-contained and execute locally without any reliance on external resources.  Unit tests are considered the default test type in the Event Hubs client library and, thus, have no explicit category trait attached to them.
 
- `EVENT_HUBS_CONNECTION_STRING`  
+- **Integration tests** have dependencies on live Azure resources and require setting up your development environment prior to running.  Known in the Azure SDK project commonly as "Live" tests, these tests are decorated with a category trait of "Live".  Specifically, an Azure resource group, Event Hubs namespace, and Azure Service Principal with "contributor" rights to the Event Hub namespace is required.  The Live tests read information from the following environment variables:
+
+`EVENT_HUBS_CONNECTION_STRING`  
   The full connection string to the Event Hubs namespace, using the default shared access policy.
     
 `EVENT_HUBS_NAMESPACE`  
@@ -47,7 +49,7 @@ Integration tests, have dependencies on live Azure resources and require setting
 `EVENT_HUBS_SECRET`  
  The client secret (password) of the Azure Active Directory application that is associated with the service principal
    
-To make setting up your environment easier, a [PowerShell script](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/assets/live-tests-azure-setup.ps1) is included in the repository and will create and/or configure the needed Azure resources.  To use this script, open a PowerShell instance and login to your Azure account using `Login-AzAccount`, then execute the script.   You will need to provide some information, after which the script will configure the Azure resources and then output the set of environment variables with the correct values for running tests.
+To make setting up your environment easier, a [PowerShell script](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/assets/live-tests-azure-setup.ps1) is included in the repository and will create and/or configure the needed Azure resources.  To use this script, open a PowerShell instance and login to your Azure account using `Login-AzAccount`, then execute the script.  You will need to provide some information, after which the script will configure the Azure resources and then output the set of environment variables with the correct values for running tests.
 
 The simplest way to get started is to execute the script with your subscription name and then follow the prompts:
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -1,4 +1,4 @@
-# Azure Event Hubs client library for .NET
+﻿# Azure Event Hubs client library for .NET
 
 Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers. This lets you process and analyze the massive amounts of data produced by your connected devices and applications. Once Event Hubs has collected the data, you can retrieve, transform and store it by using any real-time analytics provider or with batching/storage adapters.  If you would like to know more about Azure Event Hubs, you may wish to review: [What is Event Hubs](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-about)? 
 
@@ -18,11 +18,11 @@ The Azure Event Hubs client library allows for publishing and consuming of Azure
 
 ### Prerequisites
 
-To use Azure services, including Azure Event Hubs, you'll need a Microsoft Azure Subscription.  If you do not have an existing Azure account, you may sign up for a free trial or use your MSDN subscriber benefits when you [create an account](https://account.windowsazure.com/Home/Index). 
+- **Microsoft Azure Subscription:**  To use Azure services, including Azure Event Hubs, you'll need a subscription.  If you do not have an existing Azure account, you may sign up for a free trial or use your MSDN subscriber benefits when you [create an account](https://account.windowsazure.com/Home/Index). 
 
-To interact with Azure Event Hubs, you'll also need to have an Event Hub available.  If you are not familiar with creating Azure resources, you may wish to follow the step-by-step guide for [creating an Event Hub using the Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create).  There, you can also find detailed instructions for using the Azure CLI, Azure PowerShell, or Azure Resource Manager (ARM) templates to create an Event Hub.
+- **Event Hubs namespace with an Event Hub:** To interact with Azure Event Hubs, you'll also need to have a namespace and Event Hub  available.  If you are not familiar with creating Azure resources, you may wish to follow the step-by-step guide for [creating an Event Hub using the Azure portal](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-create).  There, you can also find detailed instructions for using the Azure CLI, Azure PowerShell, or Azure Resource Manager (ARM) templates to create an Event Hub.
 
-To quickly create the needed Event Hubs resources in Azure and to view your connection string, you can deploy our sample template by clicking:
+To quickly create the needed Event Hubs resources in Azure and to receive a connection string for them, you can deploy our sample template by clicking:  
 
 [![](http://azuredeploy.net/deploybutton.png)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-sdk-for-net%2Fmaster%2Fsdk%2Feventhub%Azure.Messaging.EventHubs%2Fassets%2Fsamples-azure-deploy.json)
 
@@ -175,14 +175,20 @@ The available samples are:
 - [Consume events from an Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs)  
   An introduction to consuming events, using a simple Event Hub consumer.
   
-- [Consume events from an Event Hub partition in batches](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch)   
+- [Consume events from an Event Hub partition in batches](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch.cs)   
   An example of consuming events, using a batch approach to control throughput.
   
-- [Consume events from a known position in the Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition)  
+- [Consume events from a known position in the Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition.cs)  
   An example of consuming events, starting at a well-known position in the Event Hub partition.
 
 ## Contributing  
 
-Please refer to our [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
+This project welcomes contributions and suggestions.  Most contributions require you to agree to a Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us the rights to use your contribution. For details, visit https://cla.microsoft.com.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the instructions provided by the bot. You will only need to do this once across all repos using our CLA.
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
+
+Please see our [contributing guide](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md) for more information.
   
 ![Impressions](https://azure-sdk-impressions.azurewebsites.net/api/impressions/azure-sdk-for-net%2Fsdk%2Feventhub%2FAzure.Messaging.EventHubs%2FFREADME.png)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-first-preview.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-first-preview.md
@@ -1,0 +1,564 @@
+# .NET Event Hubs Client: Track Two Proposal (First Preview)
+
+## Summary
+
+Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers. This lets you process and analyze the massive amounts of data produced by your connected devices and applications. Once Event Hubs has collected the data, you can retrieve, transform and store it by using any real-time analytics provider or with batching/storage adapters.
+
+The Azure Event Hubs client libraries allow for sending and receiving of Azure Event Hubs events. Most common scenarios call for an application to act as either an event publisher or an event consumer, but rarely both.
+
+An **event publisher** is a source of telemetry data, diagnostics information, usage logs, or other log data, as part of an embedded device solution, a mobile device application, a game title running on a console or other device, some client or server based business solution, or a web site.  
+
+An **event consumer** picks up such information from the Event Hub and processes it. Processing may involve aggregation, complex computation and filtering. Processing may also involve distribution or storage of the information in a raw or transformed fashion. Event Hub consumers are often robust and high-scale platform infrastructure parts with built-in analytics capabilities, like Azure Stream Analytics, Apache Spark, or Apache Storm.  
+
+## Goals
+
+- Provide an API surface that allows for successfully implementing common scenarios with a minimal amount of boilerplate or bootstrapping needed; what a consumer views as one logical operation should feel like a single task when implementing.
+
+- Ensure that the API is as intuitive, discoverable, and straightforward as possible, guiding users of the library to success and minimizing potential pitfalls.
+
+- Present an API that is consistent and familiar across the different languages and technology stacks, while still conforming to the native idioms and conventions for a given ecosystem.
+
+- Focus the API design on the patterns best suited to users of the client library; the API may not mirror the interface used for interacting with the Event Hubs service.
+ 
+- Minimize breaking changes; ensure that changes made are done with a good reason and offer a solid return on investment.  Where possible, preserve the current interface and semantics.
+
+- Prioritize ease of use by providing reasonable defaults for common operations, allowing configuration and advanced behavior to be ignored unless specifically needed by a consuming application.
+
+- Support customization, allowing defaults to be overridden and accepting additional information such that users of the library are in control of behavior in areas supported by the Event Hubs service.
+
+- Embrace testability, ensuring that constructs from the API can be easily mocked within a consuming application such that the consumer may perform testing without the need to interact with the Event Hubs service or include it's own layer of abstraction over the API.
+
+- Make reasonable efforts to avoid redefining the vocabulary and nomenclature used with Event Hubs; to ensure that current client library users can leverage their familiarity, where possible, the new API surface should continue to use existing terminology.  Revisions and new concepts should be introduced only when necessary to reduce confusion and provide more clarity.
+
+- Align the target platforms with those approved as standards by the architecture board for .NET client libraries.  
+
+## Non-Goals
+
+- Introduction of API enhancements that require upstream changes to the Event Hubs service; the track two client library should target the existing Event Hubs service operations.
+
+- Deprecation of the track one packages or source; until such time that the track two API and associated packages are fully reviewed, tested, and deemed ready, the track one packages will continue to be available, accept issues, and receive minor enhancements and bug fixes.
+
+- Preserving compatibility with the current set of target platforms supported by the track one client library.
+
+## Non-Goals for the First Preview
+
+- A full rewrite of the track one codebase; where possible, existing code will be used with as few modifications as possible, allowing the new API surface to be built on proven, reliable, and well-tested code. 
+
+- Support for scenarios outside the identified targets or revisions to associated packages, such as the Event Hubs Processor; the initial efforts will be focused on the API surface for key operations in the core client library.
+
+- Allowing event consumers to specify a handler to be notified when new events appear in a partition _(commonly referred to as the "streaming consumer" pattern)_; this requires additional design and will be deferred until after the preview.
+
+- Support for the Event Hubs plugin model; these are considered an advanced scenario and out of scope for the preview.
+
+- Advanced batching scenarios, such as automatically splitting a set of events too large for a single batch into multiple batches or providing the ability to build a size-constrained batch, are out of scope for the preview.
+
+- Providing a full synchronous API surface; the preview design will be primarily focused on asynchronous operations.  
+
+- Design of the exception hierarchy; the preview will make use of the existing exception surfacing present in the track one client library. 
+
+- Ensuring that cancellation tokens are honored throughout the implementation; they will be accepted as part of the API but may not have an effect depending on acceptance and treatment by the infrastructure provided by the track one client library.
+
+
+## High Level Scenarios
+
+### Producers Can Publish Events
+
+Contoso is developing a new first person shooter game, _Hugs and Warfare_, intended to be delivered across multiple platforms including the PC, consoles, and mobile devices.  One of the features offered is for players to be granted badges in real-time for completing in-game actions.  In support of this feature, _Hugs and Warfare_, would like to emit observations about a player's match as they happen so that their complex event processing system can evaluate them against award rules.
+
+Due to the expected popularity of the game, Contoso expects to be sending roughly one million events per second across 300,000 concurrent players.  Because this is an action game, the budget for network activity and latency tolerance are not generous, so maintaining a persistent connection for the duration of a match is preferred over a request/response cycle with higher latency and bandwidth needs.    
+
+### Consumers Can Receive Events
+
+For _Hugs and Warfare_ to fulfill its promise of granting badges to players in real-time for actions they perform in a match, its back-end services need to have access to the stream of observations that the game client is emitting as they become available.  Contoso is also interested in analyzing the observations made by game clients in different ways, allowing them to influence the game design and to drive business decisions.
+
+Because those interested in the observations have different purposes and throughput needs, Contoso's design calls for several sets of consumers to forward observations to downstream systems.  Each set of consumers should be able to see the same stream of observations, so that all observations are available to each interested system.  The different sets are independent from one another and should not have a need to coordinate between them. 
+
+### When a Consumer Recovers from a Crash, They Can Resume Receiving Events
+
+Software, hardware, and networks are inherently unreliable.  In order to provide a good player experience for _Hugs and Warfare_, Contoso has planned for their consumers suffering the occasional crash.  They've chosen to have several monitors which test the consumers and ensure that they are healthy and working correctly.  
+
+In the case where a consumer has been restarted, Contoso's goal is to maximize recovery speed.  To ensure the best possible player experience,   a consumer needs to resume being productive by processing new observations.  Time spent reprocessing observations that had already been seen is wasted and likely to degrade the experience; it is important to understand the position in a stream that the consumer last read and have the ability to begin at an arbitrary point.  
+
+### Producers and Consumers Can View Metadata About an Event Hub
+
+Contoso has invested in a robust DevOps system to support _Hugs and Warfare_, helping to ensure that the back-end services can be deployed and scaled to meet player needs with minimal effort.  As a part of these efforts, the deployment for the observation consumers is self-managing.  When consumers are being deployed, the DevOps process will dynamically inspect the observation stream service to understand how many consumers should be created to process it, and ensure that each deployed consumer is configured to listen to the correct stream.
+
+To help Contoso understand the state of their ecosystem, each game client and back-end service sends telemetry data.  The observation consumers include information about their assigned observation stream, including those attributes that would be needed to restart the consumer and resume processing observations from the last that it had completed.
+
+## .NET API
+
+### Key Types
+
+#### `EventHubClient`
+
+The primary client for interacting with an Event Hub, intended to guide consumers towards the types used for specific Event Hub operations and simplifying the creation of those types.
+
+#### `EventProducer`
+
+Enables publishing event data to an Event Hub, supporting automatic routing of events to available partitions and targeting a specific partition.
+
+#### `EventConsumer` 
+
+Enables receiving event data from a single Event Hub partition, supporting exclusive or non-exclusive access to the partition event streams in the context of a consumer group.
+
+#### `EventProcessorHost`
+
+An opinionated extension of the `EventConsumer`, offering a ready-made solution for receiving events across all partitions and durable tracking of the current state of consumption using Azure Blob Storage.  The `EventHubProcessor` is intended to serve a simple and approachable on-boarding point for consuming Event Hubs data.     
+
+_**(not included in the first preview; will be designed and reviewed as an independent package at a later time)**_
+
+#### `EventData`
+
+The raw data and collection of metadata describing an event that flows through the system.  Both send and receive operations represent their data using this type.
+
+#### `EventPosition`
+
+Provides a means of specifying the location of a specific in the event stream, either by strong association to the desired event or by an event's proximity to a particular point in the stream.  For example, "I'd like the first available event" or "I'd like the first event enqueued at or after 12:00am on October 27th, 2015."
+
+### Examples: Creating a Client
+
+#### Using an Event Hub connection string with default options
+
+```csharp
+var connectionString = "<< CONNECTION STRING WITH EVENT HUB >>";
+var client = new EventHubClient(connectionString);
+```
+
+#### Using an namespace connection string with default options
+
+```csharp
+var connectionString = "<< CONNECTION STRING FOR NAMESPACE >>";
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+var client = new EventHubClient(connectionString, eventHubName);
+```
+
+#### Using an Event Hub connection string with custom options
+
+```csharp
+var clientOptions = new EventHubClientOptions
+{
+    TransportType = TransportType.AmqpWebSockets,
+    DefaultTimeout = new TimeSpan.FromMinutes(1),
+    Retry = new ExponentialRetry(TimeSpan.FromSeconds(0.25), TimeSpan.FromMinutes(10), 5),
+    Proxy = new WebProxy("http://proxyserver:80", true)
+};
+
+var connectionString = "<< CONNECTION STRING WITH EVENT HUB >>";
+var client = new EventHubClient(connectionString, clientOptions);
+
+```
+
+#### Using a namespace connection string with custom options
+
+```csharp
+var clientOptions = new EventHubClientOptions
+{
+    TransportType = TransportType.AmqpWebSockets,
+    DefaultTimeout = new TimeSpan.FromMinutes(1),
+    Retry = new ExponentialRetry(TimeSpan.FromSeconds(0.25), TimeSpan.FromMinutes(10), 5),
+    Proxy = new WebProxy("http://proxyserver:80", true)
+};
+
+var connectionString = "<< CONNECTION STRING FOR NAMESPACE >>";
+var eventHubName = "<< NAME OF THE EVENT HUB >>";
+var client = new EventHubClient(connectionString, eventHubName, clientOptions);
+```
+
+#### Using a token-based credential with custom options
+
+```csharp
+var clientOptions = new EventHubClientOptions
+{
+    TransportType = TransportType.AmqpTcp;
+    DefaultTimeout = TimeSpan.FromSeconds(38)
+};
+
+var credential = AquireAzureIdentityTokenFromAnotherLibrary();
+var client = new EventHubClient("hellokitty.servicebus.windows.net", "telemetry-hub", credential, clientOptions);
+```
+
+#### Using a shared key credential with default options
+
+```csharp
+var credential = new EventHubsSharedKeyCredential("<< KEY NAME >>", "<< SHARED KEY >>");
+var client = new EventHubClient("hellokitty.servicebus.windows.net", "telemetry-hub", credential);
+```
+
+### Examples: Viewing Metadata
+
+#### For an Event Hub
+
+```csharp
+var client = CreateClient();
+var eventHubProperties = await client.GetPropertiesAsync();
+
+Console.WriteLine($"Event Hub Path: { eventHubProperties.Path }");
+Console.WriteLine($"The Event Hub was created at { eventHubProperties.CreatedAtUtc }");
+Console.WriteLine($"The partitions are: { String.Join(", ", eventHubProperties.PartitionIds) }");
+```
+
+#### For a partition
+
+```csharp
+var client = CreateClient();
+var firstPartition = (await client.GetPropertiesAsync()).PartitionIds[0];
+var partitionInformation = await client.GetPartitionPropertiesAsync(firstPartition);
+
+Console.WriteLine($"Event Hub Path: { partitionInformation.EventHubPath }");
+Console.WriteLine($"Partition Id: { partitionInformation.Id }");
+Console.WriteLine($"Is the Partition Empty? { partitionInformation.IsEmpty }");
+Console.WriteLine($"The last offset enqueued in the partition was: { partitionInformation.LastEnqueuedOffset }");
+```
+
+#### Just the identifiers for each partition of the Event Hub
+
+```csharp
+var client = CreateClient();
+var partitionIds = await client.GetPartitionIdsAsync();
+
+Console.WriteLine($"The partitions are: { String.Join(", ", partitionIds) }");
+```
+
+### Examples: Creating an Event Producer
+
+#### Create a producer with default options, allowing automatic routing of events to partitions
+
+```csharp
+var client = CreateClient();
+var producer = client.CreateProducer();
+```
+
+#### Create a producer for a specific partition
+
+```csharp
+var options = new EventHubProducerOptions
+{
+    PartitionId = "abs32234-fccdba"
+};
+
+var client = CreateClient();
+var producer = client.CreateProducer(options);
+```
+
+#### Create a producer for automatic partition routing with custom options
+
+```csharp
+var options = new EventHubProducerOptions
+{
+    Timeout = new TimeSpan.FromMinutes(1),
+    Retry = new ExponentialRetry(TimeSpan.FromSeconds(0.25), TimeSpan.FromMinutes(10), 5), 
+};
+
+var client = CreateClient();
+var producer = client.CreateProducer(options);
+```
+
+### Examples: Publishing Events
+
+#### Publish a single event to an arbitrary partition
+
+```csharp
+var client = CreateClient();
+var producer = client.CreateProducer();
+
+await producer.SendAsync(new EventData(GetNextThingBytes()));
+```
+
+#### Publish events to an arbitrary partition
+
+```csharp
+var events = new[]
+{
+    new EventData(GetNextThingBytes()),
+    new EventData(GetNextThingBytes())
+};
+
+var client = CreateClient();
+var producer = client.CreateProducer();
+
+await producer.SendAsync(events);
+```
+
+#### Publish events to a specific partition
+
+```csharp
+var options = new EventHubProducerOptions
+{
+    PartitionId = "abs32234-fccdba"
+};
+
+var client = CreateClient();
+var producer = client.CreateProducer(options);
+
+var events = new[]
+{
+    new EventData(GetNextThingBytes()),
+    new EventData(GetNextThingBytes())
+};
+
+await producer.SendAsync(events);
+```
+
+#### Publish events with custom metadata to an arbitrary partition
+
+```csharp
+var playerShot = new EventData(GetPlayerShotBody());
+playerShot.Properties["eventType"] = "Sample.EventTypes.PlayerShot";
+playerShot.Properties["intendedConsumer"] = "CEP";
+
+var playerDied = new EventData(GetPlayerDiedBody());
+playerDied.Properties["eventType"] = "Sample.EventTypes.PlayerDied";
+playerDied.Properties["intendedConsumer"] = "Telemetry";
+
+var client = CreateClient();
+var producer = client.CreateProducer();
+
+await producer.SendAsync(new[] { playerShot, playerDied });
+```
+
+#### Send events that may exceed the batch size limit to an arbitrary partition
+
+```csharp
+var eventsToSend = GetPendingEvents(); 
+var client = CreateClient();
+var producer = client.CreateProducer();
+ 
+try
+{
+    await producer.SendAsync(eventsToSend);
+}
+catch (MessageSizeExceededException)
+{
+    Console.WriteLine("There were too many events in the batch");
+}
+```
+
+#### Send events with common partition hashing key to an arbitrary partition
+
+```csharp
+var sendOptions = new SendOptions
+{
+    PartitionKey = "these-go-to-the-same-partition-with-service-choice"
+};
+
+var eventsToSend = GetPendingEvents(); 
+var client = CreateClient();
+var producer = client.CreateProducer();
+
+await producer.SendAsync(eventsToSend, sendOptions);
+```
+
+### Examples: Creating an Event Consumer
+
+#### A consumer for a specific partition, starting with the first event in the partition
+
+```csharp
+var client = CreateClient();
+var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "fcbac12-43cda", EventPosition.Earliest);
+```
+
+#### A consumer for a specific partition with custom options
+
+```csharp
+var options = new EventHubConsumerOptions
+{
+    Retry = new ExponentialRetry(TimeSpan.FromSeconds(0.25), TimeSpan.FromMinutes(10), 5)
+};
+
+var client = CreateClient();
+var consumer = client.CreateConsumer("NotTheDefault", fcbac12-43cda", EventPosition.Latest, options);
+```
+
+#### A consumer that asserts exclusive ownership of a partition for a consumer group
+
+```csharp
+var options = new EventHubConsumerOptions
+{
+    OwnerLevel = 100
+};
+
+var client = CreateClient();
+var consumer = client.CreateConsumer("TelemetryConsumers", "abc-321", EventPosition.Latest, options);
+```
+
+### Examples: Consuming Events from a Partition
+
+#### Read all events 
+
+```csharp
+var client = CreateClient();
+var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "fcbac12-43cda", EventPosition.Earliest);
+var done = false;
+
+while (!done)
+{
+    var batch = await consumer.ReceiveAsync(25);
+    done = ProcessEvents(batch);
+}
+```
+
+#### Read only newly queued events using a maximum wait time specific to this request
+
+```csharp
+var client = CreateClient();
+var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "abc4321", EventPosition.Latest);
+var consecutiveEmpties = 0;
+
+while (consecutiveEmpties < 5)
+{
+    var batch = await consumer.ReceiveAsync(25, TimeSpan.FromSeconds(2));
+    
+    if (!ProcessEvents(batch))
+    {
+        ++consecutiveEmpties;
+    }
+}
+```
+
+#### Read events starting at a specific offset
+
+```csharp
+var client = CreateClient();
+var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "fcbac12-43cda", EventPosition.FromOffSet(65));
+var done = false;
+
+while (!done)
+{
+    var batch = await consumer.ReceiveAsync(25);
+    done = ProcessEvents(batch);
+}
+```
+
+#### Read events starting at a specific sequence number (inclusive) 
+
+```csharp
+var client = CreateClient();
+var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "fcbac12-43cda", EventPosition.FromSequenceNumber(44, true));
+var done = false;
+
+while (!done)
+{
+    var batch = await consumer.ReceiveAsync(25);
+    done = ProcessEvents(batch);
+}
+```
+
+#### Read events starting at a specific moment in time
+
+```csharp
+var client = CreateClient();
+var consumer = client.CreateConsumer("Group", 0", EventPosition.FromEnqueuedTime(DateTimeOffset.Parse("2015-10-25T12:00:00Z")));
+var done = false;
+
+while (!done)
+{
+    var batch = await consumer.ReceiveAsync(25);
+    done = ProcessEvents(batch);
+}
+```
+
+### Examples: Saving Recovery State
+
+```csharp
+var client = CreateClient();
+var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "a-partition", EventPosition.Latest);
+var done = false;
+
+while (!done)
+{
+    var batch = await consumer.ReceiveAsync(25);
+    done = ProcessEvents(batch);
+    
+    var lastEvent = batch.Last();
+    PersistCheckpoint(lastEvent.Offset, lastEvent.EnqueuedTimeUtc);
+}
+```
+
+### Packages
+
+#### `Azure.Messaging.EventHubs`
+
+The main client library package, containing the core components for interacting with the Azure Event Hubs service.
+
+#### `Azure.Messaging.EventHubs.Processor`
+
+The package containing the `EventProcessorHost`, allowing for interested consumers to take advantage of an opinionated, ready-made construct for receiving Event Hubs data and managing state.  
+
+_**(not included for the first preview; will be designed and reviewed at a later time)**_
+
+### Namespaces
+
+#### `Azure.Messaging.EventHubs`
+
+The top-level container for the types in the client library intended to be used by Event Hubs client library users. It is intended that types most frequently used by users for basic operations belong to this namespace to ensure ease of discovery.
+
+##### _Example Types:_
+ 
+- `EventHubClient`
+- `EventHubProducer`
+- `EventHubConsumer`
+- `EventData`
+
+#### `Azure.Messaging.EventHubs.Metadata`
+
+The location for types associated with metadata about an Event Hub instance or events.  These types are intended to be used as read-only information for consumers and are surfaced from the API on more discoverable types, such as `EventHubClient.GetPropertiesAsync`.
+
+##### _Example Types:_
+ 
+- `EventHubProperties`
+- `PartitionProperties`
+
+#### `Azure.Messaging.EventHubs.Errors`
+
+The location for exceptions and error-related information and operations. Many of these types are surfaced as information for consumers in response to conditions encountered during a basic operation.  It is not intended that consumers need to create these types directly.
+
+##### _Example Types:_
+ 
+- `MessageSizeExceededException`
+- `EventHubsException`
+
+#### `Azure.Messaging.EventHubs.Plugins`
+
+The location for types associated with customizing Event Hubs operations, for example, allowing an event to be transformed before it is sent.  These types are surfaced to consumers as base constructs for building on top of.  
+
+_**(not included for the first preview; will be considered and reviewed at a later time)**_
+
+##### _Example Types:_
+ 
+- `EventDataProcessor`
+
+#### `Azure.Messaging.EventHubs.Core`
+
+The location for internal types used by the Event Hubs library to facilitate operations; these constructs are not intended to be consumed externally. 
+
+##### _Example Types:_
+ 
+- `MessagingEntity`
+- `SystemMessagePropertyName`
+
+#### `Azure.Messaging.EventHubs.Amqp`
+
+The location for internal types used by the Event Hubs library to facilitate AMQP protocol-related activities; these constructs are not intended to be consumed externally. 
+
+##### _Example Types:_
+ 
+- `AmqpEventHubClient`
+- `AmqpEventHubConsumer`
+- `ActiveClientLinkManager`
+
+#### `Azure.Messaging.EventHubs.Diagnostics`
+
+The location for internal types used by the Event Hubs library for diagnostics and logging activities; these constructs are not intended to be consumed externally. 
+
+##### _Example Types:_
+ 
+- `EventHubsEventSource`
+- `EventHubsDiagnosticSource`
+
+#### `Azure.Messaging.EventHubs.Authorization`
+
+The location for types associated with authorizing operations against an Event Hub instance.  While some of these types may intended for consumers, the need for them is surfaced as part of the API for more discoverable types, such as `EventHubClient`.  
+
+##### _Example Types:_
+ 
+- `EventHubsSharedKeyCredential`

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsSample.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Infrastructure/IEventHubsSample.cs
@@ -11,7 +11,7 @@ namespace Azure.Messaging.EventHubs.Samples.Infrastructure
     /// </summary>
     ///
     ///
-    public interface ISample
+    public interface IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
@@ -244,12 +244,12 @@ namespace Azure.Messaging.EventHubs.Samples
         ///
         /// <returns>The set of samples defined in the solution.</returns>
         ///
-        private static IReadOnlyList<ISample> LocateSamples() =>
+        private static IReadOnlyList<IEventHubsSample> LocateSamples() =>
             typeof(Program)
               .Assembly
               .ExportedTypes
-              .Where(type => (type.IsClass && typeof(ISample).IsAssignableFrom(type)))
-              .Select(type => (ISample)Activator.CreateInstance(type))
+              .Where(type => (type.IsClass && typeof(IEventHubsSample).IsAssignableFrom(type)))
+              .Select(type => (IEventHubsSample)Activator.CreateInstance(type))
               .ToList();
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to Event Hubs, illustrating how to connect and query the service.
     /// </summary>
     ///
-    public class Sample1_HelloWorld : ISample
+    public class Sample1_HelloWorld : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample2_ClientWithCustomOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample2_ClientWithCustomOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to Event Hubs, exploring additional options for creating an <see cref="EventHubClient" />.
     /// </summary>
     ///
-    public class Sample2_ClientWithCustomOptions : ISample
+    public class Sample2_ClientWithCustomOptions : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample3_PublishAnEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample3_PublishAnEvent.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to publishing events, using a simple <see cref="EventHubProducer" />.
     /// </summary>
     ///
-    public class Sample3_PublishAnEvent : ISample
+    public class Sample3_PublishAnEvent : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample4_PublishEventsWithPartitionKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample4_PublishEventsWithPartitionKey.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to publishing events, using a partition key to group them together.
     /// </summary>
     ///
-    public class Sample4_PublishEventsWithPartitionKey : ISample
+    public class Sample4_PublishEventsWithPartitionKey : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample5_PublishEventsToSpecificPartitions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample5_PublishEventsToSpecificPartitions.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to publishing events, using an <see cref="EventHubProducer" /> that is associated with a specific partition.
     /// </summary>
     ///
-    public class Sample5_PublishEventsToSpecificPartitions : ISample
+    public class Sample5_PublishEventsToSpecificPartitions : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample6_PublishEventsWithCustomMetadata.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample6_PublishEventsWithCustomMetadata.cs
@@ -12,7 +12,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An example of publishing events, extending the event data with custom metadata.
     /// </summary>
     ///
-    public class Sample6_PublishEventsWithCustomMetadata : ISample
+    public class Sample6_PublishEventsWithCustomMetadata : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs
@@ -15,7 +15,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to consuming events, using a simple <see cref="EventHubConsumer" />.
     /// </summary>
     ///
-    public class Sample7_ConsumeEvents : ISample
+    public class Sample7_ConsumeEvents : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch.cs
@@ -14,7 +14,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An example of consuming events, using a batch approach to control throughput.
     /// </summary>
     ///
-    public class Sample8_ConsumeEventsByBatch : ISample
+    public class Sample8_ConsumeEventsByBatch : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition.cs
@@ -14,7 +14,7 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An example of consuming events, starting at a well-known position in the Event Hub partition.
     /// </summary>
     ///
-    public class Sample9_ConsumeEventsFromAKnownPosition : ISample
+    public class Sample9_ConsumeEventsFromAKnownPosition : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -126,7 +126,7 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Receives a bach of <see cref="EventData" /> from the the Event Hub partition.
+        ///   Receives a bach of <see cref="EventData" /> from the Event Hub partition.
         /// </summary>
         ///
         /// <param name="maximumMessageCount">The maximum number of messages to receive in this batch.</param>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
@@ -34,17 +34,17 @@ namespace Azure.Messaging.EventHubs.Tests
             typeof(Samples.Program)
               .Assembly
               .ExportedTypes
-              .Where(type => (type.IsClass && typeof(ISample).IsAssignableFrom(type)))
-              .Select(type => new object[] { (ISample)Activator.CreateInstance(type) });
+              .Where(type => (type.IsClass && typeof(IEventHubsSample).IsAssignableFrom(type)))
+              .Select(type => new object[] { (IEventHubsSample)Activator.CreateInstance(type) });
 
         /// <summary>
-        ///   Verifies that the specified <see cref="ISample" /> is able to
+        ///   Verifies that the specified <see cref="IEventHubsSample" /> is able to
         ///   be run without encountering an exception.
         /// </summary>
         ///
         [Test]
         [TestCaseSource(nameof(SampleTestCases))]
-        public async Task SmokeTestASample(ISample sample)
+        public async Task SmokeTestASample(IEventHubsSample sample)
         {
             await using (var scope = await EventHubScope.CreateAsync(4))
             {


### PR DESCRIPTION
# Summary

The intent of these changes is to continue to revise and improve the set of documentation for the first preview.

### Goals

- Revise the contributing section of the README, to conform to CELA requirements.

-  Inclusion of the design proposal in a `design` area, as discussed with members of the architecture board.

# Last Upstream Rebase

Wednesday, June 26, 2019  8:46am (EDT)

# Resources

- [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://gist.github.com/jsquire/75b3a3090b6b4553aa8ceb798b6fc87d)
- [.NET Event Hubs Client: Deferred Features and Functionality](https://gist.github.com/jsquire/f88922faa0f457b503234c6f168e20c9)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Client Library Track Two Preview 1](https://github.com/Azure/azure-sdk-for-net/issues/6030) (#6030)  