### PR TITLE
Rename HttpPipelineUriBuilder and make ContentTypeUtilities shared source

### DIFF
--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClient_private.cs
@@ -86,10 +86,10 @@ namespace Azure.ApplicationModel.Configuration
             };
         }
 
-        void BuildUriForKvRoute(HttpPipelineUriBuilder builder, ConfigurationSetting keyValue)
+        void BuildUriForKvRoute(RequestUriBuilder builder, ConfigurationSetting keyValue)
             => BuildUriForKvRoute(builder, keyValue.Key, keyValue.Label); // TODO (pri 2) : does this need to filter ETag?
 
-        void BuildUriForKvRoute(HttpPipelineUriBuilder builder, string key, string label)
+        void BuildUriForKvRoute(RequestUriBuilder builder, string key, string label)
         {
             builder.Uri = _baseUri;
             builder.AppendPath(KvRoute);
@@ -118,7 +118,7 @@ namespace Azure.ApplicationModel.Configuration
             return resp;
         }
 
-        internal static void BuildBatchQuery(HttpPipelineUriBuilder builder, SettingSelector selector, string pageLink)
+        internal static void BuildBatchQuery(RequestUriBuilder builder, SettingSelector selector, string pageLink)
         {
             if (selector.Keys.Count > 0)
             {
@@ -168,14 +168,14 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        void BuildUriForGetBatch(HttpPipelineUriBuilder builder, SettingSelector selector, string pageLink)
+        void BuildUriForGetBatch(RequestUriBuilder builder, SettingSelector selector, string pageLink)
         {
             builder.Uri = _baseUri;
             builder.AppendPath(KvRoute);
             BuildBatchQuery(builder, selector, pageLink);
         }
 
-        void BuildUriForRevisions(HttpPipelineUriBuilder builder, SettingSelector selector, string pageLink)
+        void BuildUriForRevisions(RequestUriBuilder builder, SettingSelector selector, string pageLink)
         {
             builder.Uri = _baseUri;
             builder.AppendPath(RevisionsRoute);

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/tests/ConfigurationSettingTests.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/tests/ConfigurationSettingTests.cs
@@ -30,7 +30,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 Labels = new List<string>() { "my_label", "label,label" },
             };
 
-            var builder = new HttpPipelineUriBuilder();
+            var builder = new RequestUriBuilder();
             builder.Uri = new Uri("http://localhost/");
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
@@ -47,7 +47,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 Labels = new List<string>() { "*label*" },
             };
 
-            var builder = new HttpPipelineUriBuilder();
+            var builder = new RequestUriBuilder();
             builder.Uri = new Uri("http://localhost/");
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
@@ -62,7 +62,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 Labels = new List<string>() { "" },
             };
 
-            var builder = new HttpPipelineUriBuilder();
+            var builder = new RequestUriBuilder();
             builder.Uri = new Uri("http://localhost/");
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
@@ -75,7 +75,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var key = "my-key";
             var selector = new SettingSelector(key);
 
-            var builder = new HttpPipelineUriBuilder();
+            var builder = new RequestUriBuilder();
             builder.Uri = new Uri("http://localhost/");
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
@@ -88,7 +88,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var label = "my-label";
             var selector = new SettingSelector(null, label);
 
-            var builder = new HttpPipelineUriBuilder();
+            var builder = new RequestUriBuilder();
             builder.Uri = new Uri("http://localhost/");
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
@@ -103,7 +103,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 Fields = SettingFields.Key | SettingFields.Value
             };
 
-            var builder = new HttpPipelineUriBuilder();
+            var builder = new RequestUriBuilder();
             builder.Uri = new Uri("http://localhost/");
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 
@@ -118,7 +118,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 Fields = SettingFields.All
             };
 
-            var builder = new HttpPipelineUriBuilder();
+            var builder = new RequestUriBuilder();
             builder.Uri = new Uri("http://localhost/");
             ConfigurationClient.BuildBatchQuery(builder, selector, null);
 

