### PR TITLE
[Event Hubs Client] Track Two: Second Preview (Small Fixes)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -3,7 +3,7 @@
     <Description>Azure Event Hubs is a highly scalable publish-subscribe service that can ingest millions of events per second and stream them to multiple consumers.  This client library allow for both sending and receiving of events using Azure Event Hubs. For more information about Event Hubs, see https://azure.microsoft.com/en-us/services/event-hubs/</Description>
     <VersionPrefix>5.0.0</VersionPrefix>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT</PackageTags>
-    <PackageReleaseNotes>https://github.com/Azure/azure-event-hubs-dotnet/releases</PackageReleaseNotes>
+    <PackageReleaseNotes>https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Azure.Messaging.EventHubs.xml</DocumentationFile>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableFxCopAnalyzers>false</EnableFxCopAnalyzers>
@@ -51,15 +51,15 @@
   <!-- Import the Azure.Core project -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
 
-  <!-- 
+  <!--
       TRACK ONE DEPENDENCIES::TO BE REMOVED
-      Dependencies needed only for the Track One client.        
+      Dependencies needed only for the Track One client.
   -->
   <ItemGroup>
     <Folder Include="TrackOneClient\" />
 
     <Compile Update="TrackOneClient\Resources.Designer.cs">
-      <DesignTime>True</DesignTime>      
+      <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>
       <DependentUpon>TrackOneClient\Resources.resx</DependentUpon>
     </Compile>
@@ -74,5 +74,5 @@
     <PackageReference Include="System.Net.Http" PrivateAssets="All" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" PrivateAssets="All" />
   </ItemGroup>
-  <!-- END TRACK ONE DEPENDENCIES -->  
+  <!-- END TRACK ONE DEPENDENCIES -->
 </Project>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -63,6 +63,12 @@ namespace Azure.Messaging.EventHubs
         public EventPosition StartingPosition { get; protected set; }
 
         /// <summary>
+        ///   The text-based identifier label that has optionally been assigned to the consumer.
+        /// </summary>
+        ///
+        public string Identifier => Options?.Identifier;
+
+        /// <summary>
         ///   The set of consumer options used for creation of this consumer.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
@@ -143,7 +143,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(properties, Is.Not.Null, "A set of properties should have been returned.");
                     Assert.That(properties.Path, Is.EqualTo(scope.EventHubName), "The property Event Hub name should match the scope.");
                     Assert.That(properties.PartitionIds.Length, Is.EqualTo(partitionCount), "The properties should have the requested number of partitions.");
-                    Assert.That(properties.CreatedAtUtc, Is.EqualTo(DateTime.UtcNow).Within(TimeSpan.FromSeconds(5)), "The Event Hub should have been created just about now.");
+                    Assert.That(properties.CreatedAtUtc, Is.EqualTo(DateTime.UtcNow).Within(TimeSpan.FromSeconds(10)), "The Event Hub should have been created just about now.");
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
@@ -1146,9 +1146,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(20)]
-        [TestCase(40)]
-        [TestCase(60)]
+        [TestCase(2)]
+        [TestCase(4)]
+        [TestCase(15)]
         public async Task ReceiveStopsWhenMaximumWaitTimeIsReached(int maximumWaitTimeInSecs)
         {
             await using (var scope = await EventHubScope.CreateAsync(1))
@@ -1188,9 +1188,9 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        [TestCase(20)]
-        [TestCase(40)]
-        [TestCase(60)]
+        [TestCase(3)]
+        [TestCase(7)]
+        [TestCase(12)]
         public async Task ReceiveStopsWhenDefaultMaximumWaitTimeIsReachedIfMaximumWaitTimeIsNotProvided(int defaultMaximumWaitTimeInSecs)
         {
             await using (var scope = await EventHubScope.CreateAsync(1))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -226,7 +226,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var client = new EventHubClient(connectionString))
+                await using (var client = new EventHubClient(connectionString, new EventHubClientOptions { DefaultTimeout = TimeSpan.FromMinutes(2) }))
                 await using (var producer = client.CreateProducer())
                 {
                     // Actual limit is 1046520 for a single event
@@ -330,7 +330,7 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
-                await using (var client = new EventHubClient(connectionString))
+                await using (var client = new EventHubClient(connectionString, new EventHubClientOptions { DefaultTimeout = TimeSpan.FromMinutes(2) }))
                 await using (var producer = client.CreateProducer())
                 {
                     // Actual limit is 1046520 for a single event

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -27,10 +27,10 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
     public sealed class EventHubScope : IAsyncDisposable
     {
         /// <summary>The maximum number of attempts to retry a management operation.</summary>
-        private const int RetryMaximumAttemps = 5;
+        private const int RetryMaximumAttemps = 8;
 
         /// <summary>The number of seconds to use as the basis for backing off on retry attempts.</summary>
-        private const double RetryExponentialBackoffSeconds = 1.0;
+        private const double RetryExponentialBackoffSeconds = 0.5;
 
         /// <summary>The number of seconds to use as the basis for applying jitter to retry backoff calculations.</summary>
         private const double RetryBaseJitterSeconds = 3.0;


### PR DESCRIPTION
# Summary

The intent of these changes is address some minor issues, primarily around test timings that differ between local and nightly runs.

# Last Upstream Rebase

Tuesday, July 2, 2019  10:26am (EDT)

