### PR TITLE
[Event Hubs Client] Track Two: Second Preview (Exceptions)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -12,7 +12,7 @@ The Azure Event Hubs client library allows for publishing and consuming of Azure
 
 - Receive events from one or more publishers, transform them to better meet the needs of your ecosystem, then publish the transformed events to a new stream for consumers to observe.
 
-[Source code](https://github.com/Azure/azure-sdk-for-net/tree/master/sdk/eventhub/Azure.Messaging.EventHubs) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs/) | [API reference documentation](https://azure.github.io/azure-sdk-for-net/api/EventHubs/Azure.Messaging.EventHubs.html) | [Product documentation](https://docs.microsoft.com/en-us/azure/event-hubs/)
+[Source code](.) | [Package (NuGet)](https://www.nuget.org/packages/Azure.Messaging.EventHubs/) | [API reference documentation](https://azure.github.io/azure-sdk-for-net/api/EventHubs/Azure.Messaging.EventHubs.html) | [Product documentation](https://docs.microsoft.com/en-us/azure/event-hubs/)
 
 ## Getting started
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-second-preview.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-second-preview.md
@@ -4,7 +4,7 @@ Azure Event Hubs is a highly scalable publish-subscribe service that can ingest 
 
 ## Design Overview
 
-This design is focused on the second preview of the track two Event Hubs client library, and limits the scope of discussion to those areas with active development for the second preview. For wider context and more general discussion of the design goals for the track two Event Hubs client, please see the [.NET Event Hubs Client: Track Two Proposal (First  Preview)](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-first-preview.md). 
+This design is focused on the second preview of the track two Event Hubs client library, and limits the scope of discussion to those areas with active development for the second preview. For wider context and more general discussion of the design goals for the track two Event Hubs client, please see the [.NET Event Hubs Client: Track Two Proposal (First Preview)](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-first-preview.md). 
 
 ## Goals for the Second Preview
 
@@ -12,7 +12,7 @@ This design is focused on the second preview of the track two Event Hubs client 
 
 - Continue to align the public API surface area to the guidance outlined in the [Azure SDK Design Guidelines for .NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html).
 
-- Design an exception hierarchy that follows the overall pattern used by the track one client, limiting changes and allowing the published  [exception guidance](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions) to remain as relevant as possible.
+- Design an exception hierarchy that follows the overall pattern used by the track one client, limiting changes and allowing the published [exception guidance](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions) to remain as relevant as possible.
 
 - Streamline the design around timeouts and retries, making the common scenarios easier while allowing developers with advanced scenarios to customize.
 
@@ -343,7 +343,7 @@ The main client library package, containing the core components for interacting 
 
 The top-level container for the types in the client library intended to be used by Event Hubs client library users. It is intended that types most frequently used by users for basic operations belong to this namespace to ensure ease of discovery.
 
-##### _Example Types:_
+##### _Example types:_
  
 - `RetryOptions`
 - `EventHubsRetryPolicy`
@@ -354,7 +354,7 @@ The top-level container for the types in the client library intended to be used 
 
 The location for exceptions and error-related information and operations. Many of these types are surfaced as information for consumers in response to conditions encountered during a basic operation. It is not intended that consumers need to create these types directly.
 
-##### _Example Types:_
+##### _Example types:_
  
 - `OperationCancelledException`
 - `TimeoutException`
@@ -365,7 +365,7 @@ The location for exceptions and error-related information and operations. Many o
 
 The location for internal types used by the Event Hubs library to facilitate operations; these constructs are not intended to be consumed externally. 
 
-##### _Example Types:_
+##### _Example types:_
  
 - `DefaultEventHubsRetryPolicy`
 - `SystemMessagePropertyName`
@@ -374,7 +374,7 @@ The location for internal types used by the Event Hubs library to facilitate ope
 
 The location for internal types used by the Event Hubs library to facilitate AMQP protocol-related activities; these constructs are not intended to be consumed externally. 
 
-##### _Example Types:_
+##### _Example types:_
  
 - `AmqpMessageConverter`
 - `AmqpEventDataBatch`
@@ -383,7 +383,7 @@ The location for internal types used by the Event Hubs library to facilitate AMQ
 
 The location for internal types used by the Event Hubs library for diagnostics and logging activities; these constructs are not intended to be consumed externally. 
 
-##### _Example Types:_
+##### _Example types:_
  
 - `EventHubsEventSource`
 - `EventHubsDiagnosticSource`

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
@@ -77,10 +77,17 @@ namespace Azure.Messaging.EventHubs.Compatibility
                     )
                 };
 
