### PR TITLE
Add Storage extension methods

### DIFF
--- a/sdk/core/Azure.Core.Extensions/samples/Azure.Core.Extensions.Samples.csproj
+++ b/sdk/core/Azure.Core.Extensions/samples/Azure.Core.Extensions.Samples.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.App" IsImplicitlyDefined="true" />
     <ProjectReference Include="..\..\..\keyvault\Azure.Security.KeyVault.Secrets\src\Azure.Security.KeyVault.Secrets.csproj" />
+    <ProjectReference Include="..\..\..\storage\Azure.Storage.Blobs\src\Azure.Storage.Blobs.csproj" />
     <ProjectReference Include="..\src\Azure.Core.Extensions.csproj" />
   </ItemGroup>
 </Project>

--- a/sdk/core/Azure.Core.Extensions/samples/appsettings.json
+++ b/sdk/core/Azure.Core.Extensions/samples/appsettings.json
@@ -16,5 +16,12 @@
   },
   "KeyVault": {
     "VaultUri": "<vault_uri>"
+  },
+  "Storage": {
+    "serviceUri": "<service_uri>",
+    "credential": {
+      "accountName": "<account_name>",
+      "accountKey": "<account_key>"
+    }
   }
 }

--- a/sdk/core/Azure.Core.Extensions/src/AzureClientBuilderExtensions.cs
+++ b/sdk/core/Azure.Core.Extensions/src/AzureClientBuilderExtensions.cs
@@ -47,6 +47,10 @@ namespace Azure.Core.Extensions
 
         public static IAzureClientBuilder<TClient, TOptions> WithVersion<TClient, TOptions, TVersion>(this IAzureClientBuilder<TClient, TOptions> builder, TVersion version) where TOptions : class
         {
+            if (typeof(TVersion).DeclaringType != typeof(TOptions))
+            {
+                throw new ArgumentException($"Version should be of type {typeof(TOptions)}.ServiceVersion");
+            }
             builder.ToBuilder().Registration.Version = version;
             return builder;
         }

--- a/sdk/core/Azure.Core.Extensions/src/Internal/ConfigurationClientFactory.cs
+++ b/sdk/core/Azure.Core.Extensions/src/Internal/ConfigurationClientFactory.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -11,12 +12,12 @@ using Microsoft.Extensions.Configuration;
 
 namespace Azure.Core.Extensions
 {
-    internal class ClientFactory
+    internal static class ClientFactory
     {
         public static object CreateClient(Type clientType, Type optionsType, object options, IConfiguration configuration, TokenCredential credential)
         {
             List<object> arguments = new List<object>();
-            foreach (var constructor in clientType.GetConstructors())
+            foreach (var constructor in clientType.GetConstructors().OrderByDescending(c => c.GetParameters().Length))
             {
                 if (!IsApplicableConstructor(constructor, optionsType))
                 {
@@ -39,14 +40,13 @@ namespace Azure.Core.Extensions
                         break;
                     }
 
-                    var value = configuration[parameter.Name];
-                    if (value == null)
+                    if (!TryConvertArgument(configuration, parameter.Name, parameter.ParameterType, out object argument))
                     {
                         match = false;
                         break;
                     }
 
-                    arguments.Add(ConvertArgument(value, parameter));
+                    arguments.Add(argument);
                 }
 
                 if (!match)
@@ -167,6 +167,7 @@ namespace Azure.Core.Extensions
 
             return builder.ToString();
         }
+
         private static bool IsApplicableConstructor(ConstructorInfo constructorInfo, Type optionsType)
         {
             var parameters = constructorInfo.GetParameters();
@@ -176,19 +177,75 @@ namespace Azure.Core.Extensions
                    IsOptionsParameter(parameters[parameters.Length - 1], optionsType);
         }
 
-        private static object ConvertArgument(string value, ParameterInfo parameter)
+        private static bool TryConvertArgument(IConfiguration configuration, string parameterName, Type parameterType, out object value)
         {
-            if (parameter.ParameterType == typeof(string))
+            if (parameterType == typeof(string))
             {
-                return value;
+                return TryConvertFromString(configuration, parameterName, s => s, out value);
             }
 
-            if (parameter.ParameterType == typeof(Uri))
+            if (parameterType == typeof(Uri))
             {
-                return new Uri(value);
+                return TryConvertFromString(configuration, parameterName, s => new Uri(s), out value);
             }
 
-            throw new InvalidOperationException($"Unable to convert value '{value}' to parameter type {parameter.ParameterType.FullName}");
+            if (configuration[parameterName] != null)
+            {
+                throw new InvalidOperationException($"Unable to convert value '{configuration[parameterName]}' to parameter type {parameterType.FullName}");
+            }
+
+            return TryCreateObject(parameterType, configuration.GetSection(parameterName), out value);
         }
+
+        private static bool TryConvertFromString(IConfiguration configuration, string parameterName, Func<string, object> func, out object value)
+        {
+            string stringValue = configuration[parameterName];
+            if (stringValue == null)
+            {
+                value = null;
+                return false;
+            }
+
+            value = func(stringValue);
+            return true;
+        }
+
+        internal static bool TryCreateObject(Type type, IConfigurationSection configuration, out object value)
+        {
+            if (configuration == null)
+            {
+                value = null;
+                return false;
+            }
+
+            List<object> arguments = new List<object>();
+            foreach (var constructor in type.GetConstructors().OrderByDescending(c => c.GetParameters().Length))
+            {
+                arguments.Clear();
+
+                bool match = true;
+                foreach (var parameter in constructor.GetParameters())
+                {
+                    if (!TryConvertArgument(configuration, parameter.Name, parameter.ParameterType, out object argument))
+                    {
+                        match = false;
+                        break;
+                    }
+
+                    arguments.Add(argument);
+                }
+
+                if (!match)
+                {
+                    continue;
+                }
+
+                value = constructor.Invoke(arguments.ToArray());
+                return true;
+            }
+
+            throw new InvalidOperationException($"Unable to convert section '{configuration.Path}' to parameter type '{type}', unable to find matching constructor.");
+        }
+
     }
 }

