### PR TITLE
Ensuring "Path" returns the right destination in the case of via-sender

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageSender.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageSender.cs
@@ -178,7 +178,6 @@ namespace Microsoft.Azure.ServiceBus.Core
                 this.isViaSender = true;
                 this.TransferDestinationPath = transferDestinationPath;
                 this.ViaEntityPath = entityPath;
-                this.Path = transferDestinationPath;
             }
 
             MessagingEventSource.Log.MessageSenderCreateStop(serviceBusConnection.Endpoint.Authority, entityPath, this.ClientId);
@@ -191,7 +190,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         public override IList<ServiceBusPlugin> RegisteredPlugins { get; } = new List<ServiceBusPlugin>();
 
         /// <summary>
-        /// Gets the entity path of the MessageSender.
+        /// Gets the entity path of the MessageSender. 
+        /// In the case of a via-sender, this returns the path of the via entity.
         /// </summary>
         public override string Path { get; }
 

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageSender.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageSender.cs
@@ -40,7 +40,6 @@ namespace Microsoft.Azure.ServiceBus.Core
         readonly ActiveClientLinkManager clientLinkManager;
         readonly ServiceBusDiagnosticSource diagnosticSource;
         readonly bool isViaSender;
-        readonly string transferDestinationPath;
 
         /// <summary>
         /// Creates a new AMQP MessageSender.
@@ -152,7 +151,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
             this.ServiceBusConnection = serviceBusConnection ?? throw new ArgumentNullException(nameof(serviceBusConnection));
             this.Path = entityPath;
-            this.TransferDestinationPath = transferDestinationPath;
+            this.SendingLinkDestination = entityPath;
             this.EntityType = entityType;
             this.ServiceBusConnection.ThrowIfClosed();
 
@@ -177,7 +176,9 @@ namespace Microsoft.Azure.ServiceBus.Core
             if (!string.IsNullOrWhiteSpace(transferDestinationPath))
             {
                 this.isViaSender = true;
-                this.transferDestinationPath = transferDestinationPath;
+                this.TransferDestinationPath = transferDestinationPath;
+                this.ViaEntityPath = entityPath;
+                this.Path = transferDestinationPath;
             }
 
             MessagingEventSource.Log.MessageSenderCreateStop(serviceBusConnection.Endpoint.Authority, entityPath, this.ClientId);
@@ -195,9 +196,14 @@ namespace Microsoft.Azure.ServiceBus.Core
         public override string Path { get; }
 
         /// <summary>
-        /// Gets the transfer destination path (send-via) of the MessageSender.
+        /// In the case of a via-sender, gets the final destination path of the messages; null otherwise.
         /// </summary>
         public string TransferDestinationPath { get; }
+
+        /// <summary>
+        /// In the case of a via-sender, the message is sent to <see cref="TransferDestinationPath"/> via <see cref="ViaEntityPath"/>; null otherwise.
+        /// </summary>
+        public string ViaEntityPath { get; }
 
         /// <summary>
         /// Duration after which individual operations will timeout.
@@ -214,6 +220,8 @@ namespace Microsoft.Azure.ServiceBus.Core
         public override ServiceBusConnection ServiceBusConnection { get; }
 
         internal MessagingEntityType? EntityType { get; }
+
+        internal string SendingLinkDestination { get; set; }
 
         ICbsTokenProvider CbsTokenProvider { get; }
 
@@ -672,13 +680,13 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         async Task<SendingAmqpLink> CreateLinkAsync(TimeSpan timeout)
         {
-            MessagingEventSource.Log.AmqpSendLinkCreateStart(this.ClientId, this.EntityType, this.Path);
+            MessagingEventSource.Log.AmqpSendLinkCreateStart(this.ClientId, this.EntityType, this.SendingLinkDestination);
 
             var amqpLinkSettings = new AmqpLinkSettings
             {
                 Role = false,
                 InitialDeliveryCount = 0,
-                Target = new Target { Address = this.Path },
+                Target = new Target { Address = this.SendingLinkDestination },
                 Source = new Source { Address = this.ClientId },
             };
             if (this.EntityType != null)
@@ -686,14 +694,14 @@ namespace Microsoft.Azure.ServiceBus.Core
                 amqpLinkSettings.AddProperty(AmqpClientConstants.EntityTypeName, (int)this.EntityType);
             }
 
-            var endpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.Path);
+            var endpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.SendingLinkDestination);
 
             string[] audience;
             if (this.isViaSender)
             {
-                var transferDestinationEndpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.transferDestinationPath);
+                var transferDestinationEndpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.TransferDestinationPath);
                 audience = new string[] { endpointUri.AbsoluteUri, transferDestinationEndpointUri.AbsoluteUri };
