### PR TITLE
[Event Hubs Client] Track Two: First Preview (Addopt Track One)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/Azure.Messaging.EventHubs.sln
@@ -7,8 +7,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.Tests", "tests\Azure.Messaging.EventHubs.Tests.csproj", "{51A23FD9-A32D-4390-9A5B-1EA7A045F0F9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Messaging.EventHubs.TrackOne", "src\TrackOneClient\Azure.Messaging.EventHubs.TrackOne.csproj", "{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Messaging.EventHubs.Samples", "samples\Azure.Messaging.EventHubs.Samples.csproj", "{AD33C619-AC51-4F29-937B-184B4F785F57}"
 EndProject
 Global
@@ -45,18 +43,6 @@ Global
 		{51A23FD9-A32D-4390-9A5B-1EA7A045F0F9}.Release|x64.Build.0 = Release|Any CPU
 		{51A23FD9-A32D-4390-9A5B-1EA7A045F0F9}.Release|x86.ActiveCfg = Release|Any CPU
 		{51A23FD9-A32D-4390-9A5B-1EA7A045F0F9}.Release|x86.Build.0 = Release|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Debug|x64.Build.0 = Debug|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Debug|x86.Build.0 = Debug|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|x64.ActiveCfg = Release|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|x64.Build.0 = Release|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|x86.ActiveCfg = Release|Any CPU
-		{B7775C9B-BC8D-43A5-A9C2-75CBA7F6E502}.Release|x86.Build.0 = Release|Any CPU
 		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AD33C619-AC51-4F29-937B-184B4F785F57}.Debug|x64.ActiveCfg = Debug|Any CPU

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -50,14 +50,28 @@
   <!-- Import the Azure.Core project -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
 
-  <!-- Track One Source, for the first preview only -->
+  <!-- 
+      TRACK ONE DEPENDENCIES::TO BE REMOVED
+      Dependencies needed only for the Track One client.        
+  -->
   <ItemGroup>
-    <Compile Remove="TrackOneClient\**" />
-    <EmbeddedResource Remove="TrackOneClient\**" />
-    <None Remove="TrackOneClient\**" />
-  </ItemGroup>
+    <Folder Include="TrackOneClient\" />
 
-  <ItemGroup>
-    <ProjectReference Include="$(MSBuildThisFileDirectory)TrackOneClient\Azure.Messaging.EventHubs.TrackOne.csproj" />
+    <Compile Update="TrackOneClient\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>      
+      <AutoGen>True</AutoGen>
+      <DependentUpon>TrackOneClient\Resources.resx</DependentUpon>
+    </Compile>
+
+    <EmbeddedResource Update="TrackOneClient\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>TrackOneClient\Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" PrivateAssets="All" />
+    <PackageReference Include="System.Net.Http" PrivateAssets="All" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" PrivateAssets="All" />
   </ItemGroup>
+  <!-- END TRACK ONE DEPENDENCIES -->  
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/Resources.Designer.cs
@@ -39,7 +39,7 @@ namespace TrackOne {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("TrackOne.Resources", typeof(Resources).Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Azure.Messaging.EventHubs.TrackOneClient.Resources", typeof(Resources).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;


### PR DESCRIPTION
# Summary

The intent of these changes is reorganize the project structures to adopt the track one client code directly, removing the sandbox project for it. 

# Last Upstream Rebase

Monday, July 1, 2019  1:40pm (EDT)

