### PR TITLE
Add Erich as code owner for eng/mgmt

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@
 ###########
 # Eng Sys
 ###########
-/eng/   @weshaggard @chidozieononiwu @mitchdenny @danieljurek
+/eng/           @weshaggard @chidozieononiwu @mitchdenny @danieljurek
+/eng/mgmt/      @erich-wang
 /**/tests.yml   @danieljurek
 /**/ci.yml      @mitchdenny


### PR DESCRIPTION
@danieljurek 

@erich-wang I'm marking you as the code owner for anything under `/eng/mgmt/`, in particular for things where the metadata files change in PR's like https://github.com/Azure/azure-sdk-for-net/pull/7005#pullrequestreview-265168531. Our engineering system team doesn't need to be added as code owner reviewers for those type of changes but I think it would be helpful for you to get automatically added.