### PR TITLE
Remove common authority and bump up the packaging/assembly versions.

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the next generation Azure Event Hubs .NET Standard Event Processor Host library. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT;Event Processor Host</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-event-hubs-dotnet/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Microsoft.Azure.EventHubs.Processor.xml</DocumentationFile>
@@ -10,6 +10,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);netstandard1.4</TargetFrameworks>
     <RootNamespace>Microsoft.Azure.EventHubs.Processor</RootNamespace>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/EventHubClient.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.EventHubs
             Uri endpointAddress,
             string path,
             AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback,
-            string authority = AzureActiveDirectoryTokenProvider.CommonAuthority,
+            string authority,
             TimeSpan? operationTimeout = null,
             TransportType transportType = TransportType.Amqp)
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
@@ -1,11 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>This is the next generation Azure Event Hubs .NET Standard client library. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-event-hubs-dotnet/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Microsoft.Azure.EventHubs.xml</DocumentationFile>
     <TargetFrameworks>$(RequiredTargetFrameworks);netstandard1.4</TargetFrameworks>
+    <AssemblyVersion>4.0.0.0</AssemblyVersion>
+    <FileVersion>4.0.0.0</FileVersion>
+    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Primitives/AzureActiveDirectoryTokenProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Primitives/AzureActiveDirectoryTokenProvider.cs
@@ -11,11 +11,6 @@ namespace Microsoft.Azure.EventHubs
     /// </summary>
     public class AzureActiveDirectoryTokenProvider : TokenProvider
     {
-        /// <summary>
-        /// Common authority for Azure Active Directory.
-        /// </summary>
-        public const string CommonAuthority = "https://login.microsoftonline.com/common";
-
         readonly string clientId;
         readonly object authCallbackState;
         readonly string authority;

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Primitives/TokenProvider.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Primitives/TokenProvider.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.EventHubs
         /// <returns>The <see cref="TokenProvider" /> for returning Json web token.</returns>
         public static TokenProvider CreateAzureActiveDirectoryTokenProvider(
             AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback,
-            string authority = AzureActiveDirectoryTokenProvider.CommonAuthority,
+            string authority,
             object state = null)
         {
             Guard.ArgumentNotNull(nameof(authCallback), authCallback);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TokenProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TokenProviderTests.cs
@@ -114,6 +114,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task UseITokenProviderWithAad()
         {
+            var appAuthority = "";
             var aadAppId = "";
             var aadAppSecret = "";
 
@@ -126,7 +127,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                     return authResult.AccessToken;
                 };
 
-            var tokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback);
+            var tokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, appAuthority);
 
             // Create new client with updated connection string.
             var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
@@ -162,6 +163,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task UseCreateApiWithAad()
         {
+            var appAuthority = "";
             var aadAppId = "";
             var aadAppSecret = "";
 
@@ -176,7 +178,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
             // Create new client with updated connection string.
             var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            var ehClient = EventHubClient.CreateWithAzureActiveDirectory(csb.Endpoint, csb.EntityPath, authCallback);
+            var ehClient = EventHubClient.CreateWithAzureActiveDirectory(csb.Endpoint, csb.EntityPath, authCallback, appAuthority);
 
             // Send one event
             TestUtility.Log($"Sending one message.");

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
@@ -939,20 +939,14 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         /// <summary>
         /// This test is for manual only purpose. Fill in the tenant-id, app-id and app-secret before running.
         /// </summary>
-        [Fact]
+        [Fact(Skip = "Manual run only")]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task SingleProcessorHostWithAadTokenProvider()
         {
-            var tenantId = "";
+            var appAuthority = "";
             var aadAppId = "";
             var aadAppSecret = "";
-
-            if (string.IsNullOrEmpty(tenantId))
-            {
-                TestUtility.Log($"Skipping test during scheduled runs.");
-                return;
-            }
 
             AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback =
                 async (audience, authority, state) =>
@@ -963,7 +957,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                     return authResult.AccessToken;
                 };
 
-            var tokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback);
+            var tokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, appAuthority);
             var epo = await GetOptionsAsync();
             var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
 


### PR DESCRIPTION
- Authority is becoming a mandatory argument for AAD token provider API
- Preparing for SDK 4.0.0 release