### PR TITLE
Enable xml doc comments for our client libraries

### DIFF
--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -107,6 +107,7 @@
     <ImportDefaultReferences>false</ImportDefaultReferences>
     <UseProjectReferenceToAzureCore>true</UseProjectReferenceToAzureCore>
     <LangVersion>preview</LangVersion>
+    <DocumentationFile>$(IntermediateOutputPath)$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(IsTestProject)' == 'true' or '$(IsTestSupportProject)' == 'true'">
@@ -114,6 +115,8 @@
     <PublicSign>false</PublicSign>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzSdkTestLibKey.snk</AssemblyOriginatorKeyFile>
+    <!-- Disable doc comments for test projects -->
+    <DocumentationFile></DocumentationFile>
   </PropertyGroup>
 
   <Import Project="Versioning.props" />

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/Azure.ApplicationModel.Configuration.csproj
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/Azure.ApplicationModel.Configuration.csproj
@@ -13,6 +13,9 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClient.cs
@@ -504,6 +504,7 @@ namespace Azure.ApplicationModel.Configuration
         /// Fetches the <see cref="ConfigurationSetting"/> from the configuration store that match the options selected in the <see cref="SettingSelector"/>.
         /// </summary>
         /// <param name="selector">Set of options for selecting settings from the configuration store.</param>