-                amqpLinkSettings.AddProperty(AmqpClientConstants.TransferDestinationAddress, this.transferDestinationPath);
+                amqpLinkSettings.AddProperty(AmqpClientConstants.TransferDestinationAddress, this.TransferDestinationPath);
             }
             else
             {
@@ -701,7 +709,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
 
             string[] claims = {ClaimConstants.Send};
-            var amqpSendReceiveLinkCreator = new AmqpSendReceiveLinkCreator(this.Path, this.ServiceBusConnection, endpointUri, audience, claims, this.CbsTokenProvider, amqpLinkSettings, this.ClientId);
+            var amqpSendReceiveLinkCreator = new AmqpSendReceiveLinkCreator(this.SendingLinkDestination, this.ServiceBusConnection, endpointUri, audience, claims, this.CbsTokenProvider, amqpLinkSettings, this.ClientId);
             Tuple<AmqpObject, DateTime> linkDetails = await amqpSendReceiveLinkCreator.CreateAndOpenAmqpLinkAsync().ConfigureAwait(false);
 
             var sendingAmqpLink = (SendingAmqpLink) linkDetails.Item1;
@@ -720,7 +728,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 
         async Task<RequestResponseAmqpLink> CreateRequestResponseLinkAsync(TimeSpan timeout)
         {
-            var entityPath = this.Path + '/' + AmqpClientConstants.ManagementAddress;
+            var entityPath = this.SendingLinkDestination + '/' + AmqpClientConstants.ManagementAddress;
             var amqpLinkSettings = new AmqpLinkSettings();
             amqpLinkSettings.AddProperty(AmqpClientConstants.EntityTypeName, AmqpClientConstants.EntityTypeManagement);
 
@@ -729,9 +737,9 @@ namespace Microsoft.Azure.ServiceBus.Core
             string[] audience;
             if (this.isViaSender)
             {
-                var transferDestinationEndpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.transferDestinationPath);
+                var transferDestinationEndpointUri = new Uri(this.ServiceBusConnection.Endpoint, this.TransferDestinationPath);
                 audience = new string[] { endpointUri.AbsoluteUri, transferDestinationEndpointUri.AbsoluteUri };
-                amqpLinkSettings.AddProperty(AmqpClientConstants.TransferDestinationAddress, this.transferDestinationPath);
+                amqpLinkSettings.AddProperty(AmqpClientConstants.TransferDestinationAddress, this.TransferDestinationPath);
             }
             else
             {

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/API/ApiApprovals.ApproveAzureServiceBus.approved.txt
@@ -592,6 +592,7 @@ namespace Microsoft.Azure.ServiceBus.Core
         public override System.Collections.Generic.IList<Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin> RegisteredPlugins { get; }
         public override Microsoft.Azure.ServiceBus.ServiceBusConnection ServiceBusConnection { get; }
         public string TransferDestinationPath { get; }
+        public string ViaEntityPath { get; }
         public System.Threading.Tasks.Task CancelScheduledMessageAsync(long sequenceNumber) { }
         protected override System.Threading.Tasks.Task OnClosingAsync() { }
         public override void RegisterPlugin(Microsoft.Azure.ServiceBus.Core.ServiceBusPlugin serviceBusPlugin) { }

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/MessageSenderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/MessageSenderTests.cs
@@ -21,15 +21,15 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
 
         [Fact]
         [DisplayTestMethodName]
-        public void Path_should_not_change()
+        public void Path_reflects_actual_link_destination()
         {
-            Assert.Equal("path", viaSender.Path);
+            Assert.Equal("via", viaSender.Path);
             Assert.Equal("path", nonViaSender.Path);
         }
 
         [Fact]
         [DisplayTestMethodName]
-        public void TransferDestinationPath_should_not_change()
+        public void TransferDestinationPath_should_be_final_destination_name()
         {
             Assert.Equal("path", viaSender.TransferDestinationPath);
             Assert.Null(nonViaSender.TransferDestinationPath);

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/MessageSenderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/MessageSenderTests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.ServiceBus.UnitTests
+{
+    using Core;
+    using Xunit;
+
+    public class MessageSenderTests
+    {
+        private MessageSender viaSender;
+        private MessageSender nonViaSender;
+
+        public MessageSenderTests()
+        {
+            var builder = new ServiceBusConnectionStringBuilder("blah.com", "path", "key-name", "key-value");
+            var connection = new ServiceBusConnection(builder);
+            viaSender = new MessageSender(connection, "path", "via");
+            nonViaSender = new MessageSender(connection, "path");
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public void Path_should_not_change()
+        {
+            Assert.Equal("path", viaSender.Path);
+            Assert.Equal("path", nonViaSender.Path);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public void TransferDestinationPath_should_not_change()
+        {
+            Assert.Equal("path", viaSender.TransferDestinationPath);
+            Assert.Null(nonViaSender.TransferDestinationPath);
+        }
+
+        [Fact]
+        [DisplayTestMethodName]
+        public void ViaEntityPath_should_be_via_entity_name()
+        {
+            Assert.Equal("via", viaSender.ViaEntityPath);
+            Assert.Null(nonViaSender.ViaEntityPath);
+        }
+    }
+}


### PR DESCRIPTION
Fixing #6031 
In the case of Via-Sender defined by 
`viaSender = new MessageSender(connection, "path", "via")`,

`Assert.Equal("path", viaSender.Path);`
`Assert.Equal("path", viaSender.TransferDestinationPath);`
`Assert.Equal("via", viaSender.ViaEntityPath);`

**EDIT**
Alternatively, to keep things from breaking and causing further confusion, keeping Path as-is and updating the xmldoc. 
1. Path will now point to wherever the amqp-link is created to.
2. viaEntityPath will point to via entity.
3. TransferDestinationPath will point to the final destination of the message