### PR TITLE
[Azure Search] Use Directory.Build.props for data plane versioning

### DIFF
--- a/sdk/search/Directory.Build.props
+++ b/sdk/search/Directory.Build.props
@@ -1,0 +1,10 @@
+﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Directory.Build.props" />
+  <Choose>
+    <When Condition="'$(IsDataPlaneProject)' == 'true'">
+      <PropertyGroup>
+        <VersionPrefix>9.0.2</VersionPrefix>
+      </PropertyGroup>
+    </When>
+  </Choose>
+</Project>

--- a/sdk/search/Microsoft.Azure.Search.Common/src/Microsoft.Azure.Search.Common.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Common/src/Microsoft.Azure.Search.Common.csproj
@@ -6,5 +6,4 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
   </PropertyGroup>
-  <Import Project="..\..\Microsoft.Azure.Search.Version.props" />
 </Project>

--- a/sdk/search/Microsoft.Azure.Search.Data/src/Microsoft.Azure.Search.Data.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Data/src/Microsoft.Azure.Search.Data.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
   </PropertyGroup>
-  <Import Project="..\..\Microsoft.Azure.Search.Version.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" />
   </ItemGroup>

--- a/sdk/search/Microsoft.Azure.Search.Service/src/Microsoft.Azure.Search.Service.csproj
+++ b/sdk/search/Microsoft.Azure.Search.Service/src/Microsoft.Azure.Search.Service.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageReleaseNotes>See the Microsoft.Azure.Search package for detailed release notes on the entire Azure Search .NET SDK.</PackageReleaseNotes>
   </PropertyGroup>
-  <Import Project="..\..\Microsoft.Azure.Search.Version.props" />
   <ItemGroup>
     <PackageReference Include="Microsoft.Spatial" />
   </ItemGroup>

--- a/sdk/search/Microsoft.Azure.Search.Version.props
+++ b/sdk/search/Microsoft.Azure.Search.Version.props
@@ -1,5 +1,0 @@
-﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <PropertyGroup>
-    <VersionPrefix>9.0.2</VersionPrefix>
-  </PropertyGroup>
-</Project>

--- a/sdk/search/Microsoft.Azure.Search/src/Microsoft.Azure.Search.csproj
+++ b/sdk/search/Microsoft.Azure.Search/src/Microsoft.Azure.Search.csproj
@@ -6,7 +6,6 @@
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <PackageReleaseNotes>This is the newest major version of the Azure Search .NET SDK, based on version 2019-05-06 of the Azure Search REST API. New in this GA version is support for Cognitive Search, complex types for richer data modeling, the Autocomplete API, and additional parsing modes for Blob indexers. See this article for help on migrating to the latest version: http://aka.ms/search-sdk-upgrade. The 9.0.1 release includes a fix for the deadlock issue (https://github.com/Azure/azure-sdk-for-net/issues/6254) in the Search API.</PackageReleaseNotes>
   </PropertyGroup>
-  <Import Project="..\..\Microsoft.Azure.Search.Version.props" />
   <ItemGroup>
     <ProjectReference Include="..\..\Microsoft.Azure.Search.Data\src\Microsoft.Azure.Search.Data.csproj" />
     <ProjectReference Include="..\..\Microsoft.Azure.Search.Service\src\Microsoft.Azure.Search.Service.csproj" />


### PR DESCRIPTION
Per feedback from @weshaggard, using `Directory.Build.props` for versioning all data plane libraries. Using conditional constructs in msbuild to ensure that the version number isn't picked up when building the management library.