### PR TITLE
[Azure Search] Fix build failures and get command-line build working again

### DIFF
--- a/sdk/search/Build-SearchPackages.ps1
+++ b/sdk/search/Build-SearchPackages.ps1
@@ -1,9 +1,9 @@
 $scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-$packagesDir = "$scriptDir\..\..\binaries\packages"
+$engDir = "$scriptDir\..\..\eng\"
 
-if (!(Test-Path -Path $packagesDir)) {
-    mkdir $packagesDir
-}
+msbuild "$scriptDir\..\..\build.proj" /t:CreateNugetPackage /p:Scope="search"
 
-msbuild "$scriptDir\..\..\build.proj" /t:CreateNugetPackage /p:Scope="sdk\search\Microsoft.Azure.Management.Search"
-msbuild "$scriptDir\..\..\build.proj" /t:CreateNugetPackage /p:Scope="sdk\search"
+dotnet restore
+dotnet build "$engDir/service.proj" /p:ServiceDirectory="search"
+dotnet test "$engDir/service.proj" /p:ServiceDirectory="search"
+dotnet pack "$engDir/service.proj" /p:ServiceDirectory="search"

--- a/sdk/search/Microsoft.Azure.Management.Search/tests/Microsoft.Azure.Management.Search.Tests.csproj
+++ b/sdk/search/Microsoft.Azure.Management.Search/tests/Microsoft.Azure.Management.Search.Tests.csproj
@@ -13,8 +13,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ExcludeFromBuild>true</ExcludeFromBuild>
-    <ExcludeFromTest>true</ExcludeFromTest>
+    <ExcludeFromBuild>false</ExcludeFromBuild>
+    <ExcludeFromTest>false</ExcludeFromTest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/search/Microsoft.Azure.Management.Search/tests/Microsoft.Azure.Management.Search.Tests.csproj
+++ b/sdk/search/Microsoft.Azure.Management.Search/tests/Microsoft.Azure.Management.Search.Tests.csproj
@@ -20,7 +20,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="1.5.0-preview" />
     <ProjectReference Include="..\src\Microsoft.Azure.Management.Search.csproj" />
-    <ProjectReference Include="..\..\Microsoft.Azure.Search\src\Microsoft.Azure.Search.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="SessionRecords\**\*.json">