-            return
-                ((await TrackOneReceiver.ReceiveAsync(maximumMessageCount, maximumWaitTime).ConfigureAwait(false))
-                    ?? Enumerable.Empty<TrackOne.EventData>())
-                .Select(TransformEvent);
+            try
+            {
+                return
+                    ((await TrackOneReceiver.ReceiveAsync(maximumMessageCount, maximumWaitTime).ConfigureAwait(false))
+                        ?? Enumerable.Empty<TrackOne.EventData>())
+                    .Select(TransformEvent);
+            }
+            catch (TrackOne.EventHubsException ex)
+            {
+                throw ex.MapToTrackTwoException();
+            }
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneExceptionExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneExceptionExtensions.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Messaging.EventHubs.Core;
+
+namespace Azure.Messaging.EventHubs.Compatibility
+{
+    /// <summary>
+    ///   The set of extension methods for exception types defined in the
+    ///   Track One client library.
+    /// </summary>
+    ///
+    internal static class TrackOneExceptionExtensions
+    {
+        /// <summary>
+        ///   Maps a <see cref="TrackOne.EventHubsException" /> or a child of it to the equivilent
+        ///   exception for the new API surface.
+        /// </summary>
+        ///
+        /// <param name="instance">The instance that this method was invoked on.</param>
+        ///
+        /// <returns>The equivalent exception type for the new API, wrapping the <paramref name="instance" /> as the inner exception.</returns>
+        ///
+        public static Errors.EventHubsException MapToTrackTwoException(this TrackOne.EventHubsException instance)
+        {
+            Guard.ArgumentNotNull(nameof(instance), instance);
+
+            switch (instance)
+            {
+                case TrackOne.EventHubsCommunicationException ex:
+                    return new Errors.EventHubsCommunicationException(ex.EventHubsNamespace, ex.RawMessage, ex);
+
+                case TrackOne.EventHubsTimeoutException ex:
+                    return new Errors.EventHubsTimeoutException(ex.EventHubsNamespace, ex.RawMessage, ex);
+
+                case TrackOne.MessagingEntityNotFoundException ex:
+                    return new Errors.EventHubsResourceNotFoundException(ex.EventHubsNamespace, ex.RawMessage, ex);
+
+                case TrackOne.MessageSizeExceededException ex:
+                    return new Errors.MessageSizeExceededException(ex.EventHubsNamespace, ex.RawMessage, ex);
+
+                case TrackOne.QuotaExceededException ex:
+                    return new Errors.QuotaExceededException(ex.EventHubsNamespace, ex.RawMessage, ex);
+
+                case TrackOne.ReceiverDisconnectedException ex:
+                    return new Errors.ConsumerDisconnectedException(ex.EventHubsNamespace, ex.RawMessage, ex);
+
+                case TrackOne.ServerBusyException ex:
+                    return new Errors.ServiceBusyException(ex.EventHubsNamespace, ex.RawMessage, ex);
+
+                default:
+                    return new Errors.EventHubsException(instance.IsTransient, instance.EventHubsNamespace, instance.RawMessage, instance);
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/ConsumerDisconnectedException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/ConsumerDisconnectedException.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs.Errors
+{
+    /// <summary>
+    ///   An exception which occurs when an <see cref="EventHubConsumer" /> is forcefully disconnected
+    ///   from an Event Hub instance.  This typically occurs when another consumer with higher <see cref="EventHubConsumer.OwnerLevel" />
+    ///   asserts ownership over the partition and consumer group.
+    /// </summary>
+    ///
+    public sealed class ConsumerDisconnectedException : EventHubsException
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ConsumerDisconnectedException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        ///
+        internal ConsumerDisconnectedException(string resourceName,
+                                               string message) : this(resourceName, message, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ConsumerDisconnectedException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal ConsumerDisconnectedException(string resourceName,
+                                               string message,
+                                               Exception innerException) : base(false, resourceName, message, innerException)
+        {
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/EventHubsCommunicationException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/EventHubsCommunicationException.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs.Errors
+{
+    /// <summary>
+    ///   An exception which occurs when there is a general communications error encountered
+    ///   when interacting with the Azure Event Hubs service.
+    /// </summary>
+    ///
+    public sealed class EventHubsCommunicationException : EventHubsException
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsCommunicationException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        ///
+        internal EventHubsCommunicationException(string resourceName,
+                                                 string message) : this(resourceName, message, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsCommunicationException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal EventHubsCommunicationException(string resourceName,
+                                                 string message,
+                                                 Exception innerException) : base(true, resourceName, message, innerException)
+        {
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/EventHubsException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/EventHubsException.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+
+namespace Azure.Messaging.EventHubs.Errors
+{
+    /// <summary>
+    ///     Serves as a basis for exceptions produced within the Event Hubs
+    ///     context.
+    /// </summary>
+    ///
+    /// <seealso cref="System.Exception" />
+    ///
+    public class EventHubsException : Exception
+    {
+        /// <summary>
+        ///   Indicates whether an exception should be considered transient or final.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if the exception is likely transient; otherwise, <c>false</c>.</value>
+        ///
+        public bool IsTransient { get; }
+
+        /// <summary>
+        ///   The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition,
+        ///   to which the exception is associated.
+        /// </summary>
+        ///
+        /// <value>The name of the resource, if available; otherwise, <c>null</c>.</value>
+        ///
+        public string ResourceName { get; }
+
+        /// <summary>
+        ///   Gets a message that describes the current exception.
+        /// </summary>
+        ///
+        public override string Message
+        {
+            get
+            {
+                if (String.IsNullOrEmpty(ResourceName))
+                {
+                    return base.Message;
+                }
+
+                return String.Format(CultureInfo.InvariantCulture, "{0}, ({1})", base.Message, ResourceName);
+            }
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsException"/> class.
+        /// </summary>
+        ///
+        /// <param name="isTransient"><c>true</c> if the exception should be considered transient; otherwise, <c>false</c>.</param>
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        ///
+        internal EventHubsException(bool isTransient,
+                                    string resourceName) : this(isTransient, resourceName, null, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsException"/> class.
+        /// </summary>
+        ///
+        /// <param name="isTransient"><c>true</c> if the exception should be considered transient; otherwise, <c>false</c>.</param>
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        ///
+        internal EventHubsException(bool isTransient,
+                                    string resourceName,
+                                    string message) : this(isTransient, resourceName, message, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsException"/> class.
+        /// </summary>
+        ///
+        /// <param name="isTransient"><c>true</c> if the exception should be considered transient; otherwise, <c>false</c>.</param>
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal EventHubsException(bool isTransient,
+                                    string resourceName,
+                                    string message,
+                                    Exception innerException) : base(message, innerException)
+        {
+            IsTransient = isTransient;
+            ResourceName = resourceName;
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/EventHubsResourceNotFoundException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/EventHubsResourceNotFoundException.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs.Errors
+{
+    /// <summary>
+    ///   An exception which occurs when an Event Hubs resource, such as an Event Hub, consumer group, or
+    ///   partition cannot be found.
+    /// </summary>
+    ///
+    public sealed class EventHubsResourceNotFoundException : EventHubsException
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsResourceNotFoundException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource that could not be found.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        ///
+        internal EventHubsResourceNotFoundException(string resourceName,
+                                                    string message) : this(resourceName, message, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsResourceNotFoundException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource that could not be found.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal EventHubsResourceNotFoundException(string resourceName,
+                                                    string message,
+                                                    Exception innerException) : base(false, resourceName, message, innerException)
+        {
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/EventHubsTimeoutException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/EventHubsTimeoutException.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs.Errors
+{
+    /// <summary>
+    ///   An exception which occurs when an operation or other request times out while
+    ///   interacting with the Azure Event Hubs service.
+    /// </summary>
+    ///
+    public sealed class EventHubsTimeoutException : EventHubsException
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsTimeoutException "/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        ///
+        internal EventHubsTimeoutException (string resourceName,
+                                            string message) : this(resourceName, message, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubsTimeoutException "/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal EventHubsTimeoutException (string resourceName,
+                                            string message,
+                                            Exception innerException) : base(true, resourceName, message, innerException)
+        {
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/MessageSizeExceededException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/MessageSizeExceededException.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Globalization;
+
+namespace Azure.Messaging.EventHubs.Errors
+{
+    /// <summary>
+    ///   An exception which occurs when a message is larger than the maximum size allowed
+    ///   for its transport.
+    /// </summary>
+    ///
+    public sealed class MessageSizeExceededException : EventHubsException
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="MessageSizeExceededException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        ///
+        internal MessageSizeExceededException(string resourceName,
+                                              string message) : this(resourceName, message, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="MessageSizeExceededException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal MessageSizeExceededException(string resourceName,
+                                              string message,
+                                              Exception innerException) : base(false, resourceName, message, innerException)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="MessageSizeExceededException"/> class using
+        ///   the default messaging.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="messageId">The identifier of the message that triggered the exception.</param>
+        /// <param name="sizeInBytes">The size, in bytes, of the message.</param>
+        /// <param name="maximumSizeInBytes">The maximum allowed size of messages, in bytes, allowed by the transport.</param>
+        ///
+        internal MessageSizeExceededException(string resourceName,
+                                              uint messageId,
+                                              ulong sizeInBytes,
+                                              ulong maximumSizeInBytes) : this(resourceName, FormatDefaultMessage(messageId, sizeInBytes, maximumSizeInBytes))
+        {
+        }
+
+        /// <summary>
+        ///   Formats the default exception message.
+        /// </summary>
+        ///
+        /// <param name="messageId">The identifier of the message that triggered the exception.</param>
+        /// <param name="sizeInBytes">The size, in bytes, of the message.</param>
+        /// <param name="maximumSizeInBytes">The maximum allowed size of messages, in bytes, allowed by the transport.</param>
+        ///
+        /// <returns>The formatted message with details for the requested message attributes.</returns>
+        ///
+        private static string FormatDefaultMessage(uint messageId,
+                                                   ulong sizeInBytes,
+                                                   ulong maximumSizeInBytes) =>
+            String.Format(CultureInfo.CurrentCulture, Resources.MessageSizeExceeded, messageId, sizeInBytes, maximumSizeInBytes);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/QuotaExceededException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/QuotaExceededException.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs.Errors
+{
+    /// <summary>
+    ///   An exception which occurs when the quota applied to an Event Hubs resource has been
+    ///   exceeded while interacting with the Azure Event Hubs service.
+    /// </summary>
+    ///
+    public sealed class QuotaExceededException : EventHubsException
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="QuotaExceededException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        ///
+        internal QuotaExceededException(string resourceName,
+                                        string message) : this(resourceName, message, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="QuotaExceededException"/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal QuotaExceededException(string resourceName,
+                                        string message,
+                                        Exception innerException) : base(false, resourceName, message, innerException)
+        {
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/ServiceBusyException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Errors/ServiceBusyException.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Messaging.EventHubs.Errors
+{
+    /// <summary>
+    ///   An exception which occurs when the Azure Event Hubs service reports that it is busy in response to a client
+    ///   request to perform an operation.
+    /// </summary>
+    ///
+    public sealed class ServiceBusyException : EventHubsException
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ServiceBusyException "/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        ///
+        internal ServiceBusyException (string resourceName,
+                                       string message) : this(resourceName, message, null)
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ServiceBusyException "/> class.
+        /// </summary>
+        ///
+        /// <param name="resourceName">The name of the Event Hubs resource, such as an Event Hub, consumer group, or partition, to which the exception is associated.</param>
+        /// <param name="message">The error message that explains the reason for the exception.</param>
+        /// <param name="innerException">The exception that is the cause of the current exception, or a null reference if no inner exception is specified.</param>
+        ///
+        internal ServiceBusyException (string resourceName,
+                                       string message,
+                                       Exception innerException) : base(true, resourceName, message, innerException)
+        {
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -208,7 +208,7 @@ namespace Azure.Messaging.EventHubs
                             return offset;
                         }
 
-                        if ((value is string token) && (long.TryParse(token, out var parsedOffset)))
+                        if ((value is string token) && (Int64.TryParse(token, out var parsedOffset)))
                         {
                             return parsedOffset;
                         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -67,6 +67,17 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The message (id:{0}, size:{1} bytes) is larger than is currently allowed ({2} bytes)..
+        /// </summary>
+        internal static string MessageSizeExceeded 
+        {
+            get 
+            {
+                return ResourceManager.GetString("MessageSizeExceeded", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The argument &apos;{0}&apos; may not be null or empty..
         /// </summary>
         internal static string ArgumentNullOrEmpty
@@ -327,6 +338,17 @@ namespace Azure.Messaging.EventHubs
             get
             {
                 return ResourceManager.GetString("SharedKeyCredentialCannotGenerateTokens", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The {0} value is expected to be a {1} bit signed integer. Actual value: '{2}'..
+        /// </summary>
+        internal static string CannotParseIntegerType
+        {
+            get
+            {
+                return ResourceManager.GetString("CannotParseIntegerType", resourceCulture);
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="MessageSizeExceeded" xml:space="preserve">
+    <value>The message (id:{0}, size:{1} bytes) is larger than is currently allowed ({2} bytes).</value>
+  </data>
   <data name="ArgumentNullOrEmpty" xml:space="preserve">
     <value>The argument '{0}' may not be null or empty.</value>
   </data>
@@ -188,5 +191,8 @@
   </data>
   <data name="SharedKeyCredentialCannotGenerateTokens" xml:space="preserve">
     <value>A shared key credential is unable to generate a token directly.  Please use this credential when creating an Event Hub Client, for proper generation of shared key tokens.</value>
+  </data>
+  <data name="CannotParseIntegerType" xml:space="preserve">
+    <value>The {0} value is expected to be a {1} bit signed integer. Actual value: '{2}'.</value>
   </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/Primitives/EventHubsException.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/Primitives/EventHubsException.cs
@@ -66,9 +66,11 @@ namespace TrackOne
                     return baseMessage;
                 }
 
-                return "{0}, ({1})".FormatInvariant(this.EventHubsNamespace);
+                return "{0}, ({1})".FormatInvariant(base.Message, this.EventHubsNamespace);
             }
         }
+
+        public string RawMessage => base.Message;
 
         /// <summary>
         /// A boolean indicating if the exception is a transient error or not.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparerTests.cs
@@ -13,6 +13,7 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
     public class TrackOneComparerTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubConsumerTests.cs
@@ -19,6 +19,7 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
     public class TrackOneEventHubConsumerTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneExceptionExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneExceptionExtensionsTests.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Messaging.EventHubs.Compatibility;
+using Azure.Messaging.EventHubs.Errors;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="TrackOneExceptionExtensions" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
+    public class TrackOneExceptionExtensionsTests
+    {
+        /// <summary>
+        ///   The set of test cases for the well-known types derived from the <see cref="EventHubsException" />
+        ///   and their expected transient status.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ExceptionMappingTestCases()
+        {
+            TrackOne.EventHubsException exception;
+
+            exception = new TrackOne.EventHubsCommunicationException("One");
+            exception.EventHubsNamespace = "test_thing";
+            yield return new object[] {exception, typeof(Errors.EventHubsCommunicationException) };
+
+            exception = new TrackOne.EventHubsTimeoutException("Two");
+            exception.EventHubsNamespace = "OMG!-Thing!";
+            yield return new object[] { exception, typeof(Errors.EventHubsTimeoutException) };
+
+            yield return new object[] { new TrackOne.MessagingEntityNotFoundException("Three"), typeof(Errors.EventHubsResourceNotFoundException) };
+            yield return new object[] { new TrackOne.MessageSizeExceededException("Four"), typeof(Errors.MessageSizeExceededException) };
+            yield return new object[] { new TrackOne.QuotaExceededException("Five"), typeof(Errors.QuotaExceededException) };
+            yield return new object[] { new TrackOne.ReceiverDisconnectedException("Six"), typeof(Errors.ConsumerDisconnectedException) };
+            yield return new object[] { new TrackOne.ServerBusyException("Seven"), typeof(Errors.ServiceBusyException) };
+            yield return new object[] { new TrackOne.EventHubsException(true, "Eight"), typeof(Errors.EventHubsException) };
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneExceptionExtensions.MapToTrackTwoException" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public void MapExceptionValidatesTheInstance()
+        {
+            Assert.That(() => ((TrackOne.EventHubsException)null).MapToTrackTwoException(), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies that well-known derived exception types have the correct value for their
+        ///   <see cref="EventHubsException.IsTransient" /> property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ExceptionMappingTestCases))]
+        public void DerrivedExceptionsHaveTheCorrectTransientValues(Exception exception,
+                                                                    Type expectedMappedType)
+        {
+            var eventHubsException = (TrackOne.EventHubsException)exception;
+            var mappedException = eventHubsException.MapToTrackTwoException();
+
+            Assert.That(mappedException, Is.Not.Null, "The mapping should produce an exception.");
+            Assert.That(mappedException.GetType(), Is.EqualTo(expectedMappedType), "The mapped exception type was incorrect.");
+            Assert.That(mappedException.IsTransient, Is.EqualTo(eventHubsException.IsTransient), "The mapped exception should agree on being transient.");
+            Assert.That(mappedException.ResourceName, Is.EqualTo(eventHubsException.EventHubsNamespace), "The mapped exception should use the namespace as its resource name.");
+            Assert.That(mappedException.Message, Does.Contain(eventHubsException.EventHubsNamespace ?? String.Empty), "The mapped exception should include the namespace in its message.");
+            Assert.That(mappedException.Message, Does.Contain(eventHubsException.RawMessage), "The mapped exception should include the message text in its message.");
+            Assert.That(mappedException.InnerException, Is.EqualTo(eventHubsException), "The mapped exception should wrap the original instance.");
+        }
+
+        /// <summary>
+        ///   Verifies that derived exception types in the current library are well-known and have a
+        ///   corresponding test case.
+        /// </summary>
+        ///
+        [Test]
+        public void EventHubsExceptionTypesShouldHaveMappings()
+        {
+            var allDerrivedTypes = typeof(EventHubsException)
+               .Assembly
+               .GetTypes()
+               .Where(type => typeof(EventHubsException).IsAssignableFrom(type))
+               .Select(type => type.Name)
+               .OrderBy(name => name);
+
+            var knownDerrivedTypes = ExceptionMappingTestCases()
+                .Select(testCase => ((Type)testCase[1]).Name)
+                .OrderBy(name => name);
+
+            Assert.That(allDerrivedTypes, Is.EquivalentTo(knownDerrivedTypes), "All exceptions derived from EventHubsException in the client library should have a matching mapping.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Messaging.EventHubs.Errors;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="EventHubsException" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Parallelizable(ParallelScope.Children)]
+    public class EventHubsExceptionTests
+    {
+        /// <summary>
+        ///   The set of test cases for the different constructor signatures.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> ConstructorPropertyTestCases()
+        {
+            Func<EventHubsException> constructor;
+
+            constructor = () => new EventHubsException(true, "test");
+            yield return new object[] { constructor, true, "test", "constructor with transient and resource" };
+
+            constructor = () => new EventHubsException(true, "thing", null);
+            yield return new object[] { constructor, true, "thing", "constructor with transient, resource, and message" };
+
+            constructor = () => new EventHubsException(true, "bobl", null, new Exception());
+            yield return new object[] { constructor, true, "bobl", "constructor with transient, resource, message, and exception" };
+        }
+
+        /// <summary>
+        ///   The set of test cases for the well-known types derived from the <see cref="EventHubsException" />
+        ///   and their expected transient status.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> DerrivedExceptionTransientTestCases()
+        {
+            // Transient exceptions
+
+            yield return new object[] { new EventHubsCommunicationException("resource", "message"), true };
+            yield return new object[] { new EventHubsTimeoutException("resource", "message"), true };
+            yield return new object[] { new ServiceBusyException("resource", "message"), true };
+
+            // Final exceptions
+
+            yield return new object[] { new MessageSizeExceededException("resource", "message"), false };
+            yield return new object[] { new EventHubsResourceNotFoundException("resource", "message"), false };
+            yield return new object[] { new QuotaExceededException("resource", "message"), false };
+            yield return new object[] { new ConsumerDisconnectedException("resource", "message"), false };
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(ConstructorPropertyTestCases))]
+        public void ConstructorSetsCustomProperties(Func<EventHubsException> constructor,
+                                                    bool expectedIsTransient,
+                                                    string expectedResourceName,
+                                                    string constructorDescription)
+        {
+            var instance = constructor();
+            Assert.That(instance.IsTransient, Is.EqualTo(expectedIsTransient), $"IsTransient should be set for the { constructorDescription }");
+            Assert.That(instance.ResourceName, Is.EqualTo(expectedResourceName), $"EventHubsNamespace should be set for the { constructorDescription }");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubsException.Message" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCase(null)]
+        [TestCase("")]
+        public void MessageIsPopulatedForNoResource(string resourceName)
+        {
+            var message = "Test message!";
+            var instance = new EventHubsException(false, resourceName, message);
+
+            Assert.That(instance.Message, Is.EqualTo(message));
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubsException.Message" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        public void MessageUsesResourceName()
+        {
+            var message = "Test message!";
+            var namespaceValue = "the-namespace";
+            var instance = new EventHubsException(false, namespaceValue, message);
+
+            Assert.That(instance.Message, Does.Contain(namespaceValue), "The message should include the Event Hubs namespace");
+            Assert.That(instance.Message, Does.Contain(message), "The message should include the exception message text");
+        }
+
+        /// <summary>
+        ///   Verifies that well-known derived exception types have the correct value for their
+        ///   <see cref="EventHubsException.IsTransient" /> property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(DerrivedExceptionTransientTestCases))]
+        public void DerrivedExceptionsHaveTheCorrectTransientValues(EventHubsException exception,
+                                                                    bool expectedTransient)
+        {
+            Assert.That(exception.IsTransient, Is.EqualTo(expectedTransient), $"The { exception.GetType().Name } has an incorrect IsTransient value.");
+        }
+
+        /// <summary>
+        ///   Verifies that derived exception types in the current library are well-known and have a
+        ///   corresponding test case.
+        /// </summary>
+        ///
+        [Test]
+        public void DerrivedExceptionsAreWellKnown()
+        {
+            var allDerrivedTypes = typeof(EventHubsException)
+               .Assembly
+               .GetTypes()
+               .Where(type => (type != typeof(EventHubsException) && typeof(EventHubsException).IsAssignableFrom(type)))
+               .Select(type => type.Name)
+               .OrderBy(name => name);
+
+            var knownDerrivedTypes = DerrivedExceptionTransientTestCases()
+                .Select(testCase => testCase[0].GetType().Name)
+                .OrderBy(name => name);
+
+            Assert.That(allDerrivedTypes, Is.EquivalentTo(knownDerrivedTypes), "All exceptions derived from EventHubsException in the client library should have a matching IsTransient test case.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Errors;
 using Azure.Messaging.EventHubs.Tests.Infrastructure;
 using NUnit.Framework;
 
@@ -979,7 +980,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     await using (var consumer = client.CreateConsumer("nonExistentConsumerGroup", partition, EventPosition.Latest))
                     {
-                        Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.MessagingEntityNotFoundException>());
+                        Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<EventHubsResourceNotFoundException>());
                     }
                 }
             }
@@ -1007,7 +1008,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
 
-                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
+                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                 }
             }
         }
@@ -1034,7 +1035,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     var lowerExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest, new EventHubConsumerOptions { OwnerLevel = 10 });
 
-                    Assert.That(async () => await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
+                    Assert.That(async () => await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                 }
             }
         }
@@ -1131,7 +1132,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     await Task.Delay(TimeSpan.FromSeconds(5));
 
-                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
+                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                 }
             }
         }
@@ -1160,7 +1161,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     await Task.Delay(TimeSpan.FromSeconds(5));
 
-                    Assert.That(async () => await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
+                    Assert.That(async () => await lowerExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                 }
             }
         }
@@ -1253,7 +1254,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Failing at consumer creation should not compromise future ReceiveAsync calls.
 
-                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
+                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
 
                     // It should be possible to create new valid consumers.
 
@@ -1270,9 +1271,9 @@ namespace Azure.Messaging.EventHubs.Tests
                     var invalidPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "XYZ", EventPosition.Latest);
                     var invalidConsumerGroupConsumer = client.CreateConsumer("imNotAConsumerGroup", partitionIds[0], EventPosition.Latest);
 
-                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
+                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                     Assert.That(async () => await invalidPartitionConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ArgumentOutOfRangeException>());
-                    Assert.That(async () => await invalidConsumerGroupConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.MessagingEntityNotFoundException>());
+                    Assert.That(async () => await invalidConsumerGroupConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<EventHubsResourceNotFoundException>());
                 }
             }
         }
@@ -1311,9 +1312,9 @@ namespace Azure.Messaging.EventHubs.Tests
                     var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
                     var invalidConsumerGroupConsumer = client.CreateConsumer("imNotAConsumerGroup", partition, EventPosition.Latest);
 
-                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
+                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                     Assert.That(async () => await invalidPartitionConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ArgumentOutOfRangeException>());
-                    Assert.That(async () => await invalidConsumerGroupConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.MessagingEntityNotFoundException>());
+                    Assert.That(async () => await invalidConsumerGroupConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<EventHubsResourceNotFoundException>());
                 }
             }
         }
@@ -1339,7 +1340,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     // Failing at consumer creation should not compromise future ReceiveAsync calls.
 
-                    Assert.That(async () => await invalidConsumerGroupConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.MessagingEntityNotFoundException>());
+                    Assert.That(async () => await invalidConsumerGroupConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<EventHubsResourceNotFoundException>());
 
                     // It should be possible to create new valid consumers.
 
@@ -1352,9 +1353,9 @@ namespace Azure.Messaging.EventHubs.Tests
                     var nonExclusiveConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Latest);
                     var invalidPartitionConsumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, "XYZ", EventPosition.Latest);
 
-                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.ReceiverDisconnectedException>());
+                    Assert.That(async () => await nonExclusiveConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ConsumerDisconnectedException>());
                     Assert.That(async () => await invalidPartitionConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ArgumentOutOfRangeException>());
-                    Assert.That(async () => await invalidConsumerGroupConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<TrackOne.MessagingEntityNotFoundException>());
+                    Assert.That(async () => await invalidConsumerGroupConsumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<EventHubsResourceNotFoundException>());
                 }
             }
         }
@@ -1650,7 +1651,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         throw new InvalidOperationException("6th consumer should have encountered QuotaExceededException.");
                     }
-                    catch (TrackOne.QuotaExceededException ex)
+                    catch (QuotaExceededException ex)
                     {
                         foreach (var consumer in consumers)
                         {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -8,6 +8,7 @@ using System.Net;
 using System.Net.WebSockets;
 using System.Text;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Errors;
 using Azure.Messaging.EventHubs.Tests.Infrastructure;
 using NUnit.Framework;
 
@@ -260,8 +261,8 @@ namespace Azure.Messaging.EventHubs.Tests
                     var singleEvent = new EventData(new byte[1500000]);
                     var eventBatch = new[] { new EventData(new byte[1500000]) };
 
-                    Assert.That(async () => await producer.SendAsync(singleEvent), Throws.TypeOf<TrackOne.MessageSizeExceededException>());
-                    Assert.That(async () => await producer.SendAsync(eventBatch), Throws.TypeOf<TrackOne.MessageSizeExceededException>());
+                    Assert.That(async () => await producer.SendAsync(singleEvent), Throws.TypeOf<MessageSizeExceededException>());
+                    Assert.That(async () => await producer.SendAsync(eventBatch), Throws.TypeOf<MessageSizeExceededException>());
                 }
             }
         }
@@ -371,7 +372,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         new EventData(new byte[1500000 / 3])
                     };
 
-                    Assert.That(async () => await producer.SendAsync(events), Throws.TypeOf<TrackOne.MessageSizeExceededException>());
+                    Assert.That(async () => await producer.SendAsync(events), Throws.TypeOf<MessageSizeExceededException>());
                 }
             }
         }


### PR DESCRIPTION
# Summary

The intent of these changes is create and expose an exception hierarchy that covers the known scenarios and stays consistent with the Event Hubs service model.  The exception model is also intended to
provide retry hints for the built-in and any custom developer-provided retry policy implementations based on the pending retry design revisions.

# Last Upstream Rebase

Thursday, July 11, 2019  9:34am (EDT)

# Resources

- [Azure Messaging Exception Documentation](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions)
- [.NET Event Hubs Client: Second Preview Design Proposal](https://github.com/jsquire/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-second-preview.md)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 2](https://github.com/Azure/azure-sdk-for-net/issues/6752) (#6752)
- [Create an exception hierarchy](https://github.com/Azure/azure-sdk-for-net/issues/6782) (#6782)