### PR TITLE
Throwing communicationException when it is connectionError

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Amqp/AmqpExceptionHelper.cs
@@ -206,11 +206,19 @@ namespace Microsoft.Azure.ServiceBus.Amqp
                 case OperationCanceledException operationCanceledException when operationCanceledException.InnerException is AmqpException amqpException:
                     return amqpException.Error.ToMessagingContractException(connectionError);
 
+                case OperationCanceledException _ when connectionError:
+                    return new ServiceBusCommunicationException(message, aggregateException);
+
                 case OperationCanceledException _:
                     return new ServiceBusException(true, message, aggregateException);
 
                 case TimeoutException _:
                     return new ServiceBusTimeoutException(message, aggregateException);
+            }
+
+            if (connectionError)
+            {
+                return new ServiceBusCommunicationException(message, aggregateException);
             }
 
             return aggregateException;

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/MessageReceiver.cs
@@ -1065,7 +1065,7 @@ namespace Microsoft.Azure.ServiceBus.Core
             }
             catch (Exception exception)
             {
-                throw AmqpExceptionHelper.GetClientException(exception, receiveLink?.GetTrackingId(), null, receiveLink?.Session.IsClosing() ?? false);
+                throw AmqpExceptionHelper.GetClientException(exception, receiveLink?.GetTrackingId(), null, receiveLink?.IsClosing() ?? false);
             }
         }
 


### PR DESCRIPTION
Multiple errors can happen when link/session is closing. Throw `ServiceBusCommunicationException` instead of `ServiceBusException`.

Fixes #6097 