### PR TITLE
Adding custom non-batched return types for non-batch calls

### DIFF
--- a/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/EntitiesResult.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/EntitiesResult.cs
@@ -1,0 +1,62 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+//
+
+namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Models
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public partial class EntitiesResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the EntitiesResult class.
+        /// </summary>
+        public EntitiesResult()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the EntitiesResult class.
+        /// </summary>
+        /// <param name="entities">Recognized entities in the document.</param>
+        /// <param name="errorMessage">Error or Warning related to the document.</param>
+        /// <param name="statistics">(Optional) if showStats=true was specified
+        /// in the request this field will contain information about the
+        /// request payload.</param>
+        public EntitiesResult(IList<EntityRecord> entities = default(IList<EntityRecord>), string errorMessage = default(string), RequestStatistics statistics = default(RequestStatistics))
+        {
+            Entities = entities;
+            ErrorMessage = errorMessage;
+            Statistics = statistics;
+            CustomInit();
+        }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets recognized entities in the document.
+        /// </summary>
+        [JsonProperty(PropertyName = "entities")]
+        public IList<EntityRecord> Entities { get; private set; }
+
+        /// <summary>
+        /// Gets error or warning for the request.
+        /// </summary>
+        [JsonProperty(PropertyName = "ErrorMessage")]
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Gets (Optional) if showStats=true was specified in the request this
+        /// field will contain information about the request payload.
+        /// </summary>
+        [JsonProperty(PropertyName = "statistics")]
+        public RequestStatistics Statistics { get; set; }
+    }
+}

--- a/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/KeyPhraseResult.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/KeyPhraseResult.cs
@@ -1,0 +1,67 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+//
+
+namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Models
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+
+    public partial class KeyPhraseResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the KeyPhraseResult class.
+        /// </summary>
+        public KeyPhraseResult()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the KeyPhraseResult class.
+        /// </summary>
+        /// <param name="keyPhrases">A list of representative words or phrases.
+        /// The number of key phrases returned is proportional to the number of
+        /// words in the input document.</param>
+        /// <param name="errorMessage">Error or Warning related to the document.</param>
+        /// <param name="statistics">(Optional) if showStats=true was specified
+        /// in the request this field will contain information about the
+        /// request payload.</param>
+        public KeyPhraseResult(IList<string> keyPhrases = default(IList<string>), string errorMessage = default(string), RequestStatistics statistics = default(RequestStatistics))
+        {
+            KeyPhrases = keyPhrases;
+            ErrorMessage = errorMessage;
+            Statistics = statistics;
+            CustomInit();
+        }
+
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets a list of representative words or phrases. The number of key
+        /// phrases returned is proportional to the number of words in the
+        /// input document.
+        /// </summary>
+        [JsonProperty(PropertyName = "keyPhrases")]
+        public IList<string> KeyPhrases { get; private set; }
+
+        /// <summary>
+        /// Gets error or warning for the request.
+        /// </summary>
+        [JsonProperty(PropertyName = "ErrorMessage")]
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Gets (Optional) if showStats=true was specified in the request this
+        /// field will contain information about the request payload.
+        /// </summary>
+        [JsonProperty(PropertyName = "statistics")]
+        public RequestStatistics Statistics { get; set; }
+    }
+}

