### PR TITLE
Support recursive test directories in service.proj

### DIFF
--- a/eng/service.proj
+++ b/eng/service.proj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <ExcludeMgmtLib Include="..\sdk\$(ServiceDirectory)\*.Management.*\**\*.csproj;..\sdk\*mgmt*\**\*.csproj;" />
-    <TestProjects Include="..\sdk\$(ServiceDirectory)\*\tests\**\*.csproj" />
+    <TestProjects Include="..\sdk\$(ServiceDirectory)\**\tests\**\*.csproj" />
     <SrcProjects Include="..\sdk\$(ServiceDirectory)\**\*.csproj" Exclude="@(TestProjects)" />
     <ProjectReference Include="@(TestProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeTests)' == 'true'" />
     <ProjectReference Include="@(SrcProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeSrc)' == 'true'" />


### PR DESCRIPTION
@chidozieononiwu we need to support recursive test directories so using `**` instead of `*`. This enables cases where someone passes another folder under the service like batch\package\.


cc @Azure/azure-sdk-eng 

