### PR TITLE
Apply ClientOptions analyzers to client libraries.

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Update="ApprovalTests" Version="3.0.22" />
     <PackageReference Update="ApprovalUtilities" Version="3.0.22" />
-    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20190503.1" />
+    <PackageReference Update="Azure.ClientSdk.Analyzers" Version="0.1.1-dev.20190711.4" />
     <PackageReference Update="Azure.Core" Version="1.0.0-preview.6" />
     <PackageReference Update="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Update="FsCheck.Xunit" Version="2.14.0" />

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientOptions.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientOptions.cs
@@ -17,9 +17,7 @@ namespace Azure.ApplicationModel.Configuration
         /// </summary>
         public enum ServiceVersion
         {
-#pragma warning disable CA1707 // Identifiers should not contain underscores
             Default = 0
-#pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
         /// <summary>

--- a/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientOptions.cs
+++ b/sdk/appconfiguration/Azure.ApplicationModel.Configuration/src/ConfigurationClientOptions.cs
@@ -7,5 +7,38 @@ namespace Azure.ApplicationModel.Configuration
 {
     public class ConfigurationClientOptions: ClientOptions
     {
+        /// <summary>
+        /// The latest service version supported by this client library.
+        /// </summary>
+        internal const ServiceVersion LatestVersion = ServiceVersion.Default;
+
+        /// <summary>
+        /// The versions of App Config Service supported by this client library.
+        /// </summary>
+        public enum ServiceVersion
+        {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+            Default = 0
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ServiceVersion"/> of the service API used when
+        /// making requests.
+        /// </summary>
+        public ServiceVersion Version { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConfigurationClientOptions"/>
+        /// class.
+        /// </summary>
+        /// <param name="version">
+        /// The <see cref="ServiceVersion"/> of the service API used when
+        /// making requests. 
+        /// </param>
+        public ConfigurationClientOptions(ServiceVersion version = ServiceVersion.Default)
+        {
+            this.Version = version;
+        }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClientOptions.cs
@@ -13,7 +13,7 @@ namespace Azure.Security.KeyVault.Certificates
         /// For more information, see 
         /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V0_7_0;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V7_0;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client
@@ -25,7 +25,7 @@ namespace Azure.Security.KeyVault.Certificates
             /// <summary>
             /// The Key Vault API version 7.0.
             /// </summary>
-            V0_7_0 = 0
+            V7_0 = 0
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -44,7 +44,7 @@ namespace Azure.Security.KeyVault.Certificates
         /// The <see cref="ServiceVersion"/> of the service API used when
         /// making requests.
         /// </param>
-        public CertificateClientOptions(ServiceVersion version = ServiceVersion.V0_7_0)
+        public CertificateClientOptions(ServiceVersion version = ServiceVersion.V7_0)
         {
             this.Version = version;
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateClientOptions.cs
@@ -8,5 +8,45 @@ namespace Azure.Security.KeyVault.Certificates
 {
     public class CertificateClientOptions : ClientOptions
     {
+        /// <summary>
+        /// The latest service version supported by this client library.
+        /// For more information, see 
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
+        /// </summary>
+        internal const ServiceVersion LatestVersion = ServiceVersion.V0_7_0;
+
+        /// <summary>
+        /// The versions of Azure Key Vault supported by this client
+        /// library. 
+        /// </summary>
+        public enum ServiceVersion
+        {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+            /// <summary>
+            /// The Key Vault API version 7.0.
+            /// </summary>
+            V0_7_0 = 0
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ServiceVersion"/> of the service API used when
+        /// making requests. For more information, see 
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
+        /// </summary>
+        public ServiceVersion Version { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CertificateClientOptions"/>
+        /// class.
+        /// </summary>
+        /// <param name="version">
+        /// The <see cref="ServiceVersion"/> of the service API used when
+        /// making requests.
+        /// </param>
+        public CertificateClientOptions(ServiceVersion version = ServiceVersion.V0_7_0)
+        {
+            this.Version = version;
+        }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -51,6 +51,7 @@ namespace Azure.Security.KeyVault.Keys
         {
             _vaultUri = vaultUri ?? throw new ArgumentNullException(nameof(credential));
             options = options ?? new KeyClientOptions();
+            options.SetVersionString(out this.ApiVersion);
 
             _pipeline = HttpPipelineBuilder.Build(options,
                     bufferResponse: true,

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient.cs
@@ -51,7 +51,7 @@ namespace Azure.Security.KeyVault.Keys
         {
             _vaultUri = vaultUri ?? throw new ArgumentNullException(nameof(credential));
             options = options ?? new KeyClientOptions();
-            options.SetVersionString(out this.ApiVersion);
+            this.ApiVersion = options.GetVersionString();
 
             _pipeline = HttpPipelineBuilder.Build(options,
                     bufferResponse: true,

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
@@ -11,5 +11,60 @@ namespace Azure.Security.KeyVault.Keys
     /// </summary>
     public class KeyClientOptions : ClientOptions
     {
+        /// <summary>
+        /// The latest service version supported by this client library.
+        /// For more information, see 
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
+        /// </summary>
+        internal const ServiceVersion LatestVersion = ServiceVersion.V0_7_0;
+
+        /// <summary>
+        /// The versions of Azure Key Vault supported by this client
+        /// library. 
+        /// </summary>
+        public enum ServiceVersion
+        {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+            /// <summary>
+            /// The Key Vault API version 7.0.
+            /// </summary>
+            V0_7_0 = 0
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ServiceVersion"/> of the service API used when
+        /// making requests. For more information, see 
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
+        /// </summary>
+        public ServiceVersion Version { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyClientOptions"/>
+        /// class.
+        /// </summary>
+        /// <param name="version">
+        /// The <see cref="ServiceVersion"/> of the service API used when
+        /// making requests. 
+        /// </param>
+        public KeyClientOptions(ServiceVersion version = ServiceVersion.V0_7_0)
+        {
+            this.Version = version;
+        }
+        
+        internal void SetVersionString(out string version)
+        {
+            version = string.Empty;
+
+            switch (this.Version)
+            {
+                case ServiceVersion.V0_7_0:
+                    version = "7.0";
+                    break;
+
+                default:
+                    break;
+            }
+        }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClientOptions.cs
@@ -3,6 +3,7 @@
 // license information.
 
 using Azure.Core.Pipeline;
+using System;
 
 namespace Azure.Security.KeyVault.Keys
 {
@@ -16,7 +17,7 @@ namespace Azure.Security.KeyVault.Keys
         /// For more information, see 
         /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V0_7_0;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V7_0;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client
@@ -28,7 +29,7 @@ namespace Azure.Security.KeyVault.Keys
             /// <summary>
             /// The Key Vault API version 7.0.
             /// </summary>
-            V0_7_0 = 0
+            V7_0 = 0
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -47,24 +48,26 @@ namespace Azure.Security.KeyVault.Keys
         /// The <see cref="ServiceVersion"/> of the service API used when
         /// making requests. 
         /// </param>
-        public KeyClientOptions(ServiceVersion version = ServiceVersion.V0_7_0)
+        public KeyClientOptions(ServiceVersion version = ServiceVersion.V7_0)
         {
             this.Version = version;
         }
         
-        internal void SetVersionString(out string version)
+        internal string GetVersionString()
         {
-            version = string.Empty;
+            var version = string.Empty;
 
             switch (this.Version)
             {
-                case ServiceVersion.V0_7_0:
+                case ServiceVersion.V7_0:
                     version = "7.0";
                     break;
 
                 default:
-                    break;
+                    throw new ArgumentException(this.Version.ToString());
             }
+
+            return version;
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient_private.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient_private.cs
@@ -11,7 +11,7 @@ namespace Azure.Security.KeyVault.Keys
     {
         private const string KeysPath = "/keys/";
         private const string DeletedKeysPath = "/deletedkeys/";
-        private readonly string ApiVersion = "7.0";
+        private readonly string ApiVersion;
 
         private async Task<Response<TResult>> SendRequestAsync<TContent, TResult>(RequestMethod method, TContent content, Func<TResult> resultFactory, CancellationToken cancellationToken, params string[] path)
             where TContent : Model

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient_private.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyClient_private.cs
@@ -9,9 +9,9 @@ namespace Azure.Security.KeyVault.Keys
 {
     public partial class KeyClient
     {
-        private const string ApiVersion = "7.0";
         private const string KeysPath = "/keys/";
         private const string DeletedKeysPath = "/deletedkeys/";
+        private readonly string ApiVersion = "7.0";
 
         private async Task<Response<TResult>> SendRequestAsync<TContent, TResult>(RequestMethod method, TContent content, Func<TResult> resultFactory, CancellationToken cancellationToken, params string[] path)
             where TContent : Model

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -21,7 +21,7 @@ namespace Azure.Security.KeyVault.Secrets
     public class SecretClient
     {
         private readonly Uri _vaultUri;
-        private const string ApiVersion = "7.0";
+        private readonly string ApiVersion = "7.0";
         private readonly HttpPipeline _pipeline;
 
         private const string SecretsPath = "/secrets/";
@@ -56,6 +56,7 @@ namespace Azure.Security.KeyVault.Secrets
         {
             _vaultUri = vaultUri ?? throw new ArgumentNullException(nameof(credential));
             options = options ?? new SecretClientOptions();
+            options.SetVersionString(out this.ApiVersion);
 
             _pipeline = HttpPipelineBuilder.Build(options,
                     bufferResponse: true,

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClient.cs
@@ -21,7 +21,7 @@ namespace Azure.Security.KeyVault.Secrets
     public class SecretClient
     {
         private readonly Uri _vaultUri;
-        private readonly string ApiVersion = "7.0";
+        private readonly string ApiVersion;
         private readonly HttpPipeline _pipeline;
 
         private const string SecretsPath = "/secrets/";
@@ -56,7 +56,7 @@ namespace Azure.Security.KeyVault.Secrets
         {
             _vaultUri = vaultUri ?? throw new ArgumentNullException(nameof(credential));
             options = options ?? new SecretClientOptions();
-            options.SetVersionString(out this.ApiVersion);
+            this.ApiVersion = options.GetVersionString();
 
             _pipeline = HttpPipelineBuilder.Build(options,
                     bufferResponse: true,

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
@@ -3,6 +3,7 @@
 // license information.
 
 using Azure.Core.Pipeline;
+using System;
 
 namespace Azure.Security.KeyVault.Secrets
 {
@@ -16,7 +17,7 @@ namespace Azure.Security.KeyVault.Secrets
         /// For more information, see 
         /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
         /// </summary>
-        internal const ServiceVersion LatestVersion = ServiceVersion.V0_7_0;
+        internal const ServiceVersion LatestVersion = ServiceVersion.V7_0;
 
         /// <summary>
         /// The versions of Azure Key Vault supported by this client
@@ -28,7 +29,7 @@ namespace Azure.Security.KeyVault.Secrets
             /// <summary>
             /// The Key Vault API version 7.0.
             /// </summary>
-            V0_7_0 = 0
+            V7_0 = 0
 #pragma warning restore CA1707 // Identifiers should not contain underscores
         }
 
@@ -47,24 +48,26 @@ namespace Azure.Security.KeyVault.Secrets
         /// The <see cref="ServiceVersion"/> of the service API used when
         /// making requests. 
         /// </param>
-        public SecretClientOptions(ServiceVersion version = ServiceVersion.V0_7_0)
+        public SecretClientOptions(ServiceVersion version = ServiceVersion.V7_0)
         {
             this.Version = version;
         }
 
-        internal void SetVersionString(out string version)
+        internal string GetVersionString()
         {
-            version = string.Empty;
+            var version = string.Empty;
 
             switch (this.Version)
             {
-                case ServiceVersion.V0_7_0:
+                case ServiceVersion.V7_0:
                     version = "7.0";
                     break;
 
                 default:
-                    break;
+                    throw new ArgumentException(this.Version.ToString());
             }
+
+            return version;
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretClientOptions.cs
@@ -11,5 +11,60 @@ namespace Azure.Security.KeyVault.Secrets
     /// </summary>
     public class SecretClientOptions : ClientOptions
     {
+        /// <summary>
+        /// The latest service version supported by this client library.
+        /// For more information, see 
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
+        /// </summary>
+        internal const ServiceVersion LatestVersion = ServiceVersion.V0_7_0;
+
+        /// <summary>
+        /// The versions of Azure Key Vault supported by this client
+        /// library. 
+        /// </summary>
+        public enum ServiceVersion
+        {
+#pragma warning disable CA1707 // Identifiers should not contain underscores
+            /// <summary>
+            /// The Key Vault API version 7.0.
+            /// </summary>
+            V0_7_0 = 0
+#pragma warning restore CA1707 // Identifiers should not contain underscores
+        }
+
+        /// <summary>
+        /// Gets the <see cref="ServiceVersion"/> of the service API used when
+        /// making requests. For more information, see 
+        /// <see href="https://docs.microsoft.com/en-us/rest/api/keyvault/key-vault-versions"/>
+        /// </summary>
+        public ServiceVersion Version { get; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SecretClientOptions"/>
+        /// class.
+        /// </summary>
+        /// <param name="version">
+        /// The <see cref="ServiceVersion"/> of the service API used when
+        /// making requests. 
+        /// </param>
+        public SecretClientOptions(ServiceVersion version = ServiceVersion.V0_7_0)
+        {
+            this.Version = version;
+        }
+
+        internal void SetVersionString(out string version)
+        {
+            version = string.Empty;
+
+            switch (this.Version)
+            {
+                case ServiceVersion.V0_7_0:
+                    version = "7.0";
+                    break;
+
+                default:
+                    break;
+            }
+        }
     }
 }


### PR DESCRIPTION
Applying analyzers for the following .NET guidelines from section 2.2.6:

✅DO call the highest supported service API version by default.
✅DO allow explicitly selecting a supported service API versions when instantiating service client types.

This should be done using a constructor parameter on the client options type.

- The parameter must be the first parameter to all constructor overloads.
- The parameter must not be optional, i.e. all constructor overloads must have it.
- The parameter should be defaulted to the latest supported service version.
- The parameter type must be an enum nested in the options type.
- The parameter type must be called ServiceVersion.