### PR TITLE
Updating xmldoc - remarks on MessageHandlerOptions.MaxAutoRenewDuration

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessageHandlerOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessageHandlerOptions.cs
@@ -64,8 +64,8 @@ namespace Microsoft.Azure.ServiceBus
         /// <summary>Gets or sets the maximum duration within which the lock will be renewed automatically. This
         /// value should be greater than the longest message lock duration; for example, the LockDuration Property. </summary>
         /// <value>The maximum duration during which locks are automatically renewed.</value>
-        /// <remarks>Messages can be renewed in the background inspite of explicity completing the message.
-        /// This could lead to false-negative MessageLockLostException being raised.</remarks>
+        /// <remarks>The message renew can continue for sometime in the background
+        /// after completion of message and result in a few false MessageLockLostExceptions temporarily.</remarks>
         public TimeSpan MaxAutoRenewDuration
         {
             get => this.maxAutoRenewDuration;

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessageHandlerOptions.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/MessageHandlerOptions.cs
@@ -64,6 +64,8 @@ namespace Microsoft.Azure.ServiceBus
         /// <summary>Gets or sets the maximum duration within which the lock will be renewed automatically. This
         /// value should be greater than the longest message lock duration; for example, the LockDuration Property. </summary>
         /// <value>The maximum duration during which locks are automatically renewed.</value>
+        /// <remarks>Messages can be renewed in the background inspite of explicity completing the message.
+        /// This could lead to false-negative MessageLockLostException being raised.</remarks>
         public TimeSpan MaxAutoRenewDuration
         {
             get => this.maxAutoRenewDuration;


### PR DESCRIPTION
Mentioning that there could be false-negative lockLost exceptions that could be raised.
Related to #6723 