### PR TITLE
Renaming ConfigurationClientModelFactory to ConfigurationModelFactory

### DIFF
--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Sample8_MockClient.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Sample8_MockClient.cs
@@ -20,7 +20,7 @@ namespace Azure.ApplicationModel.Configuration.Samples
             var mock = new Mock<ConfigurationClient>();
             // Setup client method
             mock.Setup(c => c.Get("Key", It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
-                .Returns(new Response<ConfigurationSetting>(mockResponse.Object, ConfigurationClientModelFactory.ConfigurationSetting("Key", "Value")));
+                .Returns(new Response<ConfigurationSetting>(mockResponse.Object, ConfigurationModelFactory.ConfigurationSetting("Key", "Value")));
 
             // Use the client mock
             ConfigurationClient client = mock.Object;

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientModelFactory.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientModelFactory.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Azure.ApplicationModel.Configuration
 {
-    public static class ConfigurationClientModelFactory
+    public static class ConfigurationModelFactory
     {
         public static ConfigurationSetting ConfigurationSetting(
             string key,

--- a/sdk/core/Azure.Core/README.md
+++ b/sdk/core/Azure.Core/README.md
@@ -106,7 +106,7 @@ Mocking is enabled by:
 
 - providing a protected parameterless constructor on client types.
 - making service methods virtual.
-- providing APIs for constructing model types returned from virtual service methods. To find these factory methods look for types with the _ModelFactory_ suffix, e.g. `ConfigurationClientModelFactory`.
+- providing APIs for constructing model types returned from virtual service methods. To find these factory methods look for types with the _ModelFactory_ suffix, e.g. `ConfigurationModelFactory`.
 
 For example, the ConfigurationClient.Get method can be mocked (with [Moq](https://github.com/moq/moq4)) as follows:
 
@@ -122,7 +122,7 @@ mock.Setup(c =>
     c.Get("Key", It.IsAny<string>(), It.IsAny<DateTimeOffset>(), It.IsAny<CancellationToken>()))
     .Returns(new Response<ConfigurationSetting>(mockResponse.Object, 
          // factory for the model type
-         ConfigurationClientModelFactory.ConfigurationSetting("Key", "Value")
+         ConfigurationModelFactory.ConfigurationSetting("Key", "Value")
     )
 );
 


### PR DESCRIPTION
Fixes #6738 