### PR TITLE
Fix Storage doc comments #6871

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AppendBlobClient.cs
@@ -44,6 +44,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </summary>
         public const int AppendBlobMaxBlocks = 50000;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="AppendBlobClient"/>
         /// class for mocking.
@@ -180,6 +181,7 @@ namespace Azure.Storage.Blobs.Specialized
             : base(blobUri, pipeline)
         {
         }
+        #endregion ctors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AppendBlobClient"/>
@@ -200,6 +202,7 @@ namespace Azure.Storage.Blobs.Specialized
             return new AppendBlobClient(builder.ToUri(), this.Pipeline);
         }
 
+        #region Create
         /// <summary>
         /// The <see cref="Create"/> operation creates a new 0-length
         /// append blob.  The content of any existing blob is overwritten with
@@ -236,7 +239,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata = default,
             AppendBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateAsync(
+            this.CreateInternal(
                 httpHeaders,
                 metadata,
                 accessConditions,
@@ -268,7 +271,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// newly created append blob.
         /// </returns>
         /// <remarks>
@@ -280,7 +283,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata = default,
             AppendBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateAsync(
+            await this.CreateInternal(
                 httpHeaders,
                 metadata,
                 accessConditions,
@@ -289,7 +292,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="CreateAsync"/> operation creates a new 0-length
+        /// The <see cref="CreateInternal"/> operation creates a new 0-length
         /// append blob.  The content of any existing blob is overwritten with
         /// the newly initialized append blob.  To add content to the append
         /// blob, call the <see cref="AppendBlockAsync"/> operation.
@@ -315,14 +318,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// newly created append blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobContentInfo>> CreateAsync(
+        private async Task<Response<BlobContentInfo>> CreateInternal(
             BlobHttpHeaders? httpHeaders,
             Metadata metadata,
             AppendBlobAccessConditions? accessConditions,
@@ -370,7 +373,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Create
 
+        #region AppendBlock
         /// <summary>
         /// The <see cref="AppendBlock"/> operation commits a new block
         /// of data, represented by the <paramref name="content"/> <see cref="Stream"/>,
@@ -418,7 +423,7 @@ namespace Azure.Storage.Blobs.Specialized
             AppendBlobAccessConditions? accessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            this.AppendBlockAsync(
+            this.AppendBlockInternal(
                 content,
                 transactionalContentHash,
                 accessConditions,
@@ -461,7 +466,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobAppendInfo}}"/> describing the
+        /// A <see cref="Response{BlobAppendInfo}"/> describing the
         /// state of the updated append blob.
         /// </returns>
         /// <remarks>
@@ -474,7 +479,7 @@ namespace Azure.Storage.Blobs.Specialized
             AppendBlobAccessConditions? accessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            await this.AppendBlockAsync(
+            await this.AppendBlockInternal(
                 content,
                 transactionalContentHash,
                 accessConditions,
@@ -484,9 +489,9 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="AppendBlockAsync"/> operation commits a new block
+        /// The <see cref="AppendBlockInternal"/> operation commits a new block
         /// of data, represented by the <paramref name="content"/> <see cref="Stream"/>,
-        /// to the end of the existing append blob.  The <see cref="AppendBlockAsync"/>
+        /// to the end of the existing append blob.  The <see cref="AppendBlockInternal"/>
         /// operation is only permitted if the blob was created as an append
         /// blob.
         /// 
@@ -520,14 +525,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobAppendInfo}}"/> describing the
+        /// A <see cref="Response{BlobAppendInfo}"/> describing the
         /// state of the updated append blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobAppendInfo>> AppendBlockAsync(
+        private async Task<Response<BlobAppendInfo>> AppendBlockInternal(
             Stream content,
             byte[] transactionalContentHash, 
             AppendBlobAccessConditions? accessConditions, 
@@ -585,7 +590,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion AppendBlock
 
+        #region AppendBlockFromUri
         /// <summary>
         /// The <see cref="AppendBlockFromUri"/> operation commits a new
         /// block of data, represented by the <paramref name="sourceUri"/>,
@@ -645,7 +652,7 @@ namespace Azure.Storage.Blobs.Specialized
             AppendBlobAccessConditions? accessConditions = default,
             AppendBlobAccessConditions? sourceAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.AppendBlockFromUriAsync(
+            this.AppendBlockFromUriInternal(
                 sourceUri,
                 sourceRange,
                 sourceContentHash,
@@ -700,7 +707,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobAppendInfo}}"/> describing the
+        /// A <see cref="Response{BlobAppendInfo}"/> describing the
         /// state of the updated append blob.
         /// </returns>
         /// <remarks>
@@ -714,7 +721,7 @@ namespace Azure.Storage.Blobs.Specialized
             AppendBlobAccessConditions? accessConditions = default,
             AppendBlobAccessConditions? sourceAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.AppendBlockFromUriAsync(
+            await this.AppendBlockFromUriInternal(
                 sourceUri,
                 sourceRange,
                 sourceContentHash,
@@ -725,10 +732,10 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="AppendBlockFromUriAsync"/> operation commits a new
+        /// The <see cref="AppendBlockFromUriInternal"/> operation commits a new
         /// block of data, represented by the <paramref name="sourceUri"/>,
         /// to the end of the existing append blob.  The
-        /// <see cref="AppendBlockFromUriAsync"/> operation is only permitted
+        /// <see cref="AppendBlockFromUriInternal"/> operation is only permitted
         /// if the blob was created as an append blob.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/append-block-from-url" />.
@@ -772,14 +779,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobAppendInfo}}"/> describing the
+        /// A <see cref="Response{BlobAppendInfo}"/> describing the
         /// state of the updated append blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobAppendInfo>> AppendBlockFromUriAsync(
+        private async Task<Response<BlobAppendInfo>> AppendBlockFromUriInternal(
             Uri sourceUri,
             HttpRange sourceRange,
             byte[] sourceContentHash,
@@ -831,6 +838,7 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion AppendBlockFromUri
     }
 
     /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobBaseClient.cs
@@ -45,6 +45,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </summary>
         protected internal virtual HttpPipeline Pipeline => this._pipeline;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobClient"/>
         /// class.
@@ -213,6 +214,7 @@ namespace Azure.Storage.Blobs.Specialized
             this._uri = blobUri;
             this._pipeline = pipeline;
         }
+        #endregion ctors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobClient"/>
@@ -261,8 +263,9 @@ namespace Azure.Storage.Blobs.Specialized
         //    return new BlobUri(builder.ToUri(), this.Pipeline);
         //}
 
+        #region Download
         /// <summary>
-        /// The <see cref="Download"/> operation downloads a blob from
+        /// The <see cref="Download()"/> operation downloads a blob from
         /// the service, including its metadata and properties.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
@@ -280,13 +283,13 @@ namespace Azure.Storage.Blobs.Specialized
             this.Download(CancellationToken.None);
 
         /// <summary>
-        /// The <see cref="DownloadAsync"/> operation downloads a blob from
+        /// The <see cref="DownloadAsync()"/> operation downloads a blob from
         /// the service, including its metadata and properties.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
         /// </summary>
         /// <returns>
-        /// A <see cref="Task{Response{BlobDownloadInfo}}"/> describing the
+        /// A <see cref="Response{BlobDownloadInfo}"/> describing the
         /// downloaded blob.  <see cref="BlobDownloadInfo.Content"/> contains
         /// the blob's data.
         /// </returns>
@@ -298,8 +301,8 @@ namespace Azure.Storage.Blobs.Specialized
             await this.DownloadAsync(CancellationToken.None).ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="Download"/> operation downloads a blob from
-        /// the service, including its metadata and properties.
+        /// The <see cref="Download(CancellationToken)"/> operation downloads
+        /// a blob from the service, including its metadata and properties.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
         /// </summary>
@@ -323,8 +326,9 @@ namespace Azure.Storage.Blobs.Specialized
                 cancellationToken: cancellationToken);
 
         /// <summary>
-        /// The <see cref="DownloadAsync"/> operation downloads a blob from
-        /// the service, including its metadata and properties.
+        /// The <see cref="DownloadAsync(CancellationToken)"/> operation
+        /// downloads a blob from the service, including its metadata and
+        /// properties.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
         /// </summary>
@@ -333,7 +337,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobDownloadInfo}}"/> describing the
+        /// A <see cref="Response{BlobDownloadInfo}"/> describing the
         /// downloaded blob.  <see cref="BlobDownloadInfo.Content"/> contains
         /// the blob's data.
         /// </returns>
@@ -349,8 +353,9 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="Download"/> operation downloads a blob from
-        /// the service, including its metadata and properties.
+        /// The <see cref="Download(HttpRange, BlobAccessConditions?, Boolean, CancellationToken)"/>
+        /// operation downloads a blob from the service, including its metadata
+        /// and properties.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
         /// </summary>
@@ -388,7 +393,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobAccessConditions? accessConditions = default,
             bool rangeGetContentHash = default,
             CancellationToken cancellationToken = default) =>
-            this.DownloadAsync(
+            this.DownloadInternal(
                 range,
                 accessConditions,
                 rangeGetContentHash,
@@ -397,8 +402,9 @@ namespace Azure.Storage.Blobs.Specialized
                 .EnsureCompleted();
 
         /// <summary>
-        /// The <see cref="DownloadAsync"/> operation downloads a blob from
-        /// the service, including its metadata and properties.
+        /// The <see cref="DownloadAsync(HttpRange, BlobAccessConditions?, Boolean, CancellationToken)"/>
+        /// operation downloads a blob from the service, including its metadata
+        /// and properties.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
         /// </summary>
@@ -423,7 +429,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobDownloadInfo}}"/> describing the
+        /// A <see cref="Response{BlobDownloadInfo}"/> describing the
         /// downloaded blob.  <see cref="BlobDownloadInfo.Content"/> contains
         /// the blob's data.
         /// </returns>
@@ -436,7 +442,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobAccessConditions? accessConditions = default,
             bool rangeGetContentHash = default,
             CancellationToken cancellationToken = default) =>
-            await this.DownloadAsync(
+            await this.DownloadInternal(
                 range,
                 accessConditions,
                 rangeGetContentHash,
@@ -445,8 +451,8 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="DownloadAsync"/> operation downloads a blob from
-        /// the service, including its metadata and properties.
+        /// The <see cref="DownloadInternal"/> operation downloads a blob
+        /// from the service, including its metadata and properties.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-blob" />.
         /// </summary>
@@ -474,7 +480,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobDownloadInfo}}"/> describing the
+        /// A <see cref="Response{BlobDownloadInfo}"/> describing the
         /// downloaded blob.  <see cref="BlobDownloadInfo.Content"/> contains
         /// the blob's data.
         /// </returns>
@@ -482,7 +488,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobDownloadInfo>> DownloadAsync(
+        private async Task<Response<BlobDownloadInfo>> DownloadInternal(
             HttpRange range,
             BlobAccessConditions? accessConditions,
             bool rangeGetContentHash,
@@ -580,7 +586,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobDownloadInfo}}"/> describing the
+        /// A <see cref="Response{BlobDownloadInfo}"/> describing the
         /// downloaded blob.  <see cref="BlobDownloadInfo.Content"/> contains
         /// the blob's data.
         /// </returns>
@@ -623,13 +629,15 @@ namespace Azure.Storage.Blobs.Specialized
 
             return response;
         }
+        #endregion Download
 
+        #region StartCopyFromUri
         /// <summary>
-        /// The <see cref="StartCopyFromUri"/> operation copies data at
-        /// from the <paramref name="source"/> to this blob.  You can check
-        /// the <see cref="BlobProperties.CopyStatus"/> returned from the
-        /// <see cref="GetProperties"/> to determine if the copy has
-        /// completed.
+        /// The <see cref="StartCopyFromUri(Uri, Metadata, BlobAccessConditions?, BlobAccessConditions?, CancellationToken)"/>
+        /// operation copies data at from the <paramref name="source"/> to this
+        /// blob.  You can check the <see cref="BlobProperties.CopyStatus"/>
+        /// returned from the <see cref="GetProperties"/> to determine if the
+        /// copy has completed.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
         /// </summary>
@@ -678,7 +686,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobAccessConditions? destinationAccessConditions = default,
             CancellationToken cancellationToken = default)
         {
-            var response = this.StartCopyFromUriAsync(
+            var response = this.StartCopyFromUriInternal(
                 source,
                 metadata,
                 sourceAccessConditions,
@@ -694,11 +702,11 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="StartCopyFromUriAsync"/> operation copies data at
-        /// from the <paramref name="source"/> to this blob.  You can check
-        /// the <see cref="BlobProperties.CopyStatus"/> returned from the
-        /// <see cref="GetPropertiesAsync"/> to determine if the copy has
-        /// completed.
+        /// The <see cref="StartCopyFromUri(Uri, Metadata, BlobAccessConditions?, BlobAccessConditions?, CancellationToken)"/>
+        /// operation copies data at from the <paramref name="source"/> to this
+        /// blob.  You can check the <see cref="BlobProperties.CopyStatus"/>
+        /// returned from the <see cref="GetPropertiesAsync"/> to determine if
+        /// the copy has completed.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
         /// </summary>
@@ -733,7 +741,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{CopyFromUriOperation}"/> describing the
+        /// A <see cref="CopyFromUriOperation"/> describing the
         /// state of the copy operation.
         /// </returns>
         /// <remarks>
@@ -747,7 +755,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobAccessConditions? destinationAccessConditions = default,
             CancellationToken cancellationToken = default)
         {
-            var response = await this.StartCopyFromUriAsync(
+            var response = await this.StartCopyFromUriInternal(
                 source,
                 metadata,
                 sourceAccessConditions,
@@ -763,7 +771,7 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// Get an existing copy <see cref="{Operation{Int64}}"/>.
+        /// Get an existing <see cref="CopyFromUriOperation"/>.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
         /// </summary>
@@ -775,7 +783,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{CopyFromUriOperation}"/> representing the copy
+        /// A <see cref="CopyFromUriOperation"/> representing the copy
         /// operation.
         /// </returns>
         /// <remarks>
@@ -786,7 +794,7 @@ namespace Azure.Storage.Blobs.Specialized
             string copyId,
             CancellationToken cancellationToken = default)
         {
-            var response = this.GetPropertiesAsync(
+            var response = this.GetPropertiesInternal(
                 null,
                 false, // async
                 cancellationToken)
@@ -799,7 +807,7 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// Get an existing copy <see cref="{Operation{Int64}}"/>.
+        /// Get an existing <see cref="CopyFromUriOperation"/>.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/copy-blob" />.
         /// </summary>
@@ -811,7 +819,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{CopyFromUriOperation}"/> representing the copy
+        /// A <see cref="CopyFromUriOperation"/> representing the copy
         /// operation.
         /// </returns>
         /// <remarks>
@@ -822,7 +830,7 @@ namespace Azure.Storage.Blobs.Specialized
             string copyId,
             CancellationToken cancellationToken = default)
         {
-            var response = await this.GetPropertiesAsync(
+            var response = await this.GetPropertiesInternal(
                 null,
                 true, // async
                 cancellationToken)
@@ -835,7 +843,7 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="StartCopyFromUriAsync"/> operation copies data at
+        /// The <see cref="StartCopyFromUriInternal"/> operation copies data at
         /// from the <paramref name="source"/> to this blob.  You can check
         /// the <see cref="BlobProperties.CopyStatus"/> returned from the
         /// <see cref="GetPropertiesAsync"/> to determine if the copy has
@@ -877,14 +885,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobCopyInfo}}"/> describing the
+        /// A <see cref="Response{BlobCopyInfo}"/> describing the
         /// state of the copy operation.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobCopyInfo>> StartCopyFromUriAsync(
+        private async Task<Response<BlobCopyInfo>> StartCopyFromUriInternal(
             Uri source,
             Metadata metadata,
             BlobAccessConditions? sourceAccessConditions,
@@ -932,10 +940,12 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion StartCopyFromUri
 
+        #region AbortCopyFromUri
         /// <summary>
         /// The <see cref="AbortCopyFromUri"/> operation aborts a pending
-        /// <see cref="StartCopyFromUri"/> operation, and leaves a this
+        /// <see cref="CopyFromUriOperation"/>, and leaves a this
         /// blob with zero length and full metadata.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob" />.
@@ -962,7 +972,7 @@ namespace Azure.Storage.Blobs.Specialized
             string copyId,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.AbortCopyFromUriAsync(
+            this.AbortCopyFromUriInternal(
                 copyId,
                 leaseAccessConditions,
                 false, // async
@@ -971,7 +981,7 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The <see cref="AbortCopyFromUriAsync"/> operation aborts a pending
-        /// <see cref="StartCopyFromUriAsync"/> operation, and leaves a this
+        /// <see cref="CopyFromUriOperation"/>, and leaves a this
         /// blob with zero length and full metadata.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob" />.
@@ -988,7 +998,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully aborting.
+        /// A <see cref="Response"/> on successfully aborting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -998,7 +1008,7 @@ namespace Azure.Storage.Blobs.Specialized
             string copyId,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.AbortCopyFromUriAsync(
+            await this.AbortCopyFromUriInternal(
                 copyId,
                 leaseAccessConditions,
                 true, // async
@@ -1007,7 +1017,7 @@ namespace Azure.Storage.Blobs.Specialized
 
         /// <summary>
         /// The <see cref="AbortCopyFromUriAsync"/> operation aborts a pending
-        /// <see cref="StartCopyFromUriAsync"/> operation, and leaves a this
+        /// <see cref="CopyFromUriOperation"/>, and leaves a this
         /// blob with zero length and full metadata.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/abort-copy-blob" />.
@@ -1027,13 +1037,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully aborting.
+        /// A <see cref="Response"/> on successfully aborting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> AbortCopyFromUriAsync(
+        private async Task<Response> AbortCopyFromUriInternal(
             string copyId,
             LeaseAccessConditions? leaseAccessConditions,
             bool async,
@@ -1069,7 +1079,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion AbortCopyFromUri
 
+        #region Delete
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
@@ -1103,7 +1115,7 @@ namespace Azure.Storage.Blobs.Specialized
             DeleteSnapshotsOption? deleteOptions = default,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.DeleteAsync(
+            this.DeleteInternal(
                 deleteOptions,
                 accessConditions,
                 false, // async
@@ -1133,7 +1145,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1143,7 +1155,7 @@ namespace Azure.Storage.Blobs.Specialized
             DeleteSnapshotsOption? deleteOptions = default,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.DeleteAsync(
+            await this.DeleteInternal(
                 deleteOptions,
                 accessConditions,
                 true, // async
@@ -1151,7 +1163,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="DeleteAsync"/> operation marks the specified blob
+        /// The <see cref="DeleteInternal"/> operation marks the specified blob
         /// or snapshot for  deletion. The blob is later deleted during
         /// garbage collection.
         ///
@@ -1176,13 +1188,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> DeleteAsync(
+        private async Task<Response> DeleteInternal(
             DeleteSnapshotsOption? deleteOptions,
             BlobAccessConditions? accessConditions,
             bool async,
@@ -1222,7 +1234,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Delete
 
+        #region Undelete
         /// <summary>
         /// The <see cref="Undelete"/> operation restores the contents
         /// and metadata of a soft deleted blob and any associated soft
@@ -1243,7 +1257,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual Response Undelete(
             CancellationToken cancellationToken = default) =>
-            this.UndeleteAsync(
+            this.UndeleteInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -1260,7 +1274,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1268,13 +1282,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// </remarks>
         public virtual async Task<Response> UndeleteAsync(
             CancellationToken cancellationToken = default) =>
-            await this.UndeleteAsync(
+            await this.UndeleteInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="UndeleteAsync"/> operation restores the contents
+        /// The <see cref="UndeleteInternal"/> operation restores the contents
         /// and metadata of a soft deleted blob and any associated soft
         /// deleted snapshots.
         ///
@@ -1288,13 +1302,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> UndeleteAsync(
+        private async Task<Response> UndeleteInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -1321,7 +1335,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Undelete
 
+        #region GetProperties
         /// <summary>
         /// The <see cref="GetProperties"/> operation returns all
         /// user-defined metadata, standard HTTP properties, and system
@@ -1339,7 +1355,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobProperties}}"/> describing the
+        /// A <see cref="Response{BlobProperties}"/> describing the
         /// blob's properties.
         /// </returns>
         /// <remarks>
@@ -1349,7 +1365,7 @@ namespace Azure.Storage.Blobs.Specialized
         public virtual Response<BlobProperties> GetProperties(
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 accessConditions,
                 false, // async
                 cancellationToken)
@@ -1372,7 +1388,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobProperties}}"/> describing the
+        /// A <see cref="Response{BlobProperties}"/> describing the
         /// blob's properties.
         /// </returns>
         /// <remarks>
@@ -1382,14 +1398,14 @@ namespace Azure.Storage.Blobs.Specialized
         public virtual async Task<Response<BlobProperties>> GetPropertiesAsync(
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 accessConditions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetPropertiesAsync"/> operation returns all
+        /// The <see cref="GetPropertiesInternal"/> operation returns all
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the blob. It does not return the content of the
         /// blob.
@@ -1408,14 +1424,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobProperties}}"/> describing the
+        /// A <see cref="Response{BlobProperties}"/> describing the
         /// blob's properties.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobProperties>> GetPropertiesAsync(
+        private async Task<Response<BlobProperties>> GetPropertiesInternal(
             BlobAccessConditions? accessConditions,
             bool async,
             CancellationToken cancellationToken)
@@ -1452,8 +1468,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion GetProperties
 
-
+        #region SetHttpHeaders
         /// <summary>
         /// The <see cref="SetHttpHeaders"/> operation sets system
         /// properties on the blob.
@@ -1483,7 +1500,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobHttpHeaders? httpHeaders = default,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.SetHttpHeadersAsync(
+            this.SetHttpHeadersInternal(
                 httpHeaders,
                 accessConditions,
                 false, // async
@@ -1508,7 +1525,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobInfo}}"/> describing the updated
+        /// A <see cref="Response{BlobInfo}"/> describing the updated
         /// blob.
         /// </returns>
         /// <remarks>
@@ -1519,7 +1536,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobHttpHeaders? httpHeaders = default,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.SetHttpHeadersAsync(
+            await this.SetHttpHeadersInternal(
                 httpHeaders,
                 accessConditions,
                 true, // async
@@ -1527,7 +1544,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetHttpHeadersAsync"/> operation sets system
+        /// The <see cref="SetHttpHeadersInternal"/> operation sets system
         /// properties on the blob.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-properties" />.
@@ -1547,14 +1564,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobInfo}}"/> describing the updated
+        /// A <see cref="Response{BlobInfo}"/> describing the updated
         /// blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobInfo>> SetHttpHeadersAsync(
+        private async Task<Response<BlobInfo>> SetHttpHeadersInternal(
             BlobHttpHeaders? httpHeaders,
             BlobAccessConditions? accessConditions,
             bool async,
@@ -1608,7 +1625,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion SetHttpHeaders
 
+        #region SetMetadata
         /// <summary>
         /// The <see cref="SetMetadata"/> operation sets user-defined
         /// metadata for the specified blob as one or more name-value pairs.
@@ -1638,7 +1657,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.SetMetadataAsync(
+            this.SetMetadataInternal(
                 metadata,
                 accessConditions,
                 false, // async
@@ -1663,7 +1682,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobInfo}}"/> describing the updated
+        /// A <see cref="Response{BlobInfo}"/> describing the updated
         /// blob.
         /// </returns>
         /// <remarks>
@@ -1674,7 +1693,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.SetMetadataAsync(
+            await this.SetMetadataInternal(
                 metadata,
                 accessConditions,
                 true, // async
@@ -1682,7 +1701,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetMetadataAsync"/> operation sets user-defined
+        /// The <see cref="SetMetadataInternal"/> operation sets user-defined
         /// metadata for the specified blob as one or more name-value pairs.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-blob-metadata" />.
@@ -1702,14 +1721,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobInfo}}"/> describing the updated
+        /// A <see cref="Response{BlobInfo}"/> describing the updated
         /// blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobInfo>> SetMetadataAsync(
+        private async Task<Response<BlobInfo>> SetMetadataInternal(
             Metadata metadata,
             BlobAccessConditions? accessConditions,
             bool async,
@@ -1756,7 +1775,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion SetMetadata
 
+        #region CreateSnapshot
         /// <summary>
         /// The <see cref="CreateSnapshot"/> operation creates a
         /// read-only snapshot of a blob.
@@ -1775,7 +1796,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobSnapshotInfo}}"/> describing the
+        /// A <see cref="Response{BlobSnapshotInfo}"/> describing the
         /// new blob snapshot.
         /// </returns>
         /// <remarks>
@@ -1786,7 +1807,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata = default,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateSnapshotAsync(
+            this.CreateSnapshotInternal(
                 metadata,
                 accessConditions,
                 false, // async
@@ -1811,7 +1832,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobSnapshotInfo}}"/> describing the
+        /// A <see cref="Response{BlobSnapshotInfo}"/> describing the
         /// new blob snapshot.
         /// </returns>
         /// <remarks>
@@ -1822,7 +1843,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata = default,
             BlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateSnapshotAsync(
+            await this.CreateSnapshotInternal(
                 metadata,
                 accessConditions,
                 true, // async
@@ -1830,7 +1851,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="CreateSnapshotAsync"/> operation creates a
+        /// The <see cref="CreateSnapshotInternal"/> operation creates a
         /// read-only snapshot of a blob.
         ///
         /// For more infomration, see <see href="https://docs.microsoft.com/rest/api/storageservices/snapshot-blob" />.
@@ -1850,14 +1871,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobSnapshotInfo}}"/> describing the
+        /// A <see cref="Response{BlobSnapshotInfo}"/> describing the
         /// new blob snapshot.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobSnapshotInfo>> CreateSnapshotAsync(
+        private async Task<Response<BlobSnapshotInfo>> CreateSnapshotInternal(
             Metadata metadata,
             BlobAccessConditions? accessConditions,
             bool async,
@@ -1896,7 +1917,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion CreateSnapshot
 
+        #region SetTier
         /// <summary>
         /// The <see cref="SetTier"/> operation sets the tier on a blob.
         /// The operation is allowed on a page blob in a premium storage
@@ -1934,7 +1957,7 @@ namespace Azure.Storage.Blobs.Specialized
             AccessTier accessTier,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.SetTierAsync(
+            this.SetTierInternal(
                 accessTier,
                 leaseAccessConditions,
                 false, // async
@@ -1968,7 +1991,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully setting the tier.
+        /// A <see cref="Response"/> on successfully setting the tier.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1978,7 +2001,7 @@ namespace Azure.Storage.Blobs.Specialized
             AccessTier accessTier,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.SetTierAsync(
+            await this.SetTierInternal(
                 accessTier,
                 leaseAccessConditions,
                 true, // async
@@ -1986,7 +2009,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetTierAsync"/> operation sets the tier on a blob.
+        /// The <see cref="SetTierInternal"/> operation sets the tier on a blob.
         /// The operation is allowed on a page blob in a premium storage
         /// account and on a block blob in a blob storage or general purpose
         /// v2 account.
@@ -2015,13 +2038,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully setting the tier.
+        /// A <see cref="Response"/> on successfully setting the tier.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> SetTierAsync(
+        private async Task<Response> SetTierInternal(
             AccessTier accessTier,
             LeaseAccessConditions? leaseAccessConditions,
             bool async,
@@ -2057,6 +2080,7 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion SetTier
     }
 }
 

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobClient.cs
@@ -25,6 +25,7 @@ namespace Azure.Storage.Blobs
     /// </summary>
 	public class BlobClient : BlobBaseClient
     {
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobClient"/>
         /// class for mocking.
@@ -161,9 +162,11 @@ namespace Azure.Storage.Blobs
             : base(blobUri, pipeline)
         {
         }
+        #endregion ctors
 
+        #region Upload
         /// <summary>
-        /// The <see cref="Upload"/> operation creates a new block blob
+        /// The <see cref="Upload(Stream)"/> operation creates a new block blob
         /// or updates the content of an existing block blob.  Updating an
         /// existing block blob overwrites any existing metadata on the blob.
         /// 
@@ -189,7 +192,7 @@ namespace Azure.Storage.Blobs
             this.Upload(content, CancellationToken.None);
 
         /// <summary>
-        /// The <see cref="UploadAsync"/> operation creates a new block blob
+        /// The <see cref="UploadAsync(Stream)"/> operation creates a new block blob
         /// or updates the content of an existing block blob.  Updating an
         /// existing block blob overwrites any existing metadata on the blob.
         /// 
@@ -204,7 +207,7 @@ namespace Azure.Storage.Blobs
         /// A <see cref="Stream"/> containing the content to upload.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
@@ -215,9 +218,10 @@ namespace Azure.Storage.Blobs
             await this.UploadAsync(content, CancellationToken.None).ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="Upload"/> operation creates a new block blob
-        /// or updates the content of an existing block blob.  Updating an
-        /// existing block blob overwrites any existing metadata on the blob.
+        /// The <see cref="Upload(Stream, CancellationToken)"/> operation
+        /// creates a new block blob or updates the content of an existing
+        /// block blob.  Updating an existing block blob overwrites any
+        /// existing metadata on the blob.
         /// 
         /// For partial block blob updates and other advanced features, please
         /// see <see cref="BlockBlobClient"/>.  To create or modify page or
@@ -250,9 +254,10 @@ namespace Azure.Storage.Blobs
                 cancellationToken: cancellationToken);
 
         /// <summary>
-        /// The <see cref="UploadAsync"/> operation creates a new block blob
-        /// or updates the content of an existing block blob.  Updating an
-        /// existing block blob overwrites any existing metadata on the blob.
+        /// The <see cref="UploadAsync(Stream, CancellationToken)"/> operation
+        /// creates a new block blob or updates the content of an existing
+        /// block blob.  Updating an existing block blob overwrites any
+        /// existing metadata on the blob.
         /// 
         /// For partial block blob updates and other advanced features, please
         /// see <see cref="BlockBlobClient"/>.  To create or modify page or
@@ -269,7 +274,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
@@ -286,9 +291,10 @@ namespace Azure.Storage.Blobs
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="Upload"/> operation creates a new block blob
-        /// or updates the content of an existing block blob.  Updating an
-        /// existing block blob overwrites any existing metadata on the blob.
+        /// The <see cref="Upload(Stream, BlobHttpHeaders?, Metadata, BlobAccessConditions?, IProgress{StorageProgress}, CancellationToken)"/>
+        /// operation creates a new block blob or updates the content of an
+        /// existing block blob.  Updating an existing block blob overwrites
+        /// any existing metadata on the blob.
         /// 
         /// For partial block blob updates and other advanced features, please
         /// see <see cref="BlockBlobClient"/>.  To create or modify page or
@@ -345,9 +351,10 @@ namespace Azure.Storage.Blobs
                 .EnsureCompleted();
 
         /// <summary>
-        /// The <see cref="UploadAsync"/> operation creates a new block blob
-        /// or updates the content of an existing block blob.  Updating an
-        /// existing block blob overwrites any existing metadata on the blob.
+        /// The <see cref="UploadAsync(Stream, BlobHttpHeaders?, Metadata, BlobAccessConditions?, IProgress{StorageProgress}, CancellationToken)"/>
+        /// operation creates a new block blob or updates the content of an
+        /// existing block blob.  Updating an existing block blob overwrites
+        /// any existing metadata on the blob.
         /// 
         /// For partial block blob updates and other advanced features, please
         /// see <see cref="BlockBlobClient"/>.  To create or modify page or
@@ -379,7 +386,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
@@ -441,7 +448,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
@@ -481,7 +488,7 @@ namespace Azure.Storage.Blobs
                 Stream content,
                 bool async,
                 CancellationToken cancellation) =>
-                client.UploadAsync(
+                client.UploadInternal(
                     content,
                     blobHttpHeaders,
                     metadata,
@@ -504,7 +511,7 @@ namespace Azure.Storage.Blobs
                 blockList.Add(blockId);
 
                 // Upload the block
-                return client.StageBlockAsync(
+                return client.StageBlockInternal(
                     blockId,
                     chunk,
                     null,
@@ -518,7 +525,7 @@ namespace Azure.Storage.Blobs
             Task<Response<BlobContentInfo>> CommitBlockListAsync(
                 bool async,
                 CancellationToken cancellation) =>
-                client.CommitBlockListAsync(
+                client.CommitBlockListInternal(
                     blockList,
                     blobHttpHeaders,
                     metadata,
@@ -526,5 +533,6 @@ namespace Azure.Storage.Blobs
                     async,
                     cancellationToken);
         }
+        #endregion Upload
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs
@@ -56,6 +56,7 @@ namespace Azure.Storage.Blobs
         /// </summary>
         protected internal virtual HttpPipeline Pipeline => this._pipeline;
 
+        #region ctor
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobContainerClient"/>
         /// class for mocking.
@@ -190,6 +191,7 @@ namespace Azure.Storage.Blobs
             this._uri = containerUri;
             this._pipeline = pipeline;
         }
+        #endregion ctor
 
         /// <summary>
         /// Create a new <see cref="BlobClient"/> object by appending
@@ -201,6 +203,7 @@ namespace Azure.Storage.Blobs
         /// <returns>A new <see cref="BlobClient"/> instance.</returns>
         public virtual BlobClient GetBlobClient(string blobName) => new BlobClient(this.Uri.AppendToPath(blobName), this._pipeline);
 
+        #region Create
         /// <summary>
         /// The <see cref="Create"/> operation creates a new container
         /// under the specified account. If the container with the same name
@@ -240,7 +243,7 @@ namespace Azure.Storage.Blobs
             PublicAccessType? publicAccessType = default,
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateAsync(
+            this.CreateInternal(
                 publicAccessType,
                 metadata,
                 false, // async
@@ -275,7 +278,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerInfo}}"/> describing the newly
+        /// A <see cref="Response{ContainerInfo}"/> describing the newly
         /// created container.
         /// </returns>
         /// <remarks>
@@ -286,7 +289,7 @@ namespace Azure.Storage.Blobs
             PublicAccessType? publicAccessType = default,
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateAsync(
+            await this.CreateInternal(
                 publicAccessType,
                 metadata,
                 true, // async
@@ -324,14 +327,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerInfo}}"/> describing the newly
+        /// A <see cref="Response{ContainerInfo}"/> describing the newly
         /// created container.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ContainerInfo>> CreateAsync(
+        private async Task<Response<ContainerInfo>> CreateInternal(
             PublicAccessType? publicAccessType,
             Metadata metadata,
             bool async,
@@ -366,7 +369,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion Create
 
+        #region Delete
         /// <summary>
         /// The <see cref="Delete"/> operation marks the specified
         /// container for deletion. The container and any blobs contained
@@ -392,7 +397,7 @@ namespace Azure.Storage.Blobs
         public virtual Response Delete(
             ContainerAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.DeleteAsync(
+            this.DeleteInternal(
                 accessConditions,
                 false, // async
                 cancellationToken)
@@ -414,7 +419,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -423,7 +428,7 @@ namespace Azure.Storage.Blobs
         public virtual async Task<Response> DeleteAsync(
             ContainerAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.DeleteAsync(
+            await this.DeleteInternal(
                 accessConditions,
                 true, // async
                 cancellationToken)
@@ -448,13 +453,13 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> DeleteAsync(
+        private async Task<Response> DeleteInternal(
             ContainerAccessConditions? accessConditions,
             bool async,
             CancellationToken cancellationToken)
@@ -495,7 +500,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion Delete
 
+        #region GetProperties
         /// <summary>
         /// The <see cref="GetProperties"/> operation returns all
         /// user-defined metadata and system properties for the specified
@@ -523,7 +530,7 @@ namespace Azure.Storage.Blobs
         public virtual Response<ContainerItem> GetProperties(
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 leaseAccessConditions,
                 false, // async
                 cancellationToken)
@@ -546,7 +553,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerItem}}"/> describing the
+        /// A <see cref="Response{ContainerItem}"/> describing the
         /// container and its properties.
         /// </returns>
         /// <remarks>
@@ -556,7 +563,7 @@ namespace Azure.Storage.Blobs
         public virtual async Task<Response<ContainerItem>> GetPropertiesAsync(
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 leaseAccessConditions,
                 true, // async
                 cancellationToken)
@@ -582,14 +589,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerItem}}"/> describing the
+        /// A <see cref="Response{ContainerItem}"/> describing the
         /// container and its properties.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ContainerItem>> GetPropertiesAsync(
+        private async Task<Response<ContainerItem>> GetPropertiesInternal(
             LeaseAccessConditions? leaseAccessConditions,
             bool async,
             CancellationToken cancellationToken)
@@ -645,7 +652,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetProperties
 
+        #region SetMetadata
         /// <summary>
         /// The <see cref="SetMetadata"/> operation sets one or more
         /// user-defined name-value pairs for the specified container.
@@ -664,7 +673,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response{ContainerInfo}}"/> if successful.
+        /// A <see cref="Response{ContainerInfo}"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -674,7 +683,7 @@ namespace Azure.Storage.Blobs
             Metadata metadata,
             ContainerAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.SetMetadataAsync(
+            this.SetMetadataInternal(
                 metadata,
                 accessConditions,
                 false, // async
@@ -699,7 +708,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerInfo}}}"/> if successful.
+        /// A <see cref="Response{ContainerInfo}"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -709,7 +718,7 @@ namespace Azure.Storage.Blobs
             Metadata metadata,
             ContainerAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.SetMetadataAsync(
+            await this.SetMetadataInternal(
                 metadata,
                 accessConditions,
                 true, // async
@@ -717,7 +726,7 @@ namespace Azure.Storage.Blobs
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetMetadataAsync"/> operation sets one or more
+        /// The <see cref="SetMetadataInternal"/> operation sets one or more
         /// user-defined name-value pairs for the specified container.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-container-metadata" />.
@@ -737,13 +746,13 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerInfo}}}"/> if successful.
+        /// A <see cref="Response{ContainerInfo}"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ContainerInfo>> SetMetadataAsync(
+        private async Task<Response<ContainerInfo>> SetMetadataInternal(
             Metadata metadata,
             ContainerAccessConditions? accessConditions,
             bool async,
@@ -789,7 +798,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion SetMetadata
 
+        #region GetAccessPolicy
         /// <summary>
         /// The <see cref="GetAccessPolicy"/> operation gets the
         /// permissions for this container. The permissions indicate whether
@@ -816,7 +827,7 @@ namespace Azure.Storage.Blobs
         public virtual Response<ContainerAccessPolicy> GetAccessPolicy(
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.GetAccessPolicyAsync(
+            this.GetAccessPolicyInternal(
                 leaseAccessConditions,
                 false, // async
                 cancellationToken)
@@ -838,7 +849,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerAccessPolicy}}"/> describing
+        /// A <see cref="Response{ContainerAccessPolicy}"/> describing
         /// the container's access policy.
         /// </returns>
         /// <remarks>
@@ -848,7 +859,7 @@ namespace Azure.Storage.Blobs
         public virtual async Task<Response<ContainerAccessPolicy>> GetAccessPolicyAsync(
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetAccessPolicyAsync(
+            await this.GetAccessPolicyInternal(
                 leaseAccessConditions,
                 true, // async
                 cancellationToken)
@@ -873,14 +884,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerAccessPolicy}}"/> describing
+        /// A <see cref="Response{ContainerAccessPolicy}"/> describing
         /// the container's access policy.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ContainerAccessPolicy>> GetAccessPolicyAsync(
+        private async Task<Response<ContainerAccessPolicy>> GetAccessPolicyInternal(
             LeaseAccessConditions? leaseAccessConditions,
             bool async,
             CancellationToken cancellationToken)
@@ -913,7 +924,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetAccessPolicy
 
+        #region SetAccessPolicy
         /// <summary>
         /// The <see cref="SetAccessPolicy"/> operation sets the
         /// permissions for the specified container. The permissions indicate
@@ -959,7 +972,7 @@ namespace Azure.Storage.Blobs
             IEnumerable<SignedIdentifier> permissions = default,
             ContainerAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.SetAccessPolicyAsync(
+            this.SetAccessPolicyInternal(
                 accessType,
                 permissions,
                 accessConditions,
@@ -1000,7 +1013,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerInfo}}"/> describing the
+        /// A <see cref="Response{ContainerInfo}"/> describing the
         /// updated container.
         /// </returns>
         /// <remarks>
@@ -1012,7 +1025,7 @@ namespace Azure.Storage.Blobs
             IEnumerable<SignedIdentifier> permissions = default,
             ContainerAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.SetAccessPolicyAsync(
+            await this.SetAccessPolicyInternal(
                 accessType,
                 permissions,
                 accessConditions,
@@ -1056,14 +1069,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainerInfo}}"/> describing the
+        /// A <see cref="Response{ContainerInfo}"/> describing the
         /// updated container.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ContainerInfo>> SetAccessPolicyAsync(
+        private async Task<Response<ContainerInfo>> SetAccessPolicyInternal(
             PublicAccessType? accessType,
             IEnumerable<SignedIdentifier> permissions,
             ContainerAccessConditions? accessConditions,
@@ -1108,7 +1121,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion SetAccessPolicy
 
+        #region GetBlobs
         /// <summary>
         /// The <see cref="GetBlobs"/> operation returns an async sequence
         /// of blobs in this container.  Enumerating the blobs may make
@@ -1126,8 +1141,8 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="IEnumerable{Response{BlobItem}}"/> describing the
-        /// blobs in the container.
+        /// An <see cref="IEnumerable{T}"/> of <see cref="Response{BlobItem}"/>
+        /// describing the blobs in the container.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1155,7 +1170,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="AsyncCollection{BlobItem}"/> describing the
+        /// An <see cref="AsyncCollection{BlobItem}"/> describing the
         /// blobs in the container.
         /// </returns>
         /// <remarks>
@@ -1168,7 +1183,7 @@ namespace Azure.Storage.Blobs
             new GetBlobsAsyncCollection(this, options, cancellationToken);
 
         /// <summary>
-        /// The <see cref="GetBlobsAsync"/> operation returns a
+        /// The <see cref="GetBlobsInternal"/> operation returns a
         /// single segment of blobs in this container, starting
         /// from the specified <paramref name="marker"/>.  Use an empty
         /// <paramref name="marker"/> to start enumeration from the beginning
@@ -1204,14 +1219,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobsFlatSegment}}"/> describing a
+        /// A <see cref="Response{BlobsFlatSegment}"/> describing a
         /// segment of the blobs in the container.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<BlobsFlatSegment>> GetBlobsAsync(
+        internal async Task<Response<BlobsFlatSegment>> GetBlobsInternal(
             string marker,
             GetBlobsOptions? options,
             int? pageSizeHint,
@@ -1250,7 +1265,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetBlobs
 
+        #region GetBlobsByHierarchy
         /// <summary>
         /// The <see cref="GetBlobsByHierarchy"/> operation returns
         /// an async collection of blobs in this container.  Enumerating the
@@ -1287,8 +1304,8 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="IEnumerable{Response{BlobHierarchyItem}}"/> describing
-        /// the blobs in the container.
+        /// An <see cref="IEnumerable{T}"/> of <see cref="Response{BlobHierarchyItem}"/>
+        /// describing the blobs in the container.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1336,7 +1353,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="AsyncCollection{BlobHierarchyItem}"/> describing the
+        /// An <see cref="AsyncCollection{BlobHierarchyItem}"/> describing the
         /// blobs in the container.
         /// </returns>
         /// <remarks>
@@ -1350,7 +1367,7 @@ namespace Azure.Storage.Blobs
             new GetBlobsByHierarchyAsyncCollection(this, delimiter, options, cancellationToken);
 
         /// <summary>
-        /// The <see cref="GetBlobsByHierarchyAsync"/> operation returns
+        /// The <see cref="GetBlobsByHierarchyInternal"/> operation returns
         /// a single segment of blobs in this container, starting
         /// from the specified <paramref name="marker"/>.  Use an empty
         /// <paramref name="marker"/> to start enumeration from the beginning
@@ -1405,14 +1422,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobsHierarchySegment}}"/> describing a
+        /// A <see cref="Response{BlobsHierarchySegment}"/> describing a
         /// segment of the blobs in the container.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<BlobsHierarchySegment>> GetBlobsByHierarchyAsync(
+        internal async Task<Response<BlobsHierarchySegment>> GetBlobsByHierarchyInternal(
             string marker,
             string delimiter,
             GetBlobsOptions? options,
@@ -1454,7 +1471,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetBlobsByHierarchy
 
+        #region UploadBlob
         /// <summary>
         /// The <see cref="UploadBlob"/> operation creates a new block
         /// blob or updates the content of an existing block blob in this
@@ -1477,7 +1496,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
@@ -1515,7 +1534,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
@@ -1531,7 +1550,9 @@ namespace Azure.Storage.Blobs
                     content,
                     cancellationToken)
                     .ConfigureAwait(false);
+        #endregion UploadBlob
 
+        #region DeleteBlob
         /// <summary>
         /// The <see cref="DeleteBlob"/> operation marks the specified
         /// blob or snapshot for deletion. The blob is later deleted during
@@ -1556,7 +1577,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1597,7 +1618,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1614,6 +1635,6 @@ namespace Azure.Storage.Blobs
                     accessConditions,
                     cancellationToken)
                     .ConfigureAwait(false);
+        #endregion DeleteBlob
     }
 }
-

--- a/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlobServiceClient.cs
@@ -45,6 +45,7 @@ namespace Azure.Storage.Blobs
         /// </summary>
         protected virtual HttpPipeline Pipeline => this._pipeline;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="BlobServiceClient"/>
         /// class for mocking.
@@ -185,6 +186,7 @@ namespace Azure.Storage.Blobs
             this._uri = serviceUri;
             this._pipeline = pipeline;
         }
+        #endregion ctors
 
         /// <summary>
         /// Create a new <see cref="BlobContainerClient"/> object by appending
@@ -201,6 +203,7 @@ namespace Azure.Storage.Blobs
         public virtual BlobContainerClient GetBlobContainerClient(string containerName) =>
             new BlobContainerClient(this.Uri.AppendToPath(containerName), this.Pipeline);
 
+        #region GetContainers
         /// <summary>
         /// The <see cref="GetContainers"/> operation returns an async
         /// sequence of containers in the storage account.  Enumerating the
@@ -218,8 +221,8 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="IEnumerable{Response{ContainerItem}}"/> describing the
-        /// containers in the storage account.
+        /// An <see cref="IEnumerable{T}"/> of <see cref="Response{ContainerItem}"/>
+        /// describing the containers in the storage account.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -231,14 +234,10 @@ namespace Azure.Storage.Blobs
             new GetContainersAsyncCollection(this, options, cancellationToken);
 
         /// <summary>
-        /// The <see cref="GetContainersAsync"/> operation returns a
-        /// single segment of containers in the storage account, starting
-        /// from the specified marker.  Use an empty
-        /// marker to start enumeration from the beginning
-        /// and the <see cref="ContainersSegment.NextMarker"/> if it's not
-        /// empty to make subsequent calls to <see cref="ListContainersSegmentAsync"/>
-        /// to continue enumerating the containers segment by segment.
-        /// Containers are ordered lexicographically by name.
+        /// The <see cref="GetContainersAsync"/> operation returns an async
+        /// sequence of containers in the storage account.  Enumerating the
+        /// containers may make multiple requests to the service while fetching
+        /// all the values.  Containers are ordered lexicographically by name.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/list-containers2"/>.
         /// </summary>
@@ -264,7 +263,7 @@ namespace Azure.Storage.Blobs
             new GetContainersAsyncCollection(this, options, cancellationToken);
 
         /// <summary>
-        /// The <see cref="GetContainersAsync"/> operation returns a
+        /// The <see cref="GetContainersInternal"/> operation returns a
         /// single segment of containers in the storage account, starting
         /// from the specified <paramref name="continuationToken"/>.  Use an empty
         /// <paramref name="continuationToken"/> to start enumeration from the beginning
@@ -300,14 +299,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ContainersSegment}}"/> describing a
+        /// A <see cref="Response{ContainersSegment}"/> describing a
         /// segment of the containers in the storage account.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<ContainersSegment>> GetContainersAsync(
+        internal async Task<Response<ContainersSegment>> GetContainersInternal(
             string continuationToken,
             GetContainersOptions? options,
             int? pageSizeHint,
@@ -346,7 +345,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetContainers
 
+        #region GetAccountInfo
         /// <summary>
         /// The <see cref="GetAccountInfo"/> operation returns the sku
         /// name and account kind for the specified account.
@@ -366,7 +367,7 @@ namespace Azure.Storage.Blobs
         /// </remarks>
         public virtual Response<AccountInfo> GetAccountInfo(
             CancellationToken cancellationToken = default) =>
-            this.GetAccountInfoAsync(
+            this.GetAccountInfoInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -382,7 +383,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{AccountInfo}}"/> describing the account.
+        /// A <see cref="Response{AccountInfo}"/> describing the account.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -390,13 +391,13 @@ namespace Azure.Storage.Blobs
         /// </remarks>
         public virtual async Task<Response<AccountInfo>> GetAccountInfoAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetAccountInfoAsync(
+            await this.GetAccountInfoInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetAccountInfoAsync"/> operation returns the sku
+        /// The <see cref="GetAccountInfoInternal"/> operation returns the sku
         /// name and account kind for the specified account.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-account-information" />.
@@ -409,13 +410,13 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{AccountInfo}}"/> describing the account.
+        /// A <see cref="Response{AccountInfo}"/> describing the account.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<AccountInfo>> GetAccountInfoAsync(
+        private async Task<Response<AccountInfo>> GetAccountInfoInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -442,7 +443,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetAccountInfo
 
+        #region GetProperties
         /// <summary>
         /// The <see cref="GetProperties"/> operation gets the properties
         /// of a storage account’s blob service, including properties for
@@ -455,7 +458,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceProperties}}"/> describing
+        /// A <see cref="Response{BlobServiceProperties}"/> describing
         /// the service properties.
         /// </returns>
         /// <remarks>
@@ -464,7 +467,7 @@ namespace Azure.Storage.Blobs
         /// </remarks>
         public virtual Response<BlobServiceProperties> GetProperties(
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 false, //async
                 cancellationToken)
                 .EnsureCompleted();
@@ -481,7 +484,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceProperties}}"/> describing
+        /// A <see cref="Response{BlobServiceProperties}"/> describing
         /// the service properties.
         /// </returns>
         /// <remarks>
@@ -490,13 +493,13 @@ namespace Azure.Storage.Blobs
         /// </remarks>
         public virtual async Task<Response<BlobServiceProperties>> GetPropertiesAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 true, //async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetPropertiesAsync"/> operation gets the properties
+        /// The <see cref="GetPropertiesInternal"/> operation gets the properties
         /// of a storage account’s blob service, including properties for
         /// Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
         /// 
@@ -510,14 +513,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceProperties}}"/> describing
+        /// A <see cref="Response{BlobServiceProperties}"/> describing
         /// the service properties.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobServiceProperties>> GetPropertiesAsync(
+        private async Task<Response<BlobServiceProperties>> GetPropertiesInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -544,7 +547,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetProperties
 
+        #region SetProperties
         /// <summary>
         /// The <see cref="SetProperties"/> operation sets properties for
         /// a storage account’s Blob service endpoint, including properties
@@ -571,7 +576,7 @@ namespace Azure.Storage.Blobs
         public virtual Response SetProperties(
             BlobServiceProperties properties,
             CancellationToken cancellationToken = default) =>
-            this.SetPropertiesAsync(
+            this.SetPropertiesInternal(
                 properties,
                 false, // async
                 cancellationToken)
@@ -593,7 +598,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> describing
+        /// A <see cref="Response"/> describing
         /// the service properties.
         /// </returns>
         /// <remarks>
@@ -603,14 +608,14 @@ namespace Azure.Storage.Blobs
         public virtual async Task<Response> SetPropertiesAsync(
             BlobServiceProperties properties,
             CancellationToken cancellationToken = default) =>
-            await this.SetPropertiesAsync(
+            await this.SetPropertiesInternal(
                 properties,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetPropertiesAsync"/> operation sets properties for
+        /// The <see cref="SetPropertiesInternal"/> operation sets properties for
         /// a storage account’s Blob service endpoint, including properties
         /// for Storage Analytics, CORS (Cross-Origin Resource Sharing) rules
         /// and soft delete settings.  You can also use this operation to set
@@ -628,14 +633,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> describing
+        /// A <see cref="Response"/> describing
         /// the service properties.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> SetPropertiesAsync(
+        private async Task<Response> SetPropertiesInternal(
             BlobServiceProperties properties,
             bool async,
             CancellationToken cancellationToken)
@@ -668,7 +673,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion SetProperties
 
+        #region GetStatistics
         /// <summary>
         /// The <see cref="GetStatistics"/> operation retrieves
         /// statistics related to replication for the Blob service.  It is
@@ -676,14 +683,14 @@ namespace Azure.Storage.Blobs
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRAGRS"/>)
         /// is enabled for the storage account.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceStatistics}}"/> describing
+        /// A <see cref="Response{BlobServiceStatistics}"/> describing
         /// the service replication statistics.
         /// </returns>
         /// <remarks>
@@ -692,7 +699,7 @@ namespace Azure.Storage.Blobs
         /// </remarks>
         public virtual Response<BlobServiceStatistics> GetStatistics(
             CancellationToken cancellationToken = default) =>
-            this.GetStatisticsAsync(
+            this.GetStatisticsInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -704,14 +711,14 @@ namespace Azure.Storage.Blobs
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRAGRS"/>)
         /// is enabled for the storage account.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceStatistics}}"/> describing
+        /// A <see cref="Response{BlobServiceStatistics}"/> describing
         /// the service replication statistics.
         /// </returns>
         /// <remarks>
@@ -720,19 +727,19 @@ namespace Azure.Storage.Blobs
         /// </remarks>
         public virtual async Task<Response<BlobServiceStatistics>> GetStatisticsAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetStatisticsAsync(
+            await this.GetStatisticsInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetStatisticsAsync"/> operation retrieves
+        /// The <see cref="GetStatisticsInternal"/> operation retrieves
         /// statistics related to replication for the Blob service.  It is
         /// only available on the secondary location endpoint when read-access
         /// geo-redundant replication (<see cref="Models.SkuName.StandardRAGRS"/>)
         /// is enabled for the storage account.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-blob-service-stats"/>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -742,14 +749,14 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceStatistics}}"/> describing
+        /// A <see cref="Response{BlobServiceStatistics}"/> describing
         /// the service replication statistics.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobServiceStatistics>> GetStatisticsAsync(
+        private async Task<Response<BlobServiceStatistics>> GetStatisticsInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -776,11 +783,13 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetStatistics
 
+        #region GetUserDelegationKey
         /// <summary>
         /// The <see cref="GetUserDelegationKey"/> operation retrieves a
         /// key that can be used to delegate Active Directory authorization to
-        /// shared access signatures created with <see cref="BlobSasBuilder"/>.
+        /// shared access signatures created with <see cref="Sas.BlobSasBuilder"/>.
         /// </summary>
         /// <param name="start">
         /// Start time for the key's validity, with null indicating an
@@ -795,7 +804,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceStatistics}}"/> describing
+        /// A <see cref="Response{BlobServiceStatistics}"/> describing
         /// the service replication statistics.
         /// </returns>
         /// <remarks>
@@ -806,7 +815,7 @@ namespace Azure.Storage.Blobs
             DateTimeOffset? start,
             DateTimeOffset expiry,
             CancellationToken cancellationToken = default) =>
-            this.GetUserDelegationKeyAsync(
+            this.GetUserDelegationKeyInternal(
                 start,
                 expiry,
                 false, // async
@@ -816,7 +825,7 @@ namespace Azure.Storage.Blobs
         /// <summary>
         /// The <see cref="GetUserDelegationKeyAsync"/> operation retrieves a
         /// key that can be used to delegate Active Directory authorization to
-        /// shared access signatures created with <see cref="BlobSasBuilder"/>.
+        /// shared access signatures created with <see cref="Sas.BlobSasBuilder"/>.
         /// </summary>
         /// <param name="start">
         /// Start time for the key's validity, with null indicating an
@@ -831,7 +840,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceStatistics}}"/> describing
+        /// A <see cref="Response{BlobServiceStatistics}"/> describing
         /// the service replication statistics.
         /// </returns>
         /// <remarks>
@@ -842,7 +851,7 @@ namespace Azure.Storage.Blobs
             DateTimeOffset? start,
             DateTimeOffset expiry,
             CancellationToken cancellationToken = default) =>
-            await this.GetUserDelegationKeyAsync(
+            await this.GetUserDelegationKeyInternal(
                 start,
                 expiry,
                 true, // async
@@ -850,9 +859,9 @@ namespace Azure.Storage.Blobs
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetUserDelegationKeyAsync"/> operation retrieves a
+        /// The <see cref="GetUserDelegationKeyInternal"/> operation retrieves a
         /// key that can be used to delegate Active Directory authorization to
-        /// shared access signatures created with <see cref="BlobSasBuilder"/>.
+        /// shared access signatures created with <see cref="Sas.BlobSasBuilder"/>.
         /// </summary>
         /// <param name="start">
         /// Start time for the key's validity, with null indicating an
@@ -868,14 +877,14 @@ namespace Azure.Storage.Blobs
         /// </param>
         /// <param name="async"/>
         /// <returns>
-        /// A <see cref="Task{Response{BlobServiceStatistics}}"/> describing
+        /// A <see cref="Response{BlobServiceStatistics}"/> describing
         /// the service replication statistics.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<UserDelegationKey>> GetUserDelegationKeyAsync(
+        private async Task<Response<UserDelegationKey>> GetUserDelegationKeyInternal(
             DateTimeOffset? start,
             DateTimeOffset expiry,
             bool async,
@@ -917,7 +926,9 @@ namespace Azure.Storage.Blobs
                 }
             }
         }
+        #endregion GetUserDelegationKey
 
+        #region CreateBlobContainer
         /// <summary>
         /// The <see cref="CreateBlobContainer"/> operation creates a new
         /// container under the specified account. If the container with the
@@ -949,7 +960,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContainerClient}}"/> referencing the
+        /// A <see cref="Response{BlobContainerClient}"/> referencing the
         /// newly created container.
         /// </returns>
         /// <remarks>
@@ -998,7 +1009,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContainerClient}}"/> referencing the
+        /// A <see cref="Response{BlobContainerClient}"/> referencing the
         /// newly created container.
         /// </returns>
         /// <remarks>
@@ -1015,7 +1026,9 @@ namespace Azure.Storage.Blobs
             var response = await container.CreateAsync(publicAccessType, metadata, cancellationToken).ConfigureAwait(false);
             return new Response<BlobContainerClient>(response.GetRawResponse(), container);
         }
+        #endregion CreateBlobContainer
 
+        #region DeleteBlobContainer
         /// <summary>
         /// The <see cref="DeleteBlobContainer"/> operation marks the
         /// specified container for deletion. The container and any blobs
@@ -1035,7 +1048,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1069,7 +1082,7 @@ namespace Azure.Storage.Blobs
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1085,5 +1098,6 @@ namespace Azure.Storage.Blobs
                     accessConditions,
                     cancellationToken)
                     .ConfigureAwait(false);
+        #endregion DeleteBlobContainer
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/BlockBlobClient.cs
@@ -98,6 +98,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </summary>
         public const int BlockBlobMaxBlocks = 50000;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockBlobClient"/>
         /// class for mocking.
@@ -234,6 +235,7 @@ namespace Azure.Storage.Blobs.Specialized
             : base(blobUri, pipeline)
         {
         }
+        #endregion ctors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="BlockBlobClient"/>
@@ -279,6 +281,7 @@ namespace Azure.Storage.Blobs.Specialized
         //    return new BlockBlobClient(builder.ToUri(), this.Pipeline);
         //}
 
+        #region Upload
         /// <summary>
         /// The <see cref="Upload"/> operation creates a new block  blob,
         /// or updates the content of an existing block blob.  Updating an
@@ -329,7 +332,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobAccessConditions? blobAccessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            this.UploadAsync(
+            this.UploadInternal(
                 content,
                 blobHttpHeaders,
                 metadata,
@@ -375,7 +378,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
@@ -389,7 +392,7 @@ namespace Azure.Storage.Blobs.Specialized
             BlobAccessConditions? blobAccessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            await this.UploadAsync(
+            await this.UploadInternal(
                 content,
                 blobHttpHeaders,
                 metadata,
@@ -400,7 +403,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="UploadAsync"/> operation creates a new block  blob,
+        /// The <see cref="UploadInternal"/> operation creates a new block blob,
         /// or updates the content of an existing block blob.  Updating an
         /// existing block blob overwrites any existing metadata on the blob.
         /// 
@@ -438,14 +441,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<BlobContentInfo>> UploadAsync(
+        internal async Task<Response<BlobContentInfo>> UploadInternal(
             Stream content,
             BlobHttpHeaders? blobHttpHeaders,
             Metadata metadata,
@@ -506,7 +509,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Upload
 
+        #region StageBlock
         /// <summary>
         /// The <see cref="StageBlock"/> operation creates a new block as
         /// part of a block blob's "staging area" to be eventually committed
@@ -562,7 +567,7 @@ namespace Azure.Storage.Blobs.Specialized
             LeaseAccessConditions? leaseAccessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            this.StageBlockAsync(
+            this.StageBlockInternal(
                 base64BlockId,
                 content,
                 transactionalContentHash,
@@ -613,7 +618,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlockInfo}}"/> describing the
+        /// A <see cref="Response{BlockInfo}"/> describing the
         /// state of the updated block.
         /// </returns>
         /// <remarks>
@@ -627,7 +632,7 @@ namespace Azure.Storage.Blobs.Specialized
             LeaseAccessConditions? leaseAccessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            await this.StageBlockAsync(
+            await this.StageBlockInternal(
                 base64BlockId,
                 content,
                 transactionalContentHash,
@@ -638,8 +643,8 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="StageBlockAsync"/> operation creates a new block as
-        /// part of a block blob's "staging area" to be eventually committed
+        /// The <see cref="StageBlockInternal"/> operation creates a new block
+        /// as part of a block blob's "staging area" to be eventually committed
         /// via the <see cref="CommitBlockListAsync"/> operation.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-block" />.
@@ -681,14 +686,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlockInfo}}"/> describing the
+        /// A <see cref="Response{BlockInfo}"/> describing the
         /// state of the updated block.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<BlockInfo>> StageBlockAsync(
+        internal async Task<Response<BlockInfo>> StageBlockInternal(
             string base64BlockId, 
             Stream content, 
             byte[] transactionalContentHash, 
@@ -743,7 +748,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion StageBlock
 
+        #region StageBlockFromUri
         /// <summary>
         /// The <see cref="StageBlockFromUri"/> operation creates a new
         /// block to be committed as part of a blob where the contents are 
@@ -810,7 +817,7 @@ namespace Azure.Storage.Blobs.Specialized
             HttpAccessConditions? sourceAccessConditions = default,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.StageBlockFromUriAsync(
+            this.StageBlockFromUriInternal(
                 sourceUri,
                 base64BlockId,
                 sourceRange,
@@ -872,7 +879,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlockInfo}}"/> describing the
+        /// A <see cref="Response{BlockInfo}"/> describing the
         /// state of the updated block.
         /// </returns>
         /// <remarks>
@@ -887,7 +894,7 @@ namespace Azure.Storage.Blobs.Specialized
             HttpAccessConditions? sourceAccessConditions = default,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.StageBlockFromUriAsync(
+            await this.StageBlockFromUriInternal(
                 sourceUri,
                 base64BlockId,
                 sourceRange,
@@ -899,7 +906,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="StageBlockFromUriAsync"/> operation creates a new
+        /// The <see cref="StageBlockFromUriInternal"/> operation creates a new
         /// block to be committed as part of a blob where the contents are 
         /// read from the <paramref name="sourceUri" />.
         /// 
@@ -952,14 +959,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlockInfo}}"/> describing the
+        /// A <see cref="Response{BlockInfo}"/> describing the
         /// state of the updated block.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlockInfo>> StageBlockFromUriAsync(
+        private async Task<Response<BlockInfo>> StageBlockFromUriInternal(
             Uri sourceUri,
             string base64BlockId,
             HttpRange sourceRange,
@@ -1008,7 +1015,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion StageBlockFromUri
 
+        #region CommitBlockList
         /// <summary>
         /// The <see cref="CommitBlockList"/> operation writes a blob by
         /// specifying the list of block IDs that make up the blob.  In order
@@ -1023,7 +1032,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         /// 
-        /// For more information, see  <see cref="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
+        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1061,7 +1070,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata = default,
             BlobAccessConditions? blobAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.CommitBlockListAsync(
+            this.CommitBlockListInternal(
                 base64BlockIds,
                 blobHttpHeaders,
                 metadata,
@@ -1084,7 +1093,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         /// 
-        /// For more information, see  <see cref="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
+        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1109,7 +1118,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobAppendInfo}}"/> describing the
+        /// A <see cref="Response{BlobAppendInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
@@ -1122,7 +1131,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata = default,
             BlobAccessConditions? blobAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.CommitBlockListAsync(
+            await this.CommitBlockListInternal(
                 base64BlockIds,
                 blobHttpHeaders,
                 metadata,
@@ -1132,7 +1141,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="CommitBlockListAsync"/> operation writes a blob by
+        /// The <see cref="CommitBlockListInternal"/> operation writes a blob by
         /// specifying the list of block IDs that make up the blob.  In order
         /// to be written as part of a blob, a block must have been
         /// successfully written to the server in a prior <see cref="StageBlockAsync"/>
@@ -1145,7 +1154,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// may belong to.  Any blocks not specified in the block list and
         /// permanently deleted.
         /// 
-        /// For more information, see  <see cref="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
+        /// For more information, see  <see href="https://docs.microsoft.com/rest/api/storageservices/put-block-list"/>
         /// </summary>
         /// <param name="base64BlockIds">
         /// Specify the Uncommitted Base64 encoded block IDs to indicate that
@@ -1173,14 +1182,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobAppendInfo}}"/> describing the
+        /// A <see cref="Response{BlobAppendInfo}"/> describing the
         /// state of the updated block blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<BlobContentInfo>> CommitBlockListAsync(
+        internal async Task<Response<BlobContentInfo>> CommitBlockListInternal(
             IEnumerable<string> base64BlockIds,
             BlobHttpHeaders? blobHttpHeaders,
             Metadata metadata,
@@ -1231,7 +1240,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion CommitBlockList
 
+        #region GetBlockList
         /// <summary>
         /// The <see cref="GetBlockList"/> operation operation retrieves
         /// the list of blocks that have been uploaded as part of a block blob.
@@ -1274,7 +1285,7 @@ namespace Azure.Storage.Blobs.Specialized
             string snapshot = default,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.GetBlockListAsync(
+            this.GetBlockListInternal(
                 listType,
                 snapshot,
                 leaseAccessConditions,
@@ -1312,7 +1323,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlockList}}"/> describing requested
+        /// A <see cref="Response{BlockList}"/> describing requested
         /// block list.
         /// </returns>
         /// <remarks>
@@ -1324,7 +1335,7 @@ namespace Azure.Storage.Blobs.Specialized
             string snapshot = default,
             LeaseAccessConditions? leaseAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetBlockListAsync(
+            await this.GetBlockListInternal(
                 listType,
                 snapshot,
                 leaseAccessConditions,
@@ -1333,7 +1344,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetBlockListAsync"/> operation operation retrieves
+        /// The <see cref="GetBlockListInternal"/> operation operation retrieves
         /// the list of blocks that have been uploaded as part of a block blob.
         /// There are two block lists maintained for a blob.  The Committed
         /// Block list has blocks that have been successfully committed to a
@@ -1365,14 +1376,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlockList}}"/> describing requested
+        /// A <see cref="Response{BlockList}"/> describing requested
         /// block list.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlockList>> GetBlockListAsync(
+        private async Task<Response<BlockList>> GetBlockListInternal(
             BlockListType? listType,
             string snapshot,
             LeaseAccessConditions? leaseAccessConditions,
@@ -1412,6 +1423,7 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion GetBlockList
     }
 
     /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Generated/BlobRestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
@@ -22,6 +22,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Sets properties for a storage account's Blob service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="blobServiceProperties">The StorageService properties.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -59,6 +60,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Service.SetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="blobServiceProperties">The StorageService properties.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -93,7 +95,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 System.Xml.Linq.XElement _body = Azure.Storage.Blobs.Models.BlobServiceProperties.ToXml(blobServiceProperties, "StorageServiceProperties", "");
@@ -136,6 +138,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// gets the properties of a storage account's Blob service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -170,6 +173,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Service.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -198,7 +202,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -244,6 +248,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Retrieves statistics related to replication for the Blob service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -278,6 +283,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Service.GetStatisticsAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -306,7 +312,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -352,6 +358,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The List Containers Segment operation returns a list of the containers under the specified account
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only containers whose name begins with the specified prefix.</param>
             /// <param name="marker">A string value that identifies the portion of the list of containers to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.</param>
@@ -398,6 +405,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Service.ListContainersSegmentAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only containers whose name begins with the specified prefix.</param>
             /// <param name="marker">A string value that identifies the portion of the list of containers to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.</param>
@@ -437,7 +445,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -483,6 +491,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Retrieves a user delgation key for the Blob service. This is only a valid operation when using bearer token authentication.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="keyInfo">Key information</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -520,6 +529,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Service.GetUserDelegationKeyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="keyInfo">Key information</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -554,7 +564,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 System.Xml.Linq.XElement _body = Azure.Storage.Blobs.Models.KeyInfo.ToXml(keyInfo, "KeyInfo", "");
@@ -607,6 +617,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Returns the sku name and account kind
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
             /// <param name="cancellationToken">Cancellation token.</param>
@@ -635,6 +646,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Service.GetAccountInfoAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <returns>The Service.GetAccountInfoAsync Request.</returns>
             internal static Azure.Core.Http.Request GetAccountInfoAsync_CreateRequest(
@@ -721,6 +733,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// creates a new container under the specified account. If the container with the same name already exists, the operation fails
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="metadata">Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the operation will copy the metadata from the source blob or file to the destination blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers, Blobs, and Metadata for more information.</param>
@@ -761,6 +774,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.CreateAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="metadata">Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the operation will copy the metadata from the source blob or file to the destination blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers, Blobs, and Metadata for more information.</param>
@@ -797,9 +811,9 @@ namespace Azure.Storage.Blobs
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (access != null) { _request.Headers.SetValue("x-ms-blob-public-access", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(access.Value));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (access != null) { _request.Headers.SetValue("x-ms-blob-public-access", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(access.Value)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -855,6 +869,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// returns all user-defined metadata and system properties for the specified container. The data returned does not include the container's list of blobs
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
@@ -892,6 +907,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
@@ -921,8 +937,8 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1022,6 +1038,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// operation marks the specified container for deletion. The container and any blobs contained within it are later deleted during garbage collection
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
@@ -1065,6 +1082,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.DeleteAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
@@ -1098,10 +1116,10 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1137,6 +1155,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// operation sets one or more user-defined name-value pairs for the specified container.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
@@ -1180,6 +1199,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.SetMetadataAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
@@ -1214,15 +1234,15 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1278,6 +1298,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// gets the permissions for the specified container. The permissions indicate whether container data may be accessed publicly.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
@@ -1315,6 +1336,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.GetAccessPolicyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="leaseId">If specified, the operation only succeeds if the resource's lease is active and matches this ID.</param>
@@ -1345,8 +1367,8 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1412,6 +1434,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// sets the permissions for the specified container. The permissions indicate whether blobs in a container may be accessed publicly.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="permissions">the acls for the container</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -1461,6 +1484,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.SetAccessPolicyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="permissions">the acls for the container</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -1499,11 +1523,11 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (access != null) { _request.Headers.SetValue("x-ms-blob-public-access", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(access.Value));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (access != null) { _request.Headers.SetValue("x-ms-blob-public-access", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(access.Value)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 System.Xml.Linq.XElement _body = new System.Xml.Linq.XElement(System.Xml.Linq.XName.Get("SignedIdentifiers", ""));
@@ -1573,6 +1597,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="duration">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.</param>
@@ -1619,6 +1644,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.AcquireLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="duration">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.</param>
@@ -1656,11 +1682,11 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "acquire");
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (duration != null) { _request.Headers.SetValue("x-ms-lease-duration", duration.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (proposedLeaseId != null) { _request.Headers.SetValue("x-ms-proposed-lease-id", proposedLeaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (duration != null) { _request.Headers.SetValue("x-ms-lease-duration", duration.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (proposedLeaseId != null) { _request.Headers.SetValue("x-ms-proposed-lease-id", proposedLeaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1720,6 +1746,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -1763,6 +1790,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.ReleaseLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -1803,9 +1831,9 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-lease-action", "release");
                 _request.Headers.SetValue("x-ms-lease-id", leaseId);
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1861,6 +1889,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -1904,6 +1933,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.RenewLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -1944,9 +1974,9 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-lease-action", "renew");
                 _request.Headers.SetValue("x-ms-lease-id", leaseId);
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -2006,6 +2036,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="breakPeriod">For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This break period is only used if it is shorter than the time remaining on the lease. If longer, the time remaining on the lease is used. A new lease will not be available before the break period has expired, but the lease may be held for longer than the break period. If this header does not appear with a break operation, a fixed-duration lease breaks after the remaining lease period elapses, and an infinite lease breaks immediately.</param>
@@ -2049,6 +2080,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.BreakLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="breakPeriod">For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This break period is only used if it is shorter than the time remaining on the lease. If longer, the time remaining on the lease is used. A new lease will not be available before the break period has expired, but the lease may be held for longer than the break period. If this header does not appear with a break operation, a fixed-duration lease breaks after the remaining lease period elapses, and an infinite lease breaks immediately.</param>
@@ -2084,10 +2116,10 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "break");
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (breakPeriod != null) { _request.Headers.SetValue("x-ms-lease-break-period", breakPeriod.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (breakPeriod != null) { _request.Headers.SetValue("x-ms-lease-break-period", breakPeriod.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -2159,6 +2191,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] establishes and manages a lock on a container for delete operations. The lock duration can be 15 to 60 seconds, or can be infinite
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="proposedLeaseId">Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID string formats.</param>
@@ -2205,6 +2238,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.ChangeLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="proposedLeaseId">Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID string formats.</param>
@@ -2252,9 +2286,9 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-lease-id", leaseId);
                 _request.Headers.SetValue("x-ms-proposed-lease-id", proposedLeaseId);
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -2314,6 +2348,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] The List Blobs operation returns a list of the blobs under the specified container
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only containers whose name begins with the specified prefix.</param>
             /// <param name="marker">A string value that identifies the portion of the list of containers to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.</param>
@@ -2360,6 +2395,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.ListBlobsFlatSegmentAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only containers whose name begins with the specified prefix.</param>
             /// <param name="marker">A string value that identifies the portion of the list of containers to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all containers remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.</param>
@@ -2400,7 +2436,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -2446,6 +2482,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] The List Blobs operation returns a list of the blobs under the specified container
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only containers whose name begins with the specified prefix.</param>
             /// <param name="delimiter">When the request includes this parameter, the operation returns a BlobPrefix element in the response body that acts as a placeholder for all blobs whose names begin with the same substring up to the appearance of the delimiter character. The delimiter may be a single character or a string.</param>
@@ -2495,6 +2532,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Container.ListBlobsHierarchySegmentAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only containers whose name begins with the specified prefix.</param>
             /// <param name="delimiter">When the request includes this parameter, the operation returns a BlobPrefix element in the response body that acts as a placeholder for all blobs whose names begin with the same substring up to the appearance of the delimiter character. The delimiter may be a single character or a string.</param>
@@ -2538,7 +2576,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -2592,6 +2630,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Download operation reads or downloads a blob from the system, including its metadata and properties. You can also call Download to read a snapshot.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -2650,6 +2689,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.DownloadAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -2693,18 +2733,18 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (range != null) { _request.Headers.SetValue("x-ms-range", range);  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
+                if (range != null) { _request.Headers.SetValue("x-ms-range", range); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
                 if (rangeGetContentHash != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
                 _request.Headers.SetValue("x-ms-range-get-content-md5", rangeGetContentHash.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
                 #pragma warning restore CA1308 // Normalize strings to uppercase
-                 }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -3024,6 +3064,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Get Properties operation returns all user-defined metadata, standard HTTP properties, and system properties for the blob. It does not return the content of the blob.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -3076,6 +3117,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -3115,12 +3157,12 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -3316,6 +3358,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// If the storage account's soft delete feature is disabled then, when a blob is deleted, it is permanently removed from the storage account. If the storage account's soft delete feature is enabled, then, when a blob is deleted, it is marked for deletion and becomes inaccessible immediately. However, the blob service retains the blob or snapshot for the number of days specified by the DeleteRetentionPolicy section of [Storage service properties] (Set-Blob-Service-Properties.md). After the specified number of days has passed, the blob's data is permanently removed from the storage account. Note that you continue to be charged for the soft-deleted blob's storage until it is permanently removed. Use the List Blobs API and specify the "include=deleted" query parameter to discover which blobs and snapshots have been soft deleted. You can then use the Undelete Blob API to restore a soft-deleted blob. All other operations on a soft-deleted blob or snapshot causes the service to return an HTTP status code of 404 (ResourceNotFound).
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -3371,6 +3414,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.DeleteAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -3412,13 +3456,13 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (deleteSnapshots != null) { _request.Headers.SetValue("x-ms-delete-snapshots", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(deleteSnapshots.Value));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (deleteSnapshots != null) { _request.Headers.SetValue("x-ms-delete-snapshots", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(deleteSnapshots.Value)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -3454,6 +3498,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Undelete a blob that was previously soft deleted
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -3488,6 +3533,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.UndeleteAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -3515,7 +3561,7 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -3551,6 +3597,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Set HTTP Headers operation sets system properties on the blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="blobCacheControl">Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read request.</param>
@@ -3618,6 +3665,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.SetHttpHeadersAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="blobCacheControl">Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read request.</param>
@@ -3667,28 +3715,28 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl);  }
-                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType);  }
-                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash));  }
+                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl); }
+                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType); }
+                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash)); }
                 if (blobContentEncoding != null) {
                     foreach (string _item in blobContentEncoding)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-encoding", _item);
                     }
-                 }
+                }
                 if (blobContentLanguage != null) {
                     foreach (string _item in blobContentLanguage)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-language", _item);
                     }
-                 }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -3760,6 +3808,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Set Blob Metadata operation sets user-defined metadata for the specified blob as one or more name-value pairs
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="metadata">Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the operation will copy the metadata from the source blob or file to the destination blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers, Blobs, and Metadata for more information.</param>
@@ -3812,6 +3861,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.SetMetadataAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="metadata">Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the operation will copy the metadata from the source blob or file to the destination blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers, Blobs, and Metadata for more information.</param>
@@ -3856,13 +3906,13 @@ namespace Azure.Storage.Blobs
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -3934,6 +3984,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="duration">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.</param>
@@ -3986,6 +4037,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.AcquireLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="duration">Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires. A non-infinite lease can be between 15 and 60 seconds. A lease duration cannot be changed using renew or change.</param>
@@ -4026,13 +4078,13 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "acquire");
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (duration != null) { _request.Headers.SetValue("x-ms-lease-duration", duration.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (proposedLeaseId != null) { _request.Headers.SetValue("x-ms-proposed-lease-id", proposedLeaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (duration != null) { _request.Headers.SetValue("x-ms-lease-duration", duration.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (proposedLeaseId != null) { _request.Headers.SetValue("x-ms-proposed-lease-id", proposedLeaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -4092,6 +4144,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -4141,6 +4194,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.ReleaseLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -4184,11 +4238,11 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-lease-action", "release");
                 _request.Headers.SetValue("x-ms-lease-id", leaseId);
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -4244,6 +4298,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -4293,6 +4348,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.RenewLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -4336,11 +4392,11 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-lease-action", "renew");
                 _request.Headers.SetValue("x-ms-lease-id", leaseId);
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -4400,6 +4456,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="proposedLeaseId">Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID string formats.</param>
@@ -4452,6 +4509,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.ChangeLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="leaseId">Specifies the current lease ID on the resource.</param>
             /// <param name="proposedLeaseId">Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request) if the proposed lease ID is not in the correct format. See Guid Constructor (String) for a list of valid GUID string formats.</param>
@@ -4502,11 +4560,11 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-lease-id", leaseId);
                 _request.Headers.SetValue("x-ms-proposed-lease-id", proposedLeaseId);
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -4566,6 +4624,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// [Update] The Lease Blob operation establishes and manages a lock on a blob for write and delete operations
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="breakPeriod">For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This break period is only used if it is shorter than the time remaining on the lease. If longer, the time remaining on the lease is used. A new lease will not be available before the break period has expired, but the lease may be held for longer than the break period. If this header does not appear with a break operation, a fixed-duration lease breaks after the remaining lease period elapses, and an infinite lease breaks immediately.</param>
@@ -4615,6 +4674,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.BreakLeaseAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="breakPeriod">For a break operation, proposed duration the lease should continue before it is broken, in seconds, between 0 and 60. This break period is only used if it is shorter than the time remaining on the lease. If longer, the time remaining on the lease is used. A new lease will not be available before the break period has expired, but the lease may be held for longer than the break period. If this header does not appear with a break operation, a fixed-duration lease breaks after the remaining lease period elapses, and an infinite lease breaks immediately.</param>
@@ -4653,12 +4713,12 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-lease-action", "break");
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (breakPeriod != null) { _request.Headers.SetValue("x-ms-lease-break-period", breakPeriod.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (breakPeriod != null) { _request.Headers.SetValue("x-ms-lease-break-period", breakPeriod.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -4730,6 +4790,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Create Snapshot operation creates a read-only snapshot of a blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="metadata">Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the operation will copy the metadata from the source blob or file to the destination blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers, Blobs, and Metadata for more information.</param>
@@ -4782,6 +4843,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.CreateSnapshotAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="metadata">Optional. Specifies a user-defined name-value pair associated with the blob. If no name-value pairs are specified, the operation will copy the metadata from the source blob or file to the destination blob. If one or more name-value pairs are specified, the destination blob is created with the specified metadata, and metadata is not copied from the source blob or file. Note that beginning with version 2009-09-19, metadata names must adhere to the naming rules for C# identifiers. See Naming and Referencing Containers, Blobs, and Metadata for more information.</param>
@@ -4826,13 +4888,13 @@ namespace Azure.Storage.Blobs
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -4892,6 +4954,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Start Copy From URL operation copies a blob or an internet resource to a new blob.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="copySource">Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must either be public or must be authenticated via a shared access signature.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -4959,6 +5022,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.StartCopyFromUriAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="copySource">Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must either be public or must be authenticated via a shared access signature.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -5017,17 +5081,17 @@ namespace Azure.Storage.Blobs
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString());  }
-                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString());  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString()); }
+                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString()); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -5091,6 +5155,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Copy From URL operation copies a blob or an internet resource to a new blob. It will not return a response until the copy is complete.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="copySource">Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must either be public or must be authenticated via a shared access signature.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -5158,6 +5223,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.CopyFromUriAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="copySource">Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must either be public or must be authenticated via a shared access signature.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -5217,17 +5283,17 @@ namespace Azure.Storage.Blobs
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString());  }
-                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString());  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString()); }
+                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString()); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -5291,6 +5357,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Abort Copy From URL operation aborts a pending Copy From URL operation, and leaves a destination blob with zero length and full metadata.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="copyId">The copy identifier provided in the x-ms-copy-id header of the original Copy Blob operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -5331,6 +5398,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.AbortCopyFromUriAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="copyId">The copy identifier provided in the x-ms-copy-id header of the original Copy Blob operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -5368,8 +5436,8 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-action", "abort");
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -5405,6 +5473,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Set Tier operation sets the tier on a blob. The operation is allowed on a page blob in a premium storage account and on a block blob in a blob storage account (locally redundant storage only). A premium page blob's tier determines the allowed size, IOPS, and bandwidth of the blob. A block blob's tier determines Hot/Cool/Archive storage type. This operation does not update the blob's ETag.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="tier">Indicates the tier to be set on the blob.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -5445,6 +5514,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the Blob.SetTierAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="tier">Indicates the tier to be set on the blob.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -5481,8 +5551,8 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-access-tier", tier);
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
 
                 return _request;
             }
@@ -5530,6 +5600,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Create operation creates a new page blob.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="contentLength">The length of the request.</param>
             /// <param name="blobContentLength">This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned to a 512-byte boundary.</param>
@@ -5609,6 +5680,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.CreateAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="contentLength">The length of the request.</param>
             /// <param name="blobContentLength">This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned to a 512-byte boundary.</param>
@@ -5668,35 +5740,35 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-blob-content-length", blobContentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType);  }
+                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType); }
                 if (blobContentEncoding != null) {
                     foreach (string _item in blobContentEncoding)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-encoding", _item);
                     }
-                 }
+                }
                 if (blobContentLanguage != null) {
                     foreach (string _item in blobContentLanguage)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-language", _item);
                     }
-                 }
-                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash));  }
-                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl);  }
+                }
+                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash)); }
+                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl); }
                 if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (blobSequenceNumber != null) { _request.Headers.SetValue("x-ms-blob-sequence-number", blobSequenceNumber.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (blobSequenceNumber != null) { _request.Headers.SetValue("x-ms-blob-sequence-number", blobSequenceNumber.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -5760,6 +5832,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Upload Pages operation writes a range of pages to a page blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="body">Initial data</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -5830,6 +5903,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.UploadPagesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="body">Initial data</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -5887,17 +5961,17 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-page-write", "update");
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (transactionalContentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(transactionalContentHash));  }
-                if (range != null) { _request.Headers.SetValue("x-ms-range", range);  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifSequenceNumberEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-eq", ifSequenceNumberEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (transactionalContentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(transactionalContentHash)); }
+                if (range != null) { _request.Headers.SetValue("x-ms-range", range); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifSequenceNumberEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-eq", ifSequenceNumberEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(body);
@@ -5964,6 +6038,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Clear Pages operation clears a set of pages from a page blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="contentLength">The length of the request.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6028,6 +6103,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.ClearPagesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="contentLength">The length of the request.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6077,16 +6153,16 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-page-write", "clear");
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (range != null) { _request.Headers.SetValue("x-ms-range", range);  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifSequenceNumberEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-eq", ifSequenceNumberEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (range != null) { _request.Headers.SetValue("x-ms-range", range); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifSequenceNumberEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-eq", ifSequenceNumberEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -6150,6 +6226,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Upload Pages operation writes a range of pages to a page blob where the contents are read from a URL
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="sourceUri">Specify a URL to the copy source.</param>
             /// <param name="sourceRange">Bytes of source data in the specified range. The length of this range should match the ContentLength header and x-ms-range/Range destination range header.</param>
@@ -6235,6 +6312,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.UploadPagesFromUriAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="sourceUri">Specify a URL to the copy source.</param>
             /// <param name="sourceRange">Bytes of source data in the specified range. The length of this range should match the ContentLength header and x-ms-range/Range destination range header.</param>
@@ -6313,20 +6391,20 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-range", range);
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (sourceContentHash != null) { _request.Headers.SetValue("x-ms-source-content-md5", System.Convert.ToBase64String(sourceContentHash));  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifSequenceNumberEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-eq", ifSequenceNumberEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString());  }
-                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (sourceContentHash != null) { _request.Headers.SetValue("x-ms-source-content-md5", System.Convert.ToBase64String(sourceContentHash)); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifSequenceNumberLessThanOrEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-le", ifSequenceNumberLessThanOrEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifSequenceNumberLessThan != null) { _request.Headers.SetValue("x-ms-if-sequence-number-lt", ifSequenceNumberLessThan.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifSequenceNumberEqualTo != null) { _request.Headers.SetValue("x-ms-if-sequence-number-eq", ifSequenceNumberEqualTo.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString()); }
+                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -6404,6 +6482,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Get Page Ranges operation returns the list of valid page ranges for a page blob or snapshot of a page blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6459,6 +6538,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.GetPageRangesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6501,13 +6581,13 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (range != null) { _request.Headers.SetValue("x-ms-range", range);  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (range != null) { _request.Headers.SetValue("x-ms-range", range); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -6583,6 +6663,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Get Page Ranges Diff operation returns the list of valid page ranges for a page blob that were changed between target blob and previous snapshot.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6641,6 +6722,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.GetPageRangesDiffAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6686,13 +6768,13 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (range != null) { _request.Headers.SetValue("x-ms-range", range);  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (range != null) { _request.Headers.SetValue("x-ms-range", range); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -6768,6 +6850,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Resize the Blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="blobContentLength">This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned to a 512-byte boundary.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6820,6 +6903,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.ResizeAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="blobContentLength">This header specifies the maximum size for the page blob, up to 1 TB. The page blob size must be aligned to a 512-byte boundary.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6860,12 +6944,12 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-blob-content-length", blobContentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -6925,6 +7009,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Update the sequence number of the blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="sequenceNumberAction">Required if the x-ms-blob-sequence-number header is set for the request. This property applies to page blobs only. This property indicates how the service should modify the blob's sequence number</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -6980,6 +7065,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.UpdateSequenceNumberAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="sequenceNumberAction">Required if the x-ms-blob-sequence-number header is set for the request. This property applies to page blobs only. This property indicates how the service should modify the blob's sequence number</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -7022,13 +7108,13 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-sequence-number-action", Azure.Storage.Blobs.BlobRestClient.Serialization.ToString(sequenceNumberAction));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (blobSequenceNumber != null) { _request.Headers.SetValue("x-ms-blob-sequence-number", blobSequenceNumber.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (blobSequenceNumber != null) { _request.Headers.SetValue("x-ms-blob-sequence-number", blobSequenceNumber.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -7088,6 +7174,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Copy Incremental operation copies a snapshot of the source page blob to a destination page blob. The snapshot is copied such that only the differential changes between the previously copied snapshot are transferred to the destination. The copied snapshots are complete copies of the original snapshot and can be read or copied from as usual. This API is supported since REST version 2016-05-31.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="copySource">Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must either be public or must be authenticated via a shared access signature.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -7137,6 +7224,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the PageBlob.CopyIncrementalAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="copySource">Specifies the name of the source page blob snapshot. This value is a URL of up to 2 KB in length that specifies a page blob snapshot. The value should be URL-encoded as it would appear in a request URI. The source blob must either be public or must be authenticated via a shared access signature.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -7179,11 +7267,11 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -7255,6 +7343,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Create Append Blob operation creates a new append blob.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="contentLength">The length of the request.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -7328,6 +7417,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the AppendBlob.CreateAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="contentLength">The length of the request.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
@@ -7382,34 +7472,34 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-blob-type", "AppendBlob");
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType);  }
+                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType); }
                 if (blobContentEncoding != null) {
                     foreach (string _item in blobContentEncoding)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-encoding", _item);
                     }
-                 }
+                }
                 if (blobContentLanguage != null) {
                     foreach (string _item in blobContentLanguage)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-language", _item);
                     }
-                 }
-                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash));  }
-                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl);  }
+                }
+                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash)); }
+                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl); }
                 if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -7473,6 +7563,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Append Block operation commits a new block of data to the end of an existing append blob. The Append Block operation is permitted only if the blob was created with x-ms-blob-type set to AppendBlob. Append Block is supported only on version 2015-02-21 version or later.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="body">Initial data</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -7537,6 +7628,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the AppendBlob.AppendBlockAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="body">Initial data</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -7589,15 +7681,15 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (transactionalContentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(transactionalContentHash));  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (maxSize != null) { _request.Headers.SetValue("x-ms-blob-condition-maxsize", maxSize.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (appendPosition != null) { _request.Headers.SetValue("x-ms-blob-condition-appendpos", appendPosition.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (transactionalContentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(transactionalContentHash)); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (maxSize != null) { _request.Headers.SetValue("x-ms-blob-condition-maxsize", maxSize.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (appendPosition != null) { _request.Headers.SetValue("x-ms-blob-condition-appendpos", appendPosition.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(body);
@@ -7672,6 +7764,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Append Block operation commits a new block of data to the end of an existing append blob where the contents are read from a source url. The Append Block operation is permitted only if the blob was created with x-ms-blob-type set to AppendBlob. Append Block is supported only on version 2015-02-21 version or later.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="sourceUri">Specify a URL to the copy source.</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -7751,6 +7844,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the AppendBlob.AppendBlockFromUriAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="sourceUri">Specify a URL to the copy source.</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -7814,20 +7908,20 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-copy-source", sourceUri.ToString());
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (sourceRange != null) { _request.Headers.SetValue("x-ms-source-range", sourceRange);  }
-                if (sourceContentHash != null) { _request.Headers.SetValue("x-ms-source-content-md5", System.Convert.ToBase64String(sourceContentHash));  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (maxSize != null) { _request.Headers.SetValue("x-ms-blob-condition-maxsize", maxSize.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (appendPosition != null) { _request.Headers.SetValue("x-ms-blob-condition-appendpos", appendPosition.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString());  }
-                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (sourceRange != null) { _request.Headers.SetValue("x-ms-source-range", sourceRange); }
+                if (sourceContentHash != null) { _request.Headers.SetValue("x-ms-source-content-md5", System.Convert.ToBase64String(sourceContentHash)); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (maxSize != null) { _request.Headers.SetValue("x-ms-blob-condition-maxsize", maxSize.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (appendPosition != null) { _request.Headers.SetValue("x-ms-blob-condition-appendpos", appendPosition.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString()); }
+                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -7921,6 +8015,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Upload Block Blob operation updates the content of an existing block blob. Updating an existing block blob overwrites any existing metadata on the blob. Partial updates are not supported with Put Blob; the content of the existing blob is overwritten with the content of the new blob. To perform a partial update of the content of a block blob, use the Put Block List operation.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="body">Initial data</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -7997,6 +8092,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the BlockBlob.UploadAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="body">Initial data</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -8057,34 +8153,34 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("x-ms-blob-type", "BlockBlob");
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType);  }
+                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType); }
                 if (blobContentEncoding != null) {
                     foreach (string _item in blobContentEncoding)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-encoding", _item);
                     }
-                 }
+                }
                 if (blobContentLanguage != null) {
                     foreach (string _item in blobContentLanguage)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-language", _item);
                     }
-                 }
-                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash));  }
-                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl);  }
+                }
+                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash)); }
+                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl); }
                 if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(body);
@@ -8151,6 +8247,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Stage Block operation creates a new block to be committed as part of a blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="blockId">A valid Base64 string value that identifies the block. Prior to encoding, the string must be less than or equal to 64 bytes in size. For a given blob, the length of the value specified for the blockid parameter must be the same size for each block.</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -8200,6 +8297,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the BlockBlob.StageBlockAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="blockId">A valid Base64 string value that identifies the block. Prior to encoding, the string must be less than or equal to 64 bytes in size. For a given blob, the length of the value specified for the blockid parameter must be the same size for each block.</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -8247,9 +8345,9 @@ namespace Azure.Storage.Blobs
                 // Add request headers
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (transactionalContentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(transactionalContentHash));  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (transactionalContentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(transactionalContentHash)); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(body);
@@ -8304,6 +8402,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Stage Block operation creates a new block to be committed as part of a blob where the contents are read from a URL.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="blockId">A valid Base64 string value that identifies the block. Prior to encoding, the string must be less than or equal to 64 bytes in size. For a given blob, the length of the value specified for the blockid parameter must be the same size for each block.</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -8368,6 +8467,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the BlockBlob.StageBlockFromUriAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="blockId">A valid Base64 string value that identifies the block. Prior to encoding, the string must be less than or equal to 64 bytes in size. For a given blob, the length of the value specified for the blockid parameter must be the same size for each block.</param>
             /// <param name="contentLength">The length of the request.</param>
@@ -8426,14 +8526,14 @@ namespace Azure.Storage.Blobs
                 _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Headers.SetValue("x-ms-copy-source", sourceUri.ToString());
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (sourceRange != null) { _request.Headers.SetValue("x-ms-source-range", sourceRange);  }
-                if (sourceContentHash != null) { _request.Headers.SetValue("x-ms-source-content-md5", System.Convert.ToBase64String(sourceContentHash));  }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString());  }
-                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (sourceRange != null) { _request.Headers.SetValue("x-ms-source-range", sourceRange); }
+                if (sourceContentHash != null) { _request.Headers.SetValue("x-ms-source-content-md5", System.Convert.ToBase64String(sourceContentHash)); }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (sourceIfModifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-modified-since", sourceIfModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfUnmodifiedSince != null) { _request.Headers.SetValue("x-ms-source-if-unmodified-since", sourceIfUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (sourceIfMatch != null) { _request.Headers.SetValue("x-ms-source-if-match", sourceIfMatch.Value.ToString()); }
+                if (sourceIfNoneMatch != null) { _request.Headers.SetValue("x-ms-source-if-none-match", sourceIfNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -8499,7 +8599,9 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Commit Block List operation writes a blob by specifying the list of block IDs that make up the blob. In order to be written as part of a blob, a block must have been successfully written to the server in a prior Put Block operation. You can call Put Block List to update a blob by uploading only those blocks that have changed, then committing the new and existing blocks together. You can do this by specifying whether to commit a block from the committed block list or from the uncommitted block list, or to commit the most recently uploaded version of the block, whichever list it may belong to.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
+            /// <param name="blocks">A list of block IDs split between the committed block list, in the uncommitted block list, or in the uncommitted block list first and then in the committed block list.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="blobCacheControl">Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read request.</param>
             /// <param name="blobContentType">Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.</param>
@@ -8571,7 +8673,9 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the BlockBlob.CommitBlockListAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
+            /// <param name="blocks">A list of block IDs split between the committed block list, in the uncommitted block list, or in the uncommitted block list first and then in the committed block list.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/setting-timeouts-for-blob-service-operations">Setting Timeouts for Blob Service Operations.</a></param>
             /// <param name="blobCacheControl">Optional. Sets the blob's cache control. If specified, this property is stored with the blob and returned with a read request.</param>
             /// <param name="blobContentType">Optional. Sets the blob's content type. If specified, this property is stored with the blob and returned with a read request.</param>
@@ -8627,34 +8731,34 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl);  }
-                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType);  }
+                if (blobCacheControl != null) { _request.Headers.SetValue("x-ms-blob-cache-control", blobCacheControl); }
+                if (blobContentType != null) { _request.Headers.SetValue("x-ms-blob-content-type", blobContentType); }
                 if (blobContentEncoding != null) {
                     foreach (string _item in blobContentEncoding)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-encoding", _item);
                     }
-                 }
+                }
                 if (blobContentLanguage != null) {
                     foreach (string _item in blobContentLanguage)
                     {
                         _request.Headers.SetValue("x-ms-blob-content-language", _item);
                     }
-                 }
-                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash));  }
+                }
+                if (blobContentHash != null) { _request.Headers.SetValue("x-ms-blob-content-md5", System.Convert.ToBase64String(blobContentHash)); }
                 if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
                         _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition);  }
-                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture));  }
-                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString());  }
-                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString());  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (blobContentDisposition != null) { _request.Headers.SetValue("x-ms-blob-content-disposition", blobContentDisposition); }
+                if (ifModifiedSince != null) { _request.Headers.SetValue("If-Modified-Since", ifModifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifUnmodifiedSince != null) { _request.Headers.SetValue("If-Unmodified-Since", ifUnmodifiedSince.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture)); }
+                if (ifMatch != null) { _request.Headers.SetValue("If-Match", ifMatch.Value.ToString()); }
+                if (ifNoneMatch != null) { _request.Headers.SetValue("If-None-Match", ifNoneMatch.Value.ToString()); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 System.Xml.Linq.XElement _body = Azure.Storage.Blobs.Models.BlockLookupList.ToXml(blocks, "BlockList", "");
@@ -8725,6 +8829,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// The Get Block List operation retrieves the list of blocks that have been uploaded as part of a block blob
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="listType">Specifies whether to return the list of committed blocks, the list of uncommitted blocks, or both lists together.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
@@ -8768,6 +8873,7 @@ namespace Azure.Storage.Blobs
             /// <summary>
             /// Create the BlockBlob.GetBlockListAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, container, or blob that is the targe of the desired operation.</param>
             /// <param name="listType">Specifies whether to return the list of committed blocks, the list of uncommitted blocks, or both lists together.</param>
             /// <param name="snapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the blob snapshot to retrieve. For more information on working with blob snapshots, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/creating-a-snapshot-of-a-blob">Creating a Snapshot of a Blob.</a></param>
@@ -8803,8 +8909,8 @@ namespace Azure.Storage.Blobs
 
                 // Add request headers
                 _request.Headers.SetValue("x-ms-version", "2018-11-09");
-                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId);  }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                if (leaseId != null) { _request.Headers.SetValue("x-ms-lease-id", leaseId); }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -8892,7 +8998,14 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum PublicAccessType
     {
+        /// <summary>
+        /// container
+        /// </summary>
         Container,
+
+        /// <summary>
+        /// blob
+        /// </summary>
         Blob
     }
 }
@@ -8942,38 +9055,124 @@ namespace Azure.Storage.Blobs.Models
     public partial struct AccessTier : System.IEquatable<AccessTier>
     {
         #pragma warning disable CA2211 // Non-constant fields should not be visible
+        /// <summary>
+        /// P4
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier P4 = @"P4";
 
+        /// <summary>
+        /// P6
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier P6 = @"P6";
 
+        /// <summary>
+        /// P10
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier P10 = @"P10";
 
+        /// <summary>
+        /// P20
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier P20 = @"P20";
 
+        /// <summary>
+        /// P30
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier P30 = @"P30";
 
+        /// <summary>
+        /// P40
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier P40 = @"P40";
 
+        /// <summary>
+        /// P50
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier P50 = @"P50";
 
+        /// <summary>
+        /// Hot
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier Hot = @"Hot";
 
+        /// <summary>
+        /// Cool
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier Cool = @"Cool";
 
+        /// <summary>
+        /// Archive
+        /// </summary>
         public static Azure.Storage.Blobs.Models.AccessTier Archive = @"Archive";
         #pragma warning restore CA2211 // Non-constant fields should not be visible
 
+        /// <summary>
+        /// The AccessTier value.
+        /// </summary>
         private readonly string _value;
+
+        /// <summary>
+        /// Creates a new AccessTier instance.
+        /// </summary>
+        /// <param name="value">The AccessTier value.</param>
         private AccessTier(string value) { this._value = value; }
+
+        /// <summary>
+        /// Check if two AccessTier instances are equal.
+        /// </summary>
+        /// <param name="other">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(Azure.Storage.Blobs.Models.AccessTier other) => this._value.Equals(other._value, System.StringComparison.InvariantCulture);
+
+        /// <summary>
+        /// Check if two AccessTier instances are equal.
+        /// </summary>
+        /// <param name="o">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public override bool Equals(object o) => o is Azure.Storage.Blobs.Models.AccessTier other && this.Equals(other);
+
+        /// <summary>
+        /// Get a hash code for the AccessTier.
+        /// </summary>
+        /// <returns>Hash code for the AccessTier.</returns>
         public override int GetHashCode() => this._value.GetHashCode();
+
+        /// <summary>
+        /// Convert the AccessTier to a string.
+        /// </summary>
+        /// <returns>String representation of the AccessTier.</returns>
         public override string ToString() => this._value;
+
         #pragma warning disable CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Convert a string a AccessTier.
+        /// </summary>
+        /// <param name="value">The string to convert.</param>
+        /// <returns>The AccessTier value.</returns>
         public static implicit operator AccessTier(string value) => new Azure.Storage.Blobs.Models.AccessTier(value);
         #pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Convert an AccessTier to a string.
+        /// </summary>
+        /// <param name="o">The AccessTier value.</param>
+        /// <returns>String representation of the AccessTier value.</returns>
         public static implicit operator string(Azure.Storage.Blobs.Models.AccessTier o) => o._value;
+
+        /// <summary>
+        /// Check if two AccessTier instances are equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public static bool operator ==(Azure.Storage.Blobs.Models.AccessTier a, Azure.Storage.Blobs.Models.AccessTier b) => a.Equals(b);
+
+        /// <summary>
+        /// Check if two AccessTier instances are not equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're not equal, false otherwise.</returns>
         public static bool operator !=(Azure.Storage.Blobs.Models.AccessTier a, Azure.Storage.Blobs.Models.AccessTier b) => !a.Equals(b);
     }
 }
@@ -8987,8 +9186,19 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum BlockListType
     {
+        /// <summary>
+        /// committed
+        /// </summary>
         Committed,
+
+        /// <summary>
+        /// uncommitted
+        /// </summary>
         Uncommitted,
+
+        /// <summary>
+        /// all
+        /// </summary>
         All
     }
 }
@@ -9184,7 +9394,14 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum DeleteSnapshotsOption
     {
+        /// <summary>
+        /// include
+        /// </summary>
         Include,
+
+        /// <summary>
+        /// only
+        /// </summary>
         Only
     }
 }
@@ -9277,10 +9494,29 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     internal enum ListBlobsIncludeItem
     {
+        /// <summary>
+        /// copy
+        /// </summary>
         Copy,
+
+        /// <summary>
+        /// deleted
+        /// </summary>
         Deleted,
+
+        /// <summary>
+        /// metadata
+        /// </summary>
         Metadata,
+
+        /// <summary>
+        /// snapshots
+        /// </summary>
         Snapshots,
+
+        /// <summary>
+        /// uncommittedblobs
+        /// </summary>
         Uncommittedblobs
     }
 }
@@ -9341,6 +9577,9 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     internal enum ListContainersIncludeType
     {
+        /// <summary>
+        /// metadata
+        /// </summary>
         Metadata
     }
 }
@@ -9385,8 +9624,19 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum SequenceNumberAction
     {
+        /// <summary>
+        /// max
+        /// </summary>
         Max,
+
+        /// <summary>
+        /// update
+        /// </summary>
         Update,
+
+        /// <summary>
+        /// increment
+        /// </summary>
         Increment
     }
 }
@@ -10184,9 +10434,24 @@ namespace Azure.Storage.Blobs.Models
     public enum CopyStatus
     #pragma warning restore CA1717 // Only FlagsAttribute enums should have plural names
     {
+        /// <summary>
+        /// pending
+        /// </summary>
         Pending,
+
+        /// <summary>
+        /// success
+        /// </summary>
         Success,
+
+        /// <summary>
+        /// aborted
+        /// </summary>
         Aborted,
+
+        /// <summary>
+        /// failed
+        /// </summary>
         Failed
     }
 }
@@ -10243,7 +10508,14 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum LeaseDurationType
     {
+        /// <summary>
+        /// infinite
+        /// </summary>
         Infinite,
+
+        /// <summary>
+        /// fixed
+        /// </summary>
         Fixed
     }
 }
@@ -10292,10 +10564,29 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum LeaseState
     {
+        /// <summary>
+        /// available
+        /// </summary>
         Available,
+
+        /// <summary>
+        /// leased
+        /// </summary>
         Leased,
+
+        /// <summary>
+        /// expired
+        /// </summary>
         Expired,
+
+        /// <summary>
+        /// breaking
+        /// </summary>
         Breaking,
+
+        /// <summary>
+        /// broken
+        /// </summary>
         Broken
     }
 }
@@ -10358,7 +10649,14 @@ namespace Azure.Storage.Blobs.Models
     public enum LeaseStatus
     #pragma warning restore CA1717 // Only FlagsAttribute enums should have plural names
     {
+        /// <summary>
+        /// locked
+        /// </summary>
         Locked,
+
+        /// <summary>
+        /// unlocked
+        /// </summary>
         Unlocked
     }
 }
@@ -10455,22 +10753,84 @@ namespace Azure.Storage.Blobs.Models
     public partial struct ArchiveStatus : System.IEquatable<ArchiveStatus>
     {
         #pragma warning disable CA2211 // Non-constant fields should not be visible
+        /// <summary>
+        /// rehydrate-pending-to-hot
+        /// </summary>
         public static Azure.Storage.Blobs.Models.ArchiveStatus RehydratePendingToHot = @"rehydrate-pending-to-hot";
 
+        /// <summary>
+        /// rehydrate-pending-to-cool
+        /// </summary>
         public static Azure.Storage.Blobs.Models.ArchiveStatus RehydratePendingToCool = @"rehydrate-pending-to-cool";
         #pragma warning restore CA2211 // Non-constant fields should not be visible
 
+        /// <summary>
+        /// The ArchiveStatus value.
+        /// </summary>
         private readonly string _value;
+
+        /// <summary>
+        /// Creates a new ArchiveStatus instance.
+        /// </summary>
+        /// <param name="value">The ArchiveStatus value.</param>
         private ArchiveStatus(string value) { this._value = value; }
+
+        /// <summary>
+        /// Check if two ArchiveStatus instances are equal.
+        /// </summary>
+        /// <param name="other">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(Azure.Storage.Blobs.Models.ArchiveStatus other) => this._value.Equals(other._value, System.StringComparison.InvariantCulture);
+
+        /// <summary>
+        /// Check if two ArchiveStatus instances are equal.
+        /// </summary>
+        /// <param name="o">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public override bool Equals(object o) => o is Azure.Storage.Blobs.Models.ArchiveStatus other && this.Equals(other);
+
+        /// <summary>
+        /// Get a hash code for the ArchiveStatus.
+        /// </summary>
+        /// <returns>Hash code for the ArchiveStatus.</returns>
         public override int GetHashCode() => this._value.GetHashCode();
+
+        /// <summary>
+        /// Convert the ArchiveStatus to a string.
+        /// </summary>
+        /// <returns>String representation of the ArchiveStatus.</returns>
         public override string ToString() => this._value;
+
         #pragma warning disable CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Convert a string a ArchiveStatus.
+        /// </summary>
+        /// <param name="value">The string to convert.</param>
+        /// <returns>The ArchiveStatus value.</returns>
         public static implicit operator ArchiveStatus(string value) => new Azure.Storage.Blobs.Models.ArchiveStatus(value);
         #pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Convert an ArchiveStatus to a string.
+        /// </summary>
+        /// <param name="o">The ArchiveStatus value.</param>
+        /// <returns>String representation of the ArchiveStatus value.</returns>
         public static implicit operator string(Azure.Storage.Blobs.Models.ArchiveStatus o) => o._value;
+
+        /// <summary>
+        /// Check if two ArchiveStatus instances are equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public static bool operator ==(Azure.Storage.Blobs.Models.ArchiveStatus a, Azure.Storage.Blobs.Models.ArchiveStatus b) => a.Equals(b);
+
+        /// <summary>
+        /// Check if two ArchiveStatus instances are not equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're not equal, false otherwise.</returns>
         public static bool operator !=(Azure.Storage.Blobs.Models.ArchiveStatus a, Azure.Storage.Blobs.Models.ArchiveStatus b) => !a.Equals(b);
     }
 }
@@ -10484,8 +10844,19 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum BlobType
     {
+        /// <summary>
+        /// BlockBlob
+        /// </summary>
         BlockBlob,
+
+        /// <summary>
+        /// PageBlob
+        /// </summary>
         PageBlob,
+
+        /// <summary>
+        /// AppendBlob
+        /// </summary>
         AppendBlob
     }
 }
@@ -11470,7 +11841,7 @@ namespace Azure.Storage.Blobs.Models
 namespace Azure.Storage.Blobs.Models
 {
     /// <summary>
-    /// BlockLookupList
+    /// A list of block IDs split between the committed block list, in the uncommitted block list, or in the uncommitted block list first and then in the committed block list.
     /// </summary>
     internal partial class BlockLookupList
     {
@@ -11877,228 +12248,599 @@ namespace Azure.Storage.Blobs.Models
     public partial struct BlobErrorCode : System.IEquatable<BlobErrorCode>
     {
         #pragma warning disable CA2211 // Non-constant fields should not be visible
+        /// <summary>
+        /// AccountAlreadyExists
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode AccountAlreadyExists = @"AccountAlreadyExists";
 
+        /// <summary>
+        /// AccountBeingCreated
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode AccountBeingCreated = @"AccountBeingCreated";
 
+        /// <summary>
+        /// AccountIsDisabled
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode AccountIsDisabled = @"AccountIsDisabled";
 
+        /// <summary>
+        /// AuthenticationFailed
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode AuthenticationFailed = @"AuthenticationFailed";
 
+        /// <summary>
+        /// AuthorizationFailure
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode AuthorizationFailure = @"AuthorizationFailure";
 
+        /// <summary>
+        /// ConditionHeadersNotSupported
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ConditionHeadersNotSupported = @"ConditionHeadersNotSupported";
 
+        /// <summary>
+        /// ConditionNotMet
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ConditionNotMet = @"ConditionNotMet";
 
+        /// <summary>
+        /// EmptyMetadataKey
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode EmptyMetadataKey = @"EmptyMetadataKey";
 
+        /// <summary>
+        /// InsufficientAccountPermissions
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InsufficientAccountPermissions = @"InsufficientAccountPermissions";
 
+        /// <summary>
+        /// InternalError
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InternalError = @"InternalError";
 
+        /// <summary>
+        /// InvalidAuthenticationInfo
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidAuthenticationInfo = @"InvalidAuthenticationInfo";
 
+        /// <summary>
+        /// InvalidHeaderValue
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidHeaderValue = @"InvalidHeaderValue";
 
+        /// <summary>
+        /// InvalidHttpVerb
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidHttpVerb = @"InvalidHttpVerb";
 
+        /// <summary>
+        /// InvalidInput
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidInput = @"InvalidInput";
 
+        /// <summary>
+        /// InvalidMd5
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidMd5 = @"InvalidMd5";
 
+        /// <summary>
+        /// InvalidMetadata
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidMetadata = @"InvalidMetadata";
 
+        /// <summary>
+        /// InvalidQueryParameterValue
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidQueryParameterValue = @"InvalidQueryParameterValue";
 
+        /// <summary>
+        /// InvalidRange
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidRange = @"InvalidRange";
 
+        /// <summary>
+        /// InvalidResourceName
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidResourceName = @"InvalidResourceName";
 
+        /// <summary>
+        /// InvalidUri
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidUri = @"InvalidUri";
 
+        /// <summary>
+        /// InvalidXmlDocument
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidXmlDocument = @"InvalidXmlDocument";
 
+        /// <summary>
+        /// InvalidXmlNodeValue
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidXmlNodeValue = @"InvalidXmlNodeValue";
 
+        /// <summary>
+        /// Md5Mismatch
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode Md5Mismatch = @"Md5Mismatch";
 
+        /// <summary>
+        /// MetadataTooLarge
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode MetadataTooLarge = @"MetadataTooLarge";
 
+        /// <summary>
+        /// MissingContentLengthHeader
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode MissingContentLengthHeader = @"MissingContentLengthHeader";
 
+        /// <summary>
+        /// MissingRequiredQueryParameter
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode MissingRequiredQueryParameter = @"MissingRequiredQueryParameter";
 
+        /// <summary>
+        /// MissingRequiredHeader
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode MissingRequiredHeader = @"MissingRequiredHeader";
 
+        /// <summary>
+        /// MissingRequiredXmlNode
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode MissingRequiredXmlNode = @"MissingRequiredXmlNode";
 
+        /// <summary>
+        /// MultipleConditionHeadersNotSupported
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode MultipleConditionHeadersNotSupported = @"MultipleConditionHeadersNotSupported";
 
+        /// <summary>
+        /// OperationTimedOut
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode OperationTimedOut = @"OperationTimedOut";
 
+        /// <summary>
+        /// OutOfRangeInput
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode OutOfRangeInput = @"OutOfRangeInput";
 
+        /// <summary>
+        /// OutOfRangeQueryParameterValue
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode OutOfRangeQueryParameterValue = @"OutOfRangeQueryParameterValue";
 
+        /// <summary>
+        /// RequestBodyTooLarge
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode RequestBodyTooLarge = @"RequestBodyTooLarge";
 
+        /// <summary>
+        /// ResourceTypeMismatch
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ResourceTypeMismatch = @"ResourceTypeMismatch";
 
+        /// <summary>
+        /// RequestUrlFailedToParse
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode RequestUrlFailedToParse = @"RequestUrlFailedToParse";
 
+        /// <summary>
+        /// ResourceAlreadyExists
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ResourceAlreadyExists = @"ResourceAlreadyExists";
 
+        /// <summary>
+        /// ResourceNotFound
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ResourceNotFound = @"ResourceNotFound";
 
+        /// <summary>
+        /// ServerBusy
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ServerBusy = @"ServerBusy";
 
+        /// <summary>
+        /// UnsupportedHeader
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode UnsupportedHeader = @"UnsupportedHeader";
 
+        /// <summary>
+        /// UnsupportedXmlNode
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode UnsupportedXmlNode = @"UnsupportedXmlNode";
 
+        /// <summary>
+        /// UnsupportedQueryParameter
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode UnsupportedQueryParameter = @"UnsupportedQueryParameter";
 
+        /// <summary>
+        /// UnsupportedHttpVerb
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode UnsupportedHttpVerb = @"UnsupportedHttpVerb";
 
+        /// <summary>
+        /// AppendPositionConditionNotMet
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode AppendPositionConditionNotMet = @"AppendPositionConditionNotMet";
 
+        /// <summary>
+        /// BlobAlreadyExists
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlobAlreadyExists = @"BlobAlreadyExists";
 
+        /// <summary>
+        /// BlobNotFound
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlobNotFound = @"BlobNotFound";
 
+        /// <summary>
+        /// BlobOverwritten
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlobOverwritten = @"BlobOverwritten";
 
+        /// <summary>
+        /// BlobTierInadequateForContentLength
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlobTierInadequateForContentLength = @"BlobTierInadequateForContentLength";
 
+        /// <summary>
+        /// BlockCountExceedsLimit
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlockCountExceedsLimit = @"BlockCountExceedsLimit";
 
+        /// <summary>
+        /// BlockListTooLong
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlockListTooLong = @"BlockListTooLong";
 
+        /// <summary>
+        /// CannotChangeToLowerTier
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode CannotChangeToLowerTier = @"CannotChangeToLowerTier";
 
+        /// <summary>
+        /// CannotVerifyCopySource
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode CannotVerifyCopySource = @"CannotVerifyCopySource";
 
+        /// <summary>
+        /// ContainerAlreadyExists
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ContainerAlreadyExists = @"ContainerAlreadyExists";
 
+        /// <summary>
+        /// ContainerBeingDeleted
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ContainerBeingDeleted = @"ContainerBeingDeleted";
 
+        /// <summary>
+        /// ContainerDisabled
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ContainerDisabled = @"ContainerDisabled";
 
+        /// <summary>
+        /// ContainerNotFound
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ContainerNotFound = @"ContainerNotFound";
 
+        /// <summary>
+        /// ContentLengthLargerThanTierLimit
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode ContentLengthLargerThanTierLimit = @"ContentLengthLargerThanTierLimit";
 
+        /// <summary>
+        /// CopyAcrossAccountsNotSupported
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode CopyAcrossAccountsNotSupported = @"CopyAcrossAccountsNotSupported";
 
+        /// <summary>
+        /// CopyIdMismatch
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode CopyIdMismatch = @"CopyIdMismatch";
 
+        /// <summary>
+        /// FeatureVersionMismatch
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode FeatureVersionMismatch = @"FeatureVersionMismatch";
 
+        /// <summary>
+        /// IncrementalCopyBlobMismatch
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode IncrementalCopyBlobMismatch = @"IncrementalCopyBlobMismatch";
 
+        /// <summary>
+        /// IncrementalCopyOfEralierVersionSnapshotNotAllowed
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode IncrementalCopyOfEralierVersionSnapshotNotAllowed = @"IncrementalCopyOfEralierVersionSnapshotNotAllowed";
 
+        /// <summary>
+        /// IncrementalCopySourceMustBeSnapshot
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode IncrementalCopySourceMustBeSnapshot = @"IncrementalCopySourceMustBeSnapshot";
 
+        /// <summary>
+        /// InfiniteLeaseDurationRequired
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InfiniteLeaseDurationRequired = @"InfiniteLeaseDurationRequired";
 
+        /// <summary>
+        /// InvalidBlobOrBlock
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidBlobOrBlock = @"InvalidBlobOrBlock";
 
+        /// <summary>
+        /// InvalidBlobTier
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidBlobTier = @"InvalidBlobTier";
 
+        /// <summary>
+        /// InvalidBlobType
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidBlobType = @"InvalidBlobType";
 
+        /// <summary>
+        /// InvalidBlockId
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidBlockId = @"InvalidBlockId";
 
+        /// <summary>
+        /// InvalidBlockList
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidBlockList = @"InvalidBlockList";
 
+        /// <summary>
+        /// InvalidOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidOperation = @"InvalidOperation";
 
+        /// <summary>
+        /// InvalidPageRange
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidPageRange = @"InvalidPageRange";
 
+        /// <summary>
+        /// InvalidSourceBlobType
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidSourceBlobType = @"InvalidSourceBlobType";
 
+        /// <summary>
+        /// InvalidSourceBlobUrl
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidSourceBlobUrl = @"InvalidSourceBlobUrl";
 
+        /// <summary>
+        /// InvalidVersionForPageBlobOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode InvalidVersionForPageBlobOperation = @"InvalidVersionForPageBlobOperation";
 
+        /// <summary>
+        /// LeaseAlreadyPresent
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseAlreadyPresent = @"LeaseAlreadyPresent";
 
+        /// <summary>
+        /// LeaseAlreadyBroken
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseAlreadyBroken = @"LeaseAlreadyBroken";
 
+        /// <summary>
+        /// LeaseIdMismatchWithBlobOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseIdMismatchWithBlobOperation = @"LeaseIdMismatchWithBlobOperation";
 
+        /// <summary>
+        /// LeaseIdMismatchWithContainerOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseIdMismatchWithContainerOperation = @"LeaseIdMismatchWithContainerOperation";
 
+        /// <summary>
+        /// LeaseIdMismatchWithLeaseOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseIdMismatchWithLeaseOperation = @"LeaseIdMismatchWithLeaseOperation";
 
+        /// <summary>
+        /// LeaseIdMissing
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseIdMissing = @"LeaseIdMissing";
 
+        /// <summary>
+        /// LeaseIsBreakingAndCannotBeAcquired
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseIsBreakingAndCannotBeAcquired = @"LeaseIsBreakingAndCannotBeAcquired";
 
+        /// <summary>
+        /// LeaseIsBreakingAndCannotBeChanged
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseIsBreakingAndCannotBeChanged = @"LeaseIsBreakingAndCannotBeChanged";
 
+        /// <summary>
+        /// LeaseIsBrokenAndCannotBeRenewed
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseIsBrokenAndCannotBeRenewed = @"LeaseIsBrokenAndCannotBeRenewed";
 
+        /// <summary>
+        /// LeaseLost
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseLost = @"LeaseLost";
 
+        /// <summary>
+        /// LeaseNotPresentWithBlobOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseNotPresentWithBlobOperation = @"LeaseNotPresentWithBlobOperation";
 
+        /// <summary>
+        /// LeaseNotPresentWithContainerOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseNotPresentWithContainerOperation = @"LeaseNotPresentWithContainerOperation";
 
+        /// <summary>
+        /// LeaseNotPresentWithLeaseOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode LeaseNotPresentWithLeaseOperation = @"LeaseNotPresentWithLeaseOperation";
 
+        /// <summary>
+        /// MaxBlobSizeConditionNotMet
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode MaxBlobSizeConditionNotMet = @"MaxBlobSizeConditionNotMet";
 
+        /// <summary>
+        /// NoPendingCopyOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode NoPendingCopyOperation = @"NoPendingCopyOperation";
 
+        /// <summary>
+        /// OperationNotAllowedOnIncrementalCopyBlob
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode OperationNotAllowedOnIncrementalCopyBlob = @"OperationNotAllowedOnIncrementalCopyBlob";
 
+        /// <summary>
+        /// PendingCopyOperation
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode PendingCopyOperation = @"PendingCopyOperation";
 
+        /// <summary>
+        /// PreviousSnapshotCannotBeNewer
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode PreviousSnapshotCannotBeNewer = @"PreviousSnapshotCannotBeNewer";
 
+        /// <summary>
+        /// PreviousSnapshotNotFound
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode PreviousSnapshotNotFound = @"PreviousSnapshotNotFound";
 
+        /// <summary>
+        /// PreviousSnapshotOperationNotSupported
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode PreviousSnapshotOperationNotSupported = @"PreviousSnapshotOperationNotSupported";
 
+        /// <summary>
+        /// SequenceNumberConditionNotMet
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode SequenceNumberConditionNotMet = @"SequenceNumberConditionNotMet";
 
+        /// <summary>
+        /// SequenceNumberIncrementTooLarge
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode SequenceNumberIncrementTooLarge = @"SequenceNumberIncrementTooLarge";
 
+        /// <summary>
+        /// SnapshotCountExceeded
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode SnapshotCountExceeded = @"SnapshotCountExceeded";
 
+        /// <summary>
+        /// SnaphotOperationRateExceeded
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode SnaphotOperationRateExceeded = @"SnaphotOperationRateExceeded";
 
+        /// <summary>
+        /// SnapshotsPresent
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode SnapshotsPresent = @"SnapshotsPresent";
 
+        /// <summary>
+        /// SourceConditionNotMet
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode SourceConditionNotMet = @"SourceConditionNotMet";
 
+        /// <summary>
+        /// SystemInUse
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode SystemInUse = @"SystemInUse";
 
+        /// <summary>
+        /// TargetConditionNotMet
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode TargetConditionNotMet = @"TargetConditionNotMet";
 
+        /// <summary>
+        /// UnauthorizedBlobOverwrite
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode UnauthorizedBlobOverwrite = @"UnauthorizedBlobOverwrite";
 
+        /// <summary>
+        /// BlobBeingRehydrated
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlobBeingRehydrated = @"BlobBeingRehydrated";
 
+        /// <summary>
+        /// BlobArchived
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlobArchived = @"BlobArchived";
 
+        /// <summary>
+        /// BlobNotArchived
+        /// </summary>
         public static Azure.Storage.Blobs.Models.BlobErrorCode BlobNotArchived = @"BlobNotArchived";
         #pragma warning restore CA2211 // Non-constant fields should not be visible
 
+        /// <summary>
+        /// The BlobErrorCode value.
+        /// </summary>
         private readonly string _value;
+
+        /// <summary>
+        /// Creates a new BlobErrorCode instance.
+        /// </summary>
+        /// <param name="value">The BlobErrorCode value.</param>
         private BlobErrorCode(string value) { this._value = value; }
+
+        /// <summary>
+        /// Check if two BlobErrorCode instances are equal.
+        /// </summary>
+        /// <param name="other">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(Azure.Storage.Blobs.Models.BlobErrorCode other) => this._value.Equals(other._value, System.StringComparison.InvariantCulture);
+
+        /// <summary>
+        /// Check if two BlobErrorCode instances are equal.
+        /// </summary>
+        /// <param name="o">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public override bool Equals(object o) => o is Azure.Storage.Blobs.Models.BlobErrorCode other && this.Equals(other);
+
+        /// <summary>
+        /// Get a hash code for the BlobErrorCode.
+        /// </summary>
+        /// <returns>Hash code for the BlobErrorCode.</returns>
         public override int GetHashCode() => this._value.GetHashCode();
+
+        /// <summary>
+        /// Convert the BlobErrorCode to a string.
+        /// </summary>
+        /// <returns>String representation of the BlobErrorCode.</returns>
         public override string ToString() => this._value;
+
         #pragma warning disable CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Convert a string a BlobErrorCode.
+        /// </summary>
+        /// <param name="value">The string to convert.</param>
+        /// <returns>The BlobErrorCode value.</returns>
         public static implicit operator BlobErrorCode(string value) => new Azure.Storage.Blobs.Models.BlobErrorCode(value);
         #pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Convert an BlobErrorCode to a string.
+        /// </summary>
+        /// <param name="o">The BlobErrorCode value.</param>
+        /// <returns>String representation of the BlobErrorCode value.</returns>
         public static implicit operator string(Azure.Storage.Blobs.Models.BlobErrorCode o) => o._value;
+
+        /// <summary>
+        /// Check if two BlobErrorCode instances are equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public static bool operator ==(Azure.Storage.Blobs.Models.BlobErrorCode a, Azure.Storage.Blobs.Models.BlobErrorCode b) => a.Equals(b);
+
+        /// <summary>
+        /// Check if two BlobErrorCode instances are not equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're not equal, false otherwise.</returns>
         public static bool operator !=(Azure.Storage.Blobs.Models.BlobErrorCode a, Azure.Storage.Blobs.Models.BlobErrorCode b) => !a.Equals(b);
     }
 }
@@ -12114,8 +12856,19 @@ namespace Azure.Storage.Blobs.Models
     public enum GeoReplicationStatus
     #pragma warning restore CA1717 // Only FlagsAttribute enums should have plural names
     {
+        /// <summary>
+        /// live
+        /// </summary>
         Live,
+
+        /// <summary>
+        /// bootstrap
+        /// </summary>
         Bootstrap,
+
+        /// <summary>
+        /// unavailable
+        /// </summary>
         Unavailable
     }
 }
@@ -12497,10 +13250,29 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum SkuName
     {
+        /// <summary>
+        /// Standard_LRS
+        /// </summary>
         StandardLRS,
+
+        /// <summary>
+        /// Standard_GRS
+        /// </summary>
         StandardGRS,
+
+        /// <summary>
+        /// Standard_RAGRS
+        /// </summary>
         StandardRAGRS,
+
+        /// <summary>
+        /// Standard_ZRS
+        /// </summary>
         StandardZRS,
+
+        /// <summary>
+        /// Premium_LRS
+        /// </summary>
         PremiumLRS
     }
 }
@@ -12561,8 +13333,19 @@ namespace Azure.Storage.Blobs.Models
     /// </summary>
     public enum AccountKind
     {
+        /// <summary>
+        /// Storage
+        /// </summary>
         Storage,
+
+        /// <summary>
+        /// BlobStorage
+        /// </summary>
         BlobStorage,
+
+        /// <summary>
+        /// StorageV2
+        /// </summary>
         StorageV2
     }
 }

--- a/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/LeaseClient.cs
@@ -117,6 +117,7 @@ namespace Azure.Storage.Blobs.Specialized
             }
         }
 
+        #region Acquire
         /// <summary>
         /// The <see cref="Acquire"/> operation acquires a lease on
         /// the blob or container.  The lease <paramref name="duration"/> must
@@ -145,7 +146,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the lease.
+        /// A <see cref="Response{Lease}"/> describing the lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -155,7 +156,7 @@ namespace Azure.Storage.Blobs.Specialized
             int duration,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.AcquireAsync(
+            this.AcquireInternal(
                 duration,
                 httpAccessConditions,
                 false, // async
@@ -190,7 +191,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the lease.
+        /// A <see cref="Response{Lease}"/> describing the lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -200,7 +201,7 @@ namespace Azure.Storage.Blobs.Specialized
             int duration,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.AcquireAsync(
+            await this.AcquireInternal(
                 duration,
                 httpAccessConditions,
                 true, // async
@@ -208,7 +209,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="AcquireAsync"/> operation acquires a lease on
+        /// The <see cref="AcquireInternal"/> operation acquires a lease on
         /// the blob or container.  The lease <paramref name="duration"/> must
         /// be between 15 to 60 seconds, or infinite (-1).
         /// 
@@ -238,13 +239,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the lease.
+        /// A <see cref="Response{Lease}"/> describing the lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<Lease>> AcquireAsync(
+        private async Task<Response<Lease>> AcquireInternal(
             int duration,
             HttpAccessConditions? httpAccessConditions,
             bool async,
@@ -307,7 +308,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Acquire
 
+        #region Renew
         /// <summary>
         /// The <see cref="Renew"/> operation renews the blob or
         /// container's previously-acquired lease.
@@ -329,7 +332,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the lease.
+        /// A <see cref="Response{Lease}"/> describing the lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -338,7 +341,7 @@ namespace Azure.Storage.Blobs.Specialized
         public virtual Response<Lease> Renew(
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.RenewAsync(
+            this.RenewInternal(
                 httpAccessConditions,
                 false, // async
                 cancellationToken)
@@ -365,7 +368,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the lease.
+        /// A <see cref="Response{Lease}"/> describing the lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -374,14 +377,14 @@ namespace Azure.Storage.Blobs.Specialized
         public virtual async Task<Response<Lease>> RenewAsync(
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.RenewAsync(
+            await this.RenewInternal(
                 httpAccessConditions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="RenewAsync"/> operation renews the blob or
+        /// The <see cref="RenewInternal"/> operation renews the blob or
         /// container's previously-acquired lease.
         /// 
         /// The lease can be renewed if the leaseId
@@ -404,13 +407,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the lease.
+        /// A <see cref="Response{Lease}"/> describing the lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<Lease>> RenewAsync(
+        private async Task<Response<Lease>> RenewInternal(
             HttpAccessConditions? httpAccessConditions,
             bool async,
             CancellationToken cancellationToken)
@@ -469,7 +472,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Renew
 
+        #region Release
         /// <summary>
         /// The <see cref="Release"/> operation releases the 
         /// container or blob's previously-acquired lease.
@@ -500,7 +505,7 @@ namespace Azure.Storage.Blobs.Specialized
         public virtual Response<ReleasedObjectInfo> Release(
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.ReleaseAsync(
+            this.ReleaseInternal(
                 httpAccessConditions,
                 false, // async
                 cancellationToken)
@@ -526,7 +531,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ReleasedObjectInfo}}"/> describing the
+        /// A <see cref="Response{ReleasedObjectInfo}"/> describing the
         /// updated blob or container.
         /// </returns>
         /// <remarks>
@@ -536,14 +541,14 @@ namespace Azure.Storage.Blobs.Specialized
         public virtual async Task<Response<ReleasedObjectInfo>> ReleaseAsync(
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.ReleaseAsync(
+            await this.ReleaseInternal(
                 httpAccessConditions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="ReleaseAsync"/> operation releases the 
+        /// The <see cref="ReleaseInternal"/> operation releases the 
         /// container or blob's previously-acquired lease.
         /// 
         /// The lease may be released if the <see cref="LeaseId"/>
@@ -565,14 +570,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ReleasedObjectInfo}}"/> describing the
+        /// A <see cref="Response{ReleasedObjectInfo}"/> describing the
         /// updated blob or container.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<ReleasedObjectInfo>> ReleaseAsync(
+        public virtual async Task<Response<ReleasedObjectInfo>> ReleaseInternal(
             HttpAccessConditions? httpAccessConditions,
             bool async,
             CancellationToken cancellationToken)
@@ -640,7 +645,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Release
 
+        #region Change
         /// <summary>
         /// The <see cref="Change"/> operation changes the lease 
         /// of an active lease.  A change must include the current
@@ -672,7 +679,7 @@ namespace Azure.Storage.Blobs.Specialized
             string proposedId,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.ChangeAsync(
+            this.ChangeInternal(
                 proposedId,
                 httpAccessConditions,
                 false, // async
@@ -700,7 +707,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the lease.
+        /// A <see cref="Response{Lease}"/> describing the lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -710,7 +717,7 @@ namespace Azure.Storage.Blobs.Specialized
             string proposedId,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.ChangeAsync(
+            await this.ChangeInternal(
                 proposedId,
                 httpAccessConditions,
                 true, // async
@@ -718,7 +725,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="ChangeAsync"/> operation changes the lease 
+        /// The <see cref="ChangeInternal"/> operation changes the lease 
         /// of an active lease.  A change must include the current
         /// <see cref="LeaseId"/> and a new <paramref name="proposedId"/>.
         /// 
@@ -733,18 +740,21 @@ namespace Azure.Storage.Blobs.Specialized
         /// Optional <see cref="HttpAccessConditions"/> to add
         /// conditions on changing a lease.
         /// </param>
+        /// <param name="async">
+        /// Whether to invoke the operation asynchronously.
+        /// </param>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the lease.
+        /// A <see cref="Response{Lease}"/> describing the lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<Lease>> ChangeAsync(
+        private async Task<Response<Lease>> ChangeInternal(
             string proposedId,
             HttpAccessConditions? httpAccessConditions,
             bool async,
@@ -808,7 +818,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Change
 
+        #region Break
         /// <summary>
         /// The <see cref="Break"/> operation breaks the blob or
         /// container's previously-acquired lease (if it exists).
@@ -858,7 +870,7 @@ namespace Azure.Storage.Blobs.Specialized
             int? breakPeriodInSeconds = default,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.BreakAsync(
+            this.BreakInternal(
                 breakPeriodInSeconds,
                 httpAccessConditions,
                 false, // async
@@ -904,7 +916,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the broken lease.
+        /// A <see cref="Response{Lease}"/> describing the broken lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -914,7 +926,7 @@ namespace Azure.Storage.Blobs.Specialized
             int? breakPeriodInSeconds = default,
             HttpAccessConditions? httpAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.BreakAsync(
+            await this.BreakInternal(
                 breakPeriodInSeconds,
                 httpAccessConditions,
                 true, // async
@@ -922,7 +934,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="BreakAsync"/> operation breaks the blob or
+        /// The <see cref="BreakInternal"/> operation breaks the blob or
         /// container's previously-acquired lease (if it exists).
         /// 
         /// Once a lease is broken, it cannot be renewed.  Any authorized
@@ -963,13 +975,13 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{Lease}}"/> describing the broken lease.
+        /// A <see cref="Response{Lease}"/> describing the broken lease.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<Lease>> BreakAsync(
+        private async Task<Response<Lease>> BreakInternal(
             int? breakPeriodInSeconds,
             HttpAccessConditions? httpAccessConditions,
             bool async,
@@ -1032,6 +1044,7 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Break
     }
 
     /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/BlockList.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/BlockList.cs
@@ -9,7 +9,7 @@ namespace Azure.Storage.Blobs.Models
 {
     /// <summary>
     /// A block blob's <see cref="BlockList"/> returned from 
-    /// <see cref="Azure.Storage.Blobs.BlockBlobClient.GetBlockListAsync"/>.
+    /// <see cref="Azure.Storage.Blobs.Specialized.BlockBlobClient.GetBlockListAsync"/>.
     /// </summary>
     public partial class BlockList
     {
@@ -30,7 +30,7 @@ namespace Azure.Storage.Blobs.Models
 
         /// <summary>
         /// The media type of the body of the response. For the
-        /// <see cref=" Azure.Storage.Blobs.BlockBlobClient.GetBlockListAsync"/> 
+        /// <see cref=" Specialized.BlockBlobClient.GetBlockListAsync"/> 
         /// operation this is 'application/xml'.
         /// </summary>
         public string ContentType { get; internal set; }

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/CopyFromUriOperation.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/CopyFromUriOperation.cs
@@ -13,9 +13,9 @@ namespace Azure.Storage.Blobs.Models
 {
     /// <summary>
     /// An <see cref="Operation{Int64}"/> for tracking the status of a 
-    /// <see cref="BlobBaseClient.StartCopyFromUriAsync"/> request.  Its
-    /// <see cref="Value"/> upon succesful completion will be the number of
-    /// bytes copied.
+    /// <see cref="BlobBaseClient.StartCopyFromUriAsync(Uri, System.Collections.Generic.IDictionary{String, String}, BlobAccessConditions?, BlobAccessConditions?, CancellationToken)"/>
+    /// request.  Its <see cref="Operation{Int64}.Value"/> upon succesful
+    /// completion will be the number of bytes copied.
     /// </summary>
     public class CopyFromUriOperation : Operation<long>
     {
@@ -59,8 +59,8 @@ namespace Azure.Storage.Blobs.Models
 
         /// <summary>
         /// Gets a value indicating whether the operation completed and
-        /// succesfully produced a value.  The <see cref="Value"/> property
-        /// is the number of bytes copied by the operation.
+        /// succesfully produced a value.  The <see cref="Operation{Int64}.Value"/>
+        /// property is the number of bytes copied by the operation.
         /// </summary>
         public override bool HasValue => this._hasValue;
 

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobs.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobs.cs
@@ -27,8 +27,7 @@ namespace Azure.Storage.Blobs.Models
 
         /// <summary>
         /// Gets or sets a flag specifing that metadata related to any current
-        /// or previous <see cref="Specialized.BlobClient.StartCopyFromUriAsync"/>
-        /// operation should be included.
+        /// or previous copy operation should be included.
         /// </summary>
         public bool IncludeCopyOperationStatus { get; set; }
 
@@ -47,7 +46,7 @@ namespace Azure.Storage.Blobs.Models
         /// <summary>
         /// Gets or sets a flag specifing that blobs for which blocks have
         /// been uploaded, but which have not been committed using
-        /// <see cref="BlockBlobClient.CommitBlockListAsync"/> should be
+        /// <see cref="Specialized.BlockBlobClient.CommitBlockListAsync"/> should be
         /// included.
         /// </summary>
         public bool IncludeUncommittedBlobs { get; set; }
@@ -150,7 +149,7 @@ namespace Azure.Storage.Blobs.Models
             bool isAsync,
             CancellationToken cancellationToken)
         {
-            var task = this._client.GetBlobsAsync(
+            var task = this._client.GetBlobsInternal(
                 continuationToken,
                 this._options,
                 pageSizeHint,
@@ -190,7 +189,7 @@ namespace Azure.Storage.Blobs.Models
             bool isAsync,
             CancellationToken cancellationToken)
         {
-            var task = this._client.GetBlobsByHierarchyAsync(
+            var task = this._client.GetBlobsByHierarchyInternal(
                 continuationToken,
                 this._delimiter,
                 this._options,

--- a/sdk/storage/Azure.Storage.Blobs/src/Models/GetContainers.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Models/GetContainers.cs
@@ -104,7 +104,7 @@ namespace Azure.Storage.Blobs.Models
             bool isAsync,
             CancellationToken cancellationToken)
         {
-            var task = this._client.GetContainersAsync(
+            var task = this._client.GetContainersInternal(
                 continuationToken,
                 this._options,
                 pageHintSize,

--- a/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/PageBlobClient.cs
@@ -44,6 +44,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// </summary>
         public const int PageBlobMaxUploadPagesBytes = 4 * Constants.MB; // 4MB
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="PageBlobClient"/>
         /// class for mocking.
@@ -180,7 +181,8 @@ namespace Azure.Storage.Blobs.Specialized
             : base(blobUri, pipeline)
         {
         }
-        
+        #endregion ctors
+
         /// <summary>
         /// Initializes a new instance of the <see cref="PageBlobClient"/>
         /// class with an identical <see cref="Uri"/> source but the specified
@@ -223,6 +225,7 @@ namespace Azure.Storage.Blobs.Specialized
         //    return new PageBlobClient(builder.ToUri(), this.Pipeline);
         //}
 
+        #region Create
         /// <summary>
         /// The <see cref="Create"/> operation creates a new page blob of
         /// the specified <paramref name="size"/>.  The content of any
@@ -271,7 +274,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata = default,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateAsync(
+            this.CreateInternal(
                 size,
                 sequenceNumber,
                 httpHeaders,
@@ -315,7 +318,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// newly created page blob.
         /// </returns>
         /// <remarks>
@@ -329,7 +332,7 @@ namespace Azure.Storage.Blobs.Specialized
             Metadata metadata = default,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateAsync(
+            await this.CreateInternal(
                 size,
                 sequenceNumber,
                 httpHeaders,
@@ -340,8 +343,8 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="CreateAsync"/> operation creates a new page blob of
-        /// the specified <paramref name="size"/>.  The content of any
+        /// The <see cref="CreateInternal"/> operation creates a new page blob
+        /// of the specified <paramref name="size"/>.  The content of any
         /// existing blob is overwritten with the newly initialized page blob
         /// To add content to the page blob, call the
         /// <see cref="UploadPagesAsync"/> operation.
@@ -376,14 +379,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobContentInfo}}"/> describing the
+        /// A <see cref="Response{BlobContentInfo}"/> describing the
         /// newly created page blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<BlobContentInfo>> CreateAsync(
+        private async Task<Response<BlobContentInfo>> CreateInternal(
             long size,
             long? sequenceNumber,
             BlobHttpHeaders? httpHeaders,
@@ -436,7 +439,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Create
 
+        #region UploadPages
         /// <summary>
         /// The <see cref="UploadPages"/> operation writes
         /// <paramref name="content"/> to a range of pages in a page blob,
@@ -488,7 +493,7 @@ namespace Azure.Storage.Blobs.Specialized
             PageBlobAccessConditions? accessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            this.UploadPagesAsync(
+            this.UploadPagesInternal(
                 content,
                 offset,
                 transactionalContentHash,
@@ -535,7 +540,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageInfo}}"/> describing the
+        /// A <see cref="Response{PageInfo}"/> describing the
         /// state of the updated pages.
         /// </returns>
         /// <remarks>
@@ -549,7 +554,7 @@ namespace Azure.Storage.Blobs.Specialized
             PageBlobAccessConditions? accessConditions = default,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            await this.UploadPagesAsync(
+            await this.UploadPagesInternal(
                 content,
                 offset,
                 transactionalContentHash,
@@ -560,7 +565,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="UploadPagesAsync"/> operation writes
+        /// The <see cref="UploadPagesInternal"/> operation writes
         /// <paramref name="content"/> to a range of pages in a page blob,
         /// starting at <paramref name="offset"/>.
         /// 
@@ -599,14 +604,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageInfo}}"/> describing the
+        /// A <see cref="Response{PageInfo}"/> describing the
         /// state of the updated pages.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<PageInfo>> UploadPagesAsync(
+        private async Task<Response<PageInfo>> UploadPagesInternal(
             Stream content,
             long offset,
             byte[] transactionalContentHash,
@@ -670,7 +675,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion UploadPages
 
+        #region ClearPages
         /// <summary>
         /// The <see cref="ClearPages"/> operation clears one or more
         /// pages from the page blob, as specificed by the <paramref name="range"/>.
@@ -706,7 +713,7 @@ namespace Azure.Storage.Blobs.Specialized
             HttpRange range,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.ClearPagesAsync(
+            this.ClearPagesInternal(
                 range,
                 accessConditions,
                 false, // async
@@ -737,7 +744,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageInfo}}"/> describing the
+        /// A <see cref="Response{PageInfo}"/> describing the
         /// state of the updated pages.
         /// </returns>
         /// <remarks>
@@ -748,7 +755,7 @@ namespace Azure.Storage.Blobs.Specialized
             HttpRange range,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.ClearPagesAsync(
+            await this.ClearPagesInternal(
                 range,
                 accessConditions,
                 true, // async
@@ -756,7 +763,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="ClearPagesAsync"/> operation clears one or more
+        /// The <see cref="ClearPagesInternal"/> operation clears one or more
         /// pages from the page blob, as specificed by the <paramref name="range"/>.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/put-page" />.
@@ -782,14 +789,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageInfo}}"/> describing the
+        /// A <see cref="Response{PageInfo}"/> describing the
         /// state of the updated pages.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<PageInfo>> ClearPagesAsync(
+        private async Task<Response<PageInfo>> ClearPagesInternal(
             HttpRange range,
             PageBlobAccessConditions? accessConditions,
             bool async,
@@ -832,7 +839,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion ClearPages
 
+        #region GetPageRanges
         /// <summary>
         /// The <see cref="GetPageRanges"/> operation returns the list of
         /// valid page ranges for a page blob or snapshot of a page blob.
@@ -869,7 +878,7 @@ namespace Azure.Storage.Blobs.Specialized
             string snapshot = default,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.GetPageRangesAsync(
+            this.GetPageRangesInternal(
                 range,
                 snapshot,
                 accessConditions,
@@ -913,7 +922,7 @@ namespace Azure.Storage.Blobs.Specialized
             string snapshot = default,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetPageRangesAsync(
+            await this.GetPageRangesInternal(
                 range,
                 snapshot,
                 accessConditions,
@@ -922,8 +931,8 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetPageRangesAsync"/> operation returns the list of
-        /// valid page ranges for a page blob or snapshot of a page blob.
+        /// The <see cref="GetPageRangesInternal"/> operation returns the list
+        /// of valid page ranges for a page blob or snapshot of a page blob.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-page-ranges" />.
         /// </summary>
@@ -948,14 +957,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageRangesInfo}}"/> describing the
+        /// A <see cref="Response{PageRangesInfo}"/> describing the
         /// valid page ranges for this blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<PageRangesInfo>> GetPageRangesAsync(
+        private async Task<Response<PageRangesInfo>> GetPageRangesInternal(
             HttpRange? range, 
             string snapshot,
             PageBlobAccessConditions? accessConditions,
@@ -997,7 +1006,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion GetPageRanges
 
+        #region GetPageRangesDiff
         /// <summary>
         /// The <see cref="GetPageRangesDiff"/> operation returns the
         /// list of page ranges that differ between a
@@ -1044,7 +1055,7 @@ namespace Azure.Storage.Blobs.Specialized
             string previousSnapshot = default,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.GetPageRangesDiffAsync(
+            this.GetPageRangesDiffInternal(
                 range,
                 snapshot,
                 previousSnapshot,
@@ -1086,7 +1097,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageRangesInfo}}"/> describing the
+        /// A <see cref="Response{PageRangesInfo}"/> describing the
         /// valid page ranges for this blob.
         /// </returns>
         /// <remarks>
@@ -1099,7 +1110,7 @@ namespace Azure.Storage.Blobs.Specialized
             string previousSnapshot = default,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetPageRangesDiffAsync(
+            await this.GetPageRangesDiffInternal(
                 range,
                 snapshot,
                 previousSnapshot,
@@ -1109,7 +1120,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetPageRangesDiffAsync"/> operation returns the
+        /// The <see cref="GetPageRangesDiffInternal"/> operation returns the
         /// list of page ranges that differ between a
         /// <paramref name="previousSnapshot"/> and this page blob. Changed pages
         /// include both updated and cleared pages. 
@@ -1144,14 +1155,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageRangesInfo}}"/> describing the
+        /// A <see cref="Response{PageRangesInfo}"/> describing the
         /// valid page ranges for this blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<PageRangesInfo>> GetPageRangesDiffAsync(
+        private async Task<Response<PageRangesInfo>> GetPageRangesDiffInternal(
             HttpRange? range,
             string snapshot,
             string previousSnapshot,
@@ -1196,7 +1207,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion GetPageRangesDiff
 
+        #region Resize
         /// <summary>
         /// The <see cref="Resize"/> operation resizes the page blob to
         /// the specified size (which must be a multiple of 512).  If the
@@ -1231,7 +1244,7 @@ namespace Azure.Storage.Blobs.Specialized
             long size,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.ResizeAsync(
+            this.ResizeInternal(
                 size,
                 accessConditions,
                 false, // async
@@ -1261,7 +1274,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageBlobInfo}}"/> describing the resized
+        /// A <see cref="Response{PageBlobInfo}"/> describing the resized
         /// page blob.
         /// </returns>
         /// <remarks>
@@ -1272,7 +1285,7 @@ namespace Azure.Storage.Blobs.Specialized
             long size,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.ResizeAsync(
+            await this.ResizeInternal(
                 size,
                 accessConditions,
                 true, // async
@@ -1305,14 +1318,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageBlobInfo}}"/> describing the resized
+        /// A <see cref="Response{PageBlobInfo}"/> describing the resized
         /// page blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<PageBlobInfo>> ResizeAsync(
+        private async Task<Response<PageBlobInfo>> ResizeInternal(
             long size, 
             PageBlobAccessConditions? accessConditions,
             bool async,
@@ -1352,7 +1365,9 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion Resize
 
+        #region UpdateSequenceNumber
         /// <summary>
         /// The <see cref="UpdateSequenceNumber"/> operation changes the
         /// sequence number <paramref name="action"/> and <paramref name="sequenceNumber"/>
@@ -1402,7 +1417,7 @@ namespace Azure.Storage.Blobs.Specialized
             long? sequenceNumber = default,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.UpdateSequenceNumberAsync(
+            this.UpdateSequenceNumberInternal(
                 action,
                 sequenceNumber,
                 accessConditions,
@@ -1447,7 +1462,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageBlobInfo}}"/> describing the updated
+        /// A <see cref="Response{PageBlobInfo}"/> describing the updated
         /// page blob.
         /// </returns>
         /// <remarks>
@@ -1459,7 +1474,7 @@ namespace Azure.Storage.Blobs.Specialized
             long? sequenceNumber = default,
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.UpdateSequenceNumberAsync(
+            await this.UpdateSequenceNumberInternal(
                 action,
                 sequenceNumber,
                 accessConditions,
@@ -1468,7 +1483,7 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="UpdateSequenceNumberAsync"/> operation changes the
+        /// The <see cref="UpdateSequenceNumberInternal"/> operation changes the
         /// sequence number <paramref name="action"/> and <paramref name="sequenceNumber"/>
         /// for this page blob.
         /// 
@@ -1507,14 +1522,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageBlobInfo}}"/> describing the updated
+        /// A <see cref="Response{PageBlobInfo}"/> describing the updated
         /// page blob.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<PageBlobInfo>> UpdateSequenceNumberAsync(
+        private async Task<Response<PageBlobInfo>> UpdateSequenceNumberInternal(
             SequenceNumberAction action,
             long? sequenceNumber,
             PageBlobAccessConditions? accessConditions,
@@ -1557,18 +1572,19 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion UpdateSequenceNumber
 
+        #region StartCopyIncremental
         /// <summary>
-        /// The <see cref="StartCopyIncremental"/> operation starts
-        /// copying a snapshot of the 
-        /// sourceUri page blob to this page blob.  The
-        /// snapshot is copied such that only the differential changes between
-        /// the previously copied snapshot are transferred to the destination.
-        /// The copied snapshots are complete copies of the original snapshot 
-        /// and can be read or copied from as usual.  You can check the
-        /// <see cref="BlobProperties.CopyStatus"/> returned from the
-        /// <see cref="BlobClient.GetProperties"/> to determine if the
-        /// copy has completed.
+        /// The <see cref="StartCopyIncremental(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>
+        /// operation starts copying a snapshot of the sourceUri page blob to
+        /// this page blob.  The snapshot is copied such that only the
+        /// differential changes between the previously copied snapshot are
+        /// transferred to the destination.  The copied snapshots are complete
+        /// copies of the original snapshot and can be read or copied from as
+        /// usual.  You can check the <see cref="BlobProperties.CopyStatus"/>
+        /// returned from the <see cref="BlobBaseClient.GetProperties"/> to
+        /// determine if the copy has completed.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
         /// and <see href="https://docs.microsoft.com/en-us/azure/virtual-machines/windows/incremental-snapshots"/>.
@@ -1604,39 +1620,40 @@ namespace Azure.Storage.Blobs.Specialized
         /// permanently associated with the source and may only be used for
         /// incremental copies.
         /// 
-        /// The <see cref="BlobClient.GetProperties"/>,
+        /// The <see cref="BlobBaseClient.GetProperties"/>,
         /// <see cref="BlobContainerClient.GetBlobs"/>, and
         /// <see cref="BlobContainerClient.GetBlobsByHierarchy"/>
         /// operations indicate whether the blob is an incremental copy blob
         /// created in this way.  Incremental copy blobs may not be downloaded
         /// directly.  The only supported operations are
-        /// <see cref="BlobClient.GetProperties"/>,
-        /// <see cref="StartCopyIncremental"/>, and 
-        /// <see cref="BlobClient.Delete"/>.  The copied snapshots may be
-        /// read and deleted as usual.
+        /// <see cref="BlobBaseClient.GetProperties"/>,
+        /// <see cref="StartCopyIncremental(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>,
+        /// and <see cref="BlobBaseClient.Delete"/>.  The copied snapshots may
+        /// be read and deleted as usual.
         /// 
         /// An incremental copy is performed asynchronously on the service and
         /// must be polled for completion.  You can poll
-        /// <see cref="BlobClient.GetProperties"/> and check
+        /// <see cref="BlobBaseClient.GetProperties"/> and check
         /// <see cref="BlobProperties.CopyStatus"/> to determine when the copy
         /// has completed.  When the copy completes, the destination blob will
-        /// contain a new snapshot.  The <see cref="BlobClient.GetProperties"/>
+        /// contain a new snapshot.  The <see cref="BlobBaseClient.GetProperties"/>
         /// operation returns the snapshot time of the newly created snapshot.
         /// 
         /// The first time an incremental copy is performed on a destination
         /// blob, a new blob is created with a snapshot that is fully copied
-        /// from the source.  Each subsequent call to <see cref="StartCopyIncremental"/>
+        /// from the source.  Each subsequent call to <see cref="StartCopyIncremental(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>
         /// will create a new snapshot by copying only the differential
         /// changes from the previously copied snapshot.  The differential
         /// changes are computed on the server by issuing a <see cref="GetPageRanges"/>
         /// call on the source blob snapshot with prevSnapshot set to the most
         /// recently copied snapshot. Therefore, the same restrictions on
         /// <see cref="GetPageRanges"/> apply to
-        /// <see cref="StartCopyIncremental"/>.  Specifically, snapshots
-        /// must be copied in ascending order and if the source blob is
-        /// recreated using <see cref="UploadPages"/> or 
-        /// <see cref="BlobClient.StartCopyFromUri"/> then 
-        /// <see cref="StartCopyIncremental"/> on new snapshots will fail.
+        /// <see cref="StartCopyIncremental(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>.
+        /// Specifically, snapshots must be copied in ascending order and if
+        /// the source blob is recreated using <see cref="UploadPages"/> or 
+        /// <see cref="BlobBaseClient.StartCopyFromUri(Uri, Metadata, BlobAccessConditions?, BlobAccessConditions?, CancellationToken)"/>
+        /// then  <see cref="StartCopyIncremental(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>
+        /// on new snapshots will fail.
         /// 
         /// The additional storage space consumed by the copied snapshot is 
         /// the size of the differential data transferred during the copy.
@@ -1649,7 +1666,7 @@ namespace Azure.Storage.Blobs.Specialized
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default)
         {
-            var response = this.StartCopyIncrementalAsync(
+            var response = this.StartCopyIncrementalInternal(
                 sourceUri,
                 snapshot,
                 accessConditions,
@@ -1664,16 +1681,15 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="StartCopyIncrementalAsync"/> operation starts
-        /// copying a snapshot of the 
-        /// sourceUri page blob to this page blob.  The
-        /// snapshot is copied such that only the differential changes between
-        /// the previously copied snapshot are transferred to the destination.
-        /// The copied snapshots are complete copies of the original snapshot 
-        /// and can be read or copied from as usual.  You can check the
-        /// <see cref="BlobProperties.CopyStatus"/> returned from the
-        /// <see cref="BlobClient.GetPropertiesAsync"/> to determine if the
-        /// copy has completed.
+        /// The <see cref="StartCopyIncrementalAsync(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>
+        /// operation starts copying a snapshot of the sourceUri page blob to
+        /// this page blob.  The snapshot is copied such that only the
+        /// differential changes between the previously copied snapshot are
+        /// transferred to the destination. The copied snapshots are complete
+        /// copies of the original snapshot and can be read or copied from as
+        /// usual.  You can check the <see cref="BlobProperties.CopyStatus"/>
+        /// returned from the <see cref="BlobBaseClient.GetPropertiesAsync"/>
+        /// to determine if thecopy has completed.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
         /// and <see href="https://docs.microsoft.com/en-us/azure/virtual-machines/windows/incremental-snapshots"/>.
@@ -1696,7 +1712,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{CopyFromUriOperation}"/> describing the
+        /// A <see cref="CopyFromUriOperation"/> describing the
         /// state of the incremental copy operation.
         /// </returns>
         /// <remarks>
@@ -1709,39 +1725,40 @@ namespace Azure.Storage.Blobs.Specialized
         /// permanently associated with the source and may only be used for
         /// incremental copies.
         /// 
-        /// The <see cref="BlobClient.GetPropertiesAsync"/>,
+        /// The <see cref="BlobBaseClient.GetPropertiesAsync"/>,
         /// <see cref="BlobContainerClient.GetBlobsAsync"/>, and
         /// <see cref="BlobContainerClient.GetBlobsByHierarchyAsync"/>
         /// operations indicate whether the blob is an incremental copy blob
         /// created in this way.  Incremental copy blobs may not be downloaded
         /// directly.  The only supported operations are
-        /// <see cref="BlobClient.GetPropertiesAsync"/>,
-        /// <see cref="StartCopyIncrementalAsync"/>, and 
-        /// <see cref="BlobClient.DeleteAsync"/>.  The copied snapshots may be
-        /// read and deleted as usual.
+        /// <see cref="BlobBaseClient.GetPropertiesAsync"/>,
+        /// <see cref="StartCopyIncrementalAsync(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>,
+        /// and  <see cref="BlobBaseClient.DeleteAsync"/>.  The copied
+        /// snapshots may be read and deleted as usual.
         /// 
         /// An incremental copy is performed asynchronously on the service and
         /// must be polled for completion.  You can poll
-        /// <see cref="BlobClient.GetPropertiesAsync"/> and check
+        /// <see cref="BlobBaseClient.GetPropertiesAsync"/> and check
         /// <see cref="BlobProperties.CopyStatus"/> to determine when the copy
         /// has completed.  When the copy completes, the destination blob will
-        /// contain a new snapshot.  The <see cref="BlobClient.GetPropertiesAsync"/>
+        /// contain a new snapshot.  The <see cref="BlobBaseClient.GetPropertiesAsync"/>
         /// operation returns the snapshot time of the newly created snapshot.
         /// 
         /// The first time an incremental copy is performed on a destination
         /// blob, a new blob is created with a snapshot that is fully copied
-        /// from the source.  Each subsequent call to <see cref="StartCopyIncrementalAsync"/>
+        /// from the source.  Each subsequent call to <see cref="StartCopyIncrementalAsync(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>
         /// will create a new snapshot by copying only the differential
         /// changes from the previously copied snapshot.  The differential
         /// changes are computed on the server by issuing a <see cref="GetPageRangesAsync"/>
         /// call on the source blob snapshot with prevSnapshot set to the most
         /// recently copied snapshot. Therefore, the same restrictions on
         /// <see cref="GetPageRangesAsync"/> apply to
-        /// <see cref="StartCopyIncrementalAsync"/>.  Specifically, snapshots
-        /// must be copied in ascending order and if the source blob is
-        /// recreated using <see cref="UploadPagesAsync"/> or 
-        /// <see cref="BlobClient.StartCopyFromUriAsync"/> then 
-        /// <see cref="StartCopyIncrementalAsync"/> on new snapshots will fail.
+        /// <see cref="StartCopyIncrementalAsync(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>.
+        /// Specifically, snapshots must be copied in ascending order and if
+        /// the source blob is recreated using <see cref="UploadPagesAsync"/> or 
+        /// <see cref="BlobBaseClient.StartCopyFromUriAsync(Uri, Metadata, BlobAccessConditions?, BlobAccessConditions?, CancellationToken)"/>
+        /// then <see cref="StartCopyIncrementalAsync(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>
+        /// on new snapshots will fail.
         /// 
         /// The additional storage space consumed by the copied snapshot is 
         /// the size of the differential data transferred during the copy.
@@ -1754,7 +1771,7 @@ namespace Azure.Storage.Blobs.Specialized
             PageBlobAccessConditions? accessConditions = default,
             CancellationToken cancellationToken = default)
         {
-            var response = await this.StartCopyIncrementalAsync(
+            var response = await this.StartCopyIncrementalInternal(
                 sourceUri,
                 snapshot,
                 accessConditions,
@@ -1769,13 +1786,9 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="StartCopyIncremental"/> operation starts
-        /// copying a snapshot of the 
-        /// sourceUri page blob to this page blob.  The
-        /// snapshot is copied such that only the differential changes between
-        /// the previously copied snapshot are transferred to the destination.
-        /// The copied snapshots are complete copies of the original snapshot 
-        /// and can be read or copied from as usual.
+        /// The <see cref="StartCopyIncremental(String, CancellationToken)"/>
+        /// operation gets the status of an existing copy operation, specified
+        /// by the <paramref name="copyId"/>.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
         /// and <see href="https://docs.microsoft.com/en-us/azure/virtual-machines/windows/incremental-snapshots"/>.
@@ -1808,13 +1821,9 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="StartCopyIncrementalAsync"/> operation starts
-        /// copying a snapshot of the 
-        /// sourceUri page blob to this page blob.  The
-        /// snapshot is copied such that only the differential changes between
-        /// the previously copied snapshot are transferred to the destination.
-        /// The copied snapshots are complete copies of the original snapshot 
-        /// and can be read or copied from as usual.
+        /// The <see cref="StartCopyIncrementalAsync(String, CancellationToken)"/>
+        /// operation gets the status of an existing copy operation, specified
+        /// by the <paramref name="copyId"/>.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
         /// and <see href="https://docs.microsoft.com/en-us/azure/virtual-machines/windows/incremental-snapshots"/>.
@@ -1827,7 +1836,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{CopyFromUriOperation}"/> describing the
+        /// A <see cref="CopyFromUriOperation"/> describing the
         /// state of the incremental copy operation.
         /// </returns>
         /// <remarks>
@@ -1847,7 +1856,7 @@ namespace Azure.Storage.Blobs.Specialized
         }
 
         /// <summary>
-        /// The <see cref="StartCopyIncrementalAsync"/> operation starts
+        /// The <see cref="StartCopyIncrementalInternal"/> operation starts
         /// copying a snapshot of the 
         /// sourceUri page blob to this page blob.  The
         /// snapshot is copied such that only the differential changes between
@@ -1855,7 +1864,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// The copied snapshots are complete copies of the original snapshot 
         /// and can be read or copied from as usual.  You can check the
         /// <see cref="BlobProperties.CopyStatus"/> returned from the
-        /// <see cref="BlobClient.GetPropertiesAsync"/> to determine if the
+        /// <see cref="BlobBaseClient.GetPropertiesAsync"/> to determine if the
         /// copy has completed.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/incremental-copy-blob" />
@@ -1882,7 +1891,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{BlobCopyInfo}}"/> describing the
+        /// A <see cref="Response{BlobCopyInfo}"/> describing the
         /// state of the incremental copy operation.
         /// </returns>
         /// <remarks>
@@ -1895,46 +1904,47 @@ namespace Azure.Storage.Blobs.Specialized
         /// permanently associated with the source and may only be used for
         /// incremental copies.
         /// 
-        /// The <see cref="BlobClient.GetPropertiesAsync"/>,
+        /// The <see cref="BlobBaseClient.GetPropertiesAsync"/>,
         /// <see cref="BlobContainerClient.GetBlobsAsync"/>, and
         /// <see cref="BlobContainerClient.GetBlobsByHierarchyAsync"/>
         /// operations indicate whether the blob is an incremental copy blob
         /// created in this way.  Incremental copy blobs may not be downloaded
         /// directly.  The only supported operations are
-        /// <see cref="BlobClient.GetPropertiesAsync"/>,
-        /// <see cref="StartCopyIncrementalAsync"/>, and 
-        /// <see cref="BlobClient.DeleteAsync"/>.  The copied snapshots may be
-        /// read and deleted as usual.
+        /// <see cref="BlobBaseClient.GetPropertiesAsync"/>,
+        /// <see cref="StartCopyIncremental(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>,
+        /// and  <see cref="BlobBaseClient.DeleteAsync"/>.  The copied
+        /// snapshots may be read and deleted as usual.
         /// 
         /// An incremental copy is performed asynchronously on the service and
         /// must be polled for completion.  You can poll
-        /// <see cref="BlobClient.GetPropertiesAsync"/> and check
+        /// <see cref="BlobBaseClient.GetPropertiesAsync"/> and check
         /// <see cref="BlobProperties.CopyStatus"/> to determine when the copy
         /// has completed.  When the copy completes, the destination blob will
-        /// contain a new snapshot.  The <see cref="BlobClient.GetPropertiesAsync"/>
+        /// contain a new snapshot.  The <see cref="BlobBaseClient.GetPropertiesAsync"/>
         /// operation returns the snapshot time of the newly created snapshot.
         /// 
         /// The first time an incremental copy is performed on a destination
         /// blob, a new blob is created with a snapshot that is fully copied
-        /// from the source.  Each subsequent call to <see cref="StartCopyIncrementalAsync"/>
+        /// from the source.  Each subsequent call to <see cref="StartCopyIncrementalAsync(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>
         /// will create a new snapshot by copying only the differential
         /// changes from the previously copied snapshot.  The differential
         /// changes are computed on the server by issuing a <see cref="GetPageRangesAsync"/>
         /// call on the source blob snapshot with prevSnapshot set to the most
         /// recently copied snapshot. Therefore, the same restrictions on
         /// <see cref="GetPageRangesAsync"/> apply to
-        /// <see cref="StartCopyIncrementalAsync"/>.  Specifically, snapshots
-        /// must be copied in ascending order and if the source blob is
-        /// recreated using <see cref="UploadPagesAsync"/> or 
-        /// <see cref="BlobClient.StartCopyFromUriAsync"/> then 
-        /// <see cref="StartCopyIncrementalAsync"/> on new snapshots will fail.
+        /// <see cref="StartCopyIncrementalAsync(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>.
+        /// Specifically, snapshots must be copied in ascending order and if
+        /// the source blob is recreated using <see cref="UploadPagesAsync"/>
+        /// or  <see cref="BlobBaseClient.StartCopyFromUriAsync(Uri, Metadata, BlobAccessConditions?, BlobAccessConditions?, CancellationToken)"/>
+        /// then <see cref="StartCopyIncrementalAsync(Uri, String, PageBlobAccessConditions?, CancellationToken)"/>
+        /// on new snapshots will fail.
         /// 
         /// The additional storage space consumed by the copied snapshot is 
         /// the size of the differential data transferred during the copy.
         /// This can be determined by performing a <see cref="GetPageRangesDiffAsync"/>
         /// call on the snapshot to compare it to the previous snapshot.
         /// </remarks>
-        private async Task<Response<BlobCopyInfo>> StartCopyIncrementalAsync(
+        private async Task<Response<BlobCopyInfo>> StartCopyIncrementalInternal(
             Uri sourceUri, 
             string snapshot, 
             PageBlobAccessConditions? accessConditions,
@@ -1978,9 +1988,11 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion StartCopyIncremental
 
+        #region UploadPagesFromUri
         /// <summary>
-        /// The <see cref="Task{"/> operation writes a range
+        /// The <see cref="UploadPagesFromUri"/> operation writes a range
         /// of pages to a page blob where the contents are read from
         /// sourceUri.
         /// 
@@ -2043,7 +2055,7 @@ namespace Azure.Storage.Blobs.Specialized
             PageBlobAccessConditions? accessConditions = default,
             PageBlobAccessConditions? sourceAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            this.UploadPagesFromUriAsync(
+            this.UploadPagesFromUriInternal(
                 sourceUri,
                 sourceRange,
                 range,
@@ -2103,7 +2115,7 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageInfo}}"/> describing the
+        /// A <see cref="Response{PageInfo}"/> describing the
         /// state of the updated pages.
         /// </returns>
         /// <remarks>
@@ -2118,7 +2130,7 @@ namespace Azure.Storage.Blobs.Specialized
             PageBlobAccessConditions? accessConditions = default,
             PageBlobAccessConditions? sourceAccessConditions = default,
             CancellationToken cancellationToken = default) =>
-            await this.UploadPagesFromUriAsync(
+            await this.UploadPagesFromUriInternal(
                 sourceUri,
                 sourceRange,
                 range,
@@ -2130,8 +2142,8 @@ namespace Azure.Storage.Blobs.Specialized
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="UploadPagesFromUriAsync"/> operation writes a range
-        /// of pages to a page blob where the contents are read from
+        /// The <see cref="UploadPagesFromUriInternal"/> operation writes a
+        /// range of pages to a page blob where the contents are read from
         /// sourceUri.
         /// 
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-page-from-url" />.
@@ -2181,14 +2193,14 @@ namespace Azure.Storage.Blobs.Specialized
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{PageInfo}}"/> describing the
+        /// A <see cref="Response{PageInfo}"/> describing the
         /// state of the updated pages.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<PageInfo>> UploadPagesFromUriAsync(
+        private async Task<Response<PageInfo>> UploadPagesFromUriInternal(
             Uri sourceUri,
             HttpRange sourceRange,
             HttpRange range,
@@ -2243,6 +2255,7 @@ namespace Azure.Storage.Blobs.Specialized
                 }
             }
         }
+        #endregion UploadPagesFromUri
     }
 
     /// <summary>

--- a/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/Sas/BlobSasBuilder.cs
@@ -199,7 +199,7 @@ namespace Azure.Storage.Sas
         /// </summary>
         /// <param name="userDelegationKey">
         /// A <see cref="UserDelegationKey"/> returned from
-        /// <see cref="BlobServiceClient.GetUserDelegationKeyAsync"/>.
+        /// <see cref="Azure.Storage.Blobs.BlobServiceClient.GetUserDelegationKeyAsync"/>.
         /// </param>
         /// <param name="accountName">The name of the storage account.</param>
         /// <returns>

--- a/sdk/storage/Azure.Storage.Blobs/swagger/blob.json
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/blob.json
@@ -374,7 +374,7 @@
           "service"
         ],
         "operationId": "Service_GetAccountInfo",
-        "description": "Returns the sku name and account kind ",
+        "description": "Returns the sku name and account kind",
         "parameters": [
           {
             "$ref": "#/parameters/ApiVersionParameter"
@@ -5608,6 +5608,7 @@
     "BlockLookupList": {
       "type": "object",
       "x-ms-public": false,
+      "description": "A list of block IDs split between the committed block list, in the uncommitted block list, or in the uncommitted block list first and then in the committed block list.",
       "properties": {
         "Committed": {
           "type": "array",

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -143,6 +143,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
     w.line(`/// <summary>`);
     w.line(`/// ${operation.description || regionName}`);
     w.line(`/// </summary>`);
+    w.line(`/// <param name="pipeline">The pipeline used for sending requests.</param>`);
     for (const arg of operation.request.arguments) {
         const desc = arg.description || arg.model.description;
         if (desc)
@@ -154,7 +155,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
         w.line(`/// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>`);
     }
     w.line(`/// <param name="${cancellationName}">Cancellation token.</param>`);
-    w.line(`/// <returns>${operation.response.model.description || returnType}</returns>`);
+    w.line(`/// <returns>${operation.response.model.description || returnType.replace(/</g, '{').replace(/>/g, '}')}</returns>`);
     w.write(`public static async System.Threading.Tasks.Task<${returnType}> ${methodName}(`);        
     w.scope(() => {
         const separateParams = IndentWriter.createFenceposter();
@@ -208,6 +209,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
     w.line(`/// <summary>`);
     w.line(`/// Create the ${regionName} request.`);
     w.line(`/// </summary>`);
+    w.line(`/// <param name="pipeline">The pipeline used for sending requests.</param>`);
     for (const arg of operation.request.arguments) {
         const desc = arg.description || arg.model.description;
         if (desc)
@@ -232,7 +234,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
             const constant = isEnumType(param.model) && param.model.constant;
             const nullable = !constant && !param.required;
             const name = naming.variable(param.clientName);
-            if (nullable) { w.write(`if (${name} != null) { `); }
+            if (nullable) { w.write(`if (${name} != null) {`); }
             if (constant) {
                 use(`"${((<IEnumType>param.model).values[0].value || '').toString()}"`);
             } else if (param.model.type === 'dictionary') {
@@ -256,14 +258,14 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                 if (param.model.type === `boolean`) {
                     w.line();
                     w.line(`#pragma warning disable CA1308 // Normalize strings to uppercase`);
-                }
+                } else if (nullable) { w.write(` `); }
                 use(types.convertToString(name, param.model, service, param.required));
                 if (param.model.type === `boolean`) {
                     w.line();
                     w.line(`#pragma warning restore CA1308 // Normalize strings to uppercase`);
-                }
+                } else if (nullable) { w.write(` `); }
             }
-            if (nullable) { w.write(` }`); }
+            if (nullable) { w.write(`}`); }
             w.line();
         };        
 
@@ -276,7 +278,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
         }
 
         w.line(`// Create the request`);
-        w.line(`Azure.Core.Http.HttpRequest ${requestName} = ${pipelineName}.CreateRequest();`);
+        w.line(`Azure.Core.Http.Request ${requestName} = ${pipelineName}.CreateRequest();`);
         w.line();
 
         w.line(`// Set the endpoint`);
@@ -309,7 +311,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                         name = `"${header.model.dictionaryPrefix || 'x-ms-meta-'}" + ${value}.Key`;
                         value = `${value}.Value`;
                     }
-                    w.write(`${requestName}.Headers.SetValue(${name}, ${value}); `);
+                    w.write(`${requestName}.Headers.SetValue(${name}, ${value});`);
                 });
             }
             w.line();
@@ -360,7 +362,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                 
                 w.line(`string ${textName} = ${bodyName}.ToString();`);
                 w.line(`${requestName}.Headers.SetValue("Content-Type", "application/xml");`);
-                w.line(`${requestName}.Headers.SetValue("Content-Length", ${textName}.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)); `);
+                w.line(`${requestName}.Headers.SetValue("Content-Length", ${textName}.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));`);
                 w.line(`${requestName}.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(System.Text.Encoding.UTF8.GetBytes(${textName}));`);
             } else {
                 throw `Serialization format ${operation.produces} not supported (in ${name})`;
@@ -379,7 +381,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
     w.line(`/// Create the ${regionName} response or throw a failure exception.`);
     w.line(`/// </summary>`);
     w.line(`/// <param name="response">The raw Response.</param>`);
-    w.line(`/// <returns>The ${regionName} ${returnType}.</returns>`);
+    w.line(`/// <returns>The ${regionName} ${returnType.replace(/</g, '{').replace(/>/g, '}')}.</returns>`);
     w.write(`internal static ${returnType} ${methodName}_CreateResponse(`);
     w.scope(() => {
         w.write(`Azure.Response ${responseName})`);
@@ -595,12 +597,10 @@ function generateEnum(w: IndentWriter, model: IServiceModel, type: IEnumType) {
         const separator = IndentWriter.createFenceposter();
         w.scope(`{`, `}`, () => {
             for (const value of type.values) {
-                if (separator()) { w.line(','); }
-                if (value.description) {
-                    w.line(`/// <summary>`)
-                    w.line(`/// ${value.description}`);
-                    w.line(`/// </summary>`)    
-                }
+                if (separator()) { w.line(','); w.line(); }
+                w.line(`/// <summary>`);
+                w.line(`/// ${value.description || value.value || value.name}`);
+                w.line(`/// </summary>`);
                 w.write(naming.enumField(value.name || value.value));
             }
         });
@@ -673,29 +673,82 @@ function generateEnumStrings(w: IndentWriter, model: IServiceModel, type: IEnumT
                 if (separator()) { w.line(); }
                 const name = naming.property((value.name || value.value) || '').toString();
                 const text = (value.value || '').toString();
-                if (value.description) {
-                    w.line(`/// <summary>`)
-                    w.line(`/// ${value.description}`);
-                    w.line(`/// </summary>`)    
-                }
-                
+                w.line(`/// <summary>`);
+                w.line(`/// ${value.description || text}`);
+                w.line(`/// </summary>`);
                 w.line(`public static ${enumFullName} ${name} = @"${text}";`)
             }
             w.line(`#pragma warning restore CA2211 // Non-constant fields should not be visible`);
             if (separator()) { w.line(); }
 
             // Dump out the infrastructure
+            w.line(`/// <summary>`);
+            w.line(`/// The ${enumName} value.`);
+            w.line(`/// </summary>`);
             w.line(`private readonly string _value;`);
+            w.line(``);
+            w.line(`/// <summary>`);
+            w.line(`/// Creates a new ${enumName} instance.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <param name="value">The ${enumName} value.</param>`);
             w.line(`private ${enumName}(string value) { this._value = value; }`);
+            w.line(``);
+            w.line(`/// <summary>`);
+            w.line(`/// Check if two ${enumName} instances are equal.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <param name="other">The instance to compare to.</param>`);
+            w.line(`/// <returns>True if they're equal, false otherwise.</returns>`);
             w.line(`public bool Equals(${enumFullName} other) => this._value.Equals(other._value, System.StringComparison.InvariantCulture);`)
+            w.line(``);
+            w.line(`/// <summary>`);
+            w.line(`/// Check if two ${enumName} instances are equal.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <param name="o">The instance to compare to.</param>`);
+            w.line(`/// <returns>True if they're equal, false otherwise.</returns>`);
             w.line(`public override bool Equals(object o) => o is ${enumFullName} other && this.Equals(other);`);
+            w.line(``);
+            w.line(`/// <summary>`);
+            w.line(`/// Get a hash code for the ${enumName}.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <returns>Hash code for the ${enumName}.</returns>`);
             w.line(`public override int GetHashCode() => this._value.GetHashCode();`);
+            w.line(``);
+            w.line(`/// <summary>`);
+            w.line(`/// Convert the ${enumName} to a string.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <returns>String representation of the ${enumName}.</returns>`);
             w.line(`public override string ToString() => this._value;`);
+            w.line(``);
             w.line(`#pragma warning disable CA2225 // Operator overloads have named alternates`);
+            w.line(`/// <summary>`);
+            w.line(`/// Convert a string a ${enumName}.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <param name="value">The string to convert.</param>`);
+            w.line(`/// <returns>The ${enumName} value.</returns>`);
             w.line(`public static implicit operator ${enumName}(string value) => new ${enumFullName}(value);`);
             w.line(`#pragma warning restore CA2225 // Operator overloads have named alternates`);
+            w.line(``);
+            w.line(`/// <summary>`);
+            w.line(`/// Convert an ${enumName} to a string.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <param name="o">The ${enumName} value.</param>`);
+            w.line(`/// <returns>String representation of the ${enumName} value.</returns>`);
             w.line(`public static implicit operator string(${enumFullName} o) => o._value;`);
+            w.line(``);
+            w.line(`/// <summary>`);
+            w.line(`/// Check if two ${enumName} instances are equal.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <param name="a">The first instance to compare.</param>`);
+            w.line(`/// <param name="b">The second instance to compare.</param>`);
+            w.line(`/// <returns>True if they're equal, false otherwise.</returns>`);
             w.line(`public static bool operator ==(${enumFullName} a, ${enumFullName} b) => a.Equals(b);`);
+            w.line(``);
+            w.line(`/// <summary>`);
+            w.line(`/// Check if two ${enumName} instances are not equal.`);
+            w.line(`/// </summary>`);
+            w.line(`/// <param name="a">The first instance to compare.</param>`);
+            w.line(`/// <param name="b">The second instance to compare.</param>`);
+            w.line(`/// <returns>True if they're not equal, false otherwise.</returns>`);
             w.line(`public static bool operator !=(${enumFullName} a, ${enumFullName} b) => !a.Equals(b);`);
         });
     });

--- a/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/DirectoryClient.cs
@@ -40,6 +40,7 @@ namespace Azure.Storage.Files
         /// </summary>
         protected virtual HttpPipeline Pipeline => this._pipeline;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="DirectoryClient"/>
         /// class for mocking.
@@ -60,6 +61,9 @@ namespace Azure.Storage.Files
         /// </param>
         /// <param name="shareName">
         /// The name of the share in the storage account to reference.
+        /// </param>
+        /// <param name="directoryPath">
+        /// The path of the directory in the storage account to reference.
         /// </param>
         public DirectoryClient(string connectionString, string shareName, string directoryPath)
             : this(connectionString, shareName, directoryPath, null)
@@ -181,6 +185,7 @@ namespace Azure.Storage.Files
             this._uri = directoryUri;
             this._pipeline = pipeline;
         }
+        #endregion ctors
 
         /// <summary>
         /// Creates a new <see cref="FileClient"/> object by appending
@@ -204,11 +209,12 @@ namespace Azure.Storage.Files
         public virtual DirectoryClient GetSubdirectoryClient(string subdirectoryName)
             => new DirectoryClient(this.Uri.AppendToPath(subdirectoryName), this.Pipeline);
 
+        #region Create
         /// <summary>
         /// The <see cref="Create"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -228,7 +234,7 @@ namespace Azure.Storage.Files
         public virtual Response<StorageDirectoryInfo> Create(
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateAsync(
+            this.CreateInternal(
                 metadata,
                 false, // async
                 cancellationToken)
@@ -238,7 +244,7 @@ namespace Azure.Storage.Files
         /// The <see cref="CreateAsync"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -248,7 +254,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageDirectoryInfo}}"/> describing the newly
+        /// A <see cref="Response{StorageDirectoryInfo}"/> describing the newly
         /// created directory.
         /// </returns>
         /// <remarks>
@@ -258,17 +264,17 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<StorageDirectoryInfo>> CreateAsync(
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateAsync(
+            await this.CreateInternal(
                 metadata,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="CreateAsync"/> operation creates a new directory
+        /// The <see cref="CreateInternal"/> operation creates a new directory
         /// at the specified <see cref="Uri"/>.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this directory.
@@ -281,14 +287,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageDirectoryInfo}}"/> describing the newly
+        /// A <see cref="Response{StorageDirectoryInfo}"/> describing the newly
         /// created directory.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageDirectoryInfo>> CreateAsync(
+        private async Task<Response<StorageDirectoryInfo>> CreateInternal(
             Metadata metadata,
             bool async,
             CancellationToken cancellationToken)
@@ -319,25 +325,27 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion Create
 
+        #region Delete
         /// <summary>
         /// The <see cref="Delete"/> operation removes the specified empty directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// Note that the directory must be empty before it can be deleted.
         /// </remarks>
         public virtual Response Delete(
             CancellationToken cancellationToken = default) =>
-            this.DeleteAsync(
+            this.DeleteInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -345,29 +353,30 @@ namespace Azure.Storage.Files
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation removes the specified empty directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// Note that the directory must be empty before it can be deleted.
         /// </remarks>
         public virtual async Task<Response> DeleteAsync(
             CancellationToken cancellationToken = default) =>
-            await this.DeleteAsync(
+            await this.DeleteInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="DeleteAsync"/> operation removes the specified empty directory.
+        /// The <see cref="DeleteInternal"/> operation removes the specified
+        /// empty directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -377,12 +386,12 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// Note that the directory must be empty before it can be deleted.
         /// </remarks>
-        private async Task<Response> DeleteAsync(
+        private async Task<Response> DeleteInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -411,14 +420,16 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion Delete
 
+        #region GetProperties
         /// <summary>
         /// The <see cref="GetProperties"/> operation returns all
         /// user-defined metadata and system properties for the specified
         /// directory. The data returned does not include the directory's 
         /// list of subdirectories or files.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optionally specifies the share snapshot to retrieve the directory properties
@@ -430,7 +441,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageDirectoryProperties}}"/> describing the
+        /// A <see cref="Response{StorageDirectoryProperties}"/> describing the
         /// directory and its properties.
         /// </returns>
         /// <remarks>
@@ -440,7 +451,7 @@ namespace Azure.Storage.Files
         public virtual Response<StorageDirectoryProperties> GetProperties(
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 shareSnapshot,
                 false, // async
                 cancellationToken)
@@ -452,7 +463,7 @@ namespace Azure.Storage.Files
         /// directory. The data returned does not include the directory's 
         /// list of subdirectories or files.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optionally specifies the share snapshot to retrieve the directory properties
@@ -464,7 +475,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageDirectoryProperties}}"/> describing the
+        /// A <see cref="Response{StorageDirectoryProperties}"/> describing the
         /// directory and its properties.
         /// </returns>
         /// <remarks>
@@ -474,19 +485,19 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<StorageDirectoryProperties>> GetPropertiesAsync(
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 shareSnapshot,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetPropertiesAsync"/> operation returns all
+        /// The <see cref="GetPropertiesInternal"/> operation returns all
         /// user-defined metadata and system properties for the specified
         /// directory. The data returned does not include the directory's 
         /// list of subdirectories or files.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-directory-properties"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optionally specifies the share snapshot to retrieve the directory properties
@@ -501,14 +512,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageDirectoryProperties}}"/> describing the
+        /// A <see cref="Response{StorageDirectoryProperties}"/> describing the
         /// directory and its properties.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>       
-        private async Task<Response<StorageDirectoryProperties>> GetPropertiesAsync(
+        private async Task<Response<StorageDirectoryProperties>> GetPropertiesInternal(
             string shareSnapshot,
             bool async,
             CancellationToken cancellationToken)
@@ -541,12 +552,14 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetProperties
 
+        #region SetMetadata
         /// <summary>
         /// The <see cref="SetMetadata"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -556,7 +569,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Response{StorageDirectoryInfo}}"/> if successful.
+        /// A <see cref="Response{StorageDirectoryInfo}"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -565,7 +578,7 @@ namespace Azure.Storage.Files
         public virtual Response<StorageDirectoryInfo> SetMetadata(
             Metadata metadata,
             CancellationToken cancellationToken = default) =>
-            this.SetMetadataAsync(
+            this.SetMetadataInternal(
                 metadata,
                 false, // async
                 cancellationToken)
@@ -575,7 +588,7 @@ namespace Azure.Storage.Files
         /// The <see cref="SetMetadataAsync"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -585,7 +598,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageDirectoryInfo}}}"/> if successful.
+        /// A <see cref="Response{StorageDirectoryInfo}"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -594,17 +607,17 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<StorageDirectoryInfo>> SetMetadataAsync(
             Metadata metadata,
             CancellationToken cancellationToken = default) =>
-            await this.SetMetadataAsync(
+            await this.SetMetadataInternal(
                 metadata,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetMetadataAsync"/> operation sets one or more
+        /// The <see cref="SetMetadataInternal"/> operation sets one or more
         /// user-defined name-value pairs for the specified directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-directory-metadata"/>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this directory.
@@ -617,13 +630,13 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageDirectoryInfo}}}"/> if successful.
+        /// A <see cref="Response{StorageDirectoryInfo}"/> if successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageDirectoryInfo>> SetMetadataAsync(
+        private async Task<Response<StorageDirectoryInfo>> SetMetadataInternal(
             Metadata metadata,
             bool async,
             CancellationToken cancellationToken)
@@ -654,14 +667,16 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion SetMetadata
 
+        #region GetFilesAndDirectories
         /// <summary>
         /// The <see cref="GetFilesAndDirectories"/> operation returns an async
         /// sequence of files and subdirectories in this directory.
         /// Enumerating the files and directories may make multiple requests
         /// to the service while fetching all the values.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
         /// </summary>
         /// <param name="options">
         /// Specifies options for listing, filtering, and shaping the items.
@@ -671,8 +686,8 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="IEnumerable{Response{StorageFileItem}}"/> describing 
-        /// the items in the directory.
+        /// An <see cref="IEnumerable{T}" /> of <see cref="Response{StorageFileItem}"/>
+        /// describing  the items in the directory.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -689,7 +704,7 @@ namespace Azure.Storage.Files
         /// Enumerating the files and directories may make multiple requests
         /// to the service while fetching all the values.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
         /// </summary>
         /// <param name="options">
         /// Specifies options for listing, filtering, and shaping the items.
@@ -712,11 +727,11 @@ namespace Azure.Storage.Files
             new GetFilesAndDirectoriesAsyncCollection(this, options, cancellationToken);
 
         /// <summary>
-        /// The <see cref="GetFilesAndDirectoriesAsync"/> operation returns a
+        /// The <see cref="GetFilesAndDirectoriesInternal"/> operation returns a
         /// single segment of files and subdirectories in this directory, starting
         /// from the specified <paramref name="marker"/>.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-directories-and-files"/>.
         /// </summary>
         /// <param name="marker">
         /// An optional string value that identifies the segment of the list
@@ -742,14 +757,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{FilesAndDirectoriesSegment}}"/> describing a
+        /// A <see cref="Response{FilesAndDirectoriesSegment}"/> describing a
         /// segment of the items in the directory.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<FilesAndDirectoriesSegment>> GetFilesAndDirectoriesAsync(
+        internal async Task<Response<FilesAndDirectoriesSegment>> GetFilesAndDirectoriesInternal(
             string marker,
             GetFilesAndDirectoriesOptions? options,
             int? pageSizeHint,
@@ -788,7 +803,9 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetFilesAndDirectories
 
+        #region GetHandles
         /// <summary>
         /// The <see cref="GetHandles"/> operation returns an async sequence
         /// of the open handles on a directory or a file.  Enumerating the
@@ -805,8 +822,8 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="IEnumerable{Response{StorageHandle}}"/> describing the
-        /// handles in the directory.
+        /// An <see cref="IEnumerable{T}"/> of <see cref="Response{StorageHandle}"/>
+        /// describing the handles in the directory.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -874,14 +891,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageHandlesSegment}}"/> describing a
+        /// A <see cref="Response{StorageHandlesSegment}"/> describing a
         /// segment of the handles in the directory.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<StorageHandlesSegment>> GetHandlesAsync(
+        internal async Task<Response<StorageHandlesSegment>> GetHandlesInternal(
             string marker,
             int? maxResults,
             bool? recursive,
@@ -922,7 +939,9 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetHandles
 
+        #region ForceCloseHandles
         /// <summary>
         /// The <see cref="ForceCloseHandles"/> operation closes a handle or handles opened on a directory 
         /// or a file at the service. It supports closing a single handle specified by <paramref name="handleId"/> on a file or 
@@ -935,7 +954,7 @@ namespace Azure.Storage.Files
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement 
         /// or alternative for SMB close.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.
@@ -943,7 +962,7 @@ namespace Azure.Storage.Files
         /// <param name="marker">
         /// An optional string value that identifies the segment of the handles
         /// to be closed with the next call to <see cref="ForceCloseHandles"/>.  The
-        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.NextMarker"/>
+        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.Marker"/>
         /// if the operation did not return all items remaining to be
         /// closed with the current segment.  The NextMarker value can
         /// be used as the value for the <paramref name="marker"/> parameter
@@ -969,7 +988,7 @@ namespace Azure.Storage.Files
             string marker = default,
             bool? recursive = default,
             CancellationToken cancellationToken = default) =>
-            this.ForceCloseHandlesAsync(
+            this.ForceCloseHandlesInternal(
                 handleId,
                 marker,
                 recursive,
@@ -989,7 +1008,7 @@ namespace Azure.Storage.Files
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement 
         /// or alternative for SMB close.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.
@@ -997,7 +1016,7 @@ namespace Azure.Storage.Files
         /// <param name="marker">
         /// An optional string value that identifies the segment of the handles
         /// to be closed with the next call to <see cref="ForceCloseHandlesAsync"/>.  The
-        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.NextMarker"/>
+        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.Marker"/>
         /// if the operation did not return all items remaining to be
         /// closed with the current segment.  The NextMarker value can
         /// be used as the value for the <paramref name="marker"/> parameter
@@ -1011,7 +1030,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageClosedHandlesSegment}}"/> describing a
+        /// A <see cref="Response{StorageClosedHandlesSegment}"/> describing a
         /// segment of the handles closed.
         /// </returns>
         /// <remarks>
@@ -1023,7 +1042,7 @@ namespace Azure.Storage.Files
             string marker = default,
             bool? recursive = default,
             CancellationToken cancellationToken = default) =>
-            await this.ForceCloseHandlesAsync(
+            await this.ForceCloseHandlesInternal(
                 handleId,
                 marker,
                 recursive,
@@ -1043,7 +1062,7 @@ namespace Azure.Storage.Files
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement 
         /// or alternative for SMB close.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.
@@ -1051,7 +1070,7 @@ namespace Azure.Storage.Files
         /// <param name="marker">
         /// An optional string value that identifies the segment of the handles
         /// to be closed with the next call to <see cref="ForceCloseHandlesAsync"/>.  The
-        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.NextMarker"/>
+        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.Marker"/>
         /// if the operation did not return all items remaining to be
         /// closed with the current segment.  The NextMarker value can
         /// be used as the value for the <paramref name="marker"/> parameter
@@ -1068,14 +1087,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageClosedHandlesSegment}}"/> describing a
+        /// A <see cref="Response{StorageClosedHandlesSegment}"/> describing a
         /// segment of the handles closed.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks> 
-        private async Task<Response<StorageClosedHandlesSegment>> ForceCloseHandlesAsync(
+        private async Task<Response<StorageClosedHandlesSegment>> ForceCloseHandlesInternal(
             string handleId,
             string marker,
             bool? recursive,
@@ -1116,12 +1135,14 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion ForceCloseHandles
 
+        #region CreateSubdirectory
         /// <summary>
         /// The <see cref="CreateSubdirectory"/> operation creates a new
         /// subdirectory under this directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="metadata">
@@ -1153,7 +1174,7 @@ namespace Azure.Storage.Files
         /// The <see cref="CreateSubdirectoryAsync"/> operation creates a new
         /// subdirectory under this directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="metadata">
@@ -1164,7 +1185,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{DirectoryClient}}"/> referencing the
+        /// A <see cref="Response{DirectoryClient}"/> referencing the
         /// newly created directory.
         /// </returns>
         /// <remarks>
@@ -1180,12 +1201,14 @@ namespace Azure.Storage.Files
             var response = await subdir.CreateAsync(metadata, cancellationToken).ConfigureAwait(false);
             return new Response<DirectoryClient>(response.GetRawResponse(), subdir);
         }
+        #endregion CreateSubdirectory
 
+        #region DeleteSubdirectory
         /// <summary>
         /// The <see cref="DeleteSubdirectory"/> operation removes the
         /// specified empty subdirectory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="cancellationToken">
@@ -1207,7 +1230,7 @@ namespace Azure.Storage.Files
         /// The <see cref="DeleteSubdirectoryAsync"/> operation removes the
         /// specified empty subdirectory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
         /// </summary>
         /// <param name="subdirectoryName">The name of the subdirectory.</param>
         /// <param name="cancellationToken">
@@ -1215,7 +1238,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// Note that the directory must be empty before it can be deleted.
@@ -1226,11 +1249,13 @@ namespace Azure.Storage.Files
             await this.GetSubdirectoryClient(subdirectoryName)
                 .DeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
+        #endregion DeleteSubdirectory
 
+        #region CreateFile
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -1272,7 +1297,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -1293,7 +1318,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{FileClient}}"/> referencing the file.
+        /// A <see cref="Response{FileClient}"/> referencing the file.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1310,12 +1335,14 @@ namespace Azure.Storage.Files
             var response = await file.CreateAsync(maxSize, httpHeaders, metadata, cancellationToken).ConfigureAwait(false);
             return new Response<FileClient>(response.GetRawResponse(), file);
         }
+        #endregion CreateFile
 
+        #region DeleteFile
         /// <summary>
         /// The <see cref="DeleteFile"/> operation immediately removes
         /// the file from the storage account.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="cancellationToken">
@@ -1338,7 +1365,7 @@ namespace Azure.Storage.Files
         /// The <see cref="DeleteFileAsync"/> operation immediately removes
         /// the file from the storage account.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
         /// </summary>
         /// <param name="fileName">The name of the file.</param>
         /// <param name="cancellationToken">
@@ -1346,7 +1373,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1358,5 +1385,6 @@ namespace Azure.Storage.Files
             await this.GetFileClient(fileName)
                 .DeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
+        #endregion DeleteFile
     }
 }

--- a/sdk/storage/Azure.Storage.Files/src/FileClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileClient.cs
@@ -51,6 +51,7 @@ namespace Azure.Storage.Files
         //// FileMaxSizeInBytes indicates the maxiumum file size, in bytes.
         //public const Int64 FileMaxSizeInBytes = 1 * Constants.TB; // 1TB
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="FileClient"/>
         /// class for mocking.
@@ -191,6 +192,7 @@ namespace Azure.Storage.Files
             this._uri = fileUri;
             this._pipeline = pipeline;
         }
+        #endregion ctors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileClient"/>
@@ -214,10 +216,11 @@ namespace Azure.Storage.Files
             return new FileClient(builder.ToUri(), this.Pipeline);
         }
 
+        #region Create
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -249,7 +252,7 @@ namespace Azure.Storage.Files
             FileHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateAsync(
+            this.CreateInternal(
                 maxSize,
                 httpHeaders,
                 metadata,
@@ -260,7 +263,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -280,7 +283,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileInfo}"/> describing the
         /// state of the file.
         /// </returns>
         /// <remarks>
@@ -292,7 +295,7 @@ namespace Azure.Storage.Files
             FileHttpHeaders? httpHeaders = default,
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateAsync(
+            await this.CreateInternal(
                 maxSize,
                 httpHeaders,
                 metadata,
@@ -303,7 +306,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Creates a new file or replaces an existing file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/create-file"/>.
         /// </summary>
         /// <remarks>
         /// This method only initializes the file.
@@ -318,19 +321,22 @@ namespace Azure.Storage.Files
         /// <param name="metadata">
         /// Optional custom metadata to set for the file.
         /// </param>
+        /// <param name="async">
+        /// Whether to invoke the operation asynchronously.
+        /// </param>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileInfo}"/> describing the
         /// state of the file.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageFileInfo>> CreateAsync(
+        private async Task<Response<StorageFileInfo>> CreateInternal(
             long maxSize,
             FileHttpHeaders? httpHeaders,
             Metadata metadata,
@@ -373,11 +379,13 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion Create
 
+        #region StartCopy
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -401,7 +409,7 @@ namespace Azure.Storage.Files
             Uri sourceUri,
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            this.StartCopyAsync(
+            this.StartCopyInternal(
                 sourceUri,
                 metadata,
                 false, // async
@@ -411,7 +419,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -424,7 +432,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileInfo}"/> describing the
         /// state of the file copy.
         /// </returns>
         /// <remarks>
@@ -435,7 +443,7 @@ namespace Azure.Storage.Files
             Uri sourceUri,
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            await this.StartCopyAsync(
+            await this.StartCopyInternal(
                 sourceUri,
                 metadata,
                 true, // async
@@ -445,7 +453,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Copies a blob or file to a destination file within the storage account.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/copy-file"/>.
         /// </summary>
         /// <param name="sourceUri">
         /// Required. Specifies the URL of the source file or blob.
@@ -461,14 +469,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileInfo}"/> describing the
         /// state of the file copy.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageFileCopyInfo>> StartCopyAsync(
+        private async Task<Response<StorageFileCopyInfo>> StartCopyInternal(
             Uri sourceUri,
             Metadata metadata,
             bool async,
@@ -503,13 +511,15 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion StartCopy
 
         // TODO The REST documentation say "full metadata", not "empty".  Doc bug?
 
+        #region AbortCopy
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -528,7 +538,7 @@ namespace Azure.Storage.Files
         public virtual Response AbortCopy(
             string copyId,
             CancellationToken cancellationToken = default) =>
-            this.AbortCopyAsync(
+            this.AbortCopyInternal(
                 copyId,
                 false, // async
                 cancellationToken)
@@ -537,7 +547,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -547,7 +557,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully aborting.
+        /// A <see cref="Response"/> on successfully aborting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -556,7 +566,7 @@ namespace Azure.Storage.Files
         public virtual async Task<Response> AbortCopyAsync(
             string copyId,
             CancellationToken cancellationToken = default) =>
-            await this.AbortCopyAsync(
+            await this.AbortCopyInternal(
                 copyId,
                 true, // async
                 cancellationToken)
@@ -565,7 +575,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Attempts to cancel a pending copy that was previously started and leaves a destination file with zero length and full metadata.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/abort-copy-file"/>.
         /// </summary>
         /// <param name="copyId">
         /// String identifier for the copy operation.
@@ -578,13 +588,13 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully aborting.
+        /// A <see cref="Response"/> on successfully aborting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> AbortCopyAsync(
+        private async Task<Response> AbortCopyInternal(
             string copyId,
             bool async,
             CancellationToken cancellationToken)
@@ -617,11 +627,13 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion AbortCopy
 
+        #region Download
         /// <summary>
         /// The <see cref="Download"/> operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see cref="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -652,7 +664,7 @@ namespace Azure.Storage.Files
             HttpRange range = default,
             bool rangeGetContentHash = default,
             CancellationToken cancellationToken = default) =>
-            this.DownloadAsync(
+            this.DownloadInternal(
                 range,
                 rangeGetContentHash,
                 false, // async
@@ -662,7 +674,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// The <see cref="DownloadAsync"/> operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see cref="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -681,7 +693,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileDownloadInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileDownloadInfo}"/> describing the
         /// downloaded file.  <see cref="StorageFileDownloadInfo.Content"/> contains
         /// the file's data.
         /// </returns>
@@ -693,7 +705,7 @@ namespace Azure.Storage.Files
             HttpRange range = default,
             bool rangeGetContentHash = default,
             CancellationToken cancellationToken = default) =>
-            await this.DownloadAsync(
+            await this.DownloadInternal(
                 range,
                 rangeGetContentHash,
                 true, // async
@@ -701,9 +713,9 @@ namespace Azure.Storage.Files
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="DownloadAsync"/> operation reads or downloads a file from the system, including its metadata and properties.
+        /// The <see cref="DownloadInternal"/> operation reads or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information <see cref="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -725,7 +737,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileDownloadInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileDownloadInfo}"/> describing the
         /// downloaded file.  <see cref="StorageFileDownloadInfo.Content"/> contains
         /// the file's data.
         /// </returns>
@@ -733,7 +745,7 @@ namespace Azure.Storage.Files
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageFileDownloadInfo>> DownloadAsync(
+        private async Task<Response<StorageFileDownloadInfo>> DownloadInternal(
             HttpRange range,
             bool rangeGetContentHash,
             bool async,
@@ -803,7 +815,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// The <see cref="StartDownloadAsync"/> operation starts to read or downloads a file from the system, including its metadata and properties.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file"/>.
         /// </summary>
         /// <param name="range">
         /// Optional. Only download the bytes of the file in the specified
@@ -828,7 +840,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{FlattenedStorageFileProperties}}"/> describing the
+        /// A <see cref="Response{FlattenedStorageFileProperties}"/> describing the
         /// downloaded file.  <see cref="FlattenedStorageFileProperties.Content"/> contains
         /// the file's data.
         /// </returns>
@@ -857,11 +869,13 @@ namespace Azure.Storage.Files
             this.Pipeline.LogTrace($"Response: {response.GetRawResponse().Status}, ContentLength: {response.Value.ContentLength}");
             return response;
         }
+        #endregion Download
 
+        #region Delete
         /// <summary>
         /// The <see cref="Delete"/> operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -876,7 +890,7 @@ namespace Azure.Storage.Files
         /// </remarks>
         public virtual Response Delete(
             CancellationToken cancellationToken = default) =>
-            this.DeleteAsync(
+            this.DeleteInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -884,14 +898,14 @@ namespace Azure.Storage.Files
         /// <summary>
         /// The <see cref="DeleteAsync"/> operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -899,15 +913,15 @@ namespace Azure.Storage.Files
         /// </remarks>
         public virtual async Task<Response> DeleteAsync(
             CancellationToken cancellationToken = default) =>
-            await this.DeleteAsync(
+            await this.DeleteInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="DeleteAsync"/> operation immediately removes the file from the storage account.
+        /// The <see cref="DeleteInternal"/> operation immediately removes the file from the storage account.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-file2"/>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -917,13 +931,13 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> DeleteAsync(
+        private async Task<Response> DeleteInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -952,14 +966,16 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion Delete
 
+        #region GetProperties
         /// <summary>
         /// The <see cref="GetProperties"/> operation returns all
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. The snapshot identifier.
@@ -979,7 +995,7 @@ namespace Azure.Storage.Files
         public virtual Response<StorageFileProperties> GetProperties(
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 shareSnapshot,
                 false, // async
                 cancellationToken)
@@ -991,7 +1007,7 @@ namespace Azure.Storage.Files
         /// properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. The snapshot identifier.
@@ -1001,7 +1017,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileProperties}}"/> describing the
+        /// A <see cref="Response{StorageFileProperties}"/> describing the
         /// file's properties.
         /// </returns>
         /// <remarks>
@@ -1011,7 +1027,7 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<StorageFileProperties>> GetPropertiesAsync(
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 shareSnapshot,
                 true, // async
                 cancellationToken)
@@ -1023,7 +1039,7 @@ namespace Azure.Storage.Files
         /// properties for the file. It does not return the content of the
         /// file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-file-properties"/>
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. The snapshot identifier.
@@ -1036,14 +1052,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileProperties}}"/> describing the
+        /// A <see cref="Response{StorageFileProperties}"/> describing the
         /// file's properties.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageFileProperties>> GetPropertiesAsync(
+        private async Task<Response<StorageFileProperties>> GetPropertiesInternal(
             string shareSnapshot,
             bool async,
             CancellationToken cancellationToken)
@@ -1076,12 +1092,14 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetProperties
 
+        #region SetHttpHeaders
         /// <summary>
         /// The <see cref="SetHttpHeaders"/> operation sets system
         /// properties on the file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -1108,7 +1126,7 @@ namespace Azure.Storage.Files
             long? newSize = default,
             FileHttpHeaders? httpHeaders = default,
             CancellationToken cancellationToken = default) =>
-            this.SetHttpHeadersAsync(
+            this.SetHttpHeadersInternal(
                 newSize,
                 httpHeaders,
                 false, // async
@@ -1119,7 +1137,7 @@ namespace Azure.Storage.Files
         /// The <see cref="SetHttpHeadersAsync"/> operation sets system
         /// properties on the file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -1135,7 +1153,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileInfo}"/> describing the
         /// state of the file.
         /// </returns>
         /// <remarks>
@@ -1146,7 +1164,7 @@ namespace Azure.Storage.Files
             long? newSize = default,
             FileHttpHeaders? httpHeaders = default,
             CancellationToken cancellationToken = default) =>
-            await this.SetHttpHeadersAsync(
+            await this.SetHttpHeadersInternal(
                 newSize,
                 httpHeaders,
                 true, // async
@@ -1154,10 +1172,10 @@ namespace Azure.Storage.Files
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetHttpHeadersAsync"/> operation sets system
+        /// The <see cref="SetHttpHeadersInternal"/> operation sets system
         /// properties on the file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-properties"/>.
         /// </summary>
         /// <param name="newSize">
         /// Optional. Resizes a file to the specified size.
@@ -1168,19 +1186,22 @@ namespace Azure.Storage.Files
         /// <param name="httpHeaders">
         /// Optional. The standard HTTP header system properties to set.  If not specified, existing values will be cleared.
         /// </param>
+        /// <param name="async">
+        /// Whether to invoke the operation asynchronously.
+        /// </param>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileInfo}"/> describing the
         /// state of the file.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageFileInfo>> SetHttpHeadersAsync(
+        private async Task<Response<StorageFileInfo>> SetHttpHeadersInternal(
             long? newSize,
             FileHttpHeaders? httpHeaders,
             bool async,
@@ -1221,12 +1242,14 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion SetHttpHeaders
 
+        #region SetMetadata
         /// <summary>
         /// The <see cref="SetMetadata"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -1246,7 +1269,7 @@ namespace Azure.Storage.Files
         public virtual Response<StorageFileInfo> SetMetadata(
             Metadata metadata,
             CancellationToken cancellationToken = default) =>
-            this.SetMetadataAsync(
+            this.SetMetadataInternal(
                 metadata,
                 false, // async
                 cancellationToken)
@@ -1256,7 +1279,7 @@ namespace Azure.Storage.Files
         /// The <see cref="SetMetadataAsync"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -1266,7 +1289,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileInfo}}"/> describing the updated
+        /// A <see cref="Response{StorageFileInfo}"/> describing the updated
         /// file.
         /// </returns>
         /// <remarks>
@@ -1276,17 +1299,17 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<StorageFileInfo>> SetMetadataAsync(
             Metadata metadata,
             CancellationToken cancellationToken = default) =>
-            await this.SetMetadataAsync(
+            await this.SetMetadataInternal(
                 metadata,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetMetadataAsync"/> operation sets user-defined
+        /// The <see cref="SetMetadataInternal"/> operation sets user-defined
         /// metadata for the specified file as one or more name-value pairs.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-file-metadata"/>
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this file.
@@ -1299,14 +1322,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileInfo}}"/> describing the updated
+        /// A <see cref="Response{StorageFileInfo}"/> describing the updated
         /// file.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageFileInfo>> SetMetadataAsync(
+        private async Task<Response<StorageFileInfo>> SetMetadataInternal(
             Metadata metadata,
             bool async,
             CancellationToken cancellationToken)
@@ -1337,12 +1360,14 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion SetMetadata
 
+        #region UploadRange
         /// <summary>
         /// The <see cref="UploadRange"/> operation writes
         /// <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
         /// </summary>
         /// <param name="writeType">Required. Specifies whether to update or clear the range.
         /// </param>
@@ -1370,7 +1395,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileUploadInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileUploadInfo}"/> describing the
         /// state of the file.
         /// </returns>
         /// <remarks>
@@ -1384,7 +1409,7 @@ namespace Azure.Storage.Files
             byte[] transactionalContentHash = null,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            this.UploadRangeAsync(
+            this.UploadRangeInternal(
                 writeType,
                 range,
                 content,
@@ -1398,7 +1423,7 @@ namespace Azure.Storage.Files
         /// The <see cref="UploadRangeAsync"/> operation writes
         /// <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
         /// </summary>
         /// <param name="writeType">Required. Specifies whether to update or clear the range.
         /// </param>
@@ -1426,7 +1451,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileUploadInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileUploadInfo}"/> describing the
         /// state of the file.
         /// </returns>
         /// <remarks>
@@ -1440,7 +1465,7 @@ namespace Azure.Storage.Files
             byte[] transactionalContentHash = null,
             IProgress<StorageProgress> progressHandler = default,
             CancellationToken cancellationToken = default) =>
-            await this.UploadRangeAsync(
+            await this.UploadRangeInternal(
                 writeType,
                 range,
                 content,
@@ -1451,10 +1476,10 @@ namespace Azure.Storage.Files
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="UploadRangeAsync"/> operation writes
+        /// The <see cref="UploadRangeInternal"/> operation writes
         /// <paramref name="content"/> to a <paramref name="range"/> of a file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-range"/>
         /// </summary>
         /// <param name="writeType">Required. Specifies whether to update or clear the range.
         /// </param>
@@ -1485,14 +1510,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileUploadInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileUploadInfo}"/> describing the
         /// state of the file.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageFileUploadInfo>> UploadRangeAsync(
+        private async Task<Response<StorageFileUploadInfo>> UploadRangeInternal(
             FileRangeWriteType writeType,
             HttpRange range,
             Stream content,
@@ -1548,11 +1573,13 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion UploadRange
 
+        #region GetRangeList
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively. If omitted, then all ranges for the file are returned.
@@ -1576,7 +1603,7 @@ namespace Azure.Storage.Files
             HttpRange range,
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            this.GetRangeListAsync(
+            this.GetRangeListInternal(
                 range,
                 shareSnapshot,
                 false, // async
@@ -1586,7 +1613,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively. If omitted, then all ranges for the file are returned.
@@ -1599,7 +1626,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileRangeInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileRangeInfo}"/> describing the
         /// valid ranges for this file.
         /// </returns>
         /// <remarks>
@@ -1610,7 +1637,7 @@ namespace Azure.Storage.Files
             HttpRange range,
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetRangeListAsync(
+            await this.GetRangeListInternal(
                 range,
                 shareSnapshot,
                 true, // async
@@ -1620,7 +1647,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Returns the list of valid ranges for a file.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-ranges"/>.
         /// </summary>
         /// <param name="range">
         /// Optional. Specifies the range of bytes over which to list ranges, inclusively. If omitted, then all ranges for the file are returned.
@@ -1636,14 +1663,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageFileRangeInfo}}"/> describing the
+        /// A <see cref="Response{StorageFileRangeInfo}"/> describing the
         /// valid ranges for this file.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageFileRangeInfo>> GetRangeListAsync(
+        private async Task<Response<StorageFileRangeInfo>> GetRangeListInternal(
             HttpRange range,
             string shareSnapshot,
             bool async,
@@ -1678,7 +1705,9 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetRangeList
 
+        #region GetHandles
         /// <summary>
         /// The <see cref="GetHandles"/> operation returns an async sequence
         /// of the open handles on a directory or a file.  Enumerating the
@@ -1692,8 +1721,8 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="IEnumerable{Response{StorageHandle}}"/> describing the
-        /// handles in the directory.
+        /// An <see cref="IEnumerable{T}"/> of <see cref="Response{StorageHandle}"/>
+        /// describing the handles in the directory.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -1728,7 +1757,7 @@ namespace Azure.Storage.Files
             new GetFileHandlesAsyncCollection(this, cancellationToken);
 
         /// <summary>
-        /// The <see cref="GetHandlesAsync"/> operation returns a list of open
+        /// The <see cref="GetHandlesInternal"/> operation returns a list of open
         /// handles on the file.
         ///
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-handles"/>.
@@ -1755,14 +1784,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageHandlesSegment}}"/> describing a
+        /// A <see cref="Response{StorageHandlesSegment}"/> describing a
         /// segment of the handles on the file.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<StorageHandlesSegment>> GetHandlesAsync(
+        internal async Task<Response<StorageHandlesSegment>> GetHandlesInternal(
             string marker,
             int? maxResults,
             bool async,
@@ -1798,7 +1827,9 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetHandles
 
+        #region ForceCloseHandles
         /// <summary>
         /// The <see cref="ForceCloseHandles"/> operation closes a handle or handles opened on a file
         /// at the service. It supports closing a single handle specified by <paramref name="handleId"/> or
@@ -1810,7 +1841,7 @@ namespace Azure.Storage.Files
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.
@@ -1818,7 +1849,7 @@ namespace Azure.Storage.Files
         /// <param name="marker">
         /// An optional string value that identifies the segment of the handles
         /// to be closed with the next call to <see cref="ForceCloseHandles"/>.  The
-        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.NextMarker"/>
+        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.Marker"/>
         /// if the operation did not return all items remaining to be
         /// closed with the current segment.  The NextMarker value can
         /// be used as the value for the <paramref name="marker"/> parameter
@@ -1840,7 +1871,7 @@ namespace Azure.Storage.Files
             string handleId = Constants.CloseAllHandles,
             string marker = default,
             CancellationToken cancellationToken = default) =>
-            this.ForceCloseHandlesAsync(
+            this.ForceCloseHandlesInternal(
                 handleId,
                 marker,
                 false, // async,
@@ -1858,7 +1889,7 @@ namespace Azure.Storage.Files
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.
@@ -1866,7 +1897,7 @@ namespace Azure.Storage.Files
         /// <param name="marker">
         /// An optional string value that identifies the segment of the handles
         /// to be closed with the next call to <see cref="ForceCloseHandlesAsync"/>.  The
-        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.NextMarker"/>
+        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.Marker"/>
         /// if the operation did not return all items remaining to be
         /// closed with the current segment.  The NextMarker value can
         /// be used as the value for the <paramref name="marker"/> parameter
@@ -1877,7 +1908,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageClosedHandlesSegment}}"/> describing a
+        /// A <see cref="Response{StorageClosedHandlesSegment}"/> describing a
         /// segment of the handles closed.
         /// </returns>
         /// <remarks>
@@ -1888,7 +1919,7 @@ namespace Azure.Storage.Files
             string handleId = Constants.CloseAllHandles,
             string marker = default,
             CancellationToken cancellationToken = default) =>
-            await this.ForceCloseHandlesAsync(
+            await this.ForceCloseHandlesInternal(
                 handleId,
                 marker,
                 true, // async,
@@ -1896,7 +1927,7 @@ namespace Azure.Storage.Files
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="ForceCloseHandlesAsync"/> operation closes a handle or handles opened on a file
+        /// The <see cref="ForceCloseHandlesInternal"/> operation closes a handle or handles opened on a file
         /// at the service. It supports closing a single handle specified by <paramref name="handleId"/> or
         /// or closing all handles opened on that resource.
         ///
@@ -1906,7 +1937,7 @@ namespace Azure.Storage.Files
         /// errors due to failed attempts to read or write files. This API is not intended for use as a replacement
         /// or alternative for SMB close.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/force-close-handles"/>.
         /// </summary>
         /// <param name="handleId">
         /// Optional. Specifies the handle ID to be closed. If not specified, or if equal to &quot;*&quot;, will close all handles.
@@ -1914,7 +1945,7 @@ namespace Azure.Storage.Files
         /// <param name="marker">
         /// An optional string value that identifies the segment of the handles
         /// to be closed with the next call to <see cref="ForceCloseHandlesAsync"/>.  The
-        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.NextMarker"/>
+        /// operation returns a non-empty <see cref="StorageClosedHandlesSegment.Marker"/>
         /// if the operation did not return all items remaining to be
         /// closed with the current segment.  The NextMarker value can
         /// be used as the value for the <paramref name="marker"/> parameter
@@ -1928,14 +1959,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{StorageClosedHandlesSegment}}"/> describing a
+        /// A <see cref="Response{StorageClosedHandlesSegment}"/> describing a
         /// segment of the handles closed.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<StorageClosedHandlesSegment>> ForceCloseHandlesAsync(
+        private async Task<Response<StorageClosedHandlesSegment>> ForceCloseHandlesInternal(
             string handleId,
             string marker,
             bool async,
@@ -1971,6 +2002,7 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion ForceCloseHandles
     }
 }
 

--- a/sdk/storage/Azure.Storage.Files/src/FileServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/FileServiceClient.cs
@@ -42,6 +42,7 @@ namespace Azure.Storage.Files
         /// </summary>
         protected virtual HttpPipeline Pipeline => this._pipeline;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="FileServiceClient"/>
         /// class for mocking.
@@ -162,6 +163,7 @@ namespace Azure.Storage.Files
             this._uri = serviceUri;
             this._pipeline = pipeline;
         }
+        #endregion ctors
 
         /// <summary>
         /// Create a new <see cref="ShareClient"/> object by appending
@@ -177,6 +179,7 @@ namespace Azure.Storage.Files
         /// </returns>
         public virtual ShareClient GetShareClient(string shareName) => new ShareClient(this.Uri.AppendToPath(shareName), this.Pipeline);
 
+        #region GetShares
         /// <summary>
         /// The <see cref="GetShares"/> operation returns an async sequence
         /// of the shares in the storage account.  Enumerating the shares may
@@ -194,8 +197,8 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="IEnumerable{Response{ShareItem}}"/> describing the
-        /// shares in the storage account.
+        /// An <see cref="IEnumerable{T}"/> of <see cref="Response{ShareItem}"/>
+        /// describing the shares in the storage account.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -236,7 +239,7 @@ namespace Azure.Storage.Files
             new GetSharesAsyncCollection(this, options, cancellationToken);
 
         /// <summary>
-        /// The <see cref="GetSharesAsync"/> operation returns a
+        /// The <see cref="GetSharesInternal"/> operation returns a
         /// single segment of shares in the storage account, starting
         /// from the specified <paramref name="marker"/>.  Use an empty
         /// <paramref name="marker"/> to start enumeration from the beginning
@@ -271,14 +274,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{SharesSegment}}"/> describing a
+        /// A <see cref="Response{SharesSegment}"/> describing a
         /// segment of the shares in the storage account.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        internal async Task<Response<SharesSegment>> GetSharesAsync(
+        internal async Task<Response<SharesSegment>> GetSharesInternal(
             string marker,
             GetSharesOptions? options,
             int? pageSizeHint,
@@ -317,7 +320,9 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetShares
 
+        #region GetProperties
         /// <summary>
         /// The <see cref="GetProperties"/> operation gets the properties
         /// of a storage account’s file service, including properties for
@@ -339,7 +344,7 @@ namespace Azure.Storage.Files
         /// </remarks>
         public virtual Response<FileServiceProperties> GetProperties(
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -356,7 +361,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{FileServiceProperties}}"/> describing
+        /// A <see cref="Response{FileServiceProperties}"/> describing
         /// the service properties.
         /// </returns>
         /// <remarks>
@@ -365,13 +370,13 @@ namespace Azure.Storage.Files
         /// </remarks>
         public virtual async Task<Response<FileServiceProperties>> GetPropertiesAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetPropertiesAsync"/> operation gets the properties
+        /// The <see cref="GetPropertiesInternal"/> operation gets the properties
         /// of a storage account’s file service, including properties for
         /// Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
         /// 
@@ -385,14 +390,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{FileServiceProperties}}"/> describing
+        /// A <see cref="Response{FileServiceProperties}"/> describing
         /// the service properties.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<FileServiceProperties>> GetPropertiesAsync(
+        private async Task<Response<FileServiceProperties>> GetPropertiesInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -421,7 +426,9 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetProperties
 
+        #region SetProperties
         /// <summary>
         /// The <see cref="SetProperties"/> operation sets properties for
         /// a storage account’s File service endpoint, including properties
@@ -447,7 +454,7 @@ namespace Azure.Storage.Files
         public virtual Response SetProperties(
             FileServiceProperties properties,
             CancellationToken cancellationToken = default) =>
-            this.SetPropertiesAsync(
+            this.SetPropertiesInternal(
                 properties,
                 false, // async
                 cancellationToken)
@@ -469,7 +476,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> if the operation was successful.
+        /// A <see cref="Response"/> if the operation was successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -478,14 +485,14 @@ namespace Azure.Storage.Files
         public virtual async Task<Response> SetPropertiesAsync(
             FileServiceProperties properties,
             CancellationToken cancellationToken = default) =>
-            await this.SetPropertiesAsync(
+            await this.SetPropertiesInternal(
                 properties,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetPropertiesAsync"/> operation sets properties for
+        /// The <see cref="SetPropertiesInternal"/> operation sets properties for
         /// a storage account’s File service endpoint, including properties
         /// for Storage Analytics, CORS (Cross-Origin Resource Sharing) rules
         /// and soft delete settings.  You can also use this operation to set
@@ -503,13 +510,13 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> if the operation was successful.
+        /// A <see cref="Response"/> if the operation was successful.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> SetPropertiesAsync(
+        private async Task<Response> SetPropertiesInternal(
             FileServiceProperties properties,
             bool async,
             CancellationToken cancellationToken)
@@ -540,13 +547,15 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion SetProperties
 
+        #region CreateShare
         /// <summary>
         /// The <see cref="CreateShare"/> operation creates a new share
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to create.
@@ -585,7 +594,7 @@ namespace Azure.Storage.Files
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to create.
@@ -601,7 +610,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareClient}}"/> referencing the newly
+        /// A <see cref="Response{ShareClient}"/> referencing the newly
         /// created share.
         /// </returns>
         /// <remarks>
@@ -618,14 +627,16 @@ namespace Azure.Storage.Files
             var response = await share.CreateAsync(metadata, quotaInBytes, cancellationToken).ConfigureAwait(false);
             return new Response<ShareClient>(response.GetRawResponse(), share);
         }
+        #endregion CreateShare
 
+        #region DeleteShare
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         /// 
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to delete.
@@ -652,7 +663,7 @@ namespace Azure.Storage.Files
         /// 
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
         /// </summary>
         /// <param name="shareName">
         /// The name of the share to delete.
@@ -662,7 +673,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -673,6 +684,7 @@ namespace Azure.Storage.Files
             CancellationToken cancellationToken = default) =>
             await this.GetShareClient(shareName)
                 .DeleteAsync(cancellationToken: cancellationToken)
-                .ConfigureAwait(false);        
+                .ConfigureAwait(false);
+        #endregion DeleteShare
     }
 }

--- a/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Generated/FileRestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
@@ -22,6 +22,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Sets properties for a storage account's File service endpoint, including properties for Storage Analytics metrics and CORS (Cross-Origin Resource Sharing) rules.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="properties">The StorageService properties.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -56,6 +57,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Service.SetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="properties">The StorageService properties.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -87,13 +89,13 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 // Create the body
                 System.Xml.Linq.XElement _body = Azure.Storage.Files.Models.FileServiceProperties.ToXml(properties, "StorageServiceProperties", "");
                 string _text = _body.ToString();
                 _request.Headers.SetValue("Content-Type", "application/xml");
-                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)); 
+                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(System.Text.Encoding.UTF8.GetBytes(_text));
 
                 return _request;
@@ -130,6 +132,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Gets the properties of a storage account's File service, including properties for Storage Analytics metrics and CORS (Cross-Origin Resource Sharing) rules.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
@@ -161,6 +164,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Service.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <returns>The Service.GetPropertiesAsync Request.</returns>
@@ -186,7 +190,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -232,6 +236,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// The List Shares Segment operation returns a list of the shares and share snapshots under the specified account.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only entries whose name begins with the specified prefix.</param>
             /// <param name="marker">A string value that identifies the portion of the list to be returned with the next list operation. The operation returns a marker value within the response body if the list returned was not complete. The marker value may then be used in a subsequent call to request the next set of list items. The marker value is opaque to the client.</param>
@@ -275,6 +280,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Service.ListSharesSegmentAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only entries whose name begins with the specified prefix.</param>
             /// <param name="marker">A string value that identifies the portion of the list to be returned with the next list operation. The operation returns a marker value within the response body if the list returned was not complete. The marker value may then be used in a subsequent call to request the next set of list items. The marker value is opaque to the client.</param>
@@ -311,7 +317,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -365,6 +371,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Creates a new share under the specified account. If the share with the same name already exists, the operation fails.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -402,6 +409,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.CreateAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -430,14 +438,14 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (quota != null) { _request.Headers.SetValue("x-ms-share-quota", quota.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
+                }
+                if (quota != null) { _request.Headers.SetValue("x-ms-share-quota", quota.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 return _request;
             }
@@ -493,6 +501,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Returns all user-defined metadata and system properties for the specified share or share snapshot. The data returned does not include the share's list of files.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -527,6 +536,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -554,7 +564,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -622,6 +632,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Operation marks the specified share or share snapshot for deletion. The share or share snapshot and any files contained within it are later deleted during garbage collection.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -659,6 +670,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.DeleteAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -688,8 +700,8 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (deleteSnapshots != null) { _request.Headers.SetValue("x-ms-delete-snapshots", Azure.Storage.Files.FileRestClient.Serialization.ToString(deleteSnapshots.Value));  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (deleteSnapshots != null) { _request.Headers.SetValue("x-ms-delete-snapshots", Azure.Storage.Files.FileRestClient.Serialization.ToString(deleteSnapshots.Value)); }
 
                 return _request;
             }
@@ -725,6 +737,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Creates a read-only snapshot of a share.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -759,6 +772,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.CreateSnapshotAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -786,13 +800,13 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
+                }
 
                 return _request;
             }
@@ -852,6 +866,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Sets quota for the specified share.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="quota">Specifies the maximum size of the share, in gigabytes.</param>
@@ -886,6 +901,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.SetQuotaAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="quota">Specifies the maximum size of the share, in gigabytes.</param>
@@ -913,8 +929,8 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (quota != null) { _request.Headers.SetValue("x-ms-share-quota", quota.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (quota != null) { _request.Headers.SetValue("x-ms-share-quota", quota.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
 
                 return _request;
             }
@@ -970,6 +986,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Sets one or more user-defined name-value pairs for the specified share.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -1004,6 +1021,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.SetMetadataAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -1031,13 +1049,13 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
+                }
 
                 return _request;
             }
@@ -1093,6 +1111,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Returns information about stored access policies specified on the share.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
@@ -1124,6 +1143,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.GetAccessPolicyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <returns>The Share.GetAccessPolicyAsync Request.</returns>
@@ -1149,7 +1169,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -1199,6 +1219,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Sets a stored access policy for use with shared access signatures.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="permissions">The ACL for the share.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -1233,6 +1254,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.SetAccessPolicyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="permissions">The ACL for the share.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -1260,7 +1282,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 // Create the body
                 System.Xml.Linq.XElement _body = new System.Xml.Linq.XElement(System.Xml.Linq.XName.Get("SignedIdentifiers", ""));
@@ -1273,7 +1295,7 @@ namespace Azure.Storage.Files
                 }
                 string _text = _body.ToString();
                 _request.Headers.SetValue("Content-Type", "application/xml");
-                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)); 
+                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(System.Text.Encoding.UTF8.GetBytes(_text));
 
                 return _request;
@@ -1330,6 +1352,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Retrieves statistics related to the share.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
@@ -1361,6 +1384,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Share.GetStatisticsAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <returns>The Share.GetStatisticsAsync Request.</returns>
@@ -1386,7 +1410,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -1440,6 +1464,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Creates a new directory under the specified share or parent directory.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -1474,6 +1499,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Directory.CreateAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -1500,13 +1526,13 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
+                }
 
                 return _request;
             }
@@ -1562,6 +1588,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Returns all system properties for the specified directory, and can also be used to check the existence of a directory. The data returned does not include the files in the directory or any subdirectories.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -1596,6 +1623,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Directory.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -1623,7 +1651,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -1691,6 +1719,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Removes the specified empty directory. Note that the directory must be empty before it can be deleted.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
@@ -1722,6 +1751,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Directory.DeleteAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <returns>The Directory.DeleteAsync Request.</returns>
@@ -1746,7 +1776,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -1782,6 +1812,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Updates user defined metadata for the specified directory.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -1816,6 +1847,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Directory.SetMetadataAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -1843,13 +1875,13 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
+                }
 
                 return _request;
             }
@@ -1905,6 +1937,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Returns a list of files or directories under the specified share or directory. It lists the contents only for a single level of the directory hierarchy.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only entries whose name begins with the specified prefix.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
@@ -1948,6 +1981,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Directory.ListFilesAndDirectoriesSegmentAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only entries whose name begins with the specified prefix.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
@@ -1985,7 +2019,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -2031,6 +2065,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Lists handles for directory.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="marker">A string value that identifies the portion of the list to be returned with the next list operation. The operation returns a marker value within the response body if the list returned was not complete. The marker value may then be used in a subsequent call to request the next set of list items. The marker value is opaque to the client.</param>
             /// <param name="maxresults">Specifies the maximum number of entries to return. If the request does not specify maxresults, or specifies a value greater than 5,000, the server will return up to 5,000 items.</param>
@@ -2074,6 +2109,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Directory.ListHandlesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="marker">A string value that identifies the portion of the list to be returned with the next list operation. The operation returns a marker value within the response body if the list returned was not complete. The marker value may then be used in a subsequent call to request the next set of list items. The marker value is opaque to the client.</param>
             /// <param name="maxresults">Specifies the maximum number of entries to return. If the request does not specify maxresults, or specifies a value greater than 5,000, the server will return up to 5,000 items.</param>
@@ -2109,12 +2145,12 @@ namespace Azure.Storage.Files
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (recursive != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (recursive != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.Headers.SetValue("x-ms-recursive", recursive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()); 
+                _request.Headers.SetValue("x-ms-recursive", recursive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
                 #pragma warning restore CA1308 // Normalize strings to uppercase
-                 }
+                }
 
                 return _request;
             }
@@ -2160,6 +2196,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Closes all handles open for given directory.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="handleId">Specifies handle ID opened on the file or directory to be closed. Asterix (‘*’) is a wildcard that specifies all handles.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -2203,6 +2240,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the Directory.ForceCloseHandlesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="handleId">Specifies handle ID opened on the file or directory to be closed. Asterix (‘*’) is a wildcard that specifies all handles.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -2241,13 +2279,13 @@ namespace Azure.Storage.Files
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-handle-id", handleId); 
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (recursive != null) { 
+                _request.Headers.SetValue("x-ms-handle-id", handleId);
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (recursive != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.Headers.SetValue("x-ms-recursive", recursive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()); 
+                _request.Headers.SetValue("x-ms-recursive", recursive.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
                 #pragma warning restore CA1308 // Normalize strings to uppercase
-                 }
+                }
 
                 return _request;
             }
@@ -2311,6 +2349,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Creates a new file or replaces a file. Note it only initializes the file with no content.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="fileContentLength">Specifies the maximum size for the file, up to 1 TB.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -2366,6 +2405,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.CreateAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="fileContentLength">Specifies the maximum size for the file, up to 1 TB.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -2405,31 +2445,31 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                _request.Headers.SetValue("x-ms-content-length", fileContentLength.ToString(System.Globalization.CultureInfo.InvariantCulture)); 
-                _request.Headers.SetValue("x-ms-type", "file"); 
-                if (fileContentType != null) { _request.Headers.SetValue("x-ms-content-type", fileContentType);  }
-                if (fileContentEncoding != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                _request.Headers.SetValue("x-ms-content-length", fileContentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                _request.Headers.SetValue("x-ms-type", "file");
+                if (fileContentType != null) { _request.Headers.SetValue("x-ms-content-type", fileContentType); }
+                if (fileContentEncoding != null) {
                     foreach (string _item in fileContentEncoding)
                     {
-                        _request.Headers.SetValue("x-ms-content-encoding", _item); 
+                        _request.Headers.SetValue("x-ms-content-encoding", _item);
                     }
-                 }
-                if (fileContentLanguage != null) { 
+                }
+                if (fileContentLanguage != null) {
                     foreach (string _item in fileContentLanguage)
                     {
-                        _request.Headers.SetValue("x-ms-content-language", _item); 
+                        _request.Headers.SetValue("x-ms-content-language", _item);
                     }
-                 }
-                if (fileCacheControl != null) { _request.Headers.SetValue("x-ms-cache-control", fileCacheControl);  }
-                if (fileContentHash != null) { _request.Headers.SetValue("x-ms-content-md5", System.Convert.ToBase64String(fileContentHash));  }
-                if (fileContentDisposition != null) { _request.Headers.SetValue("x-ms-content-disposition", fileContentDisposition);  }
-                if (metadata != null) { 
+                }
+                if (fileCacheControl != null) { _request.Headers.SetValue("x-ms-cache-control", fileCacheControl); }
+                if (fileContentHash != null) { _request.Headers.SetValue("x-ms-content-md5", System.Convert.ToBase64String(fileContentHash)); }
+                if (fileContentDisposition != null) { _request.Headers.SetValue("x-ms-content-disposition", fileContentDisposition); }
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
+                }
 
                 return _request;
             }
@@ -2489,6 +2529,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Reads or downloads a file from the system, including its metadata and properties.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="range">Return file data only from the specified byte range.</param>
@@ -2526,6 +2567,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.DownloadAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="range">Return file data only from the specified byte range.</param>
@@ -2553,13 +2595,13 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (range != null) { _request.Headers.SetValue("x-ms-range", range);  }
-                if (rangeGetContentHash != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (range != null) { _request.Headers.SetValue("x-ms-range", range); }
+                if (rangeGetContentHash != null) {
                 #pragma warning disable CA1308 // Normalize strings to uppercase
-                _request.Headers.SetValue("x-ms-range-get-content-md5", rangeGetContentHash.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant()); 
+                _request.Headers.SetValue("x-ms-range-get-content-md5", rangeGetContentHash.Value.ToString(System.Globalization.CultureInfo.InvariantCulture).ToLowerInvariant());
                 #pragma warning restore CA1308 // Normalize strings to uppercase
-                 }
+                }
 
                 return _request;
             }
@@ -2817,6 +2859,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Returns all user-defined metadata, standard HTTP properties, and system properties for the file. It does not return the content of the file.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -2851,6 +2894,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -2877,7 +2921,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -3007,6 +3051,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// removes the file from the storage account.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="async">Whether to invoke the operation asynchronously.  The default value is true.</param>
@@ -3038,6 +3083,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.DeleteAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <returns>The File.DeleteAsync Request.</returns>
@@ -3061,7 +3107,7 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -3097,6 +3143,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Sets HTTP headers on the file.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="fileContentLength">Resizes a file to the specified size. If the specified byte value is less than the current size of the file, then all ranges above the specified byte value are cleared.</param>
@@ -3149,6 +3196,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.SetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="fileContentLength">Resizes a file to the specified size. If the specified byte value is less than the current size of the file, then all ranges above the specified byte value are cleared.</param>
@@ -3187,24 +3235,24 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (fileContentLength != null) { _request.Headers.SetValue("x-ms-content-length", fileContentLength.Value.ToString(System.Globalization.CultureInfo.InvariantCulture));  }
-                if (fileContentType != null) { _request.Headers.SetValue("x-ms-content-type", fileContentType);  }
-                if (fileContentEncoding != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (fileContentLength != null) { _request.Headers.SetValue("x-ms-content-length", fileContentLength.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)); }
+                if (fileContentType != null) { _request.Headers.SetValue("x-ms-content-type", fileContentType); }
+                if (fileContentEncoding != null) {
                     foreach (string _item in fileContentEncoding)
                     {
-                        _request.Headers.SetValue("x-ms-content-encoding", _item); 
+                        _request.Headers.SetValue("x-ms-content-encoding", _item);
                     }
-                 }
-                if (fileContentLanguage != null) { 
+                }
+                if (fileContentLanguage != null) {
                     foreach (string _item in fileContentLanguage)
                     {
-                        _request.Headers.SetValue("x-ms-content-language", _item); 
+                        _request.Headers.SetValue("x-ms-content-language", _item);
                     }
-                 }
-                if (fileCacheControl != null) { _request.Headers.SetValue("x-ms-cache-control", fileCacheControl);  }
-                if (fileContentHash != null) { _request.Headers.SetValue("x-ms-content-md5", System.Convert.ToBase64String(fileContentHash));  }
-                if (fileContentDisposition != null) { _request.Headers.SetValue("x-ms-content-disposition", fileContentDisposition);  }
+                }
+                if (fileCacheControl != null) { _request.Headers.SetValue("x-ms-cache-control", fileCacheControl); }
+                if (fileContentHash != null) { _request.Headers.SetValue("x-ms-content-md5", System.Convert.ToBase64String(fileContentHash)); }
+                if (fileContentDisposition != null) { _request.Headers.SetValue("x-ms-content-disposition", fileContentDisposition); }
 
                 return _request;
             }
@@ -3264,6 +3312,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Updates user-defined metadata for the specified file.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -3298,6 +3347,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.SetMetadataAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
             /// <param name="metadata">A name-value pair to associate with a file storage object.</param>
@@ -3324,13 +3374,13 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
+                }
 
                 return _request;
             }
@@ -3390,6 +3440,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Upload a range of bytes to a file.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="range">Specifies the range of bytes to be written. Both the start and end of the range must be specified. For an update operation, the range can be up to 4 MB in size. For a clear operation, the range can be up to the value of the file's full size. The File service accepts only a single byte range for the Range and 'x-ms-range' headers, and the byte range must be specified in the following format: bytes=startByte-endByte.</param>
             /// <param name="fileRangeWrite">Specify one of the following options: - Update: Writes the bytes specified by the request body into the specified range. The Range and Content-Length headers must match to perform the update. - Clear: Clears the specified range and releases the space used in storage for that range. To clear a range, set the Content-Length header to zero, and set the Range header to a value that indicates the range to clear, up to maximum file size.</param>
@@ -3436,6 +3487,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.UploadRangeAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="range">Specifies the range of bytes to be written. Both the start and end of the range must be specified. For an update operation, the range can be up to 4 MB in size. For a clear operation, the range can be up to the value of the file's full size. The File service accepts only a single byte range for the Range and 'x-ms-range' headers, and the byte range must be specified in the following format: bytes=startByte-endByte.</param>
             /// <param name="fileRangeWrite">Specify one of the following options: - Update: Writes the bytes specified by the request body into the specified range. The Range and Content-Length headers must match to perform the update. - Clear: Clears the specified range and releases the space used in storage for that range. To clear a range, set the Content-Length header to zero, and set the Range header to a value that indicates the range to clear, up to maximum file size.</param>
@@ -3474,11 +3526,11 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-range", range); 
-                _request.Headers.SetValue("x-ms-write", Azure.Storage.Files.FileRestClient.Serialization.ToString(fileRangeWrite)); 
-                _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture)); 
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (contentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(contentHash));  }
+                _request.Headers.SetValue("x-ms-range", range);
+                _request.Headers.SetValue("x-ms-write", Azure.Storage.Files.FileRestClient.Serialization.ToString(fileRangeWrite));
+                _request.Headers.SetValue("Content-Length", contentLength.ToString(System.Globalization.CultureInfo.InvariantCulture));
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (contentHash != null) { _request.Headers.SetValue("Content-MD5", System.Convert.ToBase64String(contentHash)); }
 
                 // Create the body
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(optionalbody);
@@ -3545,6 +3597,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Returns the list of valid ranges for a file.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -3582,6 +3635,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.GetRangeListAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="sharesnapshot">The snapshot parameter is an opaque DateTime value that, when present, specifies the share snapshot to query.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -3611,8 +3665,8 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (range != null) { _request.Headers.SetValue("x-ms-range", range);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (range != null) { _request.Headers.SetValue("x-ms-range", range); }
 
                 return _request;
             }
@@ -3678,6 +3732,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Copies a blob or file to a destination file within the storage account.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="copySource">Specifies the URL of the source file or blob, up to 2 KB in length. To copy a file to another file within the same storage account, you may use Shared Key to authenticate the source file. If you are copying a file from another storage account, or if you are copying a blob from the same storage account or another storage account, then you must authenticate the source file or blob using a shared access signature. If the source is a public blob, no authentication is required to perform the copy operation. A file in a share snapshot can also be specified as a copy source.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -3715,6 +3770,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.StartCopyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="copySource">Specifies the URL of the source file or blob, up to 2 KB in length. To copy a file to another file within the same storage account, you may use Shared Key to authenticate the source file. If you are copying a file from another storage account, or if you are copying a blob from the same storage account or another storage account, then you must authenticate the source file or blob using a shared access signature. If the source is a public blob, no authentication is required to perform the copy operation. A file in a share snapshot can also be specified as a copy source.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -3746,14 +3802,14 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                _request.Headers.SetValue("x-ms-copy-source", copySource.ToString()); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                _request.Headers.SetValue("x-ms-copy-source", copySource.ToString());
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
+                }
 
                 return _request;
             }
@@ -3817,6 +3873,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Aborts a pending Copy File operation, and leaves a destination file with zero length and full metadata.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="copyId">The copy identifier provided in the x-ms-copy-id header of the original Copy File operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -3851,6 +3908,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.AbortCopyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="copyId">The copy identifier provided in the x-ms-copy-id header of the original Copy File operation.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -3882,8 +3940,8 @@ namespace Azure.Storage.Files
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-copy-action", "abort"); 
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-copy-action", "abort");
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -3919,6 +3977,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Lists handles for file
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="marker">A string value that identifies the portion of the list to be returned with the next list operation. The operation returns a marker value within the response body if the list returned was not complete. The marker value may then be used in a subsequent call to request the next set of list items. The marker value is opaque to the client.</param>
             /// <param name="maxresults">Specifies the maximum number of entries to return. If the request does not specify maxresults, or specifies a value greater than 5,000, the server will return up to 5,000 items.</param>
@@ -3959,6 +4018,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.ListHandlesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="marker">A string value that identifies the portion of the list to be returned with the next list operation. The operation returns a marker value within the response body if the list returned was not complete. The marker value may then be used in a subsequent call to request the next set of list items. The marker value is opaque to the client.</param>
             /// <param name="maxresults">Specifies the maximum number of entries to return. If the request does not specify maxresults, or specifies a value greater than 5,000, the server will return up to 5,000 items.</param>
@@ -3992,7 +4052,7 @@ namespace Azure.Storage.Files
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -4038,6 +4098,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Closes all handles open for given file
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="handleId">Specifies handle ID opened on the file or directory to be closed. Asterix (‘*’) is a wildcard that specifies all handles.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -4078,6 +4139,7 @@ namespace Azure.Storage.Files
             /// <summary>
             /// Create the File.ForceCloseHandlesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, share, directory or file that is the target of the desired operation.</param>
             /// <param name="handleId">Specifies handle ID opened on the file or directory to be closed. Asterix (‘*’) is a wildcard that specifies all handles.</param>
             /// <param name="timeout">The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/Setting-Timeouts-for-File-Service-Operations?redirectedfrom=MSDN">Setting Timeouts for File Service Operations.</a></param>
@@ -4114,8 +4176,8 @@ namespace Azure.Storage.Files
                 if (sharesnapshot != null) { _request.UriBuilder.AppendQuery("sharesnapshot", System.Uri.EscapeDataString(sharesnapshot)); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-handle-id", handleId); 
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
+                _request.Headers.SetValue("x-ms-handle-id", handleId);
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
 
                 return _request;
             }
@@ -4181,6 +4243,9 @@ namespace Azure.Storage.Files.Models
     /// </summary>
     public enum DeleteSnapshotsOptionType
     {
+        /// <summary>
+        /// include
+        /// </summary>
         Include
     }
 }
@@ -4225,7 +4290,14 @@ namespace Azure.Storage.Files.Models
     /// </summary>
     public enum ListSharesIncludeType
     {
+        /// <summary>
+        /// snapshots
+        /// </summary>
         Snapshots,
+
+        /// <summary>
+        /// metadata
+        /// </summary>
         Metadata
     }
 }
@@ -4831,138 +4903,374 @@ namespace Azure.Storage.Files.Models
     public partial struct FileErrorCode : System.IEquatable<FileErrorCode>
     {
         #pragma warning disable CA2211 // Non-constant fields should not be visible
+        /// <summary>
+        /// AccountAlreadyExists
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode AccountAlreadyExists = @"AccountAlreadyExists";
 
+        /// <summary>
+        /// AccountBeingCreated
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode AccountBeingCreated = @"AccountBeingCreated";
 
+        /// <summary>
+        /// AccountIsDisabled
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode AccountIsDisabled = @"AccountIsDisabled";
 
+        /// <summary>
+        /// AuthenticationFailed
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode AuthenticationFailed = @"AuthenticationFailed";
 
+        /// <summary>
+        /// AuthorizationFailure
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode AuthorizationFailure = @"AuthorizationFailure";
 
+        /// <summary>
+        /// ConditionHeadersNotSupported
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ConditionHeadersNotSupported = @"ConditionHeadersNotSupported";
 
+        /// <summary>
+        /// ConditionNotMet
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ConditionNotMet = @"ConditionNotMet";
 
+        /// <summary>
+        /// EmptyMetadataKey
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode EmptyMetadataKey = @"EmptyMetadataKey";
 
+        /// <summary>
+        /// InsufficientAccountPermissions
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InsufficientAccountPermissions = @"InsufficientAccountPermissions";
 
+        /// <summary>
+        /// InternalError
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InternalError = @"InternalError";
 
+        /// <summary>
+        /// InvalidAuthenticationInfo
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidAuthenticationInfo = @"InvalidAuthenticationInfo";
 
+        /// <summary>
+        /// InvalidHeaderValue
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidHeaderValue = @"InvalidHeaderValue";
 
+        /// <summary>
+        /// InvalidHttpVerb
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidHttpVerb = @"InvalidHttpVerb";
 
+        /// <summary>
+        /// InvalidInput
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidInput = @"InvalidInput";
 
+        /// <summary>
+        /// InvalidMd5
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidMd5 = @"InvalidMd5";
 
+        /// <summary>
+        /// InvalidMetadata
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidMetadata = @"InvalidMetadata";
 
+        /// <summary>
+        /// InvalidQueryParameterValue
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidQueryParameterValue = @"InvalidQueryParameterValue";
 
+        /// <summary>
+        /// InvalidRange
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidRange = @"InvalidRange";
 
+        /// <summary>
+        /// InvalidResourceName
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidResourceName = @"InvalidResourceName";
 
+        /// <summary>
+        /// InvalidUri
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidUri = @"InvalidUri";
 
+        /// <summary>
+        /// InvalidXmlDocument
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidXmlDocument = @"InvalidXmlDocument";
 
+        /// <summary>
+        /// InvalidXmlNodeValue
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidXmlNodeValue = @"InvalidXmlNodeValue";
 
+        /// <summary>
+        /// Md5Mismatch
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode Md5Mismatch = @"Md5Mismatch";
 
+        /// <summary>
+        /// MetadataTooLarge
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode MetadataTooLarge = @"MetadataTooLarge";
 
+        /// <summary>
+        /// MissingContentLengthHeader
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode MissingContentLengthHeader = @"MissingContentLengthHeader";
 
+        /// <summary>
+        /// MissingRequiredQueryParameter
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode MissingRequiredQueryParameter = @"MissingRequiredQueryParameter";
 
+        /// <summary>
+        /// MissingRequiredHeader
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode MissingRequiredHeader = @"MissingRequiredHeader";
 
+        /// <summary>
+        /// MissingRequiredXmlNode
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode MissingRequiredXmlNode = @"MissingRequiredXmlNode";
 
+        /// <summary>
+        /// MultipleConditionHeadersNotSupported
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode MultipleConditionHeadersNotSupported = @"MultipleConditionHeadersNotSupported";
 
+        /// <summary>
+        /// OperationTimedOut
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode OperationTimedOut = @"OperationTimedOut";
 
+        /// <summary>
+        /// OutOfRangeInput
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode OutOfRangeInput = @"OutOfRangeInput";
 
+        /// <summary>
+        /// OutOfRangeQueryParameterValue
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode OutOfRangeQueryParameterValue = @"OutOfRangeQueryParameterValue";
 
+        /// <summary>
+        /// RequestBodyTooLarge
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode RequestBodyTooLarge = @"RequestBodyTooLarge";
 
+        /// <summary>
+        /// ResourceTypeMismatch
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ResourceTypeMismatch = @"ResourceTypeMismatch";
 
+        /// <summary>
+        /// RequestUrlFailedToParse
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode RequestUrlFailedToParse = @"RequestUrlFailedToParse";
 
+        /// <summary>
+        /// ResourceAlreadyExists
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ResourceAlreadyExists = @"ResourceAlreadyExists";
 
+        /// <summary>
+        /// ResourceNotFound
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ResourceNotFound = @"ResourceNotFound";
 
+        /// <summary>
+        /// ServerBusy
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ServerBusy = @"ServerBusy";
 
+        /// <summary>
+        /// UnsupportedHeader
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode UnsupportedHeader = @"UnsupportedHeader";
 
+        /// <summary>
+        /// UnsupportedXmlNode
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode UnsupportedXmlNode = @"UnsupportedXmlNode";
 
+        /// <summary>
+        /// UnsupportedQueryParameter
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode UnsupportedQueryParameter = @"UnsupportedQueryParameter";
 
+        /// <summary>
+        /// UnsupportedHttpVerb
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode UnsupportedHttpVerb = @"UnsupportedHttpVerb";
 
+        /// <summary>
+        /// CannotDeleteFileOrDirectory
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode CannotDeleteFileOrDirectory = @"CannotDeleteFileOrDirectory";
 
+        /// <summary>
+        /// ClientCacheFlushDelay
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ClientCacheFlushDelay = @"ClientCacheFlushDelay";
 
+        /// <summary>
+        /// DeletePending
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode DeletePending = @"DeletePending";
 
+        /// <summary>
+        /// DirectoryNotEmpty
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode DirectoryNotEmpty = @"DirectoryNotEmpty";
 
+        /// <summary>
+        /// FileLockConflict
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode FileLockConflict = @"FileLockConflict";
 
+        /// <summary>
+        /// InvalidFileOrDirectoryPathName
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode InvalidFileOrDirectoryPathName = @"InvalidFileOrDirectoryPathName";
 
+        /// <summary>
+        /// ParentNotFound
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ParentNotFound = @"ParentNotFound";
 
+        /// <summary>
+        /// ReadOnlyAttribute
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ReadOnlyAttribute = @"ReadOnlyAttribute";
 
+        /// <summary>
+        /// ShareAlreadyExists
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ShareAlreadyExists = @"ShareAlreadyExists";
 
+        /// <summary>
+        /// ShareBeingDeleted
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ShareBeingDeleted = @"ShareBeingDeleted";
 
+        /// <summary>
+        /// ShareDisabled
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ShareDisabled = @"ShareDisabled";
 
+        /// <summary>
+        /// ShareNotFound
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ShareNotFound = @"ShareNotFound";
 
+        /// <summary>
+        /// SharingViolation
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode SharingViolation = @"SharingViolation";
 
+        /// <summary>
+        /// ShareSnapshotInProgress
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ShareSnapshotInProgress = @"ShareSnapshotInProgress";
 
+        /// <summary>
+        /// ShareSnapshotCountExceeded
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ShareSnapshotCountExceeded = @"ShareSnapshotCountExceeded";
 
+        /// <summary>
+        /// ShareSnapshotOperationNotSupported
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ShareSnapshotOperationNotSupported = @"ShareSnapshotOperationNotSupported";
 
+        /// <summary>
+        /// ShareHasSnapshots
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ShareHasSnapshots = @"ShareHasSnapshots";
 
+        /// <summary>
+        /// ContainerQuotaDowngradeNotAllowed
+        /// </summary>
         public static Azure.Storage.Files.Models.FileErrorCode ContainerQuotaDowngradeNotAllowed = @"ContainerQuotaDowngradeNotAllowed";
         #pragma warning restore CA2211 // Non-constant fields should not be visible
 
+        /// <summary>
+        /// The FileErrorCode value.
+        /// </summary>
         private readonly string _value;
+
+        /// <summary>
+        /// Creates a new FileErrorCode instance.
+        /// </summary>
+        /// <param name="value">The FileErrorCode value.</param>
         private FileErrorCode(string value) { this._value = value; }
+
+        /// <summary>
+        /// Check if two FileErrorCode instances are equal.
+        /// </summary>
+        /// <param name="other">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(Azure.Storage.Files.Models.FileErrorCode other) => this._value.Equals(other._value, System.StringComparison.InvariantCulture);
+
+        /// <summary>
+        /// Check if two FileErrorCode instances are equal.
+        /// </summary>
+        /// <param name="o">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public override bool Equals(object o) => o is Azure.Storage.Files.Models.FileErrorCode other && this.Equals(other);
+
+        /// <summary>
+        /// Get a hash code for the FileErrorCode.
+        /// </summary>
+        /// <returns>Hash code for the FileErrorCode.</returns>
         public override int GetHashCode() => this._value.GetHashCode();
+
+        /// <summary>
+        /// Convert the FileErrorCode to a string.
+        /// </summary>
+        /// <returns>String representation of the FileErrorCode.</returns>
         public override string ToString() => this._value;
+
         #pragma warning disable CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Convert a string a FileErrorCode.
+        /// </summary>
+        /// <param name="value">The string to convert.</param>
+        /// <returns>The FileErrorCode value.</returns>
         public static implicit operator FileErrorCode(string value) => new Azure.Storage.Files.Models.FileErrorCode(value);
         #pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Convert an FileErrorCode to a string.
+        /// </summary>
+        /// <param name="o">The FileErrorCode value.</param>
+        /// <returns>String representation of the FileErrorCode value.</returns>
         public static implicit operator string(Azure.Storage.Files.Models.FileErrorCode o) => o._value;
+
+        /// <summary>
+        /// Check if two FileErrorCode instances are equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public static bool operator ==(Azure.Storage.Files.Models.FileErrorCode a, Azure.Storage.Files.Models.FileErrorCode b) => a.Equals(b);
+
+        /// <summary>
+        /// Check if two FileErrorCode instances are not equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're not equal, false otherwise.</returns>
         public static bool operator !=(Azure.Storage.Files.Models.FileErrorCode a, Azure.Storage.Files.Models.FileErrorCode b) => !a.Equals(b);
     }
 }
@@ -6213,9 +6521,24 @@ namespace Azure.Storage.Files.Models
     public enum CopyStatus
     #pragma warning restore CA1717 // Only FlagsAttribute enums should have plural names
     {
+        /// <summary>
+        /// pending
+        /// </summary>
         Pending,
+
+        /// <summary>
+        /// success
+        /// </summary>
         Success,
+
+        /// <summary>
+        /// aborted
+        /// </summary>
         Aborted,
+
+        /// <summary>
+        /// failed
+        /// </summary>
         Failed
     }
 }
@@ -6415,6 +6738,9 @@ namespace Azure.Storage.Files.Models
     /// </summary>
     public enum Header
     {
+        /// <summary>
+        /// File
+        /// </summary>
         File
     }
 }
@@ -6608,7 +6934,14 @@ namespace Azure.Storage.Files.Models
     /// </summary>
     public enum FileRangeWriteType
     {
+        /// <summary>
+        /// update
+        /// </summary>
         Update,
+
+        /// <summary>
+        /// clear
+        /// </summary>
         Clear
     }
 }

--- a/sdk/storage/Azure.Storage.Files/src/Models/GetFilesAndDirectories.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/GetFilesAndDirectories.cs
@@ -99,7 +99,7 @@ namespace Azure.Storage.Files.Models
             bool isAsync,
             CancellationToken cancellationToken)
         {
-            var task = this._client.GetFilesAndDirectoriesAsync(
+            var task = this._client.GetFilesAndDirectoriesInternal(
                 continuationToken,
                 this._options,
                 pageSizeHint,

--- a/sdk/storage/Azure.Storage.Files/src/Models/GetHandlesAsyncCollection.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/GetHandlesAsyncCollection.cs
@@ -26,7 +26,7 @@ namespace Azure.Storage.Files.Models
             bool isAsync,
             CancellationToken cancellationToken)
         {
-            var task = this._client.GetHandlesAsync(
+            var task = this._client.GetHandlesInternal(
                 continuationToken,
                 pageSizeHint,
                 isAsync,
@@ -62,7 +62,7 @@ namespace Azure.Storage.Files.Models
             bool isAsync,
             CancellationToken cancellationToken)
         {
-            var task = this._client.GetHandlesAsync(
+            var task = this._client.GetHandlesInternal(
                 continuationToken,
                 pageSizeHint,
                 this._recursive,

--- a/sdk/storage/Azure.Storage.Files/src/Models/GetShares.cs
+++ b/sdk/storage/Azure.Storage.Files/src/Models/GetShares.cs
@@ -119,7 +119,7 @@ namespace Azure.Storage.Files.Models
             bool isAsync,
             CancellationToken cancellationToken)
         {
-            var task = this._client.GetSharesAsync(
+            var task = this._client.GetSharesInternal(
                 continuationToken,
                 this._options,
                 pageSizeHint,

--- a/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
+++ b/sdk/storage/Azure.Storage.Files/src/ShareClient.cs
@@ -41,6 +41,7 @@ namespace Azure.Storage.Files
         /// </summary>
         protected virtual HttpPipeline Pipeline => this._pipeline;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="ShareClient"/>
         /// class for mocking.
@@ -172,6 +173,7 @@ namespace Azure.Storage.Files
             this._uri = shareUri;
             this._pipeline = pipeline;
         }
+        #endregion ctors
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ShareClient"/>
@@ -215,12 +217,13 @@ namespace Azure.Storage.Files
         public virtual DirectoryClient GetRootDirectoryClient()
             => this.GetDirectoryClient("");
 
+        #region Create
         /// <summary>
         /// The <see cref="Create"/> operation creates a new share
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -244,7 +247,7 @@ namespace Azure.Storage.Files
             Metadata metadata = default,
             int? quotaInBytes = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateAsync(
+            this.CreateInternal(
                 metadata,
                 quotaInBytes,
                 false, // async
@@ -256,7 +259,7 @@ namespace Azure.Storage.Files
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -269,7 +272,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareInfo}}"/> describing the newly
+        /// A <see cref="Response{ShareInfo}"/> describing the newly
         /// created share.
         /// </returns>
         /// <remarks>
@@ -280,7 +283,7 @@ namespace Azure.Storage.Files
             Metadata metadata = default,
             int? quotaInBytes = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateAsync(
+            await this.CreateInternal(
                 metadata,
                 quotaInBytes,
                 true, // async
@@ -288,11 +291,11 @@ namespace Azure.Storage.Files
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="CreateAsync"/> operation creates a new share
+        /// The <see cref="CreateInternal"/> operation creates a new share
         /// under the specified account. If a share with the same name
         /// already exists, the operation fails.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-share"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -308,14 +311,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareInfo}}"/> describing the newly
+        /// A <see cref="Response{ShareInfo}"/> describing the newly
         /// created share.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ShareInfo>> CreateAsync(
+        private async Task<Response<ShareInfo>> CreateInternal(
             Metadata metadata,
             int? quotaInBytes,
             bool async,
@@ -350,11 +353,13 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion Create
 
+        #region CreateSnapshot
         /// <summary>
         /// Creates a read-only snapshot of a share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -374,7 +379,7 @@ namespace Azure.Storage.Files
         public virtual Response<ShareSnapshotInfo> CreateSnapshot(
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateSnapshotAsync(
+            this.CreateSnapshotInternal(
                 metadata,
                 false, // async
                 cancellationToken)
@@ -383,7 +388,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Creates a read-only snapshot of a share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -393,7 +398,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareSnapshotInfo}}"/> describing the newly
+        /// A <see cref="Response{ShareSnapshotInfo}"/> describing the newly
         /// created snapshot.
         /// </returns>
         /// <remarks>
@@ -403,7 +408,7 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<ShareSnapshotInfo>> CreateSnapshotAsync(
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateSnapshotAsync(
+            await this.CreateSnapshotInternal(
                 metadata,
                 true, // async
                 cancellationToken)
@@ -412,7 +417,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Creates a read-only snapshot of a share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/snapshot-share"/>.
         /// </summary>
         /// <param name="metadata">
         /// Optional custom metadata to set for this share.
@@ -425,14 +430,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareSnapshotInfo}}"/> describing the newly
+        /// A <see cref="Response{ShareSnapshotInfo}"/> describing the newly
         /// created snapshot.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ShareSnapshotInfo>> CreateSnapshotAsync(
+        private async Task<Response<ShareSnapshotInfo>> CreateSnapshotInternal(
             Metadata metadata,
             bool async,
             CancellationToken cancellationToken)
@@ -463,14 +468,16 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion CreateSnapshot
 
+        #region Delete
         /// <summary>
         /// Marks the specified share or share snapshot for deletion.
         /// The share or share snapshot and any files contained within it are later deleted during garbage collection.
         /// 
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. Specifies the share snapshot to delete.
@@ -480,7 +487,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -489,7 +496,7 @@ namespace Azure.Storage.Files
         public virtual Response Delete(
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            this.DeleteAsync(
+            this.DeleteInternal(
                 shareSnapshot,
                 false, // async
                 cancellationToken)
@@ -501,7 +508,7 @@ namespace Azure.Storage.Files
         /// 
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. Specifies the share snapshot to delete.
@@ -511,7 +518,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -520,7 +527,7 @@ namespace Azure.Storage.Files
         public virtual async Task<Response> DeleteAsync(
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            await this.DeleteAsync(
+            await this.DeleteInternal(
                 shareSnapshot,
                 true, // async
                 cancellationToken)
@@ -532,7 +539,7 @@ namespace Azure.Storage.Files
         /// 
         /// Currently, this method will always delete snapshots.  There's no way to specify a separate value for x-ms-delete-snapshots.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-share"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. Specifies the share snapshot to delete.
@@ -545,13 +552,13 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> on successfully deleting.
+        /// A <see cref="Response"/> on successfully deleting.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response> DeleteAsync(
+        private async Task<Response> DeleteInternal(
             string shareSnapshot,
             bool async,
             CancellationToken cancellationToken)
@@ -584,13 +591,15 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion Delete
 
+        #region GetProperties
         /// <summary>
         /// The <see cref="GetProperties"/> operation returns all
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. Specifies the share snapshot to query for properties.
@@ -610,7 +619,7 @@ namespace Azure.Storage.Files
         public virtual Response<ShareProperties> GetProperties(
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 shareSnapshot,
                 false, // async
                 cancellationToken)
@@ -621,7 +630,7 @@ namespace Azure.Storage.Files
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. Specifies the share snapshot to query for properties.
@@ -631,7 +640,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareProperties}}"/> describing the
+        /// A <see cref="Response{ShareProperties}"/> describing the
         /// share's properties.
         /// </returns>
         /// <remarks>
@@ -641,18 +650,18 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<ShareProperties>> GetPropertiesAsync(
             string shareSnapshot = default,
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 shareSnapshot,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetPropertiesAsync"/> operation returns all
+        /// The <see cref="GetPropertiesInternal"/> operation returns all
         /// user-defined metadata, standard HTTP properties, and system
         /// properties for the share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-properties"/>.
         /// </summary>
         /// <param name="shareSnapshot">
         /// Optional. Specifies the share snapshot to query for properties.
@@ -665,14 +674,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareProperties}}"/> describing the
+        /// A <see cref="Response{ShareProperties}"/> describing the
         /// share's properties.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ShareProperties>> GetPropertiesAsync(
+        private async Task<Response<ShareProperties>> GetPropertiesInternal(
             string shareSnapshot,
             bool async,
             CancellationToken cancellationToken)
@@ -705,11 +714,13 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetProperties
 
+        #region SetQuota
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
         /// </summary>
         /// <param name="quotaInBytes">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
         /// <param name="cancellationToken">
@@ -727,7 +738,7 @@ namespace Azure.Storage.Files
         public virtual Response<ShareInfo> SetQuota(
             int quotaInBytes = default,
             CancellationToken cancellationToken = default) =>
-            this.SetQuotaAsync(
+            this.SetQuotaInternal(
                 quotaInBytes,
                 false, // async
                 cancellationToken)
@@ -736,7 +747,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
         /// </summary>
         /// <param name="quotaInBytes">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
         /// <param name="cancellationToken">
@@ -744,7 +755,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareInfo}}"/> describing the updated
+        /// A <see cref="Response{ShareInfo}"/> describing the updated
         /// share.
         /// </returns>
         /// <remarks>
@@ -754,7 +765,7 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<ShareInfo>> SetQuotaAsync(
             int quotaInBytes = default,
             CancellationToken cancellationToken = default) =>
-            await this.SetQuotaAsync(
+            await this.SetQuotaInternal(
                 quotaInBytes,
                 true, // async
                 cancellationToken)
@@ -763,7 +774,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Sets the maximum size of the share.
         ///
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-share-properties"/>.
         /// </summary>
         /// <param name="quotaInBytes">Optional. The maximum size of the share. If unspecified, use the service's default value.</param>
         /// <param name="async">
@@ -774,14 +785,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareInfo}}"/> describing the updated
+        /// A <see cref="Response{ShareInfo}"/> describing the updated
         /// share.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        public virtual async Task<Response<ShareInfo>> SetQuotaAsync(
+        public virtual async Task<Response<ShareInfo>> SetQuotaInternal(
             int quotaInBytes,
             bool async,
             CancellationToken cancellationToken)
@@ -814,12 +825,14 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion SetQuota
 
+        #region SetMetadata
         /// <summary>
         /// The <see cref="SetMetadata"/> operation sets user-defined 
         /// metadata for the specified share as one or more name-value pairs.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -839,7 +852,7 @@ namespace Azure.Storage.Files
         public virtual Response<ShareInfo> SetMetadata(
             Metadata metadata,
             CancellationToken cancellationToken = default) =>
-            this.SetMetadataAsync(
+            this.SetMetadataInternal(
                 metadata,
                 false, // async
                 cancellationToken)
@@ -849,7 +862,7 @@ namespace Azure.Storage.Files
         /// The <see cref="SetMetadataAsync"/> operation sets user-defined 
         /// metadata for the specified share as one or more name-value pairs.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -859,7 +872,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareInfo}}"/> describing the updated
+        /// A <see cref="Response{ShareInfo}"/> describing the updated
         /// share.
         /// </returns>
         /// <remarks>
@@ -869,17 +882,17 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<ShareInfo>> SetMetadataAsync(
             Metadata metadata,
             CancellationToken cancellationToken = default) =>
-            await this.SetMetadataAsync(
+            await this.SetMetadataInternal(
                 metadata,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetMetadataAsync"/> operation sets user-defined 
+        /// The <see cref="SetMetadataInternal"/> operation sets user-defined 
         /// metadata for the specified share as one or more name-value pairs.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-metadata"/>.
         /// </summary>
         /// <param name="metadata">
         /// Custom metadata to set for this share.
@@ -892,14 +905,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareInfo}}"/> describing the updated
+        /// A <see cref="Response{ShareInfo}"/> describing the updated
         /// share.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ShareInfo>> SetMetadataAsync(
+        private async Task<Response<ShareInfo>> SetMetadataInternal(
             Metadata metadata,
             bool async,
             CancellationToken cancellationToken)
@@ -930,21 +943,23 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion SetMetadata
 
+        #region GetAccessPolicy
         /// <summary>
         /// The <see cref="GetAccessPolicy"/> operation gets the
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{IEnumerable{SignedIdentifier}}}"/> describing
-        /// the share's access policy.
+        /// A <see cref="Response{T}"/> of <see cref="IEnumerable{SignedIdentifier}"/>
+        /// describing the share's access policy.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -952,7 +967,7 @@ namespace Azure.Storage.Files
         /// </remarks>
         public virtual Response<IEnumerable<SignedIdentifier>> GetAccessPolicy(
             CancellationToken cancellationToken = default) =>
-            this.GetAccessPolicyAsync(
+            this.GetAccessPolicyInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -962,15 +977,15 @@ namespace Azure.Storage.Files
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{IEnumerable{SignedIdentifier}}}"/> describing
-        /// the share's access policy.
+        /// A <see cref="Response{T}"/> of <see cref="IEnumerable{SignedIdentifier}"/>
+        /// describing the share's access policy.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
@@ -978,31 +993,34 @@ namespace Azure.Storage.Files
         /// </remarks>
         public virtual async Task<Response<IEnumerable<SignedIdentifier>>> GetAccessPolicyAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetAccessPolicyAsync(
+            await this.GetAccessPolicyInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="GetAccessPolicyAsync"/> operation gets the
+        /// The <see cref="GetAccessPolicyInternal"/> operation gets the
         /// permissions for this share. The permissions indicate whether
         /// share data may be accessed publicly.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/get-share-acl"/>.
         /// </summary>
+        /// <param name="async">
+        /// Whether to invoke the operation asynchronously.
+        /// </param>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{IEnumerable{SignedIdentifier}}}"/> describing
-        /// the share's access policy.
+        /// A <see cref="Response{T}"/> of <see cref="IEnumerable{SignedIdentifier}"/>
+        /// describing the share's access policy.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<IEnumerable<SignedIdentifier>>> GetAccessPolicyAsync(
+        private async Task<Response<IEnumerable<SignedIdentifier>>> GetAccessPolicyInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -1031,13 +1049,15 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetAccessPolicy
 
+        #region SetAccessPolicy
         /// <summary>
         /// The <see cref="SetAccessPolicy"/> operation sets the
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1058,7 +1078,7 @@ namespace Azure.Storage.Files
         public virtual Response<ShareInfo> SetAccessPolicy(
             IEnumerable<SignedIdentifier> permissions,
             CancellationToken cancellationToken = default) =>
-            this.SetAccessPolicyAsync(
+            this.SetAccessPolicyInternal(
                 permissions,
                 false, // async
                 cancellationToken)
@@ -1069,7 +1089,7 @@ namespace Azure.Storage.Files
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1080,7 +1100,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareInfo}}"/> describing the
+        /// A <see cref="Response{ShareInfo}"/> describing the
         /// updated share.
         /// </returns>
         /// <remarks>
@@ -1090,18 +1110,18 @@ namespace Azure.Storage.Files
         public virtual async Task<Response<ShareInfo>> SetAccessPolicyAsync(
             IEnumerable<SignedIdentifier> permissions,
             CancellationToken cancellationToken = default) =>
-            await this.SetAccessPolicyAsync(
+            await this.SetAccessPolicyInternal(
                 permissions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// The <see cref="SetAccessPolicyAsync"/> operation sets the
+        /// The <see cref="SetAccessPolicyInternal"/> operation sets the
         /// permissions for the specified share. The permissions indicate
         /// whether share data may be accessed publicly.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/set-share-acl"/>.
         /// </summary>
         /// <param name="permissions">
         /// Stored access policies that you can use to provide fine grained
@@ -1115,14 +1135,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareInfo}}"/> describing the
+        /// A <see cref="Response{ShareInfo}"/> describing the
         /// updated share.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ShareInfo>> SetAccessPolicyAsync(
+        private async Task<Response<ShareInfo>> SetAccessPolicyInternal(
             IEnumerable<SignedIdentifier> permissions,
             bool async,
             CancellationToken cancellationToken)
@@ -1153,11 +1173,13 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion SetAccessPolicy
 
+        #region GetStatistics
         /// <summary>
         /// Retrieves statistics related to the share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
@@ -1173,7 +1195,7 @@ namespace Azure.Storage.Files
         /// </remarks>
         public virtual Response<ShareStatistics> GetStatistics(
             CancellationToken cancellationToken = default) =>
-            this.GetStatisticsAsync(
+            this.GetStatisticsInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -1181,14 +1203,14 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Retrieves statistics related to the share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
         /// </summary>
         /// <param name="cancellationToken">
         /// Optional <see cref="CancellationToken"/> to propagate
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareStatistics}}"/> describing the
+        /// A <see cref="Response{ShareStatistics}"/> describing the
         /// share statistics.
         /// </returns>
         /// <remarks>
@@ -1197,7 +1219,7 @@ namespace Azure.Storage.Files
         /// </remarks>
         public virtual async Task<Response<ShareStatistics>> GetStatisticsAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetStatisticsAsync(
+            await this.GetStatisticsInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -1205,7 +1227,7 @@ namespace Azure.Storage.Files
         /// <summary>
         /// Retrieves statistics related to the share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-share-stats"/>.
         /// </summary>
         /// <param name="async">
         /// Whether to invoke the operation asynchronously.
@@ -1215,14 +1237,14 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{ShareStatistics}}"/> describing the
+        /// A <see cref="Response{ShareStatistics}"/> describing the
         /// share statistics.
         /// </returns>
         /// <remarks>
         /// A <see cref="StorageRequestFailedException"/> will be thrown if
         /// a failure occurs.
         /// </remarks>
-        private async Task<Response<ShareStatistics>> GetStatisticsAsync(
+        private async Task<Response<ShareStatistics>> GetStatisticsInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -1251,12 +1273,14 @@ namespace Azure.Storage.Files
                 }
             }
         }
+        #endregion GetStatistics
 
+        #region CreateDirectory
         /// <summary>
         /// The <see cref="CreateDirectory"/> operation creates a new
         /// directory in this share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to create.
@@ -1269,7 +1293,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{DirectoryClient}}"/> referencing the
+        /// A <see cref="Response{DirectoryClient}"/> referencing the
         /// newly created directory.
         /// </returns>
         /// <remarks>
@@ -1290,7 +1314,7 @@ namespace Azure.Storage.Files
         /// The <see cref="CreateDirectoryAsync"/> operation creates a new
         /// directory in this share.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/create-directory"/>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to create.
@@ -1303,7 +1327,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response{DirectoryClient}}"/> referencing the
+        /// A <see cref="Response{DirectoryClient}"/> referencing the
         /// newly created directory.
         /// </returns>
         /// <remarks>
@@ -1319,12 +1343,14 @@ namespace Azure.Storage.Files
             var response = await directory.CreateAsync(metadata, cancellationToken).ConfigureAwait(false);
             return new Response<DirectoryClient>(response.GetRawResponse(), directory);
         }
+        #endregion CreateDirectory
 
+        #region DeleteDirectory
         /// <summary>
         /// The <see cref="DeleteDirectory"/> operation removes the specified empty
         /// directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to delete.
@@ -1348,7 +1374,7 @@ namespace Azure.Storage.Files
         /// The <see cref="DeleteDirectoryAsync"/> operation removes the specified empty
         /// directory.
         /// 
-        /// For more information, see <see cref="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/rest/api/storageservices/delete-directory"/>.
         /// </summary>
         /// <param name="directoryName">T
         /// The name of the directory to delete.
@@ -1358,7 +1384,7 @@ namespace Azure.Storage.Files
         /// notifications that the operation should be cancelled.
         /// </param>
         /// <returns>
-        /// A <see cref="Task{Response}"/> if successful.
+        /// A <see cref="Response"/> if successful.
         /// </returns>
         /// <remarks>
         /// Note that the directory must be empty before it can be deleted.
@@ -1369,5 +1395,6 @@ namespace Azure.Storage.Files
             await this.GetDirectoryClient(directoryName)
                 .DeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
+        #endregion DeleteDirectory
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Generated/QueueRestClient.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
@@ -22,7 +22,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Sets properties for a storage account's Queue service endpoint, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules
             /// </summary>
-            /// <param name="pipeline"></param>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="properties">The StorageService properties.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
@@ -60,6 +60,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Service.SetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="properties">The StorageService properties.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
@@ -93,14 +94,14 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 System.Xml.Linq.XElement _body = Azure.Storage.Queues.Models.QueueServiceProperties.ToXml(properties, "StorageServiceProperties", "");
                 string _text = _body.ToString();
                 _request.Headers.SetValue("Content-Type", "application/xml");
-                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)); 
+                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(System.Text.Encoding.UTF8.GetBytes(_text));
 
                 return _request;
@@ -137,6 +138,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// gets the properties of a storage account's Queue service, including properties for Storage Analytics and CORS (Cross-Origin Resource Sharing) rules.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -171,6 +173,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Service.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -198,8 +201,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -208,7 +211,7 @@ namespace Azure.Storage.Queues
             /// Create the Service.GetPropertiesAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetPropertiesAsync Azure.Response{Azure.Storage.Queues.Models.QueueServiceProperties>}.</returns>
+            /// <returns>The Service.GetPropertiesAsync Azure.Response{Azure.Storage.Queues.Models.QueueServiceProperties}.</returns>
             internal static Azure.Response<Azure.Storage.Queues.Models.QueueServiceProperties> GetPropertiesAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -245,6 +248,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Retrieves statistics related to replication for the Queue service. It is only available on the secondary location endpoint when read-access geo-redundant replication is enabled for the storage account.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -279,6 +283,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Service.GetStatisticsAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -306,8 +311,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -316,7 +321,7 @@ namespace Azure.Storage.Queues
             /// Create the Service.GetStatisticsAsync response or throw a failure exception.
             /// </summary>
             /// <param name="response">The raw Response.</param>
-            /// <returns>The Service.GetStatisticsAsync Azure.Response{Azure.Storage.Queues.Models.QueueServiceStatistics}>.</returns>
+            /// <returns>The Service.GetStatisticsAsync Azure.Response{Azure.Storage.Queues.Models.QueueServiceStatistics}.</returns>
             internal static Azure.Response<Azure.Storage.Queues.Models.QueueServiceStatistics> GetStatisticsAsync_CreateResponse(
                 Azure.Response response)
             {
@@ -353,6 +358,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// The List Queues Segment operation returns a list of the queues under the specified account
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only queues whose name begins with the specified prefix.</param>
             /// <param name="marker">A string value that identifies the portion of the list of queues to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all queues remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.</param>
@@ -399,6 +405,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Service.ListQueuesSegmentAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="prefix">Filters the results to return only queues whose name begins with the specified prefix.</param>
             /// <param name="marker">A string value that identifies the portion of the list of queues to be returned with the next listing operation. The operation returns the NextMarker value within the response body if the listing operation did not return all queues remaining to be listed with the current page. The NextMarker value can be used as the value for the marker parameter in a subsequent call to request the next page of list items. The marker value is opaque to the client.</param>
@@ -437,8 +444,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -492,6 +499,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// creates a new queue under the given account.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="metadata">Optional. Include this parameter to specify that the queue's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Queue service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.</param>
@@ -529,6 +537,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Queue.CreateAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="metadata">Optional. Include this parameter to specify that the queue's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Queue service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.</param>
@@ -556,14 +565,14 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -603,6 +612,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// operation permanently deletes the specified queue
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -637,6 +647,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Queue.DeleteAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -662,8 +673,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -699,6 +710,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Retrieves user-defined metadata and queue properties on the specified queue. Metadata is associated with the queue as name-values pairs.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -733,6 +745,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Queue.GetPropertiesAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -759,8 +772,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -820,6 +833,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="metadata">Optional. Include this parameter to specify that the queue's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Queue service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.</param>
@@ -857,6 +871,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Queue.SetMetadataAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="metadata">Optional. Include this parameter to specify that the queue's metadata be returned as part of the response body. Note that metadata requested with this parameter must be stored in accordance with the naming restrictions imposed by the 2009-09-19 version of the Queue service. Beginning with this version, all metadata names must adhere to the naming conventions for C# identifiers.</param>
@@ -885,14 +900,14 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (metadata != null) { 
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (metadata != null) {
                     foreach (System.Collections.Generic.KeyValuePair<string, string> _pair in metadata)
                     {
-                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value); 
+                        _request.Headers.SetValue("x-ms-meta-" + _pair.Key, _pair.Value);
                     }
-                 }
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                }
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -928,6 +943,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// returns details about any stored access policies specified on the queue that may be used with Shared Access Signatures.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -962,6 +978,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Queue.GetAccessPolicyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -988,8 +1005,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1039,6 +1056,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// sets stored access policies for the queue that may be used with Shared Access Signatures
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="permissions">the acls for the queue</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
@@ -1076,6 +1094,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Queue.SetAccessPolicyAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="permissions">the acls for the queue</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
@@ -1104,8 +1123,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 System.Xml.Linq.XElement _body = new System.Xml.Linq.XElement(System.Xml.Linq.XName.Get("SignedIdentifiers", ""));
@@ -1118,7 +1137,7 @@ namespace Azure.Storage.Queues
                 }
                 string _text = _body.ToString();
                 _request.Headers.SetValue("Content-Type", "application/xml");
-                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)); 
+                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(System.Text.Encoding.UTF8.GetBytes(_text));
 
                 return _request;
@@ -1163,6 +1182,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// The Dequeue operation retrieves one or more messages from the front of the queue.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="numberOfMessages">Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32. If fewer are visible, the visible messages are returned. By default, a single message is retrieved from the queue with this operation.</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
@@ -1203,6 +1223,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Messages.DequeueAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="numberOfMessages">Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32. If fewer are visible, the visible messages are returned. By default, a single message is retrieved from the queue with this operation.</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
@@ -1234,8 +1255,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1285,6 +1306,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// The Clear operation deletes all messages from the specified queue.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -1319,6 +1341,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Messages.ClearAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
             /// <param name="requestId">Provides a client-generated, opaque value with a 1 KB character limit that is recorded in the analytics logs when storage analytics logging is enabled.</param>
@@ -1344,8 +1367,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1381,6 +1404,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// The Enqueue operation adds a new message to the back of the message queue. A visibility timeout can also be specified to make the message invisible until the visibility timeout expires. A message must be in a format that can be included in an XML request with UTF-8 encoding. The encoded message can be up to 64 KB in size for versions 2011-08-18 and newer, or 8 KB in size for previous versions.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="message">A Message object which can be stored in a Queue</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
@@ -1424,6 +1448,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Messages.EnqueueAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="message">A Message object which can be stored in a Queue</param>
             /// <param name="visibilitytimeout">Optional. Specifies the new visibility timeout value, in seconds, relative to server time. The default value is 30 seconds. A specified value must be larger than or equal to 1 second, and cannot be larger than 7 days, or larger than 2 hours on REST protocol versions prior to version 2011-08-18. The visibility timeout of a message can be set to a value later than the expiry time.</param>
@@ -1461,14 +1486,14 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 System.Xml.Linq.XElement _body = Azure.Storage.Queues.Models.QueueMessage.ToXml(message, "QueueMessage", "");
                 string _text = _body.ToString();
                 _request.Headers.SetValue("Content-Type", "application/xml");
-                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)); 
+                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(System.Text.Encoding.UTF8.GetBytes(_text));
 
                 return _request;
@@ -1519,6 +1544,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// The Peek operation retrieves one or more messages from the front of the queue, but does not alter the visibility of the message.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="numberOfMessages">Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32. If fewer are visible, the visible messages are returned. By default, a single message is retrieved from the queue with this operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
@@ -1556,6 +1582,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the Messages.PeekAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="numberOfMessages">Optional. A nonzero integer value that specifies the number of messages to retrieve from the queue, up to a maximum of 32. If fewer are visible, the visible messages are returned. By default, a single message is retrieved from the queue with this operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
@@ -1585,8 +1612,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -1644,6 +1671,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// The Update operation was introduced with version 2011-08-18 of the Queue service API. The Update Message operation updates the visibility timeout of a message. You can also use this operation to update the contents of a message. A message must be in a format that can be included in an XML request with UTF-8 encoding, and the encoded message can be up to 64KB in size.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="message">A Message object which can be stored in a Queue</param>
             /// <param name="popReceipt">Required. Specifies the valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.</param>
@@ -1687,6 +1715,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the MessageId.UpdateAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="message">A Message object which can be stored in a Queue</param>
             /// <param name="popReceipt">Required. Specifies the valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.</param>
@@ -1728,14 +1757,14 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 // Create the body
                 System.Xml.Linq.XElement _body = Azure.Storage.Queues.Models.QueueMessage.ToXml(message, "QueueMessage", "");
                 string _text = _body.ToString();
                 _request.Headers.SetValue("Content-Type", "application/xml");
-                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture)); 
+                _request.Headers.SetValue("Content-Length", _text.Length.ToString(System.Globalization.CultureInfo.InvariantCulture));
                 _request.Content = Azure.Core.Pipeline.HttpPipelineRequestContent.Create(System.Text.Encoding.UTF8.GetBytes(_text));
 
                 return _request;
@@ -1792,6 +1821,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// The Delete operation deletes the specified message.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="popReceipt">Required. Specifies the valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
@@ -1829,6 +1859,7 @@ namespace Azure.Storage.Queues
             /// <summary>
             /// Create the MessageId.DeleteAsync request.
             /// </summary>
+            /// <param name="pipeline">The pipeline used for sending requests.</param>
             /// <param name="resourceUri">The URL of the service account, queue or message that is the targe of the desired operation.</param>
             /// <param name="popReceipt">Required. Specifies the valid pop receipt value returned from an earlier call to the Get Messages or Update Message operation.</param>
             /// <param name="timeout">The The timeout parameter is expressed in seconds. For more information, see <a href="https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations">Setting Timeouts for Queue Service Operations.</a></param>
@@ -1861,8 +1892,8 @@ namespace Azure.Storage.Queues
                 if (timeout != null) { _request.UriBuilder.AppendQuery("timeout", System.Uri.EscapeDataString(timeout.Value.ToString(System.Globalization.CultureInfo.InvariantCulture))); }
 
                 // Add request headers
-                _request.Headers.SetValue("x-ms-version", "2018-11-09"); 
-                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId);  }
+                _request.Headers.SetValue("x-ms-version", "2018-11-09");
+                if (requestId != null) { _request.Headers.SetValue("x-ms-client-request-id", requestId); }
 
                 return _request;
             }
@@ -2051,6 +2082,9 @@ namespace Azure.Storage.Queues.Models
     /// </summary>
     internal enum ListQueuesIncludeType
     {
+        /// <summary>
+        /// metadata
+        /// </summary>
         Metadata
     }
 }
@@ -2841,120 +2875,329 @@ namespace Azure.Storage.Queues.Models
     public partial struct QueueErrorCode : System.IEquatable<QueueErrorCode>
     {
         #pragma warning disable CA2211 // Non-constant fields should not be visible
+        /// <summary>
+        /// AccountAlreadyExists
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode AccountAlreadyExists = @"AccountAlreadyExists";
 
+        /// <summary>
+        /// AccountBeingCreated
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode AccountBeingCreated = @"AccountBeingCreated";
 
+        /// <summary>
+        /// AccountIsDisabled
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode AccountIsDisabled = @"AccountIsDisabled";
 
+        /// <summary>
+        /// AuthenticationFailed
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode AuthenticationFailed = @"AuthenticationFailed";
 
+        /// <summary>
+        /// AuthorizationFailure
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode AuthorizationFailure = @"AuthorizationFailure";
 
+        /// <summary>
+        /// ConditionHeadersNotSupported
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode ConditionHeadersNotSupported = @"ConditionHeadersNotSupported";
 
+        /// <summary>
+        /// ConditionNotMet
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode ConditionNotMet = @"ConditionNotMet";
 
+        /// <summary>
+        /// EmptyMetadataKey
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode EmptyMetadataKey = @"EmptyMetadataKey";
 
+        /// <summary>
+        /// InsufficientAccountPermissions
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InsufficientAccountPermissions = @"InsufficientAccountPermissions";
 
+        /// <summary>
+        /// InternalError
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InternalError = @"InternalError";
 
+        /// <summary>
+        /// InvalidAuthenticationInfo
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidAuthenticationInfo = @"InvalidAuthenticationInfo";
 
+        /// <summary>
+        /// InvalidHeaderValue
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidHeaderValue = @"InvalidHeaderValue";
 
+        /// <summary>
+        /// InvalidHttpVerb
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidHttpVerb = @"InvalidHttpVerb";
 
+        /// <summary>
+        /// InvalidInput
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidInput = @"InvalidInput";
 
+        /// <summary>
+        /// InvalidMd5
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidMd5 = @"InvalidMd5";
 
+        /// <summary>
+        /// InvalidMetadata
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidMetadata = @"InvalidMetadata";
 
+        /// <summary>
+        /// InvalidQueryParameterValue
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidQueryParameterValue = @"InvalidQueryParameterValue";
 
+        /// <summary>
+        /// InvalidRange
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidRange = @"InvalidRange";
 
+        /// <summary>
+        /// InvalidResourceName
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidResourceName = @"InvalidResourceName";
 
+        /// <summary>
+        /// InvalidUri
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidUri = @"InvalidUri";
 
+        /// <summary>
+        /// InvalidXmlDocument
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidXmlDocument = @"InvalidXmlDocument";
 
+        /// <summary>
+        /// InvalidXmlNodeValue
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidXmlNodeValue = @"InvalidXmlNodeValue";
 
+        /// <summary>
+        /// Md5Mismatch
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode Md5Mismatch = @"Md5Mismatch";
 
+        /// <summary>
+        /// MetadataTooLarge
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode MetadataTooLarge = @"MetadataTooLarge";
 
+        /// <summary>
+        /// MissingContentLengthHeader
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode MissingContentLengthHeader = @"MissingContentLengthHeader";
 
+        /// <summary>
+        /// MissingRequiredQueryParameter
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode MissingRequiredQueryParameter = @"MissingRequiredQueryParameter";
 
+        /// <summary>
+        /// MissingRequiredHeader
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode MissingRequiredHeader = @"MissingRequiredHeader";
 
+        /// <summary>
+        /// MissingRequiredXmlNode
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode MissingRequiredXmlNode = @"MissingRequiredXmlNode";
 
+        /// <summary>
+        /// MultipleConditionHeadersNotSupported
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode MultipleConditionHeadersNotSupported = @"MultipleConditionHeadersNotSupported";
 
+        /// <summary>
+        /// OperationTimedOut
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode OperationTimedOut = @"OperationTimedOut";
 
+        /// <summary>
+        /// OutOfRangeInput
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode OutOfRangeInput = @"OutOfRangeInput";
 
+        /// <summary>
+        /// OutOfRangeQueryParameterValue
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode OutOfRangeQueryParameterValue = @"OutOfRangeQueryParameterValue";
 
+        /// <summary>
+        /// RequestBodyTooLarge
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode RequestBodyTooLarge = @"RequestBodyTooLarge";
 
+        /// <summary>
+        /// ResourceTypeMismatch
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode ResourceTypeMismatch = @"ResourceTypeMismatch";
 
+        /// <summary>
+        /// RequestUrlFailedToParse
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode RequestUrlFailedToParse = @"RequestUrlFailedToParse";
 
+        /// <summary>
+        /// ResourceAlreadyExists
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode ResourceAlreadyExists = @"ResourceAlreadyExists";
 
+        /// <summary>
+        /// ResourceNotFound
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode ResourceNotFound = @"ResourceNotFound";
 
+        /// <summary>
+        /// ServerBusy
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode ServerBusy = @"ServerBusy";
 
+        /// <summary>
+        /// UnsupportedHeader
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode UnsupportedHeader = @"UnsupportedHeader";
 
+        /// <summary>
+        /// UnsupportedXmlNode
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode UnsupportedXmlNode = @"UnsupportedXmlNode";
 
+        /// <summary>
+        /// UnsupportedQueryParameter
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode UnsupportedQueryParameter = @"UnsupportedQueryParameter";
 
+        /// <summary>
+        /// UnsupportedHttpVerb
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode UnsupportedHttpVerb = @"UnsupportedHttpVerb";
 
+        /// <summary>
+        /// InvalidMarker
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode InvalidMarker = @"InvalidMarker";
 
+        /// <summary>
+        /// MessageNotFound
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode MessageNotFound = @"MessageNotFound";
 
+        /// <summary>
+        /// MessageTooLarge
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode MessageTooLarge = @"MessageTooLarge";
 
+        /// <summary>
+        /// PopReceiptMismatch
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode PopReceiptMismatch = @"PopReceiptMismatch";
 
+        /// <summary>
+        /// QueueAlreadyExists
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode QueueAlreadyExists = @"QueueAlreadyExists";
 
+        /// <summary>
+        /// QueueBeingDeleted
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode QueueBeingDeleted = @"QueueBeingDeleted";
 
+        /// <summary>
+        /// QueueDisabled
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode QueueDisabled = @"QueueDisabled";
 
+        /// <summary>
+        /// QueueNotEmpty
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode QueueNotEmpty = @"QueueNotEmpty";
 
+        /// <summary>
+        /// QueueNotFound
+        /// </summary>
         public static Azure.Storage.Queues.Models.QueueErrorCode QueueNotFound = @"QueueNotFound";
         #pragma warning restore CA2211 // Non-constant fields should not be visible
 
+        /// <summary>
+        /// The QueueErrorCode value.
+        /// </summary>
         private readonly string _value;
+
+        /// <summary>
+        /// Creates a new QueueErrorCode instance.
+        /// </summary>
+        /// <param name="value">The QueueErrorCode value.</param>
         private QueueErrorCode(string value) { this._value = value; }
+
+        /// <summary>
+        /// Check if two QueueErrorCode instances are equal.
+        /// </summary>
+        /// <param name="other">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(Azure.Storage.Queues.Models.QueueErrorCode other) => this._value.Equals(other._value, System.StringComparison.InvariantCulture);
+
+        /// <summary>
+        /// Check if two QueueErrorCode instances are equal.
+        /// </summary>
+        /// <param name="o">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public override bool Equals(object o) => o is Azure.Storage.Queues.Models.QueueErrorCode other && this.Equals(other);
+
+        /// <summary>
+        /// Get a hash code for the QueueErrorCode.
+        /// </summary>
+        /// <returns>Hash code for the QueueErrorCode.</returns>
         public override int GetHashCode() => this._value.GetHashCode();
+
+        /// <summary>
+        /// Convert the QueueErrorCode to a string.
+        /// </summary>
+        /// <returns>String representation of the QueueErrorCode.</returns>
         public override string ToString() => this._value;
+
         #pragma warning disable CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Convert a string a QueueErrorCode.
+        /// </summary>
+        /// <param name="value">The string to convert.</param>
+        /// <returns>The QueueErrorCode value.</returns>
         public static implicit operator QueueErrorCode(string value) => new Azure.Storage.Queues.Models.QueueErrorCode(value);
         #pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Convert an QueueErrorCode to a string.
+        /// </summary>
+        /// <param name="o">The QueueErrorCode value.</param>
+        /// <returns>String representation of the QueueErrorCode value.</returns>
         public static implicit operator string(Azure.Storage.Queues.Models.QueueErrorCode o) => o._value;
+
+        /// <summary>
+        /// Check if two QueueErrorCode instances are equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public static bool operator ==(Azure.Storage.Queues.Models.QueueErrorCode a, Azure.Storage.Queues.Models.QueueErrorCode b) => a.Equals(b);
+
+        /// <summary>
+        /// Check if two QueueErrorCode instances are not equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're not equal, false otherwise.</returns>
         public static bool operator !=(Azure.Storage.Queues.Models.QueueErrorCode a, Azure.Storage.Queues.Models.QueueErrorCode b) => !a.Equals(b);
     }
 }
@@ -2969,24 +3212,89 @@ namespace Azure.Storage.Queues.Models
     public partial struct GeoReplicationStatus : System.IEquatable<GeoReplicationStatus>
     {
         #pragma warning disable CA2211 // Non-constant fields should not be visible
+        /// <summary>
+        /// live
+        /// </summary>
         public static Azure.Storage.Queues.Models.GeoReplicationStatus Live = @"live";
 
+        /// <summary>
+        /// bootstrap
+        /// </summary>
         public static Azure.Storage.Queues.Models.GeoReplicationStatus Bootstrap = @"bootstrap";
 
+        /// <summary>
+        /// unavailable
+        /// </summary>
         public static Azure.Storage.Queues.Models.GeoReplicationStatus Unavailable = @"unavailable";
         #pragma warning restore CA2211 // Non-constant fields should not be visible
 
+        /// <summary>
+        /// The GeoReplicationStatus value.
+        /// </summary>
         private readonly string _value;
+
+        /// <summary>
+        /// Creates a new GeoReplicationStatus instance.
+        /// </summary>
+        /// <param name="value">The GeoReplicationStatus value.</param>
         private GeoReplicationStatus(string value) { this._value = value; }
+
+        /// <summary>
+        /// Check if two GeoReplicationStatus instances are equal.
+        /// </summary>
+        /// <param name="other">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public bool Equals(Azure.Storage.Queues.Models.GeoReplicationStatus other) => this._value.Equals(other._value, System.StringComparison.InvariantCulture);
+
+        /// <summary>
+        /// Check if two GeoReplicationStatus instances are equal.
+        /// </summary>
+        /// <param name="o">The instance to compare to.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public override bool Equals(object o) => o is Azure.Storage.Queues.Models.GeoReplicationStatus other && this.Equals(other);
+
+        /// <summary>
+        /// Get a hash code for the GeoReplicationStatus.
+        /// </summary>
+        /// <returns>Hash code for the GeoReplicationStatus.</returns>
         public override int GetHashCode() => this._value.GetHashCode();
+
+        /// <summary>
+        /// Convert the GeoReplicationStatus to a string.
+        /// </summary>
+        /// <returns>String representation of the GeoReplicationStatus.</returns>
         public override string ToString() => this._value;
+
         #pragma warning disable CA2225 // Operator overloads have named alternates
+        /// <summary>
+        /// Convert a string a GeoReplicationStatus.
+        /// </summary>
+        /// <param name="value">The string to convert.</param>
+        /// <returns>The GeoReplicationStatus value.</returns>
         public static implicit operator GeoReplicationStatus(string value) => new Azure.Storage.Queues.Models.GeoReplicationStatus(value);
         #pragma warning restore CA2225 // Operator overloads have named alternates
+
+        /// <summary>
+        /// Convert an GeoReplicationStatus to a string.
+        /// </summary>
+        /// <param name="o">The GeoReplicationStatus value.</param>
+        /// <returns>String representation of the GeoReplicationStatus value.</returns>
         public static implicit operator string(Azure.Storage.Queues.Models.GeoReplicationStatus o) => o._value;
+
+        /// <summary>
+        /// Check if two GeoReplicationStatus instances are equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're equal, false otherwise.</returns>
         public static bool operator ==(Azure.Storage.Queues.Models.GeoReplicationStatus a, Azure.Storage.Queues.Models.GeoReplicationStatus b) => a.Equals(b);
+
+        /// <summary>
+        /// Check if two GeoReplicationStatus instances are not equal.
+        /// </summary>
+        /// <param name="a">The first instance to compare.</param>
+        /// <param name="b">The second instance to compare.</param>
+        /// <returns>True if they're not equal, false otherwise.</returns>
         public static bool operator !=(Azure.Storage.Queues.Models.GeoReplicationStatus a, Azure.Storage.Queues.Models.GeoReplicationStatus b) => !a.Equals(b);
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/src/Models/GetQueues.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/Models/GetQueues.cs
@@ -105,7 +105,7 @@ namespace Azure.Storage.Queues.Models
             bool isAsync,
             CancellationToken cancellationToken)
         {
-            var task = this._client.GetQueuesAsync(
+            var task = this._client.GetQueuesInternal(
                 continuationToken,
                 this._options,
                 pageSizeHint,

--- a/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueClient.cs
@@ -68,6 +68,7 @@ namespace Azure.Storage.Queues
         /// </summary>
         public const int MessageMaxBytes = 64 * Constants.KB;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="QueueClient"/>
         /// class for mocking.
@@ -227,7 +228,9 @@ namespace Azure.Storage.Queues
             this._messagesUri = queueUri.AppendToPath("messages");
             this._pipeline = pipeline;
         }
+        #endregion ctors
 
+        #region Create
         /// <summary>
         /// Creates a queue.
         /// 
@@ -245,7 +248,7 @@ namespace Azure.Storage.Queues
         public virtual Response Create(
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            this.CreateAsync(
+            this.CreateInternal(
                 metadata,
                 false, // async
                 cancellationToken)
@@ -263,12 +266,12 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
         public virtual async Task<Response> CreateAsync(
             Metadata metadata = default,
             CancellationToken cancellationToken = default) =>
-            await this.CreateAsync(
+            await this.CreateInternal(
                 metadata,
                 true, // async
                 cancellationToken)
@@ -289,9 +292,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
-        private async Task<Response> CreateAsync(
+        private async Task<Response> CreateInternal(
             Metadata metadata,
             bool async,
             CancellationToken cancellationToken)
@@ -322,7 +325,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion Create
 
+        #region Delete
         /// <summary>
         /// Deletes a queue.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-queue3"/>.
@@ -335,7 +340,7 @@ namespace Azure.Storage.Queues
         /// </returns>
         public virtual Response Delete(
             CancellationToken cancellationToken = default) =>
-            this.DeleteAsync(
+            this.DeleteInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -348,11 +353,11 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
         public virtual async Task<Response> DeleteAsync(
             CancellationToken cancellationToken = default) =>
-            await this.DeleteAsync(
+            await this.DeleteInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -368,9 +373,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
-        private async Task<Response> DeleteAsync(
+        private async Task<Response> DeleteInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -399,7 +404,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion Delete
 
+        #region GetProperties
         /// <summary>
         /// Retrieves queue properties and user-defined metadata and properties on the specified queue.
         /// Metadata is associated with the queue as name-values pairs.
@@ -413,7 +420,7 @@ namespace Azure.Storage.Queues
         /// </returns>
         public virtual Response<QueueProperties> GetProperties(
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -427,11 +434,11 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{QueueProperties}}"/>
+        /// <see cref="Response{QueueProperties}"/>
         /// </returns>
         public virtual async Task<Response<QueueProperties>> GetPropertiesAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -448,9 +455,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{QueueProperties}}"/>
+        /// <see cref="Response{QueueProperties}"/>
         /// </returns>
-        private async Task<Response<QueueProperties>> GetPropertiesAsync(
+        private async Task<Response<QueueProperties>> GetPropertiesInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -479,7 +486,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion GetProperties
 
+        #region SetMetadata
         /// <summary>
         /// Sets user-defined metadata on the specified queue. Metadata is associated with the queue as name-value pairs.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-metadata"/>.
@@ -496,7 +505,7 @@ namespace Azure.Storage.Queues
         public virtual Response SetMetadata(
             Metadata metadata,
             CancellationToken cancellationToken = default) =>
-            this.SetMetadataAsync(
+            this.SetMetadataInternal(
                 metadata,
                 false, // async
                 cancellationToken)
@@ -513,12 +522,12 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
         public virtual async Task<Response> SetMetadataAsync(
             Metadata metadata,
             CancellationToken cancellationToken = default) =>
-            await this.SetMetadataAsync(
+            await this.SetMetadataInternal(
                 metadata,
                 true, // async
                 cancellationToken)
@@ -538,9 +547,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
-        private async Task<Response> SetMetadataAsync(
+        private async Task<Response> SetMetadataInternal(
             Metadata metadata,
             bool async,
             CancellationToken cancellationToken)
@@ -571,7 +580,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion SetMetadata
 
+        #region GetAccessPolicy
         /// <summary>
         /// Returns details about any stored access policies specified on the queue that may be used with
         /// Shared Access Signatures.
@@ -581,11 +592,11 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Response{IEnumerable{SignedIdentifier}}"/>
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{SignedIdentifier}" />
         /// </returns>
         public virtual Response<IEnumerable<SignedIdentifier>> GetAccessPolicy(
             CancellationToken cancellationToken = default) =>
-            this.GetAccessPolicyAsync(
+            this.GetAccessPolicyInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -599,11 +610,11 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Task{Response{IEnumerable{SignedIdentifier}}}"/>
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{SignedIdentifier}" />
         /// </returns>
         public virtual async Task<Response<IEnumerable<SignedIdentifier>>> GetAccessPolicyAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetAccessPolicyAsync(
+            await this.GetAccessPolicyInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -620,9 +631,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Task{Response{IEnumerable{SignedIdentifier}}}"/>
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{SignedIdentifier}" />
         /// </returns>
-        private async Task<Response<IEnumerable<SignedIdentifier>>> GetAccessPolicyAsync(
+        private async Task<Response<IEnumerable<SignedIdentifier>>> GetAccessPolicyInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -651,7 +662,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion GetAccessPolicy
 
+        #region SetAccessPolicy
         /// <summary>
         /// SetAccessPolicyAsync sets stored access policies for the queue that may be used with Shared Access Signatures.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-acl"/>.
@@ -668,7 +681,7 @@ namespace Azure.Storage.Queues
         public virtual Response SetAccessPolicy(
             IEnumerable<SignedIdentifier> permissions,
             CancellationToken cancellationToken = default) =>
-            this.SetAccessPolicyAsync(
+            this.SetAccessPolicyInternal(
                 permissions,
                 false, // async
                 cancellationToken)
@@ -685,19 +698,19 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
         public virtual async Task<Response> SetAccessPolicyAsync(
             IEnumerable<SignedIdentifier> permissions,
             CancellationToken cancellationToken = default) =>
-            await this.SetAccessPolicyAsync(
+            await this.SetAccessPolicyInternal(
                 permissions,
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
 
         /// <summary>
-        /// SetAccessPolicyAsync sets stored access policies for the queue that may be used with Shared Access Signatures.
+        /// SetAccessPolicyInternal sets stored access policies for the queue that may be used with Shared Access Signatures.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-acl"/>.
         /// </summary>
         /// <param name="permissions">
@@ -710,9 +723,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
-        private async Task<Response> SetAccessPolicyAsync(
+        private async Task<Response> SetAccessPolicyInternal(
             IEnumerable<SignedIdentifier> permissions,
             bool async,
             CancellationToken cancellationToken)
@@ -743,7 +756,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion SetAccessPolicy
 
+        #region ClearMessages
         /// <summary>
         /// Clear deletes all messages from a queue.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/clear-messages"/>.
@@ -756,7 +771,7 @@ namespace Azure.Storage.Queues
         /// </returns>
         public virtual Response ClearMessages(
             CancellationToken cancellationToken = default) =>
-            this.ClearMessagesAsync(
+            this.ClearMessagesInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -769,11 +784,11 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>.
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
         public virtual async Task<Response> ClearMessagesAsync(
             CancellationToken cancellationToken = default) =>
-            await this.ClearMessagesAsync(
+            await this.ClearMessagesInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -789,9 +804,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>.
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
-        private async Task<Response> ClearMessagesAsync(
+        private async Task<Response> ClearMessagesInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -820,11 +835,13 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion ClearMessages
 
+        #region EnqueueMessage
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -846,7 +863,7 @@ namespace Azure.Storage.Queues
             TimeSpan? visibilityTimeout = default,
             TimeSpan? timeToLive = default,
             CancellationToken cancellationToken = default) =>
-            this.EnqueueMessageAsync(
+            this.EnqueueMessageInternal(
                 messageText,
                 visibilityTimeout,
                 timeToLive,
@@ -857,7 +874,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -872,14 +889,14 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>.
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{EnqueuedMessage}}"/>
+        /// <see cref="Response{EnqueuedMessage}"/>
         /// </returns>
         public virtual async Task<Response<EnqueuedMessage>> EnqueueMessageAsync(
             string messageText,
             TimeSpan? visibilityTimeout = default,
             TimeSpan? timeToLive = default,
             CancellationToken cancellationToken = default) =>
-            await this.EnqueueMessageAsync(
+            await this.EnqueueMessageInternal(
                 messageText,
                 visibilityTimeout,
                 timeToLive,
@@ -890,7 +907,7 @@ namespace Azure.Storage.Queues
         /// <summary>
         /// Adds a new message to the back of a queue. The visibility timeout specifies how long the message should be invisible
         /// to Dequeue and Peek operations. The message content must be a UTF-8 encoded string that is up to 64KB in size.
-        /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/put-message"/>.
         /// </summary>
         /// <param name="messageText">
         /// Message text.
@@ -908,9 +925,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>.
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{EnqueuedMessage}}"/>
+        /// <see cref="Response{EnqueuedMessage}"/>
         /// </returns>
-        private async Task<Response<EnqueuedMessage>> EnqueueMessageAsync(
+        private async Task<Response<EnqueuedMessage>> EnqueueMessageInternal(
             string messageText,
             TimeSpan? visibilityTimeout,
             TimeSpan? timeToLive,
@@ -954,7 +971,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion EnqueueMessage
 
+        #region DequeueMessages
         /// <summary>
         /// Retrieves one or more messages from the front of the queue.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-messages"/>.
@@ -970,13 +989,13 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Response{IEnumerable{DequeuedMessage}}"/>.
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{DequeuedMessage}"/>
         /// </returns>
         public virtual Response<IEnumerable<DequeuedMessage>> DequeueMessages(
             int? maxMessages = default,
             TimeSpan? visibilityTimeout = default,
             CancellationToken cancellationToken = default) =>
-            this.DequeueMessagesAsync(
+            this.DequeueMessagesInternal(
                 maxMessages,
                 visibilityTimeout,
                 false, // async
@@ -998,13 +1017,13 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Task{Response{IEnumerable{DequeuedMessage}}}"/>.
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{DequeuedMessage}"/>
         /// </returns>
         public virtual async Task<Response<IEnumerable<DequeuedMessage>>> DequeueMessagesAsync(
             int? maxMessages = default,
             TimeSpan? visibilityTimeout = default,
             CancellationToken cancellationToken = default) =>
-            await this.DequeueMessagesAsync(
+            await this.DequeueMessagesInternal(
                 maxMessages,
                 visibilityTimeout,
                 true, // async
@@ -1029,9 +1048,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Task{Response{IEnumerable{DequeuedMessage}}}"/>.
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{DequeuedMessage}"/>
         /// </returns>
-        private async Task<Response<IEnumerable<DequeuedMessage>>> DequeueMessagesAsync(
+        private async Task<Response<IEnumerable<DequeuedMessage>>> DequeueMessagesInternal(
             int? maxMessages,
             TimeSpan? visibilityTimeout,
             bool async,
@@ -1067,7 +1086,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion DequeueMessages
 
+        #region PeekMessages
         /// <summary>
         /// Retrieves one or more messages from the front of the queue but does not alter the visibility of the message.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/peek-messages"/>.
@@ -1080,12 +1101,12 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Response{IEnumerable{PeekedMessage}}"/>.
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{PeekedMessage}"/>
         /// </returns>
         public virtual Response<IEnumerable<PeekedMessage>> PeekMessages(
             int? maxMessages = default,
             CancellationToken cancellationToken = default) =>
-            this.PeekMessagesAsync(
+            this.PeekMessagesInternal(
                 maxMessages,
                 false, // async
                 cancellationToken)
@@ -1103,12 +1124,12 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Task{Response{IEnumerable{PeekedMessage}}}"/>.
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{PeekedMessage}"/>
         /// </returns>
         public virtual async Task<Response<IEnumerable<PeekedMessage>>> PeekMessagesAsync(
             int? maxMessages = default,
             CancellationToken cancellationToken = default) =>
-            await this.PeekMessagesAsync(
+            await this.PeekMessagesInternal(
                 maxMessages,
                 true, // async
                 cancellationToken)
@@ -1129,9 +1150,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// IEnumerable of <see cref="Task{Response{IEnumerable{PeekedMessage}}}"/>.
+        /// <see cref="Response{T}"/> of <see cref="IEnumerable{PeekedMessage}"/>
         /// </returns>
-        private async Task<Response<IEnumerable<PeekedMessage>>> PeekMessagesAsync(
+        private async Task<Response<IEnumerable<PeekedMessage>>> PeekMessagesInternal(
             int? maxMessages,
             bool async,
             CancellationToken cancellationToken)
@@ -1164,6 +1185,7 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion PeekMessages
 
         /// <summary>
         /// Get the URI to a specific message given its ID.
@@ -1173,6 +1195,7 @@ namespace Azure.Storage.Queues
         private Uri GetMessageUri(string messageId) =>
             this.MessagesUri.AppendToPath(messageId.ToString(CultureInfo.InvariantCulture));
 
+        #region DeleteMessage
         /// <summary>
         /// Permanently removes the specified message from its queue.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/delete-message2"/>.
@@ -1191,7 +1214,7 @@ namespace Azure.Storage.Queues
             string messageId,
             string popReceipt,
             CancellationToken cancellationToken = default) =>
-            this.DeleteMessageAsync(
+            this.DeleteMessageInternal(
                 messageId,
                 popReceipt,
                 false, // async
@@ -1210,13 +1233,13 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>.
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>.
+        /// <see cref="Response"/>.
         /// </returns>
         public virtual async Task<Response> DeleteMessageAsync(
             string messageId,
             string popReceipt,
             CancellationToken cancellationToken = default) =>
-            await this.DeleteMessageAsync(
+            await this.DeleteMessageInternal(
                 messageId,
                 popReceipt,
                 true, // async
@@ -1238,9 +1261,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>.
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>.
+        /// <see cref="Response"/>.
         /// </returns>
-        private async Task<Response> DeleteMessageAsync(
+        private async Task<Response> DeleteMessageInternal(
             string messageId,
             string popReceipt,
             bool async,
@@ -1275,7 +1298,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion DeleteMessage
 
+        #region UpdateMessage
         /// <summary>
         /// Changes a message's visibility timeout and contents. The message content must be a UTF-8 encoded string that is up to 64KB in size.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/update-message"/>.
@@ -1304,7 +1329,7 @@ namespace Azure.Storage.Queues
             string popReceipt,
             TimeSpan visibilityTimeout = default,
             CancellationToken cancellationToken = default) =>
-            this.UpdateMessageAsync(
+            this.UpdateMessageInternal(
                 messageText,
                 messageId,
                 popReceipt,
@@ -1333,7 +1358,7 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>.
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{UpdatedMessage}}"/>.
+        /// <see cref="Response{UpdatedMessage}"/>.
         /// </returns>
         public virtual async Task<Response<UpdatedMessage>> UpdateMessageAsync(
             string messageText,
@@ -1341,7 +1366,7 @@ namespace Azure.Storage.Queues
             string popReceipt,
             TimeSpan visibilityTimeout = default,
             CancellationToken cancellationToken = default) =>
-            await this.UpdateMessageAsync(
+            await this.UpdateMessageInternal(
                 messageText,
                 messageId,
                 popReceipt,
@@ -1373,9 +1398,9 @@ namespace Azure.Storage.Queues
         /// Optional <see cref="CancellationToken"/>.
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{UpdatedMessage}}"/>.
+        /// <see cref="Response{UpdatedMessage}"/>.
         /// </returns>
-        private async Task<Response<UpdatedMessage>> UpdateMessageAsync(
+        private async Task<Response<UpdatedMessage>> UpdateMessageInternal(
             string messageText,
             string messageId,
             string popReceipt,
@@ -1415,5 +1440,6 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion UpdateMessage
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueServiceClient.cs
@@ -38,6 +38,7 @@ namespace Azure.Storage.Queues
         /// </summary>
         protected virtual HttpPipeline Pipeline => this._pipeline;
 
+        #region ctors
         /// <summary>
         /// Initializes a new instance of the <see cref="QueueServiceClient"/>
         /// class for mocking.
@@ -178,6 +179,7 @@ namespace Azure.Storage.Queues
             this._uri = serviceUri;
             this._pipeline = pipeline;
         }
+        #endregion ctors
 
         /// <summary>
         /// Create a new <see cref="QueueClient"/> object by appending
@@ -194,6 +196,7 @@ namespace Azure.Storage.Queues
         public virtual QueueClient GetQueueClient(string queueName)
             => new QueueClient(this.Uri.AppendToPath(queueName), this.Pipeline);
 
+        #region GetQueues
         /// <summary>
         /// The <see cref="GetQueues"/> operation returns an async
         /// sequence of queues in the storage account.  Enumerating the
@@ -247,10 +250,16 @@ namespace Azure.Storage.Queues
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/list-queues1"/>
         /// </summary>
         /// <param name="options">
-        /// <see cref="QueuesSegmentOptions"/>
+        /// <see cref="GetQueuesOptions"/>
         /// </param>
         /// <param name="marker">
         /// Marker from the previous request.
+        /// </param>
+        /// <param name="pageSizeHint">
+        /// Optional hint to specify the desired size of the page returned.
+        /// </param>
+        /// <param name="async">
+        /// Whether to invoke the operation asynchronously.
         /// </param>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -262,7 +271,7 @@ namespace Azure.Storage.Queues
         /// Use an empty marker to start enumeration from the beginning. Queue names are returned in lexicographic order.
         /// After getting a segment, process it, and then call ListQueuesSegmentAsync again (passing in the next marker) to get the next segment. 
         /// </remarks>
-        internal async Task<Response<QueuesSegment>> GetQueuesAsync(
+        internal async Task<Response<QueuesSegment>> GetQueuesInternal(
             string marker,
             GetQueuesOptions? options,
             int? pageSizeHint,
@@ -301,7 +310,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion GetQueues
 
+        #region GetProperties
         /// <summary>
         /// Gets the properties of the queue service.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/get-queue-service-properties"/>.
@@ -314,7 +325,7 @@ namespace Azure.Storage.Queues
         /// </returns>
         public virtual Response<QueueServiceProperties> GetProperties(
             CancellationToken cancellationToken = default) =>
-            this.GetPropertiesAsync(
+            this.GetPropertiesInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -327,11 +338,11 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{QueueServiceProperties}}"/>
+        /// <see cref="Response{QueueServiceProperties}"/>
         /// </returns>
         public virtual async Task<Response<QueueServiceProperties>> GetPropertiesAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetPropertiesAsync(
+            await this.GetPropertiesInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -347,9 +358,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{QueueServiceProperties}}"/>
+        /// <see cref="Response{QueueServiceProperties}"/>
         /// </returns>
-        private async Task<Response<QueueServiceProperties>> GetPropertiesAsync(
+        private async Task<Response<QueueServiceProperties>> GetPropertiesInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -378,7 +389,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion GetProperties
 
+        #region SetProperties
         /// <summary>
         /// Sets the properties of the queue service.
         /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/set-queue-service-properties"/>.
@@ -395,7 +408,7 @@ namespace Azure.Storage.Queues
         public virtual Response SetProperties(
             QueueServiceProperties properties,
             CancellationToken cancellationToken = default) =>
-            this.SetPropertiesAsync(
+            this.SetPropertiesInternal(
                 properties,
                 false, // async
                 cancellationToken)
@@ -412,12 +425,12 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
         public virtual async Task<Response> SetPropertiesAsync(
             QueueServiceProperties properties,
             CancellationToken cancellationToken = default) =>
-            await this.SetPropertiesAsync(
+            await this.SetPropertiesInternal(
                 properties,
                 true, // async
                 cancellationToken)
@@ -437,9 +450,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
-        private async Task<Response> SetPropertiesAsync(
+        private async Task<Response> SetPropertiesInternal(
             QueueServiceProperties properties,
             bool async,
             CancellationToken cancellationToken)
@@ -472,7 +485,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion SetProperties
 
+        #region GetStatistics
         /// <summary>
         /// Retrieves statistics related to replication for the Blob service. It is
         /// only available on the secondary location endpoint when read-access
@@ -487,7 +502,7 @@ namespace Azure.Storage.Queues
         /// </returns>
         public virtual Response<QueueServiceStatistics> GetStatistics(
             CancellationToken cancellationToken = default) =>
-            this.GetStatisticsAsync(
+            this.GetStatisticsInternal(
                 false, // async
                 cancellationToken)
                 .EnsureCompleted();
@@ -502,11 +517,11 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{QueueServiceStatistics}}"/>
+        /// <see cref="Response{QueueServiceStatistics}"/>
         /// </returns>
         public virtual async Task<Response<QueueServiceStatistics>> GetStatisticsAsync(
             CancellationToken cancellationToken = default) =>
-            await this.GetStatisticsAsync(
+            await this.GetStatisticsInternal(
                 true, // async
                 cancellationToken)
                 .ConfigureAwait(false);
@@ -524,9 +539,9 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response{QueueServiceStatistics}}"/>
+        /// <see cref="Response{QueueServiceStatistics}"/>
         /// </returns>
-        private async Task<Response<QueueServiceStatistics>> GetStatisticsAsync(
+        private async Task<Response<QueueServiceStatistics>> GetStatisticsInternal(
             bool async,
             CancellationToken cancellationToken)
         {
@@ -555,7 +570,9 @@ namespace Azure.Storage.Queues
                 }
             }
         }
+        #endregion GetStatistics
 
+        #region CreateQueue
         /// <summary>
         /// Creates a queue.
         /// 
@@ -565,7 +582,7 @@ namespace Azure.Storage.Queues
         /// The name of the queue to create.
         /// </param>
         /// <param name="metadata">
-        /// Optional <see cref="Metadata"/>.
+        /// Optional <see cref="IDictionary{String, String}"/>.
         /// </param>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -592,7 +609,7 @@ namespace Azure.Storage.Queues
         /// The name of the queue to create.
         /// </param>
         /// <param name="metadata">
-        /// Optional <see cref="Metadata"/>.
+        /// Optional <see cref="IDictionary{String, String}"/>.
         /// </param>
         /// <param name="cancellationToken">
         /// <see cref="CancellationToken"/>
@@ -609,7 +626,9 @@ namespace Azure.Storage.Queues
             var response = await queue.CreateAsync(metadata, cancellationToken).ConfigureAwait(false);
             return new Response<QueueClient>(response, queue);
         }
+        #endregion CreateQueue
 
+        #region DeleteQueue
         /// <summary>
         /// Deletes a queue.
         /// 
@@ -641,7 +660,7 @@ namespace Azure.Storage.Queues
         /// <see cref="CancellationToken"/>
         /// </param>
         /// <returns>
-        /// <see cref="Task{Response}"/>
+        /// <see cref="Response"/>
         /// </returns>
         public virtual async Task<Response> DeleteQueueAsync(
             string queueName,
@@ -649,5 +668,6 @@ namespace Azure.Storage.Queues
             await this.GetQueueClient(queueName)
                 .DeleteAsync(cancellationToken)
                 .ConfigureAwait(false);
+        #endregion DeleteQueue
     }
 }

--- a/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/QueueUriBuilder.cs
@@ -10,7 +10,7 @@ namespace Azure.Storage.Queues
 {
     /// <summary>
     /// Constructs a Queue URI.
-    /// For more information, see <see cref="https://docs.microsoft.com/en-us/rest/api/storageservices/addressing-queue-service-resources"/>
+    /// For more information, see <see href="https://docs.microsoft.com/en-us/rest/api/storageservices/addressing-queue-service-resources"/>
     /// </summary>
     internal struct QueueUriBuilder : IEquatable<QueueUriBuilder>
     {

--- a/sdk/storage/Azure.Storage.Queues/swagger/queue.json
+++ b/sdk/storage/Azure.Storage.Queues/swagger/queue.json
@@ -1774,7 +1774,7 @@
       "type": "integer",
       "minimum": 0,
       "x-ms-parameter-location": "method",
-      "description": "The The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations>Setting Timeouts for Queue Service Operations.</a>"
+      "description": "The The timeout parameter is expressed in seconds. For more information, see <a href=\"https://docs.microsoft.com/en-us/rest/api/storageservices/setting-timeouts-for-queue-service-operations\">Setting Timeouts for Queue Service Operations.</a>"
     },
     "VisibilityTimeout": {
       "name": "visibilitytimeout",

--- a/sdk/storage/Directory.Build.props
+++ b/sdk/storage/Directory.Build.props
@@ -18,9 +18,6 @@
      -->
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>
 
-    <!-- Disable some xml doc comment warnings until we can fix them -->
-    <NoWarn>$(NoWarn);1591;1573;1574;1584;1658;0419</NoWarn>
-
     <!--
     Storage used to point to its main documentation page, but the rest of the
     Azure .NET SDK projects point to the github repo instead.  I'm leaving this


### PR DESCRIPTION
- Code: Change to use `Foo`/`FooAsync`/`FooInternal` for operation naming convention _(which I wanted to do anyway and automatically fixed most ambiguous doc comments)_:
      `Foo`: sync overload calling `FooInternal`
      `FooAsync`: async overload calling `FooInternal`
      `FooInternal`: do the actual work
- Code: Wrap operations and ctors in `#region`s
- Code: Disambiguate overloads in doc comments
- Code: Clean up remaining doc comment errors
- Generator: Replace angle brackets in response type comments
- Generator: Add default comments for everything
- Generator: Remove end of line spaces to prevent editors from accidentally changing the file and making diffs excessive

/cc @kfarmer-msft @seanmcc-msft 