### PR TITLE
[Azure Search] Script install of build tools and update generate.ps1

### DIFF
--- a/sdk/search/Build-SearchPackages.ps1
+++ b/sdk/search/Build-SearchPackages.ps1
@@ -1,9 +1,6 @@
-$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-$engDir = "$scriptDir\..\..\eng\"
+$engDir = "$PSScriptRoot\..\..\eng\"
 
-dotnet msbuild "$scriptDir\..\..\mgmt.proj" /t:CreateNugetPackage /p:Scope=Search
+dotnet msbuild "$PSScriptRoot\..\..\mgmt.proj" /t:CreateNugetPackage /p:Scope=Search
 
-dotnet restore
-dotnet build "$engDir/service.proj" /p:ServiceDirectory="search"
 dotnet test "$engDir/service.proj" /p:ServiceDirectory="search"
 dotnet pack "$engDir/service.proj" /p:ServiceDirectory="search"

--- a/sdk/search/Build-SearchPackages.ps1
+++ b/sdk/search/Build-SearchPackages.ps1
@@ -1,7 +1,7 @@
 $scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
 $engDir = "$scriptDir\..\..\eng\"
 
-msbuild "$scriptDir\..\..\build.proj" /t:CreateNugetPackage /p:Scope="search"
+dotnet msbuild "$scriptDir\..\..\mgmt.proj" /t:CreateNugetPackage /p:Scope=Search
 
 dotnet restore
 dotnet build "$engDir/service.proj" /p:ServiceDirectory="search"

--- a/sdk/search/Install-BuildTools.ps1
+++ b/sdk/search/Install-BuildTools.ps1
@@ -1,3 +1,1 @@
-$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
-
-msbuild "$scriptDir\..\..\build.proj" /t:Util /p:UtilityName="InstallPsModules"
+msbuild "$PSScriptRoot\..\..\build.proj" /t:Util /p:UtilityName="InstallPsModules"

--- a/sdk/search/Install-BuildTools.ps1
+++ b/sdk/search/Install-BuildTools.ps1
@@ -1,0 +1,3 @@
+$scriptDir = Split-Path $MyInvocation.MyCommand.Path -Parent
+
+msbuild "$scriptDir\..\..\build.proj" /t:Util /p:UtilityName="InstallPsModules"

--- a/sdk/search/Microsoft.Azure.Management.Search/AzSdk.RP.props
+++ b/sdk/search/Microsoft.Azure.Management.Search/AzSdk.RP.props
@@ -1,7 +1,8 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!--This file and it's contents are updated at build time moving or editing might result in build failure. Take due deligence while editing this file-->
   <PropertyGroup>
-    <AzureApiTag>Search_2015-08-19;</AzureApiTag>
+    <AzureApiTag>
+    </AzureApiTag>
     <PackageTags>$(PackageTags);$(CommonTags);$(AzureApiTag);</PackageTags>
   </PropertyGroup>
 </Project>

--- a/sdk/search/Microsoft.Azure.Management.Search/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Management.Search/src/generate.ps1
@@ -27,4 +27,6 @@ Param(
     [string] $SpecsRepoBranch = "master"
 )
 
+"$PSScriptRoot\..\..\Install-BuildTools.ps1"
+
 Start-AutoRestCodeGeneration -ResourceProvider "search/resource-manager" -AutoRestVersion "latest" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch

--- a/sdk/search/Microsoft.Azure.Management.Search/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Management.Search/src/generate.ps1
@@ -27,7 +27,4 @@ Param(
     [string] $SpecsRepoBranch = "master"
 )
 
-$repoRoot = "$PSScriptRoot\..\..\..\..\.."
-$generateFolder = "$PSScriptRoot\Generated"
-
 Start-AutoRestCodeGeneration -ResourceProvider "search/resource-manager" -AutoRestVersion "latest" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch

--- a/sdk/search/Microsoft.Azure.Search.Data/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/generate.ps1
@@ -27,7 +27,6 @@ Param(
     [string] $SpecsRepoBranch = "master"
 )
 
-$repoRoot = "$PSScriptRoot\..\..\..\..\.."
 $generateFolder = "$PSScriptRoot\Generated"
 
 # TODO: Change AutoRestVersion back to "latest" when the hanging issue is fixed.

--- a/sdk/search/Microsoft.Azure.Search.Data/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/generate.ps1
@@ -27,6 +27,8 @@ Param(
     [string] $SpecsRepoBranch = "master"
 )
 
+"$PSScriptRoot\..\..\Install-BuildTools.ps1"
+
 $generateFolder = "$PSScriptRoot\Generated"
 
 # TODO: Change AutoRestVersion back to "latest" when the hanging issue is fixed.

--- a/sdk/search/Microsoft.Azure.Search.Service/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/generate.ps1
@@ -28,7 +28,7 @@ Param(
 )
 
 $generateFolder = "$PSScriptRoot\Generated"
-$sharedGenerateFolder = "$generateFolder\..\..\Microsoft.Azure.Search.Common\Generated"
+$sharedGenerateFolder = "$PSScriptRoot\..\..\Microsoft.Azure.Search.Common\src\Generated"
 
 Start-AutoRestCodeGeneration -ResourceProvider "search/data-plane/Microsoft.Azure.Search.Service" -AutoRestVersion "latest" -SpecsRepoFork $SpecsRepoFork -SpecsRepoBranch $SpecsRepoBranch
 

--- a/sdk/search/Microsoft.Azure.Search.Service/src/generate.ps1
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/generate.ps1
@@ -27,6 +27,8 @@ Param(
     [string] $SpecsRepoBranch = "master"
 )
 
+"$PSScriptRoot\..\..\Install-BuildTools.ps1"
+
 $generateFolder = "$PSScriptRoot\Generated"
 $sharedGenerateFolder = "$PSScriptRoot\..\..\Microsoft.Azure.Search.Common\src\Generated"
 


### PR DESCRIPTION
I've confirmed that generate.ps1 now works for each of the SDK projects. You have to run Install-BuildTools as a prerequisite.

FYI @natinimni @ishansrivastava90 @updixit @shmed @arv100kri @weshaggard @chidozieononiwu 

If you approve this PR and you have merge permission, please merge. Thanks :)