### PR TITLE
Remove version properties from eventhub projects

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Microsoft.Azure.EventHubs.Processor.csproj
@@ -10,7 +10,6 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks);netstandard1.4</TargetFrameworks>
     <RootNamespace>Microsoft.Azure.EventHubs.Processor</RootNamespace>
-    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
@@ -6,9 +6,6 @@
     <PackageReleaseNotes>https://github.com/Azure/azure-event-hubs-dotnet/releases</PackageReleaseNotes>
     <DocumentationFile>$(OutputPath)$(TargetFramework)\Microsoft.Azure.EventHubs.xml</DocumentationFile>
     <TargetFrameworks>$(RequiredTargetFrameworks);netstandard1.4</TargetFrameworks>
-    <AssemblyVersion>4.0.0.0</AssemblyVersion>
-    <FileVersion>4.0.0.0</FileVersion>
-    <Version>4.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The only version property that should be set is VersionPrefix so
cleaning out the other version properties that cause issues with
our nightly build publishing because they override the prerelease
label generation.

Fixes versioning issues introduced by https://github.com/Azure/azure-sdk-for-net/pull/6750

@serkantkaraca  @jsquire @AlexGhiondea 