--- a/sdk/search/Microsoft.Azure.Management.Search/tests/ModelComparer/TypeExtensions.cs
+++ b/sdk/search/Microsoft.Azure.Management.Search/tests/ModelComparer/TypeExtensions.cs
@@ -2,26 +2,18 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
 namespace System
 {
-    using Collections.Generic;
-    using Linq;
-    using Microsoft.Azure.Search.Models;
-    using Reflection;
-
     public static class TypeExtensions
     {
         public static bool CanBeNull(this Type type) => type.IsReferenceType() || type.IsNullable();
 
         public static Type GetIEnumerable(this Type type) =>
             type.IsGenericEnumerable() ? type : type.GetTypeInfo().ImplementedInterfaces.FirstOrDefault(IsGenericEnumerable);
-
-        public static Type GetIResourceWithETag(this Type type)
-        {
-            TypeInfo typeInfo = type.GetTypeInfo();
-            Type resourceWithETag = typeof(IResourceWithETag);
-            return type == resourceWithETag ? type : typeInfo.ImplementedInterfaces.FirstOrDefault(t => t == resourceWithETag);
-        }
 
         public static bool ImplementsGenericEquatable(this Type type) =>
             type.IsGenericEquatable() || type.GetTypeInfo().ImplementedInterfaces.Any(IsGenericEquatable);

--- a/sdk/search/Microsoft.Azure.Search.sln
+++ b/sdk/search/Microsoft.Azure.Search.sln
@@ -15,6 +15,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Search.Serv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Management.Search.Tests", "Microsoft.Azure.Management.Search\tests\Microsoft.Azure.Management.Search.Tests.csproj", "{766B6848-B73A-4B61-8AA7-55C6D3FF5EF4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Management.Search", "Microsoft.Azure.Management.Search\src\Microsoft.Azure.Management.Search.csproj", "{385AB742-370A-4A66-89C2-797D851460AD}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{766B6848-B73A-4B61-8AA7-55C6D3FF5EF4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{766B6848-B73A-4B61-8AA7-55C6D3FF5EF4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{766B6848-B73A-4B61-8AA7-55C6D3FF5EF4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{385AB742-370A-4A66-89C2-797D851460AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{385AB742-370A-4A66-89C2-797D851460AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{385AB742-370A-4A66-89C2-797D851460AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{385AB742-370A-4A66-89C2-797D851460AD}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/search/Microsoft.Azure.Search/tests/Microsoft.Azure.Search.Tests.csproj
+++ b/sdk/search/Microsoft.Azure.Search/tests/Microsoft.Azure.Search.Tests.csproj
@@ -6,9 +6,10 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
+
   <PropertyGroup>
-    <ExcludeFromBuild>true</ExcludeFromBuild>
-    <ExcludeFromTest>true</ExcludeFromTest>
+    <ExcludeFromBuild>false</ExcludeFromBuild>
+    <ExcludeFromTest>false</ExcludeFromTest>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/search/Microsoft.Azure.Search/tests/ModelComparer/DataPlaneModelComparer.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/ModelComparer/DataPlaneModelComparer.cs
@@ -1,0 +1,79 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+namespace Microsoft.Azure.Search.Tests.Utilities
+{
+    using Microsoft.Azure.Search.Models;
+    using System;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+
+    /// <summary>
+    /// Compares instances of a type for structural equality, including special rules specific to the data plane SDK (comparing OData collections and ETags).
+    /// </summary>
+    /// <typeparam name="T">Type of objects to compare.</typeparam>
+    public sealed class DataPlaneModelComparer<T> : IEqualityComparer<T>
+    {
+        private readonly IEqualityComparer<T> _comparer = new ModelComparer<T>(areBothNull: CompareNull, shouldIgnoreProperty: IsETagProperty);
+
+        public bool Equals(T x, T y) => _comparer.Equals(x, y);
+
+        public int GetHashCode(T obj) => obj?.GetHashCode() ?? 0;
+
+        private static bool CompareNull(object x, object y)
+        {
+            if (x == null && y == null)
+            {
+                return true;
+            }
+
+            object notNull = x ?? y;
+            Type type = notNull.GetType();
+
+            // DataPlaneModelComparer is used to compare model classes that map to OData JSON payloads. In OData, the default value of
+            // a collection is an empty collection, not null. However, in .NET, missing JSON properties are modeled as null. To compensate
+            // for this semantic gap, we will consider null and empty enumerables to be equivalent.
+            if (type.IsIEnumerable())
+            {
+                IEnumerator enumerator = ((IEnumerable)notNull).GetEnumerator();
+                enumerator.Reset();
+                bool isEmpty = !enumerator.MoveNext();
+                return isEmpty;
+            }
+
+            // For value types, we go by the rule that null is equal to default(T). This works for cases where a client omits a property in
+            // a request, and the property comes back with its default value in the response.
+            if (type.GetTypeInfo().IsValueType)
+            {
+                object defaultInstance = Activator.CreateInstance(type);
+                return notNull.Equals(defaultInstance);
+            }
+
+            return false;
+        }
+
+        private static bool IsETagProperty(PropertyInfo property)
+        {
+            Type type = property.DeclaringType;
+
+            Type GetIResourceWithETag()
+            {
+                TypeInfo typeInfo = type.GetTypeInfo();
+                Type resourceWithETagType = typeof(IResourceWithETag);
+                return type == resourceWithETagType ? type : typeInfo.ImplementedInterfaces.FirstOrDefault(t => t == resourceWithETagType);
+            }
+
+            Type resourceWithETag = GetIResourceWithETag();
+            if (resourceWithETag != null)
+            {
+                PropertyInfo[] resourceProperties = resourceWithETag.GetProperties(BindingFlags.Public | BindingFlags.Instance);
+                return resourceProperties.Any(p => p.Name == property.Name && p.PropertyType == property.PropertyType);
+            }
+
+            return false;
+        }
+    }
+}

--- a/sdk/search/Microsoft.Azure.Search/tests/ModelComparer/DataPlaneModelComparerTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/ModelComparer/DataPlaneModelComparerTests.cs
@@ -1,0 +1,78 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Microsoft.Azure.Search.Models;
+using Microsoft.Azure.Search.Tests.Utilities;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Microsoft.Azure.Search.Tests
+{
+    public sealed class DataPlaneModelComparerTests
+    {
+        [Fact]
+        public void NullEqualsDefault()
+        {
+            int? maybeZero = 0;
+            int? maybeFive = 5;
+            int? nullNumber = null;
+
+            bool? maybeFalse = false;
+            bool? maybeTrue = true;
+            bool? nullBool = null;
+
+            Assert.Equal(maybeZero, nullNumber, new DataPlaneModelComparer<int?>());
+            Assert.Equal(nullNumber, maybeZero, new DataPlaneModelComparer<int?>());
+            Assert.Equal(maybeFalse, nullBool, new DataPlaneModelComparer<bool?>());
+            Assert.Equal(nullBool, maybeFalse, new DataPlaneModelComparer<bool?>());
+
+            Assert.NotEqual(maybeFive, nullNumber, new DataPlaneModelComparer<int?>());
+            Assert.NotEqual(nullNumber, maybeFive, new DataPlaneModelComparer<int?>());
+            Assert.NotEqual(maybeTrue, nullBool, new DataPlaneModelComparer<bool?>());
+            Assert.NotEqual(nullBool, maybeTrue, new DataPlaneModelComparer<bool?>());
+        }
+
+        [Fact]
+        public void ComparisonIgnoresETags()
+        {
+            var model = new Model() { Name = "Magical Trevor", Age = 11, ETag = "1" };
+            var sameModel = new Model(model) { ETag = "2" };
+
+            Assert.Equal(model, sameModel, new DataPlaneModelComparer<Model>());
+        }
+
+        [Fact]
+        public void NullEqualsEmptyCollection()
+        {
+            IEnumerable<int> nullCollection = null;
+            var emptyArray = new int[0];
+            var emptyList = new List<int>();
+
+            var comparer = new DataPlaneModelComparer<IEnumerable<int>>();
+
+            Assert.True(comparer.Equals(nullCollection, emptyArray));
+            Assert.True(comparer.Equals(emptyArray, nullCollection));
+            Assert.True(comparer.Equals(nullCollection, emptyList));
+            Assert.True(comparer.Equals(emptyList, nullCollection));
+        }
+
+        private class Model : IResourceWithETag
+        {
+            public Model() { }
+
+            public Model(Model other)
+            {
+                Name = other.Name;
+                Age = other.Age;
+                ETag = other.ETag;
+            }
+
+            public string Name { get; set; }
+
+            public int Age { get; set; }
+
+            public string ETag { get; set; }
+        }
+    }
+}

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/CustomAnalyzerTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/CustomAnalyzerTests.cs
@@ -2,18 +2,18 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Azure.Search.Tests.Utilities;
+using Xunit;
+
 namespace Microsoft.Azure.Search.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-    using System.Linq;
-    using System.Net;
-    using System.Reflection;
-    using Microsoft.Azure.Search.Models;
-    using Microsoft.Azure.Search.Tests.Utilities;
-    using Xunit;
-
     public sealed class CustomAnalyzerTests : SearchTestBase<IndexFixture>
     {
         [Fact]
@@ -715,25 +715,25 @@ namespace Microsoft.Azure.Search.Tests
             Assert.Equal(expected.Analyzers?.Count ?? 0, actual.Analyzers?.Count ?? 0);
             for (int i = 0; i < expected.Analyzers?.Count; i++)
             {
-                Assert.Equal(expected.Analyzers[i], actual.Analyzers[i], new ModelComparer<Analyzer>());
+                Assert.Equal(expected.Analyzers[i], actual.Analyzers[i], new DataPlaneModelComparer<Analyzer>());
             }
 
             Assert.Equal(expected.Tokenizers?.Count ?? 0, actual.Tokenizers?.Count ?? 0);
             for (int i = 0; i < expected.Tokenizers?.Count; i++)
             {
-                Assert.Equal(expected.Tokenizers[i], actual.Tokenizers[i], new ModelComparer<Tokenizer>());
+                Assert.Equal(expected.Tokenizers[i], actual.Tokenizers[i], new DataPlaneModelComparer<Tokenizer>());
             }
 
             Assert.Equal(expected.TokenFilters?.Count ?? 0, actual.TokenFilters?.Count ?? 0);
             for (int i = 0; i < expected.TokenFilters?.Count; i++)
             {
-                Assert.Equal(expected.TokenFilters[i], actual.TokenFilters[i], new ModelComparer<TokenFilter>());
+                Assert.Equal(expected.TokenFilters[i], actual.TokenFilters[i], new DataPlaneModelComparer<TokenFilter>());
             }
 
             Assert.Equal(expected.CharFilters?.Count ?? 0, actual.CharFilters?.Count ?? 0);
             for (int i = 0; i < expected.CharFilters?.Count; i++)
             {
-                Assert.Equal(expected.CharFilters[i], actual.CharFilters[i], new ModelComparer<CharFilter>());
+                Assert.Equal(expected.CharFilters[i], actual.CharFilters[i], new DataPlaneModelComparer<CharFilter>());
             }
         }
 

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/DataSourceTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/DataSourceTests.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Azure.Search.Tests
 
         private static void AssertDataSourcesEqual(DataSource expected, DataSource actual)
         {
-            Assert.Equal(expected, actual, new ModelComparer<DataSource>());
+            Assert.Equal(expected, actual, new DataPlaneModelComparer<DataSource>());
         }
 
         private static DataSource CreateTestDataSource()

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/FieldBuilderTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/FieldBuilderTests.cs
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.Search.Tests
                 serviceClient.Indexes.Create(actualIndex);
                 actualIndex = serviceClient.Indexes.Get(otherIndexName);
 
-                Assert.Equal(expectedIndex.Fields, actualIndex.Fields, new ModelComparer<IList<Field>>());
+                Assert.Equal(expectedIndex.Fields, actualIndex.Fields, new DataPlaneModelComparer<IList<Field>>());
             });
         }
 

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/FieldTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/FieldTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Search.Tests
                     indexAnalyzerName: expectedField.IndexAnalyzer,
                     synonymMaps: expectedField.SynonymMaps);
 
-            Assert.Equal(expectedField, actualField, new ModelComparer<Field>());
+            Assert.Equal(expectedField, actualField, new DataPlaneModelComparer<Field>());
         }
 
         [Theory]
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Search.Tests
                     isFacetable: expectedField.IsFacetable.Value,
                     synonymMaps: expectedField.SynonymMaps);
 
-            Assert.Equal(expectedField, actualField, new ModelComparer<Field>());
+            Assert.Equal(expectedField, actualField, new DataPlaneModelComparer<Field>());
         }
 
         [Fact]
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Search.Tests
                     isFacetable: expectedField.IsFacetable.Value,
                     synonymMaps: expectedField.SynonymMaps);
 
-            Assert.Equal(expectedField, actualField, new ModelComparer<Field>());
+            Assert.Equal(expectedField, actualField, new DataPlaneModelComparer<Field>());
         }
 
         [Theory]

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/IndexManagementTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/IndexManagementTests.cs
@@ -528,7 +528,7 @@ namespace Microsoft.Azure.Search.Tests
 
         private static void AssertIndexesEqual(Index expected, Index actual)
         {
-            Assert.Equal(expected, actual, new ModelComparer<Index>());
+            Assert.Equal(expected, actual, new DataPlaneModelComparer<Index>());
         }
 
         private Index CreateOrUpdateIndex(Index index, SearchRequestOptions options, AccessCondition condition) =>

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/IndexerTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/IndexerTests.cs
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.Search.Tests
 
         private static void AssertIndexersEqual(Indexer expected, Indexer actual)
         {
-            Assert.Equal(expected, actual, new ModelComparer<Indexer>());
+            Assert.Equal(expected, actual, new DataPlaneModelComparer<Indexer>());
         }
 
         private static void ExpectSameStartTime(Indexer expected, Indexer actual)

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/Serialization/DocumentConverterTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/Serialization/DocumentConverterTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Search.Tests
         private static Document Deserialize(string json) => JsonConvert.DeserializeObject<Document>(json, Settings);
 
         private static void AssertDocumentsEqual(Document expectedDoc, Document actualDoc) =>
-            Assert.Equal(expectedDoc, actualDoc, new ModelComparer<Document>());
+            Assert.Equal(expectedDoc, actualDoc, new DataPlaneModelComparer<Document>());
 
         // Functional tests that ensure expected behavior of DocumentConverter.
         public sealed class Functional

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/ServiceStatsTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/ServiceStatsTests.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Search.Tests
                 };
 
                 ServiceStatistics stats = searchClient.GetServiceStatistics();
-                Assert.Equal(expectedStats, stats, new ModelComparer<ServiceStatistics>());
+                Assert.Equal(expectedStats, stats, new DataPlaneModelComparer<ServiceStatistics>());
             });
         }
     }

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/SkillsetsTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/SkillsetsTests.cs
@@ -2,17 +2,15 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.Azure.Search.Models;
+using Microsoft.Azure.Search.Tests.Utilities;
+using Microsoft.Rest.Azure;
+using Xunit;
+
 namespace Microsoft.Azure.Search.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Net;
-    using Microsoft.Azure.Search.Models;
-    using Microsoft.Azure.Search.Tests.Utilities;
-    using Microsoft.Rest.Azure;
-    using Xunit;
-
     public sealed class SkillsetsTests : SearchTestBase<SearchServiceFixture>
     {
         public const string InputImageFieldName = "image";
@@ -568,7 +566,7 @@ namespace Microsoft.Azure.Search.Tests
 
         private static void AssertSkillsetEqual(Skillset expected, Skillset actual)
         {
-            Assert.Equal(expected, actual, new ModelComparer<Skillset>());
+            Assert.Equal(expected, actual, new DataPlaneModelComparer<Skillset>());
         }
 
         private static Skillset CreateTestSkillsetOcrKeyPhrase(OcrSkillLanguage ocrLanguageCode, KeyPhraseExtractionSkillLanguage keyPhraseLanguageCode)

--- a/sdk/search/Microsoft.Azure.Search/tests/Tests/SynonymMapTests.cs
+++ b/sdk/search/Microsoft.Azure.Search/tests/Tests/SynonymMapTests.cs
@@ -305,7 +305,7 @@ namespace Microsoft.Azure.Search.Tests
 
         private static void AssertSynonymMapsEqual(SynonymMap expected, SynonymMap actual)
         {
-            Assert.Equal(expected, actual, new ModelComparer<SynonymMap>());
+            Assert.Equal(expected, actual, new DataPlaneModelComparer<SynonymMap>());
         }
 
         private static SynonymMap CreateTestSynonymMap()


### PR DESCRIPTION
See individual commits for details.

With this change, `Build-SearchPackages.ps1` now works as expected. Each `generate.ps1` is still broken, however.