### PR TITLE
Make default policy types private

### DIFF
--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Sample6_ConfiguringRetries.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/samples/Sample6_ConfiguringRetries.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
-using Azure.Core.Pipeline.Policies;
 using NUnit.Framework;
 using System;
+using Azure.Core.Pipeline;
 
 namespace Azure.ApplicationModel.Configuration.Samples
 {

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/BufferResponsePolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/BufferResponsePolicy.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace Azure.Core.Pipeline.Policies
 {
-    public class BufferResponsePolicy: HttpPipelinePolicy
+    internal class BufferResponsePolicy: HttpPipelinePolicy
     {
         protected BufferResponsePolicy()
         {

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/ClientRequestIdPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/ClientRequestIdPolicy.cs
@@ -3,7 +3,7 @@
 
 namespace Azure.Core.Pipeline.Policies
 {
-    public class ClientRequestIdPolicy : SynchronousHttpPipelinePolicy
+    internal class ClientRequestIdPolicy : SynchronousHttpPipelinePolicy
     {
         private const string ClientRequestIdHeader = "x-ms-client-request-id";
         private const string EchoClientRequestId = "x-ms-return-client-request-id";

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/LoggingPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/LoggingPolicy.cs
@@ -11,7 +11,7 @@ using Azure.Core.Diagnostics;
 
 namespace Azure.Core.Pipeline.Policies
 {
-    public class LoggingPolicy : HttpPipelinePolicy
+    internal class LoggingPolicy : HttpPipelinePolicy
     {
         private const long DelayWarningThreshold = 3000; // 3000ms
         private static readonly long s_frequency = Stopwatch.Frequency;

--- a/sdk/core/Azure.Core/src/Pipeline/Policies/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/Policies/RetryPolicy.cs
@@ -10,7 +10,7 @@ using Azure.Core.Diagnostics;
 
 namespace Azure.Core.Pipeline.Policies
 {
-    public class RetryPolicy : HttpPipelinePolicy
+    internal class RetryPolicy : HttpPipelinePolicy
     {
         private readonly RetryMode _mode;
         private readonly TimeSpan _delay;

--- a/sdk/core/Azure.Core/src/Pipeline/RetryMode.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RetryMode.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-namespace Azure.Core.Pipeline.Policies
+namespace Azure.Core.Pipeline
 {
     public enum RetryMode
     {

--- a/sdk/core/Azure.Core/tests/RetryPolicyTestBase.cs
+++ b/sdk/core/Azure.Core/tests/RetryPolicyTestBase.cs
@@ -300,7 +300,7 @@ namespace Azure.Core.Tests
             return (policy, policy.DelayGate);
         }
 
-        protected class RetryPolicyMock: RetryPolicy
+        internal class RetryPolicyMock: RetryPolicy
         {
             public RetryPolicyMock(RetryMode mode, int maxRetries = 3, TimeSpan delay = default, TimeSpan maxDelay = default): base(mode, delay, maxDelay, maxRetries)
             {

--- a/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
+++ b/sdk/storage/Azure.Storage.Queues/tests/QueueTestBase.cs
@@ -5,8 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Threading.Tasks;
-using Azure.Core.Pipeline.Policies;
+using Azure.Core.Pipeline;
 using Azure.Core.Testing;
 using Azure.Storage.Queues.Models;
 using Azure.Storage.Sas;


### PR DESCRIPTION
No-one should be using them directly. HttpPipelineBuilder would add them.

### Breaking change

Before:

Shouldn't be used directly

After:

Couldn't be used directly.