--- a/sdk/core/Azure.Core/src/HttpPipelineUriBuilder.cs
+++ b/sdk/core/Azure.Core/src/HttpPipelineUriBuilder.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Azure.Core
 {
-    public class HttpPipelineUriBuilder
+    public class RequestUriBuilder
     {
         private const char QuerySeparator = '?';
 

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -10,7 +10,7 @@ namespace Azure
 {
     public abstract class Request : IDisposable
     {
-        public virtual HttpPipelineUriBuilder UriBuilder { get; set; } = new HttpPipelineUriBuilder();
+        public virtual RequestUriBuilder UriBuilder { get; set; } = new RequestUriBuilder();
 
         public virtual RequestMethod Method { get; set; }
 

--- a/sdk/core/Azure.Core/src/Shared/ContentTypeUtilities.cs
+++ b/sdk/core/Azure.Core/src/Shared/ContentTypeUtilities.cs
@@ -6,7 +6,7 @@ using System.Text;
 
 namespace Azure.Core.Pipeline
 {
-    public static class ContentTypeUtilities
+    internal static class ContentTypeUtilities
     {
         public static bool TryGetTextEncoding(string contentType, out Encoding encoding)
         {

--- a/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
+++ b/sdk/core/Azure.Core/tests/RequestUriBuilderTest.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 
 namespace Azure.Core.Tests
 {
-    public class HttpPipelineUriBuilderTest
+    public class RequestUriBuilderTest
     {
         public static Uri[] Uris { get; } = {
             new Uri("https://localhost:20/query?query"),
@@ -21,7 +21,7 @@ namespace Azure.Core.Tests
         [TestCaseSource(nameof(Uris))]
         public void RoundtripWithUri(Uri uri)
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Uri = uri;
 
             Assert.AreEqual(uri.Scheme, uriBuilder.Scheme);
@@ -39,7 +39,7 @@ namespace Azure.Core.Tests
         [TestCase("/a", "http://localhost/a")]
         public void AddsLeadingSlashToPath(string path, string expected)
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Scheme = "http";
             uriBuilder.Host = "localhost";
             uriBuilder.Port = 80;
@@ -54,7 +54,7 @@ namespace Azure.Core.Tests
         [TestCase("?a", "http://localhost/?a")]
         public void AddsLeadingQuestionMarkToQuery(string query, string expected)
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Scheme = "http";
             uriBuilder.Host = "localhost";
             uriBuilder.Port = 80;
@@ -67,7 +67,7 @@ namespace Azure.Core.Tests
         [TestCase("")]
         public void SettingQueryToEmptyRemovesQuestionMark(string query)
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Scheme = "http";
             uriBuilder.Host = "localhost";
             uriBuilder.Port = 80;
@@ -87,7 +87,7 @@ namespace Azure.Core.Tests
         [TestCase("%#?&", "%25#?&")]
         public void PathIsEscaped(string path, string expectedPath)
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Scheme = "http";
             uriBuilder.Host = "localhost";
             uriBuilder.Port = 80;
@@ -99,7 +99,7 @@ namespace Azure.Core.Tests
         [Test]
         public void QueryIsNotEscaped()
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Scheme = "http";
             uriBuilder.Host = "localhost";
             uriBuilder.Port = 80;
@@ -111,7 +111,7 @@ namespace Azure.Core.Tests
         [Test]
         public void AppendQueryWithEmptyValueWorks()
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Scheme = "http";
             uriBuilder.Host = "localhost";
             uriBuilder.Port = 80;
@@ -127,7 +127,7 @@ namespace Azure.Core.Tests
         [TestCase("?initial", "http://localhost/?initial&a=b&c=d")]
         public void AppendQueryWorks(string initialQuery, string expectedResult)
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Scheme = "http";
             uriBuilder.Host = "localhost";
             uriBuilder.Port = 80;
@@ -146,7 +146,7 @@ namespace Azure.Core.Tests
         [TestCase("", "\u1234", "http://localhost/%E1%88%B4")]
         public void AppendPathWorks(string initialPath, string append, string expectedResult)
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Scheme = "http";
             uriBuilder.Host = "localhost";
             uriBuilder.Port = 80;
@@ -159,7 +159,7 @@ namespace Azure.Core.Tests
         [Test]
         public void AppendingQueryResetsUri()
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Uri = new Uri("http://localhost/");
             uriBuilder.AppendQuery("a","b");
 
@@ -169,7 +169,7 @@ namespace Azure.Core.Tests
         [Test]
         public void AppendingPathResetsUri()
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Uri = new Uri("http://localhost/");
             uriBuilder.AppendPath("a");
 
@@ -179,7 +179,7 @@ namespace Azure.Core.Tests
         [Test]
         public void AppendingPathAfterQueryAndSettingTheUriWorks()
         {
-            var uriBuilder = new HttpPipelineUriBuilder();
+            var uriBuilder = new RequestUriBuilder();
             uriBuilder.Uri = new Uri("http://localhost/");
             uriBuilder.AppendQuery("query", "value");
             uriBuilder.AppendPath("a");

--- a/sdk/core/Azure.Core/tests/TestFramework.props
+++ b/sdk/core/Azure.Core/tests/TestFramework.props
@@ -1,7 +1,7 @@
 ﻿<Project ToolsVersion="15.0">
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)\TestFramework\*.cs" Link="TestFramework\%(RecursiveDir)\%(Filename)%(Extension)" />
-    <Compile Include="$(MSBuildThisFileDirectory)\..\src\shared\ContentTypeUtilities.cs" Link="TestFramework\ContentTypeUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\src\Shared\ContentTypeUtilities.cs" Link="TestFramework\ContentTypeUtilities.cs" />
     <None Update="SessionRecords\**\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/sdk/core/Azure.Core/tests/TestFramework.props
+++ b/sdk/core/Azure.Core/tests/TestFramework.props
@@ -1,6 +1,7 @@
 ﻿<Project ToolsVersion="15.0">
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)\TestFramework\*.cs" Link="TestFramework\%(RecursiveDir)\%(Filename)%(Extension)" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\src\shared\ContentTypeUtilities.cs" Link="TestFramework\ContentTypeUtilities.cs" />
     <None Update="SessionRecords\**\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient_private.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient_private.cs
@@ -144,7 +144,7 @@ namespace Azure.Security.KeyVault.Keys
 
         private Uri CreateFirstPageUri(string path)
         {
-            var firstPage = new HttpPipelineUriBuilder();
+            var firstPage = new RequestUriBuilder();
             firstPage.Uri = _vaultUri;
             firstPage.AppendPath(path);
             firstPage.AppendQuery("api-version", ApiVersion);


### PR DESCRIPTION
Contributes to https://github.com/Azure/azure-sdk-for-net/issues/6831 