### PR TITLE
Use tools package from tools feed instead of local folder

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -6,16 +6,4 @@
     <add key="roslyn" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="azure-sdk-tools" value="https://azuresdkartifacts.blob.core.windows.net/azure-sdk-tools/index.json" />
   </packageSources>
-  <config>
-		<add key="globalPackagesFolder" value="restoredPackages" />
-    <add key="RestorePackagesPath" value="restoredPackages" />
-	</config>
-  
-	<packageRestore>
-		<!-- Allow NuGet to download missing packages -->
-		<add key="enabled" value="True" />
-
-		<!-- Automatically check for missing packages during build in Visual Studio -->
-		<add key="automatic" value="True" />
-  </packageRestore>
 </configuration>


### PR DESCRIPTION
- Remove local package for our tools and use from feed
- Remove scoped package cache from nuget.config

 @erich-wang @shahabhijeet @chidozieononiwu

cc @Azure/azure-sdk-eng 