### PR TITLE
Update service.proj to fix check and mgmt filtering

### DIFF
--- a/eng/service.proj
+++ b/eng/service.proj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ExcludeMgmtLib Include="..\sdk\$(ServiceDirectory)\*.Management.*\**\*.csproj;..\sdk\*mgmt*\**\*.csproj;" />
+    <ExcludeMgmtLib Include="..\sdk\*\*.Management.*\**\*.csproj;..\sdk\*mgmt*\**\*.csproj;" />
     <TestProjects Include="..\sdk\$(ServiceDirectory)\**\tests\**\*.csproj" />
     <SrcProjects Include="..\sdk\$(ServiceDirectory)\**\*.csproj" Exclude="@(TestProjects)" />
     <ProjectReference Include="@(TestProjects)" Exclude="@(ExcludeMgmtLib)" Condition="'$(IncludeTests)' == 'true'" />
@@ -17,7 +17,8 @@
   <Import Project="..\sdk\$(ServiceDirectory)\*.projects" />
 
   <Target Name="CheckProjects" AfterTargets="Build">
-    <Error Condition="'@(ProjectReference)' == ''"
+    <!-- If scope is set this likely came from a call to build.proj and in cases where there is only mgmt projects we don't want to error so skip this extra check -->
+    <Error Condition="'$(Scope)' == '' and '@(ProjectReference)' == ''"
         Text="No Projects found with patttern [..\sdk\$(ServiceDirectory)\**\*.csproj], please make sure you have passed in the correct ServiceDirectory." />
   </Target>
 </Project>


### PR DESCRIPTION
@shahabhijeet this should fix the issue where people building with build.proj in a scope that only contained management plane projects was failing.

 @chidozieononiwu @schaabs this also updates the management filtering so that it works when someone provides a ServiceDirectory with wildcards in it like `keyvault/Microsoft.*`

@azure/azure-sdk-eng