### PR TITLE
Fixes issue using AAD credentials with EventHubs.

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneGenericTokenProvider.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneGenericTokenProvider.cs
@@ -22,7 +22,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
     internal sealed class TrackOneGenericTokenProvider : TokenProvider
     {
         /// <summary>The default scope to use for token aquisition with the Event Hubs service.</summary>
-        private static readonly string[] EventHubsDefaultScopes = new[] { "https://eventhubs.Azure.net//.default" };
+        private static readonly string[] EventHubsDefaultScopes = new[] { "https://eventhubs.azure.net/.default" };
 
         /// <summary>
         ///   The <see cref="EventHubTokenCredential" /> that forms the basis of this security token.


### PR DESCRIPTION
I've discovered what I think is an error in the scope value that the EventHubs client is passing to token providers when it requests a token. This incorrect value affects AAD-based credential types such as ```ClientSecretCredential``` and ```ManagedIdentityCredential```. I didn't test the later but I'm pretty confident it'll stop any AAD based credential from working with EventHubs - so I think we probably need to ship an update to the EventHubs library.

I verified that the capitalization of ```Azure``` was the issue in the scope value by creating a man-in-the-middle token provider which substituted the scopes when fetching a token to compensate for the error. If you want a repro here you go:

```csharp
public class MimCredential : ClientSecretCredential
    {
        public MimCredential(string tenantId, string clientId, string clientSecret) : base(tenantId, clientId, clientSecret)
        {
        }

        public override Task<AccessToken> GetTokenAsync(string[] scopes, CancellationToken cancellationToken = default)
        {
            scopes[0] = scopes[0].ToLower(); // HACK!!!!
            return base.GetTokenAsync(scopes, cancellationToken);
        }
    }
```

I also removed the (what I think) is a redundant backslash).