### PR TITLE
Throw ServiceBusCommunicationException when session is being created at the same time when connection is being closed.

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
@@ -211,6 +211,9 @@ namespace Microsoft.Azure.ServiceBus.Amqp
 
                 case TimeoutException _:
                     return new ServiceBusTimeoutException(message, aggregateException);
+
+                case InvalidOperationException _ when connectionError:
+                    return new ServiceBusCommunicationException(message, aggregateException);
             }
 
             return aggregateException;

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpLinkCreator.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpLinkCreator.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.ServiceBus.Amqp
             {
                 MessagingEventSource.Log.AmqpSessionCreationException(this.entityPath, amqpConnection, exception);
                 session?.Abort();
-                throw AmqpExceptionHelper.GetClientException(exception, null, session.GetInnerException());
+                throw AmqpExceptionHelper.GetClientException(exception, null, session.GetInnerException(), amqpConnection.IsClosing());
             }
 
             AmqpObject link = null;


### PR DESCRIPTION
Throw ServiceBusCommunicationException instead of InvalidOperationException when you try to create a session/link at the same time when connection/session is being closed.