### PR TITLE
HttpPipelineContent.WriteTo Cancellations

### DIFF
--- a/sdk/core/Azure.Core/tests/HttpPipelineContentTests.cs
+++ b/sdk/core/Azure.Core/tests/HttpPipelineContentTests.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics.Tracing;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using Azure.Core.Pipeline;
+using NUnit.Framework;
+
+namespace Azure.Core.Tests
+{
+    public class HttpPipelineRequestContentTests
+    {
+        [Test]
+        public void StreamCopyToCancellation()
+        {
+            int size = 100; 
+            var source = new MemoryStream(size);
+            var destination = new MemoryStream(size);
+            var content = HttpPipelineRequestContent.Create(source);
+            var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+            Assert.Throws<OperationCanceledException>(() => { content.WriteTo(destination, cancellation.Token); });
+        }
+
+        [Test]
+        public void StreamCopyTo()
+        {
+            int size = 100;
+            var sourceArray = new byte[size];
+            var destinationArray = new byte[size * 2];
+            new Random(100).NextBytes(sourceArray);
+
+            var source = new MemoryStream(sourceArray);
+            var destination = new MemoryStream(destinationArray);
+            var content = HttpPipelineRequestContent.Create(source);
+
+            content.WriteTo(destination, default);
+
+            for(int i=0; i<size; i++){
+                Assert.AreEqual(sourceArray[i], destinationArray[i]);
+            }
+            for (int i = size; i < destinationArray.Length; i++) {
+                Assert.AreEqual(0, destinationArray[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds the ability to cancel synchronous HttpPipelineContent.WriteTo
