### PR TITLE
Fix versioning props for keyvault track 1

### DIFF
--- a/sdk/keyvault/Directory.Build.props
+++ b/sdk/keyvault/Directory.Build.props
@@ -1,5 +1,12 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup Condition="'$(IsDataPlane)' == 'true'">
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Samples'))">
+    <IsTestProject>true</IsTestProject>
+    <IsTestSupportProject>true</IsTestSupportProject>
+  </PropertyGroup>
+
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
+
+  <PropertyGroup Condition="'$(IsDataPlaneProject)' == 'true'">
     <VersionPrefix>3.0.4</VersionPrefix>
     <PackageTags>Microsoft Azure Key Vault;Key Vault;REST HTTP client;azureofficial;windowsazureofficial</PackageTags>
     <PackageReleaseNotes>
@@ -8,11 +15,4 @@
       ]]>
     </PackageReleaseNotes>
   </PropertyGroup>
-
-  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Samples'))">
-    <IsTestProject>true</IsTestProject>
-    <IsTestSupportProject>true</IsTestSupportProject>
-  </PropertyGroup>
-
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory).., Directory.Build.props))\Directory.Build.props" />
 </Project>


### PR DESCRIPTION
@schaabs this will fix your track 1 package dependencies. Apparently this has been broken for a while. I accidentally broken it with https://github.com/Azure/azure-sdk-for-net/pull/6554. 

FYI @chidozieononiwu 