--- a/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/LanguageInput.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/LanguageInput.cs
@@ -7,7 +7,6 @@
 namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Models
 {
     using Newtonsoft.Json;
-    using System.Linq;
 
     public partial class LanguageInput
     {

--- a/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/LanguageResult.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/LanguageResult.cs
@@ -1,0 +1,63 @@
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+//
+
+namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Models
+{
+    using Newtonsoft.Json;
+    using System.Collections.Generic;
+
+    public partial class LanguageResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the LanguageResult class.
+        /// </summary>
+        public LanguageResult()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the LanguageResult class.
+        /// </summary>
+        /// <param name="detectedLanguages">A list of extracted languages.</param>
+        /// <param name="errorMessage">Error or Warning related to the document.</param>
+        /// <param name="statistics">(Optional) if showStats=true was specified
+        /// in the request this field will contain information about the
+        /// request payload.</param>
+        public LanguageResult(IList<DetectedLanguage> detectedLanguages = default(IList<DetectedLanguage>), string errorMessage = default(string), RequestStatistics statistics = default(RequestStatistics))
+        {
+            DetectedLanguages = detectedLanguages;
+            ErrorMessage = errorMessage;
+            Statistics = statistics;
+            CustomInit();
+        }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets a list of extracted languages.
+        /// </summary>
+        [JsonProperty(PropertyName = "detectedLanguages")]
+        public IList<DetectedLanguage> DetectedLanguages { get; set; }
+
+        /// <summary>
+        /// Gets error or warning for the request.
+        /// </summary>
+        [JsonProperty(PropertyName = "ErrorMessage")]
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Gets (Optional) if showStats=true was specified in the request this
+        /// field will contain information about the request payload.
+        /// </summary>
+        [JsonProperty(PropertyName = "statistics")]
+        public RequestStatistics Statistics { get; private set; }
+
+    }
+}

--- a/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/SentimentResult.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/Models/SentimentResult.cs
@@ -1,0 +1,67 @@
+﻿//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+//
+
+namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Models
+{
+    using Newtonsoft.Json;
+
+    public partial class SentimentResult
+    {
+        /// <summary>
+        /// Initializes a new instance of the SentimentResult class.
+        /// </summary>
+        public SentimentResult()
+        {
+            CustomInit();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the SentimentResult class.
+        /// </summary>
+        /// <param name="score">A decimal number between 0 and 1 denoting the
+        /// sentiment of the document. A score above 0.7 usually refers to a
+        /// positive document while a score below 0.3 normally has a negative
+        /// connotation. Mid values refer to neutral text.</param>
+        /// <param name="errorMessage">Error or Warning related to the document.</param>
+        /// <param name="statistics">(Optional) if showStats=true was specified
+        /// in the request this field will contain information about the
+        /// request payload.</param>
+        public SentimentResult(double? score = default(double?), string errorMessage = default(string), RequestStatistics statistics = default(RequestStatistics))
+        {
+            Score = score;
+            ErrorMessage = errorMessage;
+            Statistics = statistics;
+            CustomInit();
+        }
+
+        /// <summary>
+        /// An initialization method that performs custom operations like setting defaults
+        /// </summary>
+        partial void CustomInit();
+
+        /// <summary>
+        /// Gets or sets a decimal number between 0 and 1 denoting the
+        /// sentiment of the document. A score above 0.7 usually refers to a
+        /// positive document while a score below 0.3 normally has a negative
+        /// connotation. Mid values refer to neutral text.
+        /// </summary>
+        [JsonProperty(PropertyName = "score")]
+        public double? Score { get; set; }
+
+        /// <summary>
+        /// Gets error or warning for the request.
+        /// </summary>
+        [JsonProperty(PropertyName = "ErrorMessage")]
+        public string ErrorMessage { get; private set; }
+
+        /// <summary>
+        /// Gets (Optional) if showStats=true was specified in the request this
+        /// field will contain information about the request payload.
+        /// </summary>
+        [JsonProperty(PropertyName = "statistics")]
+        public RequestStatistics Statistics { get; set; }
+    }
+}

--- a/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/TextAnalyticsClientExtensions.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/src/Customizations/TextAnalytics/TextAnalyticsClientExtensions.cs
@@ -7,6 +7,7 @@
 namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
 {
     using Models;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
@@ -163,7 +164,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static async Task<LanguageBatchResult> DetectLanguageAsync(
+        public static async Task<LanguageResult> DetectLanguageAsync(
             this ITextAnalyticsClient operations,
             string inputText = default,
             string countryHint = "en",
@@ -173,7 +174,11 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
             var languageBatchInput = new LanguageBatchInput(new List<LanguageInput> { new LanguageInput("1", inputText, countryHint) });
             using (var _result = await operations.DetectLanguageWithHttpMessagesAsync(showStats, languageBatchInput, null, cancellationToken).ConfigureAwait(false))
             {
-                return _result.Body;
+                IList<DetectedLanguage> languages = _result.Body.Documents.Count > 0 ? _result.Body.Documents[0].DetectedLanguages : null;
+                string errorMessage = _result.Body.Errors.Count > 0 ? _result.Body.Errors[0].Message : null;
+                RequestStatistics stats = _result.Body.Statistics;
+
+                return new LanguageResult(languages, errorMessage, stats);
             }
         }
 
@@ -204,7 +209,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static async Task<EntitiesBatchResult> EntitiesAsync(
+        public static async Task<EntitiesResult> EntitiesAsync(
             this ITextAnalyticsClient operations,
             string inputText = default,
             string language = "en",
@@ -214,7 +219,11 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
             var multiLanguageBatchInput = new MultiLanguageBatchInput(new List<MultiLanguageInput> { new MultiLanguageInput("1", inputText, language) });
             using (var _result = await operations.EntitiesWithHttpMessagesAsync(showStats, multiLanguageBatchInput, null, cancellationToken).ConfigureAwait(false))
             {
-                return _result.Body;
+                IList<EntityRecord> entities = _result.Body.Documents.Count > 0 ? _result.Body.Documents[0].Entities : null;
+                string errorMessage = _result.Body.Errors.Count > 0 ? _result.Body.Errors[0].Message : null;
+                RequestStatistics stats = _result.Body.Statistics;
+
+                return new EntitiesResult(entities, errorMessage, stats);
             }
         }
 
@@ -244,7 +253,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static async Task<KeyPhraseBatchResult> KeyPhrasesAsync(
+        public static async Task<KeyPhraseResult> KeyPhrasesAsync(
             this ITextAnalyticsClient operations,
             string inputText = default,
             string language = "en",
@@ -254,7 +263,11 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
             var multiLanguageBatchInput = new MultiLanguageBatchInput(new List<MultiLanguageInput> { new MultiLanguageInput("1", inputText, language) });
             using (var _result = await operations.KeyPhrasesWithHttpMessagesAsync(showStats, multiLanguageBatchInput, null, cancellationToken).ConfigureAwait(false))
             {
-                return _result.Body;
+                IList<string> keyPhrases = _result.Body.Documents.Count > 0 ? _result.Body.Documents[0].KeyPhrases : null;
+                string errorMessage = _result.Body.Errors.Count > 0 ? _result.Body.Errors[0].Message : null;
+                RequestStatistics stats = _result.Body.Statistics;
+
+                return new KeyPhraseResult(keyPhrases, errorMessage, stats);
             }
         }
 
@@ -285,7 +298,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static async Task<SentimentBatchResult> SentimentAsync(
+        public static async Task<SentimentResult> SentimentAsync(
             this ITextAnalyticsClient operations,
             string inputText = default,
             string language = "en",
@@ -295,7 +308,11 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
             var multiLanguageBatchInput = new MultiLanguageBatchInput(new List<MultiLanguageInput> { new MultiLanguageInput("1", inputText, language) });
             using (var _result = await operations.SentimentWithHttpMessagesAsync(showStats, multiLanguageBatchInput, null, cancellationToken).ConfigureAwait(false))
             {
-                return _result.Body;
+                double? score = _result.Body.Documents.Count > 0 ? _result.Body.Documents[0].Score : null;
+                string errorMessage = _result.Body.Errors.Count > 0 ? _result.Body.Errors[0].Message : null;
+                RequestStatistics stats = _result.Body.Statistics;
+
+                return new SentimentResult(score, errorMessage, stats);
             }
         }
 
@@ -438,7 +455,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static LanguageBatchResult DetectLanguage(
+        public static LanguageResult DetectLanguage(
             this ITextAnalyticsClient operations,
             string inputText = default,
             string countryHint = "en",
@@ -447,7 +464,12 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         {
             var languageBatchInput = new LanguageBatchInput(new List<LanguageInput> { new LanguageInput("1", inputText, countryHint) });
             var _result = operations.DetectLanguageWithHttpMessagesAsync(showStats, languageBatchInput, null, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
-            return _result.Body;
+
+            IList<DetectedLanguage> languages = _result.Body.Documents.Count > 0 ? _result.Body.Documents[0].DetectedLanguages : null;
+            string errorMessage = _result.Body.Errors.Count > 0 ? _result.Body.Errors[0].Message : null;
+            RequestStatistics stats = _result.Body.Statistics;
+
+            return new LanguageResult(languages, errorMessage, stats);
         }
 
         /// <summary>
@@ -477,7 +499,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static EntitiesBatchResult Entities(
+        public static EntitiesResult Entities(
             this ITextAnalyticsClient operations,
             string inputText = default,
             string language = "en",
@@ -486,7 +508,12 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         {
             var multiLanguageBatchInput = new MultiLanguageBatchInput(new List<MultiLanguageInput> { new MultiLanguageInput("1", inputText, language) });
             var _result = operations.EntitiesWithHttpMessagesAsync(showStats, multiLanguageBatchInput, null, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
-            return _result.Body;
+
+            IList<EntityRecord> entities = _result.Body.Documents.Count > 0 ? _result.Body.Documents[0].Entities : null;
+            string errorMessage = _result.Body.Errors.Count > 0 ? _result.Body.Errors[0].Message : null;
+            RequestStatistics stats = _result.Body.Statistics;
+
+            return new EntitiesResult(entities, errorMessage, stats);
         }
 
         /// <summary>
@@ -515,7 +542,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static KeyPhraseBatchResult KeyPhrases(
+        public static KeyPhraseResult KeyPhrases(
             this ITextAnalyticsClient operations,
             string inputText = default,
             string language = "en",
@@ -524,7 +551,12 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         {
             var multiLanguageBatchInput = new MultiLanguageBatchInput(new List<MultiLanguageInput> { new MultiLanguageInput("1", inputText, language) });
             var _result = operations.KeyPhrasesWithHttpMessagesAsync(showStats, multiLanguageBatchInput, null, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
-            return _result.Body;
+
+            IList<string> keyPhrases = _result.Body.Documents.Count > 0 ? _result.Body.Documents[0].KeyPhrases : null;
+            string errorMessage = _result.Body.Errors.Count > 0 ? _result.Body.Errors[0].Message : null;
+            RequestStatistics stats = _result.Body.Statistics;
+
+            return new KeyPhraseResult(keyPhrases, errorMessage, stats);
         }
 
         /// <summary>
@@ -554,7 +586,7 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         /// <param name='cancellationToken'>
         /// The cancellation token.
         /// </param>
-        public static SentimentBatchResult Sentiment(
+        public static SentimentResult Sentiment(
             this ITextAnalyticsClient operations,
             string inputText = default,
             string language = "en",
@@ -563,7 +595,12 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics
         {
             var multiLanguageBatchInput = new MultiLanguageBatchInput(new List<MultiLanguageInput> { new MultiLanguageInput("1", inputText, language) });
             var _result = operations.SentimentWithHttpMessagesAsync(showStats, multiLanguageBatchInput, null, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
-            return _result.Body;
+
+            double? score = _result.Body.Documents.Count > 0 ? _result.Body.Documents[0].Score : null;
+            string errorMessage = _result.Body.Errors.Count > 0 ? _result.Body.Errors[0].Message : null;
+            RequestStatistics stats = _result.Body.Statistics;
+
+            return new SentimentResult(score, errorMessage, stats);
         }
     }
 }

--- a/sdk/cognitiveservices/Language.TextAnalytics/tests/TextAnalytics/DetectLanguageTests.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/tests/TextAnalytics/DetectLanguageTests.cs
@@ -41,12 +41,12 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Tests
             {
                 HttpMockServer.Initialize(this.GetType().FullName, "DetectLanguageAsync");
                 ITextAnalyticsClient client = GetClient(HttpMockServer.CreateInstance());
-                LanguageBatchResult result = await client.DetectLanguageAsync(
+                LanguageResult result = await client.DetectLanguageAsync(
                     "I love my team mates");
 
-                Assert.Equal("English", result.Documents[0].DetectedLanguages[0].Name);
-                Assert.Equal("en", result.Documents[0].DetectedLanguages[0].Iso6391Name);
-                Assert.True(result.Documents[0].DetectedLanguages[0].Score > 0.7);
+                Assert.Equal("English", result.DetectedLanguages[0].Name);
+                Assert.Equal("en", result.DetectedLanguages[0].Iso6391Name);
+                Assert.True(result.DetectedLanguages[0].Score > 0.7);
                 context.Stop();
             }
         }
@@ -79,12 +79,12 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Tests
             {
                 HttpMockServer.Initialize(this.GetType().FullName, "DetectLanguage");
                 ITextAnalyticsClient client = GetClient(HttpMockServer.CreateInstance());
-                LanguageBatchResult result = client.DetectLanguage(
+                LanguageResult result = client.DetectLanguage(
                     "I love my team mates");
 
-                Assert.Equal("English", result.Documents[0].DetectedLanguages[0].Name);
-                Assert.Equal("en", result.Documents[0].DetectedLanguages[0].Iso6391Name);
-                Assert.True(result.Documents[0].DetectedLanguages[0].Score > 0.7);
+                Assert.Equal("English", result.DetectedLanguages[0].Name);
+                Assert.Equal("en", result.DetectedLanguages[0].Iso6391Name);
+                Assert.True(result.DetectedLanguages[0].Score > 0.7);
                 context.Stop();
             }
         }

--- a/sdk/cognitiveservices/Language.TextAnalytics/tests/TextAnalytics/EntitiesTests.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/tests/TextAnalytics/EntitiesTests.cs
@@ -45,14 +45,13 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Tests
             {
                 HttpMockServer.Initialize(this.GetType().FullName, "EntitiesAsync");
                 ITextAnalyticsClient client = GetClient(HttpMockServer.CreateInstance());
-                EntitiesBatchResult result = await client.EntitiesAsync(
-                    "Microsoft released Windows 10");
+                EntitiesResult result = await client.EntitiesAsync("Microsoft released Windows 10");
 
-                Assert.Equal("Microsoft", result.Documents[0].Entities[0].Name);
-                Assert.Equal("a093e9b9-90f5-a3d5-c4b8-5855e1b01f85", result.Documents[0].Entities[0].BingId);
-                Assert.Equal("Microsoft", result.Documents[0].Entities[0].Matches[0].Text);
-                Assert.Equal(0.12508682244047509, result.Documents[0].Entities[0].Matches[0].WikipediaScore);
-                Assert.Equal(0.99999618530273438, result.Documents[0].Entities[0].Matches[0].EntityTypeScore);
+                Assert.Equal("Microsoft", result.Entities[0].Name);
+                Assert.Equal("a093e9b9-90f5-a3d5-c4b8-5855e1b01f85", result.Entities[0].BingId);
+                Assert.Equal("Microsoft", result.Entities[0].Matches[0].Text);
+                Assert.Equal(0.12508682244047509, result.Entities[0].Matches[0].WikipediaScore);
+                Assert.Equal(0.99999618530273438, result.Entities[0].Matches[0].EntityTypeScore);
                 context.Stop();
             }
         }
@@ -92,14 +91,13 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Tests
             {
                 HttpMockServer.Initialize(this.GetType().FullName, "Entities");
                 ITextAnalyticsClient client = GetClient(HttpMockServer.CreateInstance());
-                EntitiesBatchResult result = client.Entities(
-                    "Microsoft released Windows 10");
+                EntitiesResult result = client.Entities("Microsoft released Windows 10");
 
-                Assert.Equal("Microsoft", result.Documents[0].Entities[0].Name);
-                Assert.Equal("a093e9b9-90f5-a3d5-c4b8-5855e1b01f85", result.Documents[0].Entities[0].BingId);
-                Assert.Equal("Microsoft", result.Documents[0].Entities[0].Matches[0].Text);
-                Assert.Equal(0.12508682244047509, result.Documents[0].Entities[0].Matches[0].WikipediaScore);
-                Assert.Equal(0.99999618530273438, result.Documents[0].Entities[0].Matches[0].EntityTypeScore);
+                Assert.Equal("Microsoft", result.Entities[0].Name);
+                Assert.Equal("a093e9b9-90f5-a3d5-c4b8-5855e1b01f85", result.Entities[0].BingId);
+                Assert.Equal("Microsoft", result.Entities[0].Matches[0].Text);
+                Assert.Equal(0.12508682244047509, result.Entities[0].Matches[0].WikipediaScore);
+                Assert.Equal(0.99999618530273438, result.Entities[0].Matches[0].EntityTypeScore);
                 context.Stop();
             }
         }

--- a/sdk/cognitiveservices/Language.TextAnalytics/tests/TextAnalytics/KeyPhrasesTests.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/tests/TextAnalytics/KeyPhrasesTests.cs
@@ -43,10 +43,9 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Tests
             {
                 HttpMockServer.Initialize(this.GetType().FullName, "KeyPhrasesAsync");
                 ITextAnalyticsClient client = GetClient(HttpMockServer.CreateInstance());
-                KeyPhraseBatchResult result = await client.KeyPhrasesAsync(
-                    "I love my team mates");
+                KeyPhraseResult result = await client.KeyPhrasesAsync("I love my team mates");
 
-                Assert.Equal("team mates", result.Documents[0].KeyPhrases[0]);
+                Assert.Equal("team mates", result.KeyPhrases[0]);
             }
         }
 
@@ -80,10 +79,9 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Tests
             {
                 HttpMockServer.Initialize(this.GetType().FullName, "KeyPhrases");
                 ITextAnalyticsClient client = GetClient(HttpMockServer.CreateInstance());
-                KeyPhraseBatchResult result = client.KeyPhrases(
-                    "I love my team mates");
+                KeyPhraseResult result = client.KeyPhrases("I love my team mates");
 
-                Assert.Equal("team mates", result.Documents[0].KeyPhrases[0]);
+                Assert.Equal("team mates", result.KeyPhrases[0]);
             }
         }
 

--- a/sdk/cognitiveservices/Language.TextAnalytics/tests/TextAnalytics/SentimentTests.cs
+++ b/sdk/cognitiveservices/Language.TextAnalytics/tests/TextAnalytics/SentimentTests.cs
@@ -43,10 +43,9 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Tests
             {
                 HttpMockServer.Initialize(this.GetType().FullName, "SentimentAsync");
                 ITextAnalyticsClient client = GetClient(HttpMockServer.CreateInstance());
-                SentimentBatchResult result = await client.SentimentAsync(
-                    "I love my team mates");
+                SentimentResult result = await client.SentimentAsync("I love my team mates");
 
-                Assert.True(result.Documents[0].Score > 0);
+                Assert.True(result.Score > 0);
             }
         }
 
@@ -80,10 +79,9 @@ namespace Microsoft.Azure.CognitiveServices.Language.TextAnalytics.Tests
             {
                 HttpMockServer.Initialize(this.GetType().FullName, "Sentiment");
                 ITextAnalyticsClient client = GetClient(HttpMockServer.CreateInstance());
-                SentimentBatchResult result = client.Sentiment(
-                    "I love my team mates");
+                SentimentResult result = client.Sentiment("I love my team mates");
 
-                Assert.True(result.Documents[0].Score > 0);
+                Assert.True(result.Score > 0);
             }
         }
     }


### PR DESCRIPTION
An update to v4.0.0 which has not been published yet (hence the same version number). 
Adding custom non-batched return types for non-batch calls simplifying the callee code.

Previously, the non-batch methods would send a single document for analysis but return a batch response that can only contain a single document. Instead, we now return a single response from these methods and unwrap the list for you. The same is done for any potential errors and statistics responses. 

Previously:

```csharp
var result = client.DetectLanguage("This is a document written in English.");

// Printing detected languages
Console.WriteLine($"Language: {result.documents[0].DetectedLanguages[0].Name}");
```

And now:

```csharp
var result = client.DetectLanguage("This is a document written in English.");

// Printing detected languages
Console.WriteLine($"Language: {result.DetectedLanguages[0].Name}");
```

This is a simplification over a batch service REST API that hasn't changed. Will be mainly used for example/documentation purposes. 