+        /// <param name="pageLink"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         private async Task<PageResponse<ConfigurationSetting>> GetSettingsPageAsync(SettingSelector selector, string pageLink, CancellationToken cancellationToken = default)
         {
@@ -527,6 +528,7 @@ namespace Azure.ApplicationModel.Configuration
         /// Fetches the <see cref="ConfigurationSetting"/> from the configuration store that match the options selected in the <see cref="SettingSelector"/>.
         /// </summary>
         /// <param name="selector">Set of options for selecting settings from the configuration store.</param>
+        /// <param name="pageLink"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         private PageResponse<ConfigurationSetting> GetSettingsPage(SettingSelector selector, string pageLink, CancellationToken cancellationToken = default)
         {
@@ -566,6 +568,7 @@ namespace Azure.ApplicationModel.Configuration
         /// </summary>
         /// <remarks>Revisions are provided in descending order from their respective <see cref="ConfigurationSetting.LastModified"/> date.</remarks>
         /// <param name="selector">Set of options for selecting settings from the configuration store.</param>
+        /// <param name="pageLink"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         private async Task<PageResponse<ConfigurationSetting>> GetRevisionsPageAsync(SettingSelector selector, string pageLink, CancellationToken cancellationToken = default)
         {
@@ -589,6 +592,7 @@ namespace Azure.ApplicationModel.Configuration
         /// </summary>
         /// <remarks>Revisions are provided in descending order from their respective <see cref="ConfigurationSetting.LastModified"/> date.</remarks>
         /// <param name="selector">Set of options for selecting settings from the configuration store.</param>
+        /// <param name="pageLink"></param>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> controlling the request lifetime.</param>
         private PageResponse<ConfigurationSetting> GetRevisionsPage(SettingSelector selector, string pageLink, CancellationToken cancellationToken = default)
         {

--- a/sdk/core/Azure.Core.Extensions/src/Azure.Core.Extensions.csproj
+++ b/sdk/core/Azure.Core.Extensions/src/Azure.Core.Extensions.csproj
@@ -14,10 +14,11 @@
     <!-- Make sure that we don't pull in additional dependencies during build or package -->
     <ImportDefaultReferences>false</ImportDefaultReferences>
 
-    <LangVersion>preview</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
+    <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -12,6 +12,9 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
+
+    <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sdk/core/Azure.Core/src/Http/HttpRange.cs
+++ b/sdk/core/Azure.Core/src/Http/HttpRange.cs
@@ -46,6 +46,7 @@ namespace Azure.Core.Http
 
         /// <summary>
         /// Converts the specified range to a string.
+        /// </summary>
         /// <returns>String representation of the range.</returns>
         /// <remarks>For more information, see https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-the-range-header-for-file-service-operations. </remarks>
         public override string ToString()

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs
@@ -10,7 +10,7 @@ namespace Azure.Core.Pipeline
     public abstract class HttpPipelinePolicy
     {
         /// <summary>
-        /// Applies the policy to the <see cref="message"/>. Implementers are expected to mutate <see cref="HttpPipelineMessage.Request"/> before calling <see cref="ProcessNextAsync"/> and observe the <see cref="HttpPipelineMessage.Response"/> changes after.
+        /// Applies the policy to the <paramref name="message"/>. Implementers are expected to mutate <see cref="HttpPipelineMessage.Request"/> before calling <see cref="ProcessNextAsync"/> and observe the <see cref="HttpPipelineMessage.Response"/> changes after.
         /// Last policy in the pipeline is expected to set the <see cref="HttpPipelineMessage.Response"/>
         /// </summary>
         /// <param name="message">The <see cref="HttpPipelineMessage"/> this policy would be applied to.</param>
@@ -21,7 +21,7 @@ namespace Azure.Core.Pipeline
         public abstract void Process(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline);
 
         /// <summary>
-        /// Invokes the next <see cref="HttpPipelinePolicy"/> in the <see cref="pipeline"/>.
+        /// Invokes the next <see cref="HttpPipelinePolicy"/> in the <paramref name="pipeline"/>.
         /// </summary>
         /// <param name="message">The <see cref="HttpPipelineMessage"/> next policy would be applied to.</param>
         /// <param name="pipeline">The set of <see cref="HttpPipelinePolicy"/> to execute after next one.</param>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
@@ -259,7 +259,7 @@ namespace Azure.Messaging.EventHubs.Samples
         ///
         private class CommandLineArguments
         {
-            /// <summary>The sequence of characters that prefix a command-line argument./summary>
+            /// <summary>The sequence of characters that prefix a command-line argument.</summary>
             public const string ArgumentPrefix = "--";
 
             /// <summary>The connection string to the Azure Event Hubs namespace for samples.</summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -4,7 +4,6 @@
     <VersionPrefix>5.0.0</VersionPrefix>
     <PackageTags>Azure;Event Hubs;EventHubs;.NET;AMQP;IoT</PackageTags>
     <PackageReleaseNotes>https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md</PackageReleaseNotes>
-    <DocumentationFile>$(OutputPath)$(TargetFramework)\Azure.Messaging.EventHubs.xml</DocumentationFile>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <EnableFxCopAnalyzers>false</EnableFxCopAnalyzers>
   </PropertyGroup>

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/Azure.Security.KeyVault.Certificates.csproj
@@ -13,6 +13,9 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
 
   <!-- Import the Azure.Core project -->

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/Azure.Security.KeyVault.Keys.csproj
@@ -12,11 +12,14 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <NoWarn>$(NoWarn);3021</NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+
+    <!-- Disable warning for missing xml doc comments until we can add all the missing ones -->
+    <NoWarn>$(NoWarn);1591</NoWarn>
   </PropertyGroup>
-  
+
   <!-- Import the Azure.Core project -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\..\core\Azure.Core\src\Azure.Core.props" />
-    
+
   <ItemGroup>
     <PackageReference Include="System.Memory" />
     <PackageReference Include="System.Text.Json" />
@@ -28,5 +31,5 @@
     <Compile Include="$(AzureCoreSharedSources)PageResponse.cs" />
     <Compile Include="$(AzureCoreSharedSources)PageResponseEnumerator.cs" />
   </ItemGroup>
-  
+
 </Project>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -242,14 +242,14 @@ namespace Azure.Storage.Blobs.Specialized
             return new BlobBaseClient(builder.ToUri(), this.Pipeline);
         }
 
-        /// <summary>
-        /// Creates a clone of this instance that references a version ID rather than the base blob.
-        /// </summary>
-        /// /// <remarks>
-        /// Pass null or empty string to remove the verion ID returning a URL to the base blob.
-        /// </remarks>
-        /// <param name="versionId">The version ID to use on this blob. An empty string or null indicates to use the base blob.</param>
-        /// <returns>The new <see cref="BlobClient"/> instance referencing the verionId.</returns>
+        ///// <summary>
+        ///// Creates a clone of this instance that references a version ID rather than the base blob.
+        ///// </summary>
+        ///// /// <remarks>
+        ///// Pass null or empty string to remove the verion ID returning a URL to the base blob.
+        ///// </remarks>
+        ///// <param name="versionId">The version ID to use on this blob. An empty string or null indicates to use the base blob.</param>
+        ///// <returns>The new <see cref="BlobClient"/> instance referencing the verionId.</returns>
         //public virtual BlobBaseClient WithVersionId(string versionId) => this.WithVersionIdImpl(versionId);
 
         //protected virtual BlobBaseClient WithVersionIdImpl(string versionId)

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -233,8 +233,8 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="GetContainersAsync"/> operation returns a
         /// single segment of containers in the storage account, starting
-        /// from the specified <paramref name="marker"/>.  Use an empty
-        /// <paramref name="marker"/> to start enumeration from the beginning
+        /// from the specified marker.  Use an empty
+        /// marker to start enumeration from the beginning
         /// and the <see cref="ContainersSegment.NextMarker"/> if it's not
         /// empty to make subsequent calls to <see cref="ListContainersSegmentAsync"/>
         /// to continue enumerating the containers segment by segment.
@@ -866,6 +866,7 @@ namespace Azure.Storage.Blobs
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
+        /// <param name="async"/>
         /// <returns>
         /// A <see cref="Task{Response{BlobServiceStatistics}}"/> describing
         /// the service replication statistics.

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobUriBuilder.cs
@@ -64,9 +64,9 @@ namespace Azure.Storage.Blobs
         /// </summary>
         public string Snapshot;
 
-        /// <summary>
-        /// VersionId.  Empty string if not present in URI.
-        /// </summary>
+        ///// <summary>
+        ///// VersionId.  Empty string if not present in URI.
+        ///// </summary>
         //public string VersionId;
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// Check if two BlobUriBuilder instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(BlobUriBuilder other)
             => this.Scheme == other.Scheme

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -263,14 +263,14 @@ namespace Azure.Storage.Blobs.Specialized
             return new BlockBlobClient(builder.ToUri(), this.Pipeline);
         }
 
-        /// <summary>
-        /// Creates a new BlockBlobURL object identical to the source but with the specified version ID.
-        /// </summary>
-        /// <remarks>
-        /// Pass null or empty string to remove the snapshot returning a URL to the base blob.
-        /// </remarks>
-        /// <param name="versionId">A string of the version identifier.</param>
-        /// <returns></returns>
+        ///// <summary>
+        ///// Creates a new BlockBlobURL object identical to the source but with the specified version ID.
+        ///// </summary>
+        ///// <remarks>
+        ///// Pass null or empty string to remove the snapshot returning a URL to the base blob.
+        ///// </remarks>
+        ///// <param name="versionId">A string of the version identifier.</param>
+        ///// <returns></returns>
         //public new BlockBlobClient WithVersionId(string versionId) => (BlockBlobUri)this.WithVersionIdImpl(versionId);
 
         //protected sealed override Blobclient WithVersionIdImpl(string versionId)
@@ -514,7 +514,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block" />.
         /// </summary>
-        /// <param name="base64BlockID">
+        /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
         /// encoding, the string must be less than or equal to 64 bytes in
         /// size.
@@ -579,7 +579,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block" />.
         /// </summary>
-        /// <param name="base64BlockID">
+        /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
         /// encoding, the string must be less than or equal to 64 bytes in
         /// size.
@@ -644,7 +644,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block" />.
         /// </summary>
-        /// <param name="base64BlockID">
+        /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
         /// encoding, the string must be less than or equal to 64 bytes in
         /// size.
@@ -758,11 +758,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// shared access signature. If the source blob is public, no
         /// authentication is required to perform the operation.
         /// </param>
-        /// <param name="base64BlockID">
+        /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
         /// encoding, the string must be less than or equal to 64 bytes in
         /// size.  For a given blob, the length of the value specified for
-        /// the <paramref name="base64BlockID"/> parameter must be the same
+        /// the <paramref name="base64BlockId"/> parameter must be the same
         /// size for each block.  Note that the Base64 string must be
         /// URL-encoded.
         /// </param>
@@ -835,11 +835,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// shared access signature. If the source blob is public, no
         /// authentication is required to perform the operation.
         /// </param>
-        /// <param name="base64BlockID">
+        /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
         /// encoding, the string must be less than or equal to 64 bytes in
         /// size.  For a given blob, the length of the value specified for
-        /// the <paramref name="base64BlockID"/> parameter must be the same
+        /// the <paramref name="base64BlockId"/> parameter must be the same
         /// size for each block.  Note that the Base64 string must be
         /// URL-encoded.
         /// </param>
@@ -912,11 +912,11 @@ namespace Azure.Storage.Blobs.Specialized
         /// shared access signature. If the source blob is public, no
         /// authentication is required to perform the operation.
         /// </param>
-        /// <param name="base64BlockID">
+        /// <param name="base64BlockId">
         /// A valid Base64 string value that identifies the block. Prior to
         /// encoding, the string must be less than or equal to 64 bytes in
         /// size.  For a given blob, the length of the value specified for
-        /// the <paramref name="base64BlockID"/> parameter must be the same
+        /// the <paramref name="base64BlockId"/> parameter must be the same
         /// size for each block.  Note that the Base64 string must be
         /// URL-encoded.
         /// </param>
@@ -1025,7 +1025,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see  <see cref="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
         /// </summary>
-        /// <param name="base64BlockIDs">
+        /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
         /// the blob service should search only the uncommitted block list for
         /// the named blocks.  If the block is not found in the uncommitted
@@ -1086,7 +1086,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see  <see cref="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
         /// </summary>
-        /// <param name="base64BlockIDs">
+        /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
         /// the blob service should search only the uncommitted block list for
         /// the named blocks.  If the block is not found in the uncommitted
@@ -1147,7 +1147,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see  <see cref="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
         /// </summary>
-        /// <param name="base64BlockIDs">
+        /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
         /// the blob service should search only the uncommitted block list for
         /// the named blocks.  If the block is not found in the uncommitted

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
@@ -207,7 +207,7 @@ namespace Azure.Storage.Blobs
             /// Create the Service.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetPropertiesAsync Azure.Response<Azure.Storage.Blobs.Models.BlobServiceProperties>.</returns>
+            /// <returns>The Service.GetPropertiesAsync Azure.Response{Azure.Storage.Blobs.Models.BlobServiceProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobServiceProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -315,7 +315,7 @@ namespace Azure.Storage.Blobs
             /// Create the Service.GetStatisticsAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetStatisticsAsync Azure.Response<Azure.Storage.Blobs.Models.BlobServiceStatistics>.</returns>
+            /// <returns>The Service.GetStatisticsAsync Azure.Response{Azure.Storage.Blobs.Models.BlobServiceStatistics}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobServiceStatistics> GetStatisticsAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -446,7 +446,7 @@ namespace Azure.Storage.Blobs
             /// Create the Service.ListContainersSegmentAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.ListContainersSegmentAsync Azure.Response<Azure.Storage.Blobs.Models.ContainersSegment>.</returns>
+            /// <returns>The Service.ListContainersSegmentAsync Azure.Response{Azure.Storage.Blobs.Models.ContainersSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.ContainersSegment> ListContainersSegmentAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -570,7 +570,7 @@ namespace Azure.Storage.Blobs
             /// Create the Service.GetUserDelegationKeyAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetUserDelegationKeyAsync Azure.Response<Azure.Storage.Blobs.Models.UserDelegationKey>.</returns>
+            /// <returns>The Service.GetUserDelegationKeyAsync Azure.Response{Azure.Storage.Blobs.Models.UserDelegationKey}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.UserDelegationKey> GetUserDelegationKeyAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -610,7 +610,7 @@ namespace Azure.Storage.Blobs
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.AccountInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.AccountInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.AccountInfo>> GetAccountInfoAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -666,7 +666,7 @@ namespace Azure.Storage.Blobs
             /// Create the Service.GetAccountInfoAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetAccountInfoAsync Azure.Response<Azure.Storage.Blobs.Models.AccountInfo>.</returns>
+            /// <returns>The Service.GetAccountInfoAsync Azure.Response{Azure.Storage.Blobs.Models.AccountInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.AccountInfo> GetAccountInfoAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -728,7 +728,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.ContainerInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>> CreateAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -808,7 +808,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.CreateAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.CreateAsync Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>.</returns>
+            /// <returns>The Container.CreateAsync Azure.Response{Azure.Storage.Blobs.Models.ContainerInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo> CreateAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -861,7 +861,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.FlattenedContainerItem></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.FlattenedContainerItem}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.FlattenedContainerItem>> GetPropertiesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -931,7 +931,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.GetPropertiesAsync Azure.Response<Azure.Storage.Blobs.Models.FlattenedContainerItem>.</returns>
+            /// <returns>The Container.GetPropertiesAsync Azure.Response{Azure.Storage.Blobs.Models.FlattenedContainerItem}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.FlattenedContainerItem> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1145,7 +1145,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.ContainerInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>> SetMetadataAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1231,7 +1231,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.SetMetadataAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.SetMetadataAsync Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>.</returns>
+            /// <returns>The Container.SetMetadataAsync Azure.Response{Azure.Storage.Blobs.Models.ContainerInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo> SetMetadataAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1284,7 +1284,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.ContainerAccessPolicy></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.ContainerAccessPolicy}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.ContainerAccessPolicy>> GetAccessPolicyAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1355,7 +1355,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.GetAccessPolicyAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.GetAccessPolicyAsync Azure.Response<Azure.Storage.Blobs.Models.ContainerAccessPolicy>.</returns>
+            /// <returns>The Container.GetAccessPolicyAsync Azure.Response{Azure.Storage.Blobs.Models.ContainerAccessPolicy}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.ContainerAccessPolicy> GetAccessPolicyAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1422,7 +1422,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.ContainerInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>> SetAccessPolicyAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1526,7 +1526,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.SetAccessPolicyAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.SetAccessPolicyAsync Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>.</returns>
+            /// <returns>The Container.SetAccessPolicyAsync Azure.Response{Azure.Storage.Blobs.Models.ContainerInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo> SetAccessPolicyAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1582,7 +1582,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.Lease></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.Lease}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.Lease>> AcquireLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1669,7 +1669,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.AcquireLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.AcquireLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.Lease>.</returns>
+            /// <returns>The Container.AcquireLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.Lease}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.Lease> AcquireLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1728,7 +1728,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.ContainerInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>> ReleaseLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1814,7 +1814,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.ReleaseLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.ReleaseLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo>.</returns>
+            /// <returns>The Container.ReleaseLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.ContainerInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.ContainerInfo> ReleaseLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1869,7 +1869,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.Lease></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.Lease}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.Lease>> RenewLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1955,7 +1955,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.RenewLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.RenewLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.Lease>.</returns>
+            /// <returns>The Container.RenewLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.Lease}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.Lease> RenewLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2014,7 +2014,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BrokenLease></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BrokenLease}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BrokenLease>> BreakLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -2096,7 +2096,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.BreakLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.BreakLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.BrokenLease>.</returns>
+            /// <returns>The Container.BreakLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.BrokenLease}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BrokenLease> BreakLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2168,7 +2168,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.Lease></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.Lease}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.Lease>> ChangeLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -2263,7 +2263,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.ChangeLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.ChangeLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.Lease>.</returns>
+            /// <returns>The Container.ChangeLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.Lease}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.Lease> ChangeLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2409,7 +2409,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.ListBlobsFlatSegmentAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.ListBlobsFlatSegmentAsync Azure.Response<Azure.Storage.Blobs.Models.BlobsFlatSegment>.</returns>
+            /// <returns>The Container.ListBlobsFlatSegmentAsync Azure.Response{Azure.Storage.Blobs.Models.BlobsFlatSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobsFlatSegment> ListBlobsFlatSegmentAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2547,7 +2547,7 @@ namespace Azure.Storage.Blobs
             /// Create the Container.ListBlobsHierarchySegmentAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Container.ListBlobsHierarchySegmentAsync Azure.Response<Azure.Storage.Blobs.Models.BlobsHierarchySegment>.</returns>
+            /// <returns>The Container.ListBlobsHierarchySegmentAsync Azure.Response{Azure.Storage.Blobs.Models.BlobsHierarchySegment}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobsHierarchySegment> ListBlobsHierarchySegmentAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2605,7 +2605,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.FlattenedDownloadProperties></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.FlattenedDownloadProperties}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.FlattenedDownloadProperties>> DownloadAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -2713,7 +2713,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.DownloadAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.DownloadAsync Azure.Response<Azure.Storage.Blobs.Models.FlattenedDownloadProperties>.</returns>
+            /// <returns>The Blob.DownloadAsync Azure.Response{Azure.Storage.Blobs.Models.FlattenedDownloadProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.FlattenedDownloadProperties> DownloadAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3035,7 +3035,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobProperties></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobProperties}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobProperties>> GetPropertiesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -3129,7 +3129,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.GetPropertiesAsync Azure.Response<Azure.Storage.Blobs.Models.BlobProperties>.</returns>
+            /// <returns>The Blob.GetPropertiesAsync Azure.Response{Azure.Storage.Blobs.Models.BlobProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3567,7 +3567,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.SetHttpHeadersOperation></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.SetHttpHeadersOperation}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.SetHttpHeadersOperation>> SetHttpHeadersAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -3697,7 +3697,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.SetHttpHeadersAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.SetHttpHeadersAsync Azure.Response<Azure.Storage.Blobs.Models.SetHttpHeadersOperation>.</returns>
+            /// <returns>The Blob.SetHttpHeadersAsync Azure.Response{Azure.Storage.Blobs.Models.SetHttpHeadersOperation}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.SetHttpHeadersOperation> SetHttpHeadersAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3771,7 +3771,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.SetMetadataOperation></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.SetMetadataOperation}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.SetMetadataOperation>> SetMetadataAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -3871,7 +3871,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.SetMetadataAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.SetMetadataAsync Azure.Response<Azure.Storage.Blobs.Models.SetMetadataOperation>.</returns>
+            /// <returns>The Blob.SetMetadataAsync Azure.Response{Azure.Storage.Blobs.Models.SetMetadataOperation}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.SetMetadataOperation> SetMetadataAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3945,7 +3945,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.Lease></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.Lease}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.Lease>> AcquireLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -4041,7 +4041,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.AcquireLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.AcquireLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.Lease>.</returns>
+            /// <returns>The Blob.AcquireLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.Lease}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.Lease> AcquireLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -4102,7 +4102,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobInfo>> ReleaseLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -4197,7 +4197,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.ReleaseLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.ReleaseLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.BlobInfo>.</returns>
+            /// <returns>The Blob.ReleaseLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.BlobInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobInfo> ReleaseLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -4254,7 +4254,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.Lease></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.Lease}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.Lease>> RenewLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -4349,7 +4349,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.RenewLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.RenewLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.Lease>.</returns>
+            /// <returns>The Blob.RenewLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.Lease}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.Lease> RenewLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -4411,7 +4411,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.Lease></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.Lease}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.Lease>> ChangeLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -4515,7 +4515,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.ChangeLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.ChangeLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.Lease>.</returns>
+            /// <returns>The Blob.ChangeLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.Lease}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.Lease> ChangeLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -4576,7 +4576,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BrokenLease></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BrokenLease}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BrokenLease>> BreakLeaseAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -4667,7 +4667,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.BreakLeaseAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.BreakLeaseAsync Azure.Response<Azure.Storage.Blobs.Models.BrokenLease>.</returns>
+            /// <returns>The Blob.BreakLeaseAsync Azure.Response{Azure.Storage.Blobs.Models.BrokenLease}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BrokenLease> BreakLeaseAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -4741,7 +4741,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobSnapshotInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobSnapshotInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobSnapshotInfo>> CreateSnapshotAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -4841,7 +4841,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.CreateSnapshotAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.CreateSnapshotAsync Azure.Response<Azure.Storage.Blobs.Models.BlobSnapshotInfo>.</returns>
+            /// <returns>The Blob.CreateSnapshotAsync Azure.Response{Azure.Storage.Blobs.Models.BlobSnapshotInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobSnapshotInfo> CreateSnapshotAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -4908,7 +4908,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobCopyInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>> StartCopyFromUriAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -5036,7 +5036,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.StartCopyFromUriAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.StartCopyFromUriAsync Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>.</returns>
+            /// <returns>The Blob.StartCopyFromUriAsync Azure.Response{Azure.Storage.Blobs.Models.BlobCopyInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo> StartCopyFromUriAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -5107,7 +5107,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobCopyInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>> CopyFromUriAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -5236,7 +5236,7 @@ namespace Azure.Storage.Blobs
             /// Create the Blob.CopyFromUriAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Blob.CopyFromUriAsync Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>.</returns>
+            /// <returns>The Blob.CopyFromUriAsync Azure.Response{Azure.Storage.Blobs.Models.BlobCopyInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo> CopyFromUriAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -5550,7 +5550,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobContentInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> CreateAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -5705,7 +5705,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.CreateAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.CreateAsync Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>.</returns>
+            /// <returns>The PageBlob.CreateAsync Azure.Response{Azure.Storage.Blobs.Models.BlobContentInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo> CreateAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -5777,7 +5777,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.PageInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.PageInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.PageInfo>> UploadPagesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -5909,7 +5909,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.UploadPagesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.UploadPagesAsync Azure.Response<Azure.Storage.Blobs.Models.PageInfo>.</returns>
+            /// <returns>The PageBlob.UploadPagesAsync Azure.Response{Azure.Storage.Blobs.Models.PageInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.PageInfo> UploadPagesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -5979,7 +5979,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.PageInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.PageInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.PageInfo>> ClearPagesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -6095,7 +6095,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.ClearPagesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.ClearPagesAsync Azure.Response<Azure.Storage.Blobs.Models.PageInfo>.</returns>
+            /// <returns>The PageBlob.ClearPagesAsync Azure.Response{Azure.Storage.Blobs.Models.PageInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.PageInfo> ClearPagesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -6172,7 +6172,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.PageInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.PageInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.PageInfo>> UploadPagesFromUriAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -6335,7 +6335,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.UploadPagesFromUriAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.UploadPagesFromUriAsync Azure.Response<Azure.Storage.Blobs.Models.PageInfo>.</returns>
+            /// <returns>The PageBlob.UploadPagesFromUriAsync Azure.Response{Azure.Storage.Blobs.Models.PageInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.PageInfo> UploadPagesFromUriAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -6416,7 +6416,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.PageRangesInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo>> GetPageRangesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -6516,7 +6516,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.GetPageRangesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.GetPageRangesAsync Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo>.</returns>
+            /// <returns>The PageBlob.GetPageRangesAsync Azure.Response{Azure.Storage.Blobs.Models.PageRangesInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo> GetPageRangesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -6596,7 +6596,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.PageRangesInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo>> GetPageRangesDiffAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -6701,7 +6701,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.GetPageRangesDiffAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.GetPageRangesDiffAsync Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo>.</returns>
+            /// <returns>The PageBlob.GetPageRangesDiffAsync Azure.Response{Azure.Storage.Blobs.Models.PageRangesInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.PageRangesInfo> GetPageRangesDiffAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -6779,7 +6779,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.PageBlobInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo>> ResizeAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -6874,7 +6874,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.ResizeAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.ResizeAsync Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo>.</returns>
+            /// <returns>The PageBlob.ResizeAsync Azure.Response{Azure.Storage.Blobs.Models.PageBlobInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo> ResizeAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -6937,7 +6937,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.PageBlobInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo>> UpdateSequenceNumberAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -7037,7 +7037,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.UpdateSequenceNumberAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.UpdateSequenceNumberAsync Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo>.</returns>
+            /// <returns>The PageBlob.UpdateSequenceNumberAsync Azure.Response{Azure.Storage.Blobs.Models.PageBlobInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.PageBlobInfo> UpdateSequenceNumberAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -7098,7 +7098,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobCopyInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>> CopyIncrementalAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -7192,7 +7192,7 @@ namespace Azure.Storage.Blobs
             /// Create the PageBlob.CopyIncrementalAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The PageBlob.CopyIncrementalAsync Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo>.</returns>
+            /// <returns>The PageBlob.CopyIncrementalAsync Azure.Response{Azure.Storage.Blobs.Models.BlobCopyInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobCopyInfo> CopyIncrementalAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -7273,7 +7273,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobContentInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> CreateAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -7418,7 +7418,7 @@ namespace Azure.Storage.Blobs
             /// Create the AppendBlob.CreateAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The AppendBlob.CreateAsync Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>.</returns>
+            /// <returns>The AppendBlob.CreateAsync Azure.Response{Azure.Storage.Blobs.Models.BlobContentInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo> CreateAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -7488,7 +7488,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobAppendInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo>> AppendBlockAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -7609,7 +7609,7 @@ namespace Azure.Storage.Blobs
             /// Create the AppendBlob.AppendBlockAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The AppendBlob.AppendBlockAsync Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo>.</returns>
+            /// <returns>The AppendBlob.AppendBlockAsync Azure.Response{Azure.Storage.Blobs.Models.BlobAppendInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo> AppendBlockAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -7692,7 +7692,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobAppendInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo>> AppendBlockFromUriAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -7836,7 +7836,7 @@ namespace Azure.Storage.Blobs
             /// Create the AppendBlob.AppendBlockFromUriAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The AppendBlob.AppendBlockFromUriAsync Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo>.</returns>
+            /// <returns>The AppendBlob.AppendBlockFromUriAsync Azure.Response{Azure.Storage.Blobs.Models.BlobAppendInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobAppendInfo> AppendBlockFromUriAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -7940,7 +7940,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobContentInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> UploadAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -8096,7 +8096,7 @@ namespace Azure.Storage.Blobs
             /// Create the BlockBlob.UploadAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The BlockBlob.UploadAsync Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>.</returns>
+            /// <returns>The BlockBlob.UploadAsync Azure.Response{Azure.Storage.Blobs.Models.BlobContentInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo> UploadAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -8161,7 +8161,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlockInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlockInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlockInfo>> StageBlockAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -8261,7 +8261,7 @@ namespace Azure.Storage.Blobs
             /// Create the BlockBlob.StageBlockAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The BlockBlob.StageBlockAsync Azure.Response<Azure.Storage.Blobs.Models.BlockInfo>.</returns>
+            /// <returns>The BlockBlob.StageBlockAsync Azure.Response{Azure.Storage.Blobs.Models.BlockInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlockInfo> StageBlockAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -8319,7 +8319,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlockInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlockInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlockInfo>> StageBlockFromUriAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -8442,7 +8442,7 @@ namespace Azure.Storage.Blobs
             /// Create the BlockBlob.StageBlockFromUriAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The BlockBlob.StageBlockFromUriAsync Azure.Response<Azure.Storage.Blobs.Models.BlockInfo>.</returns>
+            /// <returns>The BlockBlob.StageBlockFromUriAsync Azure.Response{Azure.Storage.Blobs.Models.BlockInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlockInfo> StageBlockFromUriAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -8516,7 +8516,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.BlobContentInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>> CommitBlockListAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -8670,7 +8670,7 @@ namespace Azure.Storage.Blobs
             /// Create the BlockBlob.CommitBlockListAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The BlockBlob.CommitBlockListAsync Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo>.</returns>
+            /// <returns>The BlockBlob.CommitBlockListAsync Azure.Response{Azure.Storage.Blobs.Models.BlobContentInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.BlobContentInfo> CommitBlockListAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -8733,7 +8733,7 @@ namespace Azure.Storage.Blobs
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Blobs.Models.GetBlockListOperation></returns>
+            /// <returns>Azure.Response{Azure.Storage.Blobs.Models.GetBlockListOperation}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Blobs.Models.GetBlockListOperation>> GetBlockListAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -8813,7 +8813,7 @@ namespace Azure.Storage.Blobs
             /// Create the BlockBlob.GetBlockListAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The BlockBlob.GetBlockListAsync Azure.Response<Azure.Storage.Blobs.Models.GetBlockListOperation>.</returns>
+            /// <returns>The BlockBlob.GetBlockListAsync Azure.Response{Azure.Storage.Blobs.Models.GetBlockListOperation}.</returns>
             internal static Azure.Response<Azure.Storage.Blobs.Models.GetBlockListOperation> GetBlockListAsync_CreateResponse(
                 Azure.Response response)
             {

--- a/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
@@ -136,7 +136,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 60 seconds. A lease duration cannot be changed using
         /// <see cref="RenewAsync"/> or <see cref="ChangeAsync"/>.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on acquiring a lease.
         /// </param>
@@ -181,7 +181,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 60 seconds. A lease duration cannot be changed using
         /// <see cref="RenewAsync"/> or <see cref="ChangeAsync"/>.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on acquiring a lease.
         /// </param>
@@ -226,7 +226,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 60 seconds. A lease duration cannot be changed using
         /// <see cref="RenewAsync"/> or <see cref="ChangeAsync"/>.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on acquiring a lease.
         /// </param>
@@ -312,7 +312,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="Renew"/> operation renews the blob or
         /// container's previously-acquired lease.
         /// 
-        /// The lease can be renewed if the <paramref name="leaseId"/> 
+        /// The lease can be renewed if the leaseId
         /// matches that associated with the blob or container.  Note that the]
         /// lease may be renewed even if it has expired as long as the blob or 
         /// container has not been leased again since the expiration of that
@@ -320,7 +320,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on renewing a lease.
         /// </param>
@@ -348,7 +348,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="RenewAsync"/> operation renews the blob or
         /// container's previously-acquired lease.
         /// 
-        /// The lease can be renewed if the <paramref name="leaseId"/> 
+        /// The lease can be renewed if the leaseId
         /// matches that associated with the blob or container.  Note that the]
         /// lease may be renewed even if it has expired as long as the blob or 
         /// container has not been leased again since the expiration of that
@@ -356,7 +356,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on renewing a lease.
         /// </param>
@@ -384,7 +384,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// The <see cref="RenewAsync"/> operation renews the blob or
         /// container's previously-acquired lease.
         /// 
-        /// The lease can be renewed if the <paramref name="leaseId"/> 
+        /// The lease can be renewed if the leaseId
         /// matches that associated with the blob or container.  Note that the]
         /// lease may be renewed even if it has expired as long as the blob or 
         /// container has not been leased again since the expiration of that
@@ -392,7 +392,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on renewing a lease.
         /// </param>
@@ -481,7 +481,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on releasing a lease.
         /// </param>
@@ -517,7 +517,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on releasing a lease.
         /// </param>
@@ -553,7 +553,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/lease-container" />.
         /// </summary>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on releasing a lease.
         /// </param>
@@ -653,7 +653,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="StorageRequestFailedException"/> will be thrown if the
         /// proposed lease ID is not in the correct format.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on changing a lease.
         /// </param>
@@ -691,7 +691,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="StorageRequestFailedException"/> will be thrown if the
         /// proposed lease ID is not in the correct format.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on changing a lease.
         /// </param>
@@ -729,7 +729,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <see cref="StorageRequestFailedException"/> will be thrown if the
         /// proposed lease ID is not in the correct format.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on changing a lease.
         /// </param>
@@ -839,7 +839,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// is not provided, a fixed-duration lease breaks after the remaining
         /// lease period elapses, and an infinite lease breaks immediately.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on breaking a lease.
         /// </param>
@@ -895,7 +895,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// is not provided, a fixed-duration lease breaks after the remaining
         /// lease period elapses, and an infinite lease breaks immediately.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on breaking a lease.
         /// </param>
@@ -951,7 +951,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// is not provided, a fixed-duration lease breaks after the remaining
         /// lease period elapses, and an infinite lease breaks immediately.
         /// </param>
-        /// <param name="accessConditions">
+        /// <param name="httpAccessConditions">
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on breaking a lease.
         /// </param>

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/AccessConditions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/AccessConditions.cs
@@ -4,9 +4,6 @@
 
 using System;
 
-/// <summary>
-/// <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations" />
-/// </summary>
 namespace Azure.Storage.Blobs.Models
 {
     /// <summary>
@@ -74,7 +71,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two HttpAccessConditions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(HttpAccessConditions other)
             => this.IfMatch == other.IfMatch
@@ -145,7 +142,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two ContainerAccessConditions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(ContainerAccessConditions other)
             => this.HttpAccessConditions == other.HttpAccessConditions
@@ -213,7 +210,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two BlobAccessConditions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(BlobAccessConditions other)
             => this.HttpAccessConditions == other.HttpAccessConditions
@@ -276,7 +273,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two LeaseAccessConditions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(LeaseAccessConditions other)
             => this.LeaseId == other.LeaseId;
@@ -358,7 +355,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two AppendBlobAccessConditions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(AppendBlobAccessConditions other)
             => this.HttpAccessConditions == other.HttpAccessConditions
@@ -451,7 +448,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two PageBlobAccessConditions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(PageBlobAccessConditions other)
             => this.HttpAccessConditions == other.HttpAccessConditions

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlobHttpHeaders.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlobHttpHeaders.cs
@@ -99,7 +99,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two BlobHttpHeaders instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         public bool Equals(BlobHttpHeaders other)
             => this.CacheControl == other.CacheControl
             && this.ContentDisposition == other.ContentDisposition

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/CopyFromUriOperation.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/CopyFromUriOperation.cs
@@ -149,6 +149,7 @@ namespace Azure.Storage.Blobs.Models
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
+        /// <param name="async" />
         /// <returns>The <see cref="Response"/> with the status update.</returns>
         private async Task<Response> UpdateStatusAsync(bool async, CancellationToken cancellationToken)
         {

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobs.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobs.cs
@@ -118,7 +118,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two GetBlobsOptions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(GetBlobsOptions other) =>
             this.IncludeCopyOperationStatus == other.IncludeCopyOperationStatus &&

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/GetContainers.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/GetContainers.cs
@@ -76,7 +76,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Check if two GetContainersOptions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(GetContainersOptions other) =>
             this.IncludeMetadata == other.IncludeMetadata &&

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -184,7 +184,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// Initializes a new instance of the <see cref="PageBlobClient"/>
         /// class with an identical <see cref="Uri"/> source but the specified
-        /// <paramref name="snapshot"/> timestamp.
+        /// snapshot timestamp.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/creating-a-snapshot-of-a-blob" />.
         /// </summary>
@@ -199,7 +199,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// Creates a new instance of the <see cref="PageBlobClient"/> class
         /// with an identical <see cref="Uri"/> source but the specified
-        /// <paramref name="snapshot"/> timestamp.
+        /// snapshot timestamp.
         /// </summary>
         /// <param name="snapshot">The snapshot identifier.</param>
         /// <returns>A new <see cref="PageBlobClient"/> instance.</returns>
@@ -209,12 +209,12 @@ namespace Azure.Storage.Blobs.Specialized
             return new PageBlobClient(builder.ToUri(), this.Pipeline);
         }
 
-        /// <summary>
-        /// Creates a new PageBlobClient object identical to the source but with the specified version ID.
-        /// Pass "" to remove the version ID returning a URL to the base blob.
-        /// </summary>
-        /// <param name="versionId">version ID</param>
-        /// <returns></returns>
+        ///// <summary>
+        ///// Creates a new PageBlobClient object identical to the source but with the specified version ID.
+        ///// Pass "" to remove the version ID returning a URL to the base blob.
+        ///// </summary>
+        ///// <param name="versionId">version ID</param>
+        ///// <returns></returns>
         //public new PageBlobClient WithVersionId(string versionId) => (PageBlobUri)this.WithVersionIdImpl(versionId);
 
         //protected sealed override BlobBaseClient WithVersionIdImpl(string versionId)
@@ -1019,7 +1019,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// Specifies that the response will contain only pages that were
         /// changed between target blob and previous snapshot.  Changed pages
         /// include both updated and cleared pages. The target blob may be a
-        /// <paramref name="snapshot"/>, as long as the snapshot specified by
+        /// snapshot, as long as the snapshot specified by
         /// <paramref name="previousSnapshot"/> is the older of the two.
         /// </param>
         /// <param name="accessConditions">
@@ -1074,7 +1074,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// Specifies that the response will contain only pages that were
         /// changed between target blob and previous snapshot.  Changed pages
         /// include both updated and cleared pages. The target blob may be a
-        /// <paramref name="snapshot"/>, as long as the snapshot specified by
+        /// snapshot, as long as the snapshot specified by
         /// <paramref name="previousSnapshot"/> is the older of the two.
         /// </param>
         /// <param name="accessConditions">
@@ -1129,7 +1129,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// Specifies that the response will contain only pages that were
         /// changed between target blob and previous snapshot.  Changed pages
         /// include both updated and cleared pages. The target blob may be a
-        /// <paramref name="snapshot"/>, as long as the snapshot specified by
+        /// snapshot, as long as the snapshot specified by
         /// <paramref name="previousSnapshot"/> is the older of the two.
         /// </param>
         /// <param name="accessConditions">
@@ -1359,6 +1359,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// for this page blob.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// </summary>
         /// <param name="action">
         /// Specifies how the service should modify the blob's sequence number.
         /// <see cref="SequenceNumberAction.Max"/> sets the sequence number to
@@ -1415,6 +1416,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// for this page blob.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// </summary>
         /// <param name="action">
         /// Specifies how the service should modify the blob's sequence number.
         /// <see cref="SequenceNumberAction.Max"/> sets the sequence number to
@@ -1471,6 +1473,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// for this page blob.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
+        /// </summary>
         /// <param name="action">
         /// Specifies how the service should modify the blob's sequence number.
         /// <see cref="SequenceNumberAction.Max"/> sets the sequence number to
@@ -1557,8 +1560,8 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The <see cref="StartCopyIncremental"/> operation starts
-        /// copying a <paramref name="snapshot"/> of the 
-        /// <paramref name="sourceUri"/> page blob to this page blob.  The
+        /// copying a snapshot of the 
+        /// sourceUri page blob to this page blob.  The
         /// snapshot is copied such that only the differential changes between
         /// the previously copied snapshot are transferred to the destination.
         /// The copied snapshots are complete copies of the original snapshot 
@@ -1577,7 +1580,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="snapshot">
         /// The name of a snapshot to start copying from
-        /// <paramref name="sourceUri"/>.
+        /// sourceUri.
         /// </param>
         /// <param name="accessConditions">
         /// Optional <see cref="PageBlobAccessConditions"/> to add
@@ -1662,8 +1665,8 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The <see cref="StartCopyIncrementalAsync"/> operation starts
-        /// copying a <paramref name="snapshot"/> of the 
-        /// <paramref name="sourceUri"/> page blob to this page blob.  The
+        /// copying a snapshot of the 
+        /// sourceUri page blob to this page blob.  The
         /// snapshot is copied such that only the differential changes between
         /// the previously copied snapshot are transferred to the destination.
         /// The copied snapshots are complete copies of the original snapshot 
@@ -1682,7 +1685,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="snapshot">
         /// The name of a snapshot to start copying from
-        /// <paramref name="sourceUri"/>.
+        /// sourceUri.
         /// </param>
         /// <param name="accessConditions">
         /// Optional <see cref="PageBlobAccessConditions"/> to add
@@ -1767,8 +1770,8 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The <see cref="StartCopyIncremental"/> operation starts
-        /// copying a <paramref name="snapshot"/> of the 
-        /// <paramref name="sourceUri"/> page blob to this page blob.  The
+        /// copying a snapshot of the 
+        /// sourceUri page blob to this page blob.  The
         /// snapshot is copied such that only the differential changes between
         /// the previously copied snapshot are transferred to the destination.
         /// The copied snapshots are complete copies of the original snapshot 
@@ -1806,8 +1809,8 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The <see cref="StartCopyIncrementalAsync"/> operation starts
-        /// copying a <paramref name="snapshot"/> of the 
-        /// <paramref name="sourceUri"/> page blob to this page blob.  The
+        /// copying a snapshot of the 
+        /// sourceUri page blob to this page blob.  The
         /// snapshot is copied such that only the differential changes between
         /// the previously copied snapshot are transferred to the destination.
         /// The copied snapshots are complete copies of the original snapshot 
@@ -1845,8 +1848,8 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The <see cref="StartCopyIncrementalAsync"/> operation starts
-        /// copying a <paramref name="snapshot"/> of the 
-        /// <paramref name="sourceUri"/> page blob to this page blob.  The
+        /// copying a snapshot of the 
+        /// sourceUri page blob to this page blob.  The
         /// snapshot is copied such that only the differential changes between
         /// the previously copied snapshot are transferred to the destination.
         /// The copied snapshots are complete copies of the original snapshot 
@@ -1865,7 +1868,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="snapshot">
         /// The name of a snapshot to start copying from
-        /// <paramref name="sourceUri"/>.
+        /// sourceUri.
         /// </param>
         /// <param name="accessConditions">
         /// Optional <see cref="PageBlobAccessConditions"/> to add
@@ -1979,7 +1982,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="Task{"/> operation writes a range
         /// of pages to a page blob where the contents are read from
-        /// <paramref name="sourceUri"/>.
+        /// sourceUri.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url" />.
         /// </summary>
@@ -1992,7 +1995,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="sourceRange">
         /// Optionally only upload the bytes of the blob in the
-        /// <paramref name="sourceUri"/> in the specified range.
+        /// sourceUri in the specified range.
         /// </param>
         /// <param name="range">
         /// Specifies the range to be written as a page. Both the start and
@@ -2004,10 +2007,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="sourceContentHash">
         /// Optional MD5 hash of the page block content from the
-        /// <paramref name="sourceUri"/>.  This hash is used to verify the
+        /// sourceUri.  This hash is used to verify the
         /// integrity of the block during transport of the data from the Uri.
         /// When this hash is specified, the storage service compares the hash
-        /// of the content that has arrived from the <paramref name="sourceUri"/>
+        /// of the content that has arrived from the sourceUri
         /// with this value.  Note that this md5 hash is not stored with the
         /// blob.  If the two hashes do not match, the operation will fail
         /// with a <see cref="StorageRequestFailedException"/>.
@@ -2054,7 +2057,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="UploadPagesFromUriAsync"/> operation writes a range
         /// of pages to a page blob where the contents are read from
-        /// <paramref name="sourceUri"/>.
+        /// sourceUri.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url" />.
         /// </summary>
@@ -2067,7 +2070,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="sourceRange">
         /// Optionally only upload the bytes of the blob in the
-        /// <paramref name="sourceUri"/> in the specified range.
+        /// sourceUri in the specified range.
         /// </param>
         /// <param name="range">
         /// Specifies the range to be written as a page. Both the start and
@@ -2079,10 +2082,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="sourceContentHash">
         /// Optional MD5 hash of the page block content from the
-        /// <paramref name="sourceUri"/>.  This hash is used to verify the
+        /// sourceUri.  This hash is used to verify the
         /// integrity of the block during transport of the data from the Uri.
         /// When this hash is specified, the storage service compares the hash
-        /// of the content that has arrived from the <paramref name="sourceUri"/>
+        /// of the content that has arrived from the sourceUri
         /// with this value.  Note that this md5 hash is not stored with the
         /// blob.  If the two hashes do not match, the operation will fail
         /// with a <see cref="StorageRequestFailedException"/>.
@@ -2129,7 +2132,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// <summary>
         /// The <see cref="UploadPagesFromUriAsync"/> operation writes a range
         /// of pages to a page blob where the contents are read from
-        /// <paramref name="sourceUri"/>.
+        /// sourceUri.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url" />.
         /// </summary>
@@ -2142,7 +2145,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="sourceRange">
         /// Optionally only upload the bytes of the blob in the
-        /// <paramref name="sourceUri"/> in the specified range.
+        /// sourceUri in the specified range.
         /// </param>
         /// <param name="range">
         /// Specifies the range to be written as a page. Both the start and
@@ -2154,10 +2157,10 @@ namespace Azure.Storage.Blobs.Specialized
         /// </param>
         /// <param name="sourceContentHash">
         /// Optional MD5 hash of the page block content from the
-        /// <paramref name="sourceUri"/>.  This hash is used to verify the
+        /// sourceUri.  This hash is used to verify the
         /// integrity of the block during transport of the data from the Uri.
         /// When this hash is specified, the storage service compares the hash
-        /// of the content that has arrived from the <paramref name="sourceUri"/>
+        /// of the content that has arrived from the sourceUri
         /// with this value.  Note that this md5 hash is not stored with the
         /// blob.  If the two hashes do not match, the operation will fail
         /// with a <see cref="StorageRequestFailedException"/>.

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobAccountSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobAccountSasPermissions.cs
@@ -128,7 +128,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two BlobAccountSasPermissions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(BlobAccountSasPermissions other) =>
             this.Read == other.Read &&

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -390,7 +390,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two BlobSasBuilder instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(BlobSasBuilder other) =>
             this.BlobName == other.BlobName &&

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasPermissions.cs
@@ -122,7 +122,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two BlobSasPermissions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(BlobSasPermissions other)
             => this.Read == other.Read

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasQueryParameters.cs
@@ -108,10 +108,6 @@ namespace Azure.Storage.Sas
         /// <paramref name="values"/>.
         /// </summary>
         /// <param name="values">URI query parameters</param>
-        /// <param name="includeBlobParameters">
-        /// Optional flag indicating whether to process blob-specific query
-        /// parameters.  The default value is false.
-        /// </param>
         internal BlobSasQueryParameters(UriQueryParamsCollection values)
             : base(values, includeBlobParameters: true)
         {

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/ContainerSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/ContainerSasPermissions.cs
@@ -130,7 +130,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two ContainerSasPermissions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(ContainerSasPermissions other) =>
             this.Read == other.Read &&

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/SnapshotSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/SnapshotSasPermissions.cs
@@ -105,7 +105,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two SnapshotSasPermissions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(SnapshotSasPermissions other) =>
             this.Read == other.Read &&

--- a/sdk/storage/Azure.Storage.Common/src/AsyncCollection.cs
+++ b/sdk/storage/Azure.Storage.Common/src/AsyncCollection.cs
@@ -76,10 +76,6 @@ namespace Azure
         /// Enumerate the values in the collection synchronously.  This may
         /// make mutliple service requests.
         /// </summary>
-        /// <param name="cancellationToken">
-        /// The <see cref="CancellationToken"/> used for requests made while
-        /// enumerating.
-        /// </param>
         /// <returns>A sequence of values.</returns>
         protected abstract IEnumerator<Response<T>> GetEnumerator();
 

--- a/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/AccountSasBuilder.cs
@@ -7,7 +7,7 @@ using System.ComponentModel;
 
 namespace Azure.Storage.Sas
 {
-    // <summary>
+    /// <summary>
     /// <see cref="AccountSasBuilder"/> is used to generate an account level
     /// Shared Access Signature (SAS) for Azure Storage services.
     /// For more information, see

--- a/sdk/storage/Azure.Storage.Common/src/Sas/SasProtocol.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/SasProtocol.cs
@@ -56,8 +56,8 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two <see cref="SasProtocol"/> instances are equal.
         /// </summary>
-        /// <param name="left">The first instance to compare.</param>
-        /// <param name="right">The second instance to compare.</param>
+        /// <param name="o1">The first instance to compare.</param>
+        /// <param name="o2">The second instance to compare.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public static bool operator ==(SasProtocol o1, SasProtocol o2) =>
             o1.Value == o2.Value;
@@ -65,8 +65,8 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two <see cref="SasProtocol"/> instances are not equal.
         /// </summary>
-        /// <param name="left">The first instance to compare.</param>
-        /// <param name="right">The second instance to compare.</param>
+        /// <param name="o1">The first instance to compare.</param>
+        /// <param name="o2">The second instance to compare.</param>
         /// <returns>True if they're not equal, false otherwise.</returns>
         public static bool operator !=(SasProtocol o1, SasProtocol o2) =>
             o1.Value != o2.Value;

--- a/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
+++ b/sdk/storage/Azure.Storage.Common/src/Sas/SasQueryParameters.cs
@@ -15,7 +15,7 @@ namespace Azure.Storage.Sas
     /// A <see cref="SasQueryParameters"/> object represents the components
     /// that make up an Azure Storage Shared Access Signature's query
     /// parameters.  It includes components used by all Azure Storage resources
-    /// (Containers, Blobs, Files, & Queues).  You can construct a new instance
+    /// (Containers, Blobs, Files, and Queues).  You can construct a new instance
     /// using the service specific SAS builder types.
     /// 
     /// For more information, <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/constructing-a-service-sas"/>.

--- a/sdk/storage/Azure.Storage.Common/src/StorageAsyncCollection.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageAsyncCollection.cs
@@ -38,6 +38,7 @@ namespace Azure.Storage
         /// <param name="continuationToken">
         /// Continuation token indicating where to begin enumerating.
         /// </param>
+        /// <param name="pageHintSize"></param>
         /// <param name="isAsync">
         /// Whether to fetch the next page asynchronously.
         /// </param>
@@ -73,7 +74,7 @@ namespace Azure.Storage
         /// A continuation token indicating where to resume paging or null to
         /// begin paging from the beginning.
         /// </param>
-        /// <param name="pageSizeHint">
+        /// <param name="pageHintSize">
         /// The size of <see cref="Page{T}"/>s that should be requested (from
         /// service operations that support it).
         /// </param>
@@ -136,10 +137,6 @@ namespace Azure.Storage
         /// Enumerate the values in the collection synchronously.  This may
         /// make mutliple service requests.
         /// </summary>
-        /// <param name="cancellationToken">
-        /// The <see cref="CancellationToken"/> used for requests made while
-        /// enumerating.
-        /// </param>
         /// <returns>A sequence of values.</returns>
         protected override IEnumerator<Response<T>> GetEnumerator()
         {

--- a/sdk/storage/Azure.Storage.Common/src/StorageClientOptions.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageClientOptions.cs
@@ -40,7 +40,7 @@ namespace Azure.Storage
         /// <summary>
         /// Get an authentication policy to sign Storage requests.
         /// </summary>
-        /// <param name="credentials">Credential to use.</param>
+        /// <param name="credential">Credential to use.</param>
         /// <returns>An authentication policy.</returns>
         public static HttpPipelinePolicy AsPolicy(this StorageSharedKeyCredential credential) =>
             new StorageSharedKeyPipelinePolicy(
@@ -49,7 +49,7 @@ namespace Azure.Storage
         /// <summary>
         /// Get an authentication policy to sign Storage requests.
         /// </summary>
-        /// <param name="credentials">Credential to use.</param>
+        /// <param name="credential">Credential to use.</param>
         /// <returns>An authentication policy.</returns>
         public static HttpPipelinePolicy AsPolicy(this TokenCredential credential) =>
             new BearerTokenAuthenticationPolicy(

--- a/sdk/storage/Azure.Storage.Common/src/StorageConnectionString.cs
+++ b/sdk/storage/Azure.Storage.Common/src/StorageConnectionString.cs
@@ -230,7 +230,7 @@ namespace Azure.Storage.Common
         /// Initializes a new instance of the <see cref="StorageConnectionString"/> class using the specified
         /// credentials and service endpoints.
         /// </summary>
-        /// <param name="storageCredentials">A <see cref="StorageCredentials"/> object.</param>
+        /// <param name="storageCredentials">A StorageCredentials object.</param>
         /// <param name="blobEndpoint">A <see cref="System.Uri"/> specifying the primary Blob service endpoint.</param>
         /// <param name="queueEndpoint">A <see cref="System.Uri"/> specifying the primary Queue service endpoint.</param>
         /// <param name="tableEndpoint">A <see cref="System.Uri"/> specifying the primary Table service endpoint.</param>
@@ -244,11 +244,11 @@ namespace Azure.Storage.Common
         /// Initializes a new instance of the <see cref="StorageConnectionString"/> class using the specified
         /// account credentials and service endpoints.
         /// </summary>
-        /// <param name="storageCredentials">A <see cref="StorageCredentials"/> object.</param>
-        /// <param name="blobStorageUri">A <see cref="StorageUri"/> specifying the Blob service endpoint or endpoints.</param>
-        /// <param name="queueStorageUri">A <see cref="StorageUri"/> specifying the Queue service endpoint or endpoints.</param>
-        /// <param name="tableStorageUri">A <see cref="StorageUri"/> specifying the Table service endpoint or endpoints.</param>
-        /// <param name="fileStorageUri">A <see cref="StorageUri"/> specifying the File service endpoint or endpoints.</param>
+        /// <param name="storageCredentials">A StorageCredentials object.</param>
+        /// <param name="blobStorageUri">A <see cref="System.Uri"/> specifying the Blob service endpoint or endpoints.</param>
+        /// <param name="queueStorageUri">A <see cref="System.Uri"/> specifying the Queue service endpoint or endpoints.</param>
+        /// <param name="tableStorageUri">A <see cref="System.Uri"/> specifying the Table service endpoint or endpoints.</param>
+        /// <param name="fileStorageUri">A <see cref="System.Uri"/> specifying the File service endpoint or endpoints.</param>
         public StorageConnectionString(object storageCredentials, (Uri, Uri) blobStorageUri, (Uri, Uri) queueStorageUri, (Uri, Uri) tableStorageUri, (Uri, Uri) fileStorageUri)
         {
             this.Credentials = storageCredentials;
@@ -263,7 +263,7 @@ namespace Azure.Storage.Common
         /// Initializes a new instance of the <see cref="StorageConnectionString"/> class using the specified
         /// credentials, and specifies whether to use HTTP or HTTPS to connect to the storage services. 
         /// </summary>
-        /// <param name="storageCredentials">A <see cref="StorageCredentials"/> object.</param>
+        /// <param name="storageCredentials">A StorageCredentials object.</param>
         /// <param name="useHttps"><c>true</c> to use HTTPS to connect to storage service endpoints; otherwise, <c>false</c>.</param>
         /// <remarks>Using HTTPS to connect to the storage services is recommended.</remarks>
         public StorageConnectionString(object storageCredentials, bool useHttps)
@@ -275,7 +275,7 @@ namespace Azure.Storage.Common
         /// Initializes a new instance of the <see cref="StorageConnectionString"/> class using the specified
         /// credentials and endpoint suffix, and specifies whether to use HTTP or HTTPS to connect to the storage services.
         /// </summary>
-        /// <param name="storageCredentials">A <see cref="StorageCredentials"/> object.</param>
+        /// <param name="storageCredentials">A StorageCredentials object.</param>
         /// <param name="endpointSuffix">The DNS endpoint suffix for all storage services, e.g. "core.windows.net".</param>
         /// <param name="useHttps"><c>true</c> to use HTTPS to connect to storage service endpoints; otherwise, <c>false</c>.</param>
         /// <remarks>Using HTTPS to connect to the storage services is recommended.</remarks>
@@ -288,7 +288,7 @@ namespace Azure.Storage.Common
         /// Initializes a new instance of the <see cref="StorageConnectionString"/> class using the specified
         /// credentials and endpoint suffix, and specifies whether to use HTTP or HTTPS to connect to the storage services.
         /// </summary>
-        /// <param name="storageCredentials">A <see cref="StorageCredentials"/> object.</param>
+        /// <param name="storageCredentials">A StorageCredentials object.</param>
         /// <param name="accountName">The name of the account.</param>
         /// <param name="endpointSuffix">The DNS endpoint suffix for all storage services, e.g. "core.windows.net".</param>
         /// <param name="useHttps"><c>true</c> to use HTTPS to connect to storage service endpoints; otherwise, <c>false</c>.</param>
@@ -394,31 +394,31 @@ namespace Azure.Storage.Common
         /// <summary>
         /// Gets the endpoints for the Blob service at the primary and secondary location, as configured for the storage account.
         /// </summary>
-        /// <value>A <see cref="StorageUri"/> containing the Blob service endpoints.</value>
+        /// <value>A <see cref="System.Uri"/> containing the Blob service endpoints.</value>
         public (Uri PrimaryUri, Uri SecondaryUri) BlobStorageUri { get; private set; }
 
         /// <summary>
         /// Gets the endpoints for the Queue service at the primary and secondary location, as configured for the storage account.
         /// </summary>
-        /// <value>A <see cref="StorageUri"/> containing the Queue service endpoints.</value>
+        /// <value>A <see cref="System.Uri"/> containing the Queue service endpoints.</value>
         public (Uri PrimaryUri, Uri SecondaryUri) QueueStorageUri { get; private set; }
 
         /// <summary>
         /// Gets the endpoints for the Table service at the primary and secondary location, as configured for the storage account.
         /// </summary>
-        /// <value>A <see cref="StorageUri"/> containing the Table service endpoints.</value>
+        /// <value>A <see cref="System.Uri"/> containing the Table service endpoints.</value>
         public (Uri PrimaryUri, Uri SecondaryUri) TableStorageUri { get; private set; }
 
         /// <summary>
         /// Gets the endpoints for the File service at the primary and secondary location, as configured for the storage account.
         /// </summary>
-        /// <value>A <see cref="StorageUri"/> containing the File service endpoints.</value>
+        /// <value>A <see cref="System.Uri"/> containing the File service endpoints.</value>
         public (Uri PrimaryUri, Uri SecondaryUri) FileStorageUri { get; private set; }
 
         /// <summary>
         /// Gets the credentials used to create this <see cref="StorageConnectionString"/> object.
         /// </summary>
-        /// <value>A <see cref="StorageCredentials"/> object.</value>
+        /// <value>A StorageCredentials object.</value>
         public object Credentials { get; private set; }
 
         /// <summary>

--- a/sdk/storage/Azure.Storage.Files/src/FileClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClient.cs
@@ -456,9 +456,6 @@ namespace Azure.Storage.Files
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
         /// </param>
-        /// <param name="async">
-        /// Whether to invoke the operation asynchronously.
-        /// </param>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.

--- a/sdk/storage/Azure.Storage.Files/src/FileUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileUriBuilder.cs
@@ -269,7 +269,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Check if two FileUriBuilder instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(FileUriBuilder other)
             => this.Scheme == other.Scheme

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
@@ -195,7 +195,7 @@ namespace Azure.Storage.Files
             /// Create the Service.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetPropertiesAsync Azure.Response<Azure.Storage.Files.Models.FileServiceProperties>.</returns>
+            /// <returns>The Service.GetPropertiesAsync Azure.Response{Azure.Storage.Files.Models.FileServiceProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.FileServiceProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -320,7 +320,7 @@ namespace Azure.Storage.Files
             /// Create the Service.ListSharesSegmentAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.ListSharesSegmentAsync Azure.Response<Azure.Storage.Files.Models.SharesSegment>.</returns>
+            /// <returns>The Service.ListSharesSegmentAsync Azure.Response{Azure.Storage.Files.Models.SharesSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.SharesSegment> ListSharesSegmentAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -371,7 +371,7 @@ namespace Azure.Storage.Files
             /// <param name="quota">Specifies the maximum size of the share, in gigabytes.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.ShareInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.ShareInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.ShareInfo>> CreateAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -446,7 +446,7 @@ namespace Azure.Storage.Files
             /// Create the Share.CreateAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Share.CreateAsync Azure.Response<Azure.Storage.Files.Models.ShareInfo>.</returns>
+            /// <returns>The Share.CreateAsync Azure.Response{Azure.Storage.Files.Models.ShareInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.ShareInfo> CreateAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -498,7 +498,7 @@ namespace Azure.Storage.Files
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.ShareProperties></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.ShareProperties}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.ShareProperties>> GetPropertiesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -563,7 +563,7 @@ namespace Azure.Storage.Files
             /// Create the Share.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Share.GetPropertiesAsync Azure.Response<Azure.Storage.Files.Models.ShareProperties>.</returns>
+            /// <returns>The Share.GetPropertiesAsync Azure.Response{Azure.Storage.Files.Models.ShareProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.ShareProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -730,7 +730,7 @@ namespace Azure.Storage.Files
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.ShareSnapshotInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.ShareSnapshotInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.ShareSnapshotInfo>> CreateSnapshotAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -801,7 +801,7 @@ namespace Azure.Storage.Files
             /// Create the Share.CreateSnapshotAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Share.CreateSnapshotAsync Azure.Response<Azure.Storage.Files.Models.ShareSnapshotInfo>.</returns>
+            /// <returns>The Share.CreateSnapshotAsync Azure.Response{Azure.Storage.Files.Models.ShareSnapshotInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.ShareSnapshotInfo> CreateSnapshotAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -857,7 +857,7 @@ namespace Azure.Storage.Files
             /// <param name="quota">Specifies the maximum size of the share, in gigabytes.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.ShareInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.ShareInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.ShareInfo>> SetQuotaAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -923,7 +923,7 @@ namespace Azure.Storage.Files
             /// Create the Share.SetQuotaAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Share.SetQuotaAsync Azure.Response<Azure.Storage.Files.Models.ShareInfo>.</returns>
+            /// <returns>The Share.SetQuotaAsync Azure.Response{Azure.Storage.Files.Models.ShareInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.ShareInfo> SetQuotaAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -975,7 +975,7 @@ namespace Azure.Storage.Files
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.ShareInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.ShareInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.ShareInfo>> SetMetadataAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1046,7 +1046,7 @@ namespace Azure.Storage.Files
             /// Create the Share.SetMetadataAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Share.SetMetadataAsync Azure.Response<Azure.Storage.Files.Models.ShareInfo>.</returns>
+            /// <returns>The Share.SetMetadataAsync Azure.Response{Azure.Storage.Files.Models.ShareInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.ShareInfo> SetMetadataAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1158,7 +1158,7 @@ namespace Azure.Storage.Files
             /// Create the Share.GetAccessPolicyAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Share.GetAccessPolicyAsync Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Files.Models.SignedIdentifier>>.</returns>
+            /// <returns>The Share.GetAccessPolicyAsync Azure.Response{System.Collections.Generic.IEnumerable{Azure.Storage.Files.Models.SignedIdentifier}}.</returns>
             internal static Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Files.Models.SignedIdentifier>> GetAccessPolicyAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1204,7 +1204,7 @@ namespace Azure.Storage.Files
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.ShareInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.ShareInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.ShareInfo>> SetAccessPolicyAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1283,7 +1283,7 @@ namespace Azure.Storage.Files
             /// Create the Share.SetAccessPolicyAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Share.SetAccessPolicyAsync Azure.Response<Azure.Storage.Files.Models.ShareInfo>.</returns>
+            /// <returns>The Share.SetAccessPolicyAsync Azure.Response{Azure.Storage.Files.Models.ShareInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.ShareInfo> SetAccessPolicyAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1395,7 +1395,7 @@ namespace Azure.Storage.Files
             /// Create the Share.GetStatisticsAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Share.GetStatisticsAsync Azure.Response<Azure.Storage.Files.Models.ShareStatistics>.</returns>
+            /// <returns>The Share.GetStatisticsAsync Azure.Response{Azure.Storage.Files.Models.ShareStatistics}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.ShareStatistics> GetStatisticsAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1445,7 +1445,7 @@ namespace Azure.Storage.Files
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageDirectoryInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageDirectoryInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageDirectoryInfo>> CreateAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1515,7 +1515,7 @@ namespace Azure.Storage.Files
             /// Create the Directory.CreateAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Directory.CreateAsync Azure.Response<Azure.Storage.Files.Models.StorageDirectoryInfo>.</returns>
+            /// <returns>The Directory.CreateAsync Azure.Response{Azure.Storage.Files.Models.StorageDirectoryInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageDirectoryInfo> CreateAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1567,7 +1567,7 @@ namespace Azure.Storage.Files
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageDirectoryProperties></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageDirectoryProperties}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageDirectoryProperties>> GetPropertiesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1632,7 +1632,7 @@ namespace Azure.Storage.Files
             /// Create the Directory.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Directory.GetPropertiesAsync Azure.Response<Azure.Storage.Files.Models.StorageDirectoryProperties>.</returns>
+            /// <returns>The Directory.GetPropertiesAsync Azure.Response{Azure.Storage.Files.Models.StorageDirectoryProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageDirectoryProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1787,7 +1787,7 @@ namespace Azure.Storage.Files
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageDirectoryInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageDirectoryInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageDirectoryInfo>> SetMetadataAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1858,7 +1858,7 @@ namespace Azure.Storage.Files
             /// Create the Directory.SetMetadataAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Directory.SetMetadataAsync Azure.Response<Azure.Storage.Files.Models.StorageDirectoryInfo>.</returns>
+            /// <returns>The Directory.SetMetadataAsync Azure.Response{Azure.Storage.Files.Models.StorageDirectoryInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageDirectoryInfo> SetMetadataAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1994,7 +1994,7 @@ namespace Azure.Storage.Files
             /// Create the Directory.ListFilesAndDirectoriesSegmentAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Directory.ListFilesAndDirectoriesSegmentAsync Azure.Response<Azure.Storage.Files.Models.FilesAndDirectoriesSegment>.</returns>
+            /// <returns>The Directory.ListFilesAndDirectoriesSegmentAsync Azure.Response{Azure.Storage.Files.Models.FilesAndDirectoriesSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.FilesAndDirectoriesSegment> ListFilesAndDirectoriesSegmentAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2123,7 +2123,7 @@ namespace Azure.Storage.Files
             /// Create the Directory.ListHandlesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Directory.ListHandlesAsync Azure.Response<Azure.Storage.Files.Models.StorageHandlesSegment>.</returns>
+            /// <returns>The Directory.ListHandlesAsync Azure.Response{Azure.Storage.Files.Models.StorageHandlesSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageHandlesSegment> ListHandlesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2168,7 +2168,7 @@ namespace Azure.Storage.Files
             /// <param name="recursive">Specifies operation should apply to the directory specified in the URI, its files, its subdirectories and their files.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageClosedHandlesSegment}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment>> ForceCloseHandlesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -2256,7 +2256,7 @@ namespace Azure.Storage.Files
             /// Create the Directory.ForceCloseHandlesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Directory.ForceCloseHandlesAsync Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment>.</returns>
+            /// <returns>The Directory.ForceCloseHandlesAsync Azure.Response{Azure.Storage.Files.Models.StorageClosedHandlesSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment> ForceCloseHandlesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2323,7 +2323,7 @@ namespace Azure.Storage.Files
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageFileInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageFileInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageFileInfo>> CreateAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -2438,7 +2438,7 @@ namespace Azure.Storage.Files
             /// Create the File.CreateAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.CreateAsync Azure.Response<Azure.Storage.Files.Models.StorageFileInfo>.</returns>
+            /// <returns>The File.CreateAsync Azure.Response{Azure.Storage.Files.Models.StorageFileInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageFileInfo> CreateAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2495,7 +2495,7 @@ namespace Azure.Storage.Files
             /// <param name="rangeGetContentHash">When this header is set to true and specified together with the Range header, the service returns the MD5 hash for the range, as long as the range is less than or equal to 4 MB in size.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.FlattenedStorageFileProperties></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.FlattenedStorageFileProperties}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.FlattenedStorageFileProperties>> DownloadAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -2568,7 +2568,7 @@ namespace Azure.Storage.Files
             /// Create the File.DownloadAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.DownloadAsync Azure.Response<Azure.Storage.Files.Models.FlattenedStorageFileProperties>.</returns>
+            /// <returns>The File.DownloadAsync Azure.Response{Azure.Storage.Files.Models.FlattenedStorageFileProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.FlattenedStorageFileProperties> DownloadAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -2822,7 +2822,7 @@ namespace Azure.Storage.Files
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageFileProperties></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageFileProperties}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageFileProperties>> GetPropertiesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -2886,7 +2886,7 @@ namespace Azure.Storage.Files
             /// Create the File.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.GetPropertiesAsync Azure.Response<Azure.Storage.Files.Models.StorageFileProperties>.</returns>
+            /// <returns>The File.GetPropertiesAsync Azure.Response{Azure.Storage.Files.Models.StorageFileProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageFileProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3108,7 +3108,7 @@ namespace Azure.Storage.Files
             /// <param name="fileContentDisposition">Sets the file's Content-Disposition header.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageFileInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageFileInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageFileInfo>> SetPropertiesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -3213,7 +3213,7 @@ namespace Azure.Storage.Files
             /// Create the File.SetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.SetPropertiesAsync Azure.Response<Azure.Storage.Files.Models.StorageFileInfo>.</returns>
+            /// <returns>The File.SetPropertiesAsync Azure.Response{Azure.Storage.Files.Models.StorageFileInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageFileInfo> SetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3269,7 +3269,7 @@ namespace Azure.Storage.Files
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageFileInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageFileInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageFileInfo>> SetMetadataAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -3339,7 +3339,7 @@ namespace Azure.Storage.Files
             /// Create the File.SetMetadataAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.SetMetadataAsync Azure.Response<Azure.Storage.Files.Models.StorageFileInfo>.</returns>
+            /// <returns>The File.SetMetadataAsync Azure.Response{Azure.Storage.Files.Models.StorageFileInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageFileInfo> SetMetadataAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3399,7 +3399,7 @@ namespace Azure.Storage.Files
             /// <param name="contentHash">An MD5 hash of the content. This hash is used to verify the integrity of the data during transport. When the Content-MD5 header is specified, the File service compares the hash of the content that has arrived with the header value that was sent. If the two hashes do not match, the operation will fail with error code 400 (Bad Request).</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageFileUploadInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageFileUploadInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageFileUploadInfo>> UploadRangeAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -3490,7 +3490,7 @@ namespace Azure.Storage.Files
             /// Create the File.UploadRangeAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.UploadRangeAsync Azure.Response<Azure.Storage.Files.Models.StorageFileUploadInfo>.</returns>
+            /// <returns>The File.UploadRangeAsync Azure.Response{Azure.Storage.Files.Models.StorageFileUploadInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageFileUploadInfo> UploadRangeAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3551,7 +3551,7 @@ namespace Azure.Storage.Files
             /// <param name="range">Specifies the range of bytes over which to list ranges, inclusively.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageFileRangeInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageFileRangeInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageFileRangeInfo>> GetRangeListAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -3621,7 +3621,7 @@ namespace Azure.Storage.Files
             /// Create the File.GetRangeListAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.GetRangeListAsync Azure.Response<Azure.Storage.Files.Models.StorageFileRangeInfo>.</returns>
+            /// <returns>The File.GetRangeListAsync Azure.Response{Azure.Storage.Files.Models.StorageFileRangeInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageFileRangeInfo> GetRangeListAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -3684,7 +3684,7 @@ namespace Azure.Storage.Files
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageFileCopyInfo></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageFileCopyInfo}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageFileCopyInfo>> StartCopyAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -3762,7 +3762,7 @@ namespace Azure.Storage.Files
             /// Create the File.StartCopyAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.StartCopyAsync Azure.Response<Azure.Storage.Files.Models.StorageFileCopyInfo>.</returns>
+            /// <returns>The File.StartCopyAsync Azure.Response{Azure.Storage.Files.Models.StorageFileCopyInfo}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageFileCopyInfo> StartCopyAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -4001,7 +4001,7 @@ namespace Azure.Storage.Files
             /// Create the File.ListHandlesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.ListHandlesAsync Azure.Response<Azure.Storage.Files.Models.StorageHandlesSegment>.</returns>
+            /// <returns>The File.ListHandlesAsync Azure.Response{Azure.Storage.Files.Models.StorageHandlesSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageHandlesSegment> ListHandlesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -4045,7 +4045,7 @@ namespace Azure.Storage.Files
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment></returns>
+            /// <returns>Azure.Response{Azure.Storage.Files.Models.StorageClosedHandlesSegment}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment>> ForceCloseHandlesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -4124,7 +4124,7 @@ namespace Azure.Storage.Files
             /// Create the File.ForceCloseHandlesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The File.ForceCloseHandlesAsync Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment>.</returns>
+            /// <returns>The File.ForceCloseHandlesAsync Azure.Response{Azure.Storage.Files.Models.StorageClosedHandlesSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Files.Models.StorageClosedHandlesSegment> ForceCloseHandlesAsync_CreateResponse(
                 Azure.Response response)
             {

--- a/sdk/storage/Azure.Storage.Files/src/Models/FileHttpHeaders.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/FileHttpHeaders.cs
@@ -101,7 +101,7 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// Check if two FileHttpHeaders instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         public bool Equals(FileHttpHeaders other)
             => this.CacheControl == other.CacheControl
             && this.ContentDisposition == other.ContentDisposition

--- a/sdk/storage/Azure.Storage.Files/src/Models/GetFilesAndDirectories.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/GetFilesAndDirectories.cs
@@ -71,7 +71,7 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// Check if two GetFilesAndDirectoriesOptions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(GetFilesAndDirectoriesOptions other) =>
             this.ShareSnapshot == other.ShareSnapshot &&

--- a/sdk/storage/Azure.Storage.Files/src/Models/GetShares.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/GetShares.cs
@@ -90,7 +90,7 @@ namespace Azure.Storage.Files.Models
         /// <summary>
         /// Check if two GetSharesOptions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(GetSharesOptions other) =>
             this.Prefix == other.Prefix &&

--- a/sdk/storage/Azure.Storage.Files/src/Sas/FileAccountSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Sas/FileAccountSasPermissions.cs
@@ -128,7 +128,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two FileAccountSasPermissions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(FileAccountSasPermissions other) =>
             this.Read == other.Read &&

--- a/sdk/storage/Azure.Storage.Files/src/Sas/FileSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Sas/FileSasBuilder.cs
@@ -252,7 +252,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two FileSasBuilder instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(FileSasBuilder other)
             => this.CacheControl == other.CacheControl

--- a/sdk/storage/Azure.Storage.Files/src/Sas/FileSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Sas/FileSasPermissions.cs
@@ -114,7 +114,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two FileSasPermissions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(FileSasPermissions other) =>
             this.Read == other.Read &&

--- a/sdk/storage/Azure.Storage.Files/src/Sas/ShareSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Sas/ShareSasPermissions.cs
@@ -122,7 +122,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two ShareSasPermissions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(ShareSasPermissions other) =>
             this.Read == other.Read &&

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
@@ -22,9 +22,10 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Sets properties for a storage account's Queue service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules
             /// </summary>
+            /// <param name="pipeline"></param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="properties">The StorageService properties.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -61,7 +62,7 @@ namespace Azure.Storage.Queues
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="properties">The StorageService properties.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Service.SetPropertiesAsync Request.</returns>
             internal static Azure.Request SetPropertiesAsync_CreateRequest(
@@ -137,7 +138,7 @@ namespace Azure.Storage.Queues
             /// gets the properties of a storage account's Queue service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -171,7 +172,7 @@ namespace Azure.Storage.Queues
             /// Create the Service.GetPropertiesAsync request.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Service.GetPropertiesAsync Request.</returns>
             internal static Azure.Request GetPropertiesAsync_CreateRequest(
@@ -207,7 +208,7 @@ namespace Azure.Storage.Queues
             /// Create the Service.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetPropertiesAsync Azure.Response<Azure.Storage.Queues.Models.QueueServiceProperties>.</returns>
+            /// <returns>The Service.GetPropertiesAsync Azure.Response{Azure.Storage.Queues.Models.QueueServiceProperties>}.</returns>
             internal static Azure.Response<Azure.Storage.Queues.Models.QueueServiceProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -245,7 +246,7 @@ namespace Azure.Storage.Queues
             /// Retrieves statistics related to replication for the Queue service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -279,7 +280,7 @@ namespace Azure.Storage.Queues
             /// Create the Service.GetStatisticsAsync request.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Service.GetStatisticsAsync Request.</returns>
             internal static Azure.Request GetStatisticsAsync_CreateRequest(
@@ -315,7 +316,7 @@ namespace Azure.Storage.Queues
             /// Create the Service.GetStatisticsAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetStatisticsAsync Azure.Response<Azure.Storage.Queues.Models.QueueServiceStatistics>.</returns>
+            /// <returns>The Service.GetStatisticsAsync Azure.Response{Azure.Storage.Queues.Models.QueueServiceStatistics}>.</returns>
             internal static Azure.Response<Azure.Storage.Queues.Models.QueueServiceStatistics> GetStatisticsAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -357,7 +358,7 @@ namespace Azure.Storage.Queues
             /// <param name="marker">A string value that identifies the portion of the list of queues to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all queues remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.</param>
             /// <param name="maxresults">Specifies the maximum number of queues to return. If the request does not specify maxresults, or specifies a value greater than 5000, the server will return up to 5000 items. Note that if the listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder of the results. For this reason, it is possible that the service will return fewer results than specified by maxresults, or than the default of 5000.</param>
             /// <param name="include">Include this parameter to specify that the queues's metadata be returned as part of the response body.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -403,7 +404,7 @@ namespace Azure.Storage.Queues
             /// <param name="marker">A string value that identifies the portion of the list of queues to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all queues remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.</param>
             /// <param name="maxresults">Specifies the maximum number of queues to return. If the request does not specify maxresults, or specifies a value greater than 5000, the server will return up to 5000 items. Note that if the listing operation crosses a partition boundary, then the service will return a continuation token for retrieving the remainder of the results. For this reason, it is possible that the service will return fewer results than specified by maxresults, or than the default of 5000.</param>
             /// <param name="include">Include this parameter to specify that the queues's metadata be returned as part of the response body.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Service.ListQueuesSegmentAsync Request.</returns>
             internal static Azure.Request ListQueuesSegmentAsync_CreateRequest(
@@ -446,7 +447,7 @@ namespace Azure.Storage.Queues
             /// Create the Service.ListQueuesSegmentAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.ListQueuesSegmentAsync Azure.Response<Azure.Storage.Queues.Models.QueuesSegment>.</returns>
+            /// <returns>The Service.ListQueuesSegmentAsync Azure.Response{Azure.Storage.Queues.Models.QueuesSegment}.</returns>
             internal static Azure.Response<Azure.Storage.Queues.Models.QueuesSegment> ListQueuesSegmentAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -492,7 +493,7 @@ namespace Azure.Storage.Queues
             /// creates a new queue under the given account.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="metadata">Optional. Include this parameter to specify that the queue's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Queue service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.</param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
@@ -529,7 +530,7 @@ namespace Azure.Storage.Queues
             /// Create the Queue.CreateAsync request.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="metadata">Optional. Include this parameter to specify that the queue's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Queue service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.</param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Queue.CreateAsync Request.</returns>
@@ -603,7 +604,7 @@ namespace Azure.Storage.Queues
             /// operation permanently deletes the specified queue
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -637,7 +638,7 @@ namespace Azure.Storage.Queues
             /// Create the Queue.DeleteAsync request.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Queue.DeleteAsync Request.</returns>
             internal static Azure.Request DeleteAsync_CreateRequest(
@@ -699,11 +700,11 @@ namespace Azure.Storage.Queues
             /// Retrieves user-defined metadata and queue properties on the specified queue. Metadata is associated with the queue as name-values pairs.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Queues.Models.QueueProperties></returns>
+            /// <returns>Azure.Response{Azure.Storage.Queues.Models.QueueProperties}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Queues.Models.QueueProperties>> GetPropertiesAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -733,7 +734,7 @@ namespace Azure.Storage.Queues
             /// Create the Queue.GetPropertiesAsync request.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Queue.GetPropertiesAsync Request.</returns>
             internal static Azure.Request GetPropertiesAsync_CreateRequest(
@@ -768,7 +769,7 @@ namespace Azure.Storage.Queues
             /// Create the Queue.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Queue.GetPropertiesAsync Azure.Response<Azure.Storage.Queues.Models.QueueProperties>.</returns>
+            /// <returns>The Queue.GetPropertiesAsync Azure.Response{Azure.Storage.Queues.Models.QueueProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Queues.Models.QueueProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -820,7 +821,7 @@ namespace Azure.Storage.Queues
             /// sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="metadata">Optional. Include this parameter to specify that the queue's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Queue service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.</param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
@@ -857,7 +858,7 @@ namespace Azure.Storage.Queues
             /// Create the Queue.SetMetadataAsync request.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="metadata">Optional. Include this parameter to specify that the queue's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Queue service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.</param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Queue.SetMetadataAsync Request.</returns>
@@ -928,7 +929,7 @@ namespace Azure.Storage.Queues
             /// returns details about any stored access policies specified on the queue that may be used with Shared Access Signatures.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -962,7 +963,7 @@ namespace Azure.Storage.Queues
             /// Create the Queue.GetAccessPolicyAsync request.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Queue.GetAccessPolicyAsync Request.</returns>
             internal static Azure.Request GetAccessPolicyAsync_CreateRequest(
@@ -997,7 +998,7 @@ namespace Azure.Storage.Queues
             /// Create the Queue.GetAccessPolicyAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Queue.GetAccessPolicyAsync Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.SignedIdentifier>>.</returns>
+            /// <returns>The Queue.GetAccessPolicyAsync Azure.Response{System.Collections.Generic.IEnumerable{Azure.Storage.Queues.Models.SignedIdentifier}}.</returns>
             internal static Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.SignedIdentifier>> GetAccessPolicyAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1040,7 +1041,7 @@ namespace Azure.Storage.Queues
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="permissions">the acls for the queue</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -1077,7 +1078,7 @@ namespace Azure.Storage.Queues
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="permissions">the acls for the queue</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Queue.SetAccessPolicyAsync Request.</returns>
             internal static Azure.Request SetAccessPolicyAsync_CreateRequest(
@@ -1165,7 +1166,7 @@ namespace Azure.Storage.Queues
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="numberOfMessages">Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32. If fewer are visible, the visible messages are returned. By default, a single message is retrieved from the queue with this operation.</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -1205,7 +1206,7 @@ namespace Azure.Storage.Queues
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="numberOfMessages">Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32. If fewer are visible, the visible messages are returned. By default, a single message is retrieved from the queue with this operation.</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Messages.DequeueAsync Request.</returns>
             internal static Azure.Request DequeueAsync_CreateRequest(
@@ -1243,7 +1244,7 @@ namespace Azure.Storage.Queues
             /// Create the Messages.DequeueAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Messages.DequeueAsync Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.DequeuedMessage>>.</returns>
+            /// <returns>The Messages.DequeueAsync Azure.Response{System.Collections.Generic.IEnumerable{Azure.Storage.Queues.Models.DequeuedMessage}}.</returns>
             internal static Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.DequeuedMessage>> DequeueAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1285,7 +1286,7 @@ namespace Azure.Storage.Queues
             /// The Clear operation deletes all messages from the specified queue.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -1319,7 +1320,7 @@ namespace Azure.Storage.Queues
             /// Create the Messages.ClearAsync request.
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Messages.ClearAsync Request.</returns>
             internal static Azure.Request ClearAsync_CreateRequest(
@@ -1384,7 +1385,7 @@ namespace Azure.Storage.Queues
             /// <param name="message">A Message object which can be stored in a Queue</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
             /// <param name="messageTimeToLive">Optional. Specifies the time-to-live interval for the message, in seconds. Prior to version 2017-07-29, the maximum time-to-live allowed is 7 days. For version 2017-07-29 or later, the maximum time-to-live can be any positive number, as well as -1 indicating that the message does not expire. If this parameter is omitted, the default time-to-live is 7 days.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -1427,7 +1428,7 @@ namespace Azure.Storage.Queues
             /// <param name="message">A Message object which can be stored in a Queue</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
             /// <param name="messageTimeToLive">Optional. Specifies the time-to-live interval for the message, in seconds. Prior to version 2017-07-29, the maximum time-to-live allowed is 7 days. For version 2017-07-29 or later, the maximum time-to-live can be any positive number, as well as -1 indicating that the message does not expire. If this parameter is omitted, the default time-to-live is 7 days.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Messages.EnqueueAsync Request.</returns>
             internal static Azure.Request EnqueueAsync_CreateRequest(
@@ -1477,7 +1478,7 @@ namespace Azure.Storage.Queues
             /// Create the Messages.EnqueueAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Messages.EnqueueAsync Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.EnqueuedMessage>>.</returns>
+            /// <returns>The Messages.EnqueueAsync Azure.Response{System.Collections.Generic.IEnumerable{Azure.Storage.Queues.Models.EnqueuedMessage}}.</returns>
             internal static Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.EnqueuedMessage>> EnqueueAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1520,7 +1521,7 @@ namespace Azure.Storage.Queues
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="numberOfMessages">Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32. If fewer are visible, the visible messages are returned. By default, a single message is retrieved from the queue with this operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -1557,7 +1558,7 @@ namespace Azure.Storage.Queues
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="numberOfMessages">Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32. If fewer are visible, the visible messages are returned. By default, a single message is retrieved from the queue with this operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The Messages.PeekAsync Request.</returns>
             internal static Azure.Request PeekAsync_CreateRequest(
@@ -1594,7 +1595,7 @@ namespace Azure.Storage.Queues
             /// Create the Messages.PeekAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Messages.PeekAsync Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.PeekedMessage>>.</returns>
+            /// <returns>The Messages.PeekAsync Azure.Response{System.Collections.Generic.IEnumerable{Azure.Storage.Queues.Models.PeekedMessage}}.</returns>
             internal static Azure.Response<System.Collections.Generic.IEnumerable<Azure.Storage.Queues.Models.PeekedMessage>> PeekAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1647,11 +1648,11 @@ namespace Azure.Storage.Queues
             /// <param name="message">A Message object which can be stored in a Queue</param>
             /// <param name="popReceipt">Required. Specifies the valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
-            /// <returns>Azure.Response<Azure.Storage.Queues.Models.UpdatedMessage></returns>
+            /// <returns>Azure.Response{Azure.Storage.Queues.Models.UpdatedMessage}</returns>
             public static async System.Threading.Tasks.Task<Azure.Response<Azure.Storage.Queues.Models.UpdatedMessage>> UpdateAsync(
                 Azure.Core.Pipeline.HttpPipeline pipeline,
                 System.Uri resourceUri,
@@ -1690,7 +1691,7 @@ namespace Azure.Storage.Queues
             /// <param name="message">A Message object which can be stored in a Queue</param>
             /// <param name="popReceipt">Required. Specifies the valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The MessageId.UpdateAsync Request.</returns>
             internal static Azure.Request UpdateAsync_CreateRequest(
@@ -1744,7 +1745,7 @@ namespace Azure.Storage.Queues
             /// Create the MessageId.UpdateAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The MessageId.UpdateAsync Azure.Response<Azure.Storage.Queues.Models.UpdatedMessage>.</returns>
+            /// <returns>The MessageId.UpdateAsync Azure.Response{Azure.Storage.Queues.Models.UpdatedMessage}.</returns>
             internal static Azure.Response<Azure.Storage.Queues.Models.UpdatedMessage> UpdateAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -1793,7 +1794,7 @@ namespace Azure.Storage.Queues
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="popReceipt">Required. Specifies the valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -1830,7 +1831,7 @@ namespace Azure.Storage.Queues
             /// </summary>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="popReceipt">Required. Specifies the valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.</param>
-            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a></param>
+            /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
             /// <returns>The MessageId.DeleteAsync Request.</returns>
             internal static Azure.Request DeleteAsync_CreateRequest(

--- a/sdk/storage/Azure.Storage.Queues/src/Models/GetQueues.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Models/GetQueues.cs
@@ -77,7 +77,7 @@ namespace Azure.Storage.Queues.Models
         /// <summary>
         /// Check if two <see cref="GetQueuesOptions"/> instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(GetQueuesOptions other) =>
             this.IncludeMetadata == other.IncludeMetadata &&

--- a/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
@@ -212,7 +212,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Check if two QueueUriBuilder instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(QueueUriBuilder other)
             => this.Scheme == other.Scheme
@@ -251,8 +251,6 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Check if two QueueUriBuilder instances are not equal.
         /// </summary>
-        /// <param name="left"></param>
-        /// <param name="right"></param>
         /// <param name="left">The first instance to compare.</param>
         /// <param name="right">The second instance to compare.</param>
         /// <returns>True if they're not equal, false otherwise.</returns>

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueAccountSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueAccountSasPermissions.cs
@@ -13,6 +13,7 @@ namespace Azure.Storage.Sas
     /// permissions string for a queue account's access policy.  Use
     /// <see cref="ToString"/> to generate a permissions string you can provide
     /// to <see cref="QueueSasBuilder.Permissions"/>.
+    /// </summary>
     public struct QueueAccountSasPermissions : IEquatable<QueueAccountSasPermissions>
     {
         /// <summary>
@@ -122,7 +123,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two QueueAccountSasPermissions instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(QueueAccountSasPermissions other) =>
             other.Add == this.Add &&

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasBuilder.cs
@@ -197,7 +197,7 @@ namespace Azure.Storage.Sas
         /// <summary>
         /// Check if two QueueSasBuilder instances are equal.
         /// </summary>
-        /// <param name="obj">The instance to compare to.</param>
+        /// <param name="other">The instance to compare to.</param>
         /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(QueueSasBuilder other) =>
             this.ExpiryTime == other.ExpiryTime &&

--- a/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasPermissions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Sas/QueueSasPermissions.cs
@@ -12,6 +12,7 @@ namespace Azure.Storage.Sas
     /// <see cref="QueueSasPermissions"/> supports reading and writing
     /// permissions string for a queue's access policy.  Use <see cref="ToString"/>
     /// to generate a permissions string you can provide to
+    /// </summary>
     /// <see cref="QueueSasBuilder.Permissions"/>.
     public struct QueueSasPermissions : IEquatable<QueueSasPermissions>
     {

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -18,6 +18,9 @@
      -->
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
 
+    <!-- Disable some xml doc comment warnings until we can fix them -->
+    <NoWarn>$(NoWarn);1591;1573;1574;1584;1658;0419</NoWarn>
+
     <!--
     Storage used to point to its main documentation page, but the rest of the
     Azure .NET SDK projects point to the github repo instead.  I'm leaving this

--- a/sdk/template/Azure.Template/src/Class1.cs
+++ b/sdk/template/Azure.Template/src/Class1.cs
@@ -2,6 +2,7 @@
 
 namespace Azure.Data
 {
+    /// <summary> test </summary>
     public class Class1
     {
     }


### PR DESCRIPTION
As part of enabling this a number of xml doc comments needed to be fixed or
warnings temporarily disabled to get a clean build. Follow-up issues will
be filed for each class of warnings that needed to be disabled.

PTAL @AlexGhiondea @chidozieononiwu @tg-msft @pakrym 