--- a/sdk/core/Azure.Core.Extensions/src/Internal/ConfigurationClientFactory.cs
+++ b/sdk/core/Azure.Core.Extensions/src/Internal/ConfigurationClientFactory.cs
@@ -212,7 +212,7 @@ namespace Azure.Core.Extensions
 
         internal static bool TryCreateObject(Type type, IConfigurationSection configuration, out object value)
         {
-            if (configuration == null)
+            if (!configuration.GetChildren().Any())
             {
                 value = null;
                 return false;

--- a/sdk/core/Azure.Core.Extensions/tests/ClientFactoryTests.cs
+++ b/sdk/core/Azure.Core.Extensions/tests/ClientFactoryTests.cs
@@ -99,7 +99,9 @@ namespace Azure.Core.Extensions.Tests
             var exception = Assert.Throws<InvalidOperationException>(() => ClientFactory.CreateClient(typeof(TestClient), typeof(TestClientOptions), clientOptions, configuration, null));
             Assert.AreEqual("Unable to find matching constructor. Define one of the follow sets of configuration parameters:" + Environment.NewLine +
                 "1. connectionString" + Environment.NewLine +
-                "2. uri" + Environment.NewLine,
+                "2. uri" + Environment.NewLine +
+                "3. uri, composite" + Environment.NewLine +
+                "4. composite" + Environment.NewLine,
                 exception.Message);
         }
 

--- a/sdk/core/Azure.Core.Extensions/tests/TestClient.cs
+++ b/sdk/core/Azure.Core.Extensions/tests/TestClient.cs
@@ -9,12 +9,14 @@ namespace Azure.Core.Extensions.Tests
     {
         public Uri Uri { get; }
         public string ConnectionString { get; }
+        public CompositeObject Composite { get; }
         public TestClientOptions Options { get; }
 
         public TestClient(string connectionString)
         {
             ConnectionString = connectionString;
         }
+
         public TestClient(string connectionString, TestClientOptions options)
         {
             if (connectionString == "throw")
@@ -30,6 +32,42 @@ namespace Azure.Core.Extensions.Tests
         {
             Uri = uri;
             Options = options;
+        }
+
+        public TestClient(Uri uri, CompositeObject composite, TestClientOptions options)
+        {
+            Uri = uri;
+            Composite = composite;
+            Options = options;
+        }
+
+        public TestClient(CompositeObject composite, TestClientOptions options)
+        {
+            Composite = composite;
+            Options = options;
+        }
+
+        public class CompositeObject
+        {
+            public string A { get; }
+            public string B { get; }
+            public Uri C { get; }
+
+            public CompositeObject(string a)
+            {
+                A = a;
+            }
+
+            public CompositeObject(string a, string b)
+            {
+                A = a;
+                B = b;
+            }
+
+            public CompositeObject(Uri c)
+            {
+                C = c;
+            }
         }
     }
 }

--- a/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/AadIdentityClient.cs
@@ -21,7 +21,7 @@ namespace Azure.Identity
 {
     internal class AadIdentityClient
     {
-        private static Lazy<AadIdentityClient> s_sharedClient = new Lazy<AadIdentityClient>(() => new AadIdentityClient());
+        private static Lazy<AadIdentityClient> s_sharedClient = new Lazy<AadIdentityClient>(() => new AadIdentityClient(null));
 
         private readonly IdentityClientOptions _options;
         private readonly HttpPipeline _pipeline;

--- a/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
+++ b/sdk/identity/Azure.Identity/src/ManagedIdentityClient.cs
@@ -15,7 +15,7 @@ namespace Azure.Identity
 {
     internal class ManagedIdentityClient
     {
-        private static Lazy<ManagedIdentityClient> s_sharedClient = new Lazy<ManagedIdentityClient>(() => new ManagedIdentityClient());
+        private static Lazy<ManagedIdentityClient> s_sharedClient = new Lazy<ManagedIdentityClient>(() => new ManagedIdentityClient(null));
 
         private const string AuthenticationResponseInvalidFormatError = "Invalid response, the authentication response was not in the expected format.";
         private const string MsiEndpointInvalidUriError = "The environment variable MSI_ENDPOINT contains an invalid Uri.";

--- a/sdk/storage/Azure.Storage.Blobs/src/AzureClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Blobs/src/AzureClientBuilderExtensions.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.Extensions;
+
+namespace Azure.Storage.Blobs
+{
+    /// <summary>
+    /// Extension methods to add <see cref="BlobServiceClient"/> client to clients builder
+    /// </summary>
+    public static class AzureClientBuilderExtensions
+    {
+        /// <summary>
+        /// Registers a <see cref="BlobServiceClient"/> instance with the provided <paramref name="connectionString"/>
+        /// </summary>
+        public static IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddBlobServiceClient<TBuilder>(this TBuilder builder, string connectionString)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<BlobServiceClient, BlobClientOptions>(options => new BlobServiceClient(connectionString, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="BlobServiceClient"/> instance with the provided <paramref name="serviceUri"/>
+        /// </summary>
+        public static IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddBlobServiceClient<TBuilder>(this TBuilder builder, Uri serviceUri)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<BlobServiceClient, BlobClientOptions>(options => new BlobServiceClient(serviceUri, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="BlobServiceClient"/> instance with the provided <paramref name="serviceUri"/> and <paramref name="sharedKeyCredential"/>
+        /// </summary>
+        public static IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddBlobServiceClient<TBuilder>(this TBuilder builder, Uri serviceUri, StorageSharedKeyCredential sharedKeyCredential)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<BlobServiceClient, BlobClientOptions>(options => new BlobServiceClient(serviceUri, sharedKeyCredential, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="BlobServiceClient"/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
+        /// </summary>
+        public static IAzureClientBuilder<BlobServiceClient, BlobClientOptions> AddBlobServiceClient<TBuilder, TConfiguration>(this TBuilder builder, TConfiguration configuration)
+            where TBuilder: IAzureClientFactoryBuilderWithConfiguration<TConfiguration>
+        {
+            return builder.RegisterClientFactory<BlobServiceClient, BlobClientOptions>(configuration);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Files/src/AzureClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Files/src/AzureClientBuilderExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.Extensions;
+using Azure.Storage.Files;
+
+namespace Azure.Storage.Blobs
+{
+    /// <summary>
+    /// Extension methods to add <see cref="FileServiceClient"/> client to clients builder
+    /// </summary>
+    public static class AzureClientBuilderExtensions
+    {
+        /// <summary>
+        /// Registers a <see cref="FileServiceClient"/> instance with the provided <paramref name="connectionString"/>
+        /// </summary>
+        public static IAzureClientBuilder<FileServiceClient, FileClientOptions> AddFileServiceClient<TBuilder>(this TBuilder builder, string connectionString)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<FileServiceClient, FileClientOptions>(options => new FileServiceClient(connectionString, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="FileServiceClient"/> instance with the provided <paramref name="serviceUri"/>
+        /// </summary>
+        public static IAzureClientBuilder<FileServiceClient, FileClientOptions> AddFileServiceClient<TBuilder>(this TBuilder builder, Uri serviceUri)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<FileServiceClient, FileClientOptions>(options => new FileServiceClient(serviceUri, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="FileServiceClient"/> instance with the provided <paramref name="serviceUri"/> and <paramref name="sharedKeyCredential"/>
+        /// </summary>
+        public static IAzureClientBuilder<FileServiceClient, FileClientOptions> AddFileServiceClient<TBuilder>(this TBuilder builder, Uri serviceUri, StorageSharedKeyCredential sharedKeyCredential)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<FileServiceClient, FileClientOptions>(options => new FileServiceClient(serviceUri, sharedKeyCredential, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="FileServiceClient"/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
+        /// </summary>
+        public static IAzureClientBuilder<FileServiceClient, FileClientOptions> AddFileServiceClient<TBuilder, TConfiguration>(this TBuilder builder, TConfiguration configuration)
+            where TBuilder: IAzureClientFactoryBuilderWithConfiguration<TConfiguration>
+        {
+            return builder.RegisterClientFactory<FileServiceClient, FileClientOptions>(configuration);
+        }
+    }
+}

--- a/sdk/storage/Azure.Storage.Queues/src/AzureClientBuilderExtensions.cs
+++ b/sdk/storage/Azure.Storage.Queues/src/AzureClientBuilderExtensions.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using Azure.Core.Extensions;
+using Azure.Storage.Queues;
+
+namespace Azure.Storage.Blobs
+{
+    /// <summary>
+    /// Extension methods to add <see cref="QueueClientOptions"/> client to clients builder
+    /// </summary>
+    public static class AzureClientBuilderExtensions
+    {
+        /// <summary>
+        /// Registers a <see cref="QueueServiceClient"/> instance with the provided <paramref name="connectionString"/>
+        /// </summary>
+        public static IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddQueueServiceClient<TBuilder>(this TBuilder builder, string connectionString)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<QueueServiceClient, QueueClientOptions>(options => new QueueServiceClient(connectionString, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="QueueServiceClient"/> instance with the provided <paramref name="serviceUri"/>
+        /// </summary>
+        public static IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddQueueServiceClient<TBuilder>(this TBuilder builder, Uri serviceUri)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<QueueServiceClient, QueueClientOptions>(options => new QueueServiceClient(serviceUri, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="QueueServiceClient"/> instance with the provided <paramref name="serviceUri"/> and <paramref name="sharedKeyCredential"/>
+        /// </summary>
+        public static IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddQueueServiceClient<TBuilder>(this TBuilder builder, Uri serviceUri, StorageSharedKeyCredential sharedKeyCredential)
+            where TBuilder: IAzureClientFactoryBuilder
+        {
+            return builder.RegisterClientFactory<QueueServiceClient, QueueClientOptions>(options => new QueueServiceClient(serviceUri, sharedKeyCredential, options));
+        }
+
+        /// <summary>
+        /// Registers a <see cref="QueueServiceClient"/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
+        /// </summary>
+        public static IAzureClientBuilder<QueueServiceClient, QueueClientOptions> AddQueueServiceClient<TBuilder, TConfiguration>(this TBuilder builder, TConfiguration configuration)
+            where TBuilder: IAzureClientFactoryBuilderWithConfiguration<TConfiguration>
+        {
+            return builder.RegisterClientFactory<QueueServiceClient, QueueClientOptions>(configuration);
+        }
+    }
+}


### PR DESCRIPTION
Add support for loading composite objects from the configuration. Fixes https://github.com/Azure/azure-sdk-for-net/issues/6983.

Use longest constructor possible when loading from the configuration.