### PR TITLE
Stops searching /samples for readme files.

### DIFF
--- a/eng/.docsettings.yml
+++ b/eng/.docsettings.yml
@@ -6,6 +6,7 @@ omitted_paths:
   - Documentation/*
   - sdk/*mgmt*/*
   - sdk/*/*.Management.*/*
+  - samples/*
 language: net
 root_check_enabled: True
 required_readme_sections:


### PR DESCRIPTION
This PR has a quick fix for the builds against master which are failing due to the samples directory arriving and doc warden complaining about it not having README files.