### PR TITLE
[Event Hubs Client] Track Two: Doc Comment Typos

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
@@ -21,8 +21,8 @@ namespace Azure.Messaging.EventHubs
         private const string EndOfStreamOffset = "@latest";
 
         /// <summary>
-        ///   Corresponds to the location of the the first event present in the partition.  Use
-        ///   this position to begin receiving from the first event that was enqueued in the partition
+        ///   Corresponds to the location of the first event present in the partition.  Use this
+        ///   position to begin receiving from the first event that was enqueued in the partition
         ///   which has not expired due to the retention policy.
         /// </summary>
         ///


### PR DESCRIPTION
# Summary

The intent of these changes is to fix a typo in the doc comments of the code.

# Last Upstream Rebase

Thursday, June 27, 2019  9:12am (EDT)