### PR TITLE
[Event Hubs Client] Track Two: Second Preview (Spelling, Formatting, Minor Tweaks)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpMessageConverter.cs
@@ -36,7 +36,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                           string partitionKey = null)
         {
             Guard.ArgumentNotNull(nameof(source), source);
-            return BuildAmqpMessageFromEvent(source, true, partitionKey);
+            return BuildAmqpMessageFromEvent(source, partitionKey);
         }
 
         /// <summary>
@@ -52,7 +52,7 @@ namespace Azure.Messaging.EventHubs.Amqp
                                                          string partitionKey = null)
         {
             Guard.ArgumentNotNull(nameof(source), source);
-            return BuildAmqpBatchFromEvents(source, true, partitionKey);
+            return BuildAmqpBatchFromEvents(source, partitionKey);
         }
 
         /// <summary>
@@ -77,16 +77,14 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// </summary>
         ///
         /// <param name="source">The set of events to use as the body of the batch message.</param>
-        /// <param name="copyCustomProperties"><c>true</c> if the custom properties of the event should be propagated to the message; otherwise, <c>false</c>.</param>
         /// <param name="partitionKey">The partition key to annotate the AMQP message with; if no partition key is specified, the annotation will not be made.</param>
         ///
         /// <returns>The batch <see cref="AmqpMessage" /> containing the source events.</returns>
         ///
         private static AmqpMessage BuildAmqpBatchFromEvents(IEnumerable<EventData> source,
-                                                            bool copyCustomProperties,
                                                             string partitionKey) =>
             BuildAmqpBatchFromMessages(
-                source.Select(eventData => BuildAmqpMessageFromEvent(eventData, copyCustomProperties, partitionKey)),
+                source.Select(eventData => BuildAmqpMessageFromEvent(eventData, partitionKey)),
                 partitionKey);
 
         /// <summary>
@@ -136,19 +134,17 @@ namespace Azure.Messaging.EventHubs.Amqp
         /// </summary>
         ///
         /// <param name="source">The event to use as the source of the message.</param>
-        /// <param name="copyCustomProperties"><c>true</c> if the custom properties of the event should be propagated to the message; otherwise, <c>false</c>.</param>
         /// <param name="partitionKey">The partition key to annotate the AMQP message with; if no partition key is specified, the annotation will not be made.</param>
         ///
         /// <returns>The <see cref="AmqpMessage" /> constructed from the source event.</returns>
         ///
         private static AmqpMessage BuildAmqpMessageFromEvent(EventData source,
-                                                             bool copyCustomProperties,
                                                              string partitionKey)
         {
-            var body = new ArraySegment<byte>((source.Body.IsEmpty) ? new byte[0] : source.Body.ToArray());
+            var body = new ArraySegment<byte>((source.Body.IsEmpty) ? Array.Empty<byte>() : source.Body.ToArray());
             var message = AmqpMessage.Create(new Data { Value = body });
 
-            if ((copyCustomProperties) && (source.Properties?.Count > 0))
+            if (source.Properties?.Count > 0)
             {
                 message.ApplicationProperties = message.ApplicationProperties ?? new ApplicationProperties();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubProducer.cs
@@ -118,7 +118,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
                                              CancellationToken cancellationToken)
         {
             static TrackOne.EventData TransformMessage(AmqpMessage message) =>
-                new TrackOne.EventData(new byte[0])
+                new TrackOne.EventData(Array.Empty<byte>())
                 {
                     AmqpMessage = message
                 };

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -403,7 +403,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(message.DataBody, Is.Not.Null, "The batch envelope should a body.");
 
             var messageData = message.DataBody.ToList();
-            Assert.That(messageData.Count, Is.EqualTo(1), "The batch envelopeshould a single data body.");
+            Assert.That(messageData.Count, Is.EqualTo(1), "The batch envelope should a single data body.");
             Assert.That(messageData[0].Value, Is.EqualTo(eventData.Body.ToArray()), "The batch envelope data should match the event body.");
 
             Assert.That(message.ApplicationProperties.Map.TryGetValue(nameof(property), out object propertyValue), Is.True, "The application property should exist in the batch.");
@@ -608,7 +608,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(batchEnvelope.DataBody, Is.Not.Null, "The batch envelope should a body.");
 
             var messageData = batchEnvelope.DataBody.ToList();
-            Assert.That(messageData.Count, Is.EqualTo(1), "The batch envelopeshould a single data body.");
+            Assert.That(messageData.Count, Is.EqualTo(1), "The batch envelope should a single data body.");
             Assert.That(messageData[0].Value, Is.EqualTo(eventData.Body.ToArray()), "The batch envelope data should match the event body.");
 
             Assert.That(batchEnvelope.ApplicationProperties.Map.TryGetValue(nameof(property), out object propertyValue), Is.True, "The application property should exist in the batch.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/TypeExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/TypeExtensionsTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 }
 
                 // Uri exists in a different assembly for .NET core then the full framework.  Rather than
-                // using a more robust approch to reference the type, take the simple approach and cheat.
+                // using a more robust approach to reference the type, take the simple approach and cheat.
 
                 if (name == AmqpProperty.Type.Uri.ToString())
                 {
@@ -61,7 +61,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Veriies functionality of the <see cref="TypeExtensions.ToAmqpPropertyType" />
+        ///   Verifies functionality of the <see cref="TypeExtensions.ToAmqpPropertyType" />
         ///   method.
         /// </summary>
         ///
@@ -76,7 +76,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Veriies functionality of the <see cref="TypeExtensions.ToAmqpPropertyType" />
+        ///   Verifies functionality of the <see cref="TypeExtensions.ToAmqpPropertyType" />
         ///   method.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
@@ -82,7 +82,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var tokenResult = credential.GetToken(new[] { resource }, CancellationToken.None);
 
-            Assert.That(tokenResult, Is.EqualTo(accessToken), "The access token should match the return of the delgated call.");
+            Assert.That(tokenResult, Is.EqualTo(accessToken), "The access token should match the return of the delegated call.");
             mockCredential.VerifyAll();
         }
 
@@ -105,7 +105,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var tokenResult = await credential.GetTokenAsync(new[] { resource }, CancellationToken.None);
 
-            Assert.That(tokenResult, Is.EqualTo(accessToken), "The access token should match the return of the delgated call.");
+            Assert.That(tokenResult, Is.EqualTo(accessToken), "The access token should match the return of the delegated call.");
             mockCredential.VerifyAll();
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureTests.cs
@@ -339,7 +339,7 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
         ///
         [Test]
         [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey&notreal=123")]
-        [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&fale=test&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey")]
+        [TestCase("SharedAccessSignature sr=amqps%3A%2F%2Fmy.eh.com%2Fsomepath%2F&false=test&sig=%2BLsuqDlN8Us5lp%2FGdyEUMnU1XA4HdXx%2BJUdtkRNr7qI%3D&se=1562258488&skn=keykeykey")]
         public void ParseToleratesExtraTokens(string signature)
         {
             Assert.That(() => ParseSignature(signature), Throws.Nothing);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
@@ -953,7 +953,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   by accessing its private field.
         /// </summary>
         ///
-        /// <param name="policy">The ploicy to retrieve the source policy from.</param>
+        /// <param name="policy">The policy to retrieve the source policy from.</param>
         ///
         /// <returns>The retry policy</returns>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubConsumerTests.cs
@@ -239,7 +239,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   by accessing its private field.
         /// </summary>
         ///
-        /// <param name="policy">The ploicy to retrieve the source policy from.</param>
+        /// <param name="policy">The policy to retrieve the source policy from.</param>
         ///
         /// <returns>The retry policy</returns>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenTests.cs
@@ -69,7 +69,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(token.Audience, Is.EqualTo(resource), "The audience for the token should match.");
             Assert.That(token.TokenValue, Is.EqualTo(jwtToken), "The JWT token value should match.");
             Assert.That(token.Credential, Is.EqualTo(credential), "The credential should match.");
-            Assert.That(token.ExpiresAtUtc, Is.EqualTo(expiration), "The expiration shoud match.");
+            Assert.That(token.ExpiresAtUtc, Is.EqualTo(expiration), "The expiration should match.");
             Assert.That(token.TokenType, Is.EqualTo(ClientConstants.JsonWebTokenType), "The token type should identify a generic JWT.");
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneRetryPolicyTests.cs
@@ -60,7 +60,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(policy => policy.CalculateRetryDelay(It.Is<Exception>(value => Object.ReferenceEquals(value, lastException)), It.Is<int>(value => value == retryCount)))
                 .Returns(expectedInterval);
 
-            Assert.That(TrackOne.RetryPolicy.IsRetryableException(lastException), Is.True, "The operation cancelled exception should be considered as retriable by the TrackOne.RetryPolicy.");
+            Assert.That(TrackOne.RetryPolicy.IsRetryableException(lastException), Is.True, "The operation canceled exception should be considered as retriable by the TrackOne.RetryPolicy.");
             Assert.That(retryPolicy.GetNextRetryInterval(lastException, TimeSpan.FromHours(4), retryCount), Is.EqualTo(expectedInterval));
         }
 
@@ -83,7 +83,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(policy => policy.CalculateRetryDelay(It.Is<EventHubsException>(value => value.GetType() == mappedException.GetType()), It.Is<int>(value => value == retryCount)))
                 .Returns(expectedInterval);
 
-            Assert.That(TrackOne.RetryPolicy.IsRetryableException(lastException), Is.True, "The timeoutd exception should be considered as retriable by the TrackOne.RetryPolicy.");
+            Assert.That(TrackOne.RetryPolicy.IsRetryableException(lastException), Is.True, "The timeout exception should be considered as retriable by the TrackOne.RetryPolicy.");
             Assert.That(retryPolicy.GetNextRetryInterval(lastException, TimeSpan.FromHours(4), retryCount), Is.EqualTo(expectedInterval));
         }
 
@@ -98,7 +98,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var lastException = new OperationCanceledException("RETRY!");
             var retryPolicy = new TrackOneRetryPolicy(Mock.Of<EventHubRetryPolicy>());
 
-            Assert.That(TrackOne.RetryPolicy.IsRetryableException(lastException), Is.True, "The operation cancelled exception should be considered as retriable by the TrackOne.RetryPolicy.");
+            Assert.That(TrackOne.RetryPolicy.IsRetryableException(lastException), Is.True, "The operation canceled exception should be considered as retriable by the TrackOne.RetryPolicy.");
             Assert.That(retryPolicy.GetNextRetryInterval(lastException, TimeSpan.Zero, 0), Is.Null);
         }
 
@@ -119,7 +119,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(policy => policy.CalculateRetryDelay(It.Is<Exception>(value => Object.ReferenceEquals(value, lastException)), It.Is<int>(value => value == retryCount)))
                 .Returns(TimeSpan.FromHours(4));
 
-            Assert.That(TrackOne.RetryPolicy.IsRetryableException(lastException), Is.True, "The operation cancelled exception should be considered as retriable by the TrackOne.RetryPolicy.");
+            Assert.That(TrackOne.RetryPolicy.IsRetryableException(lastException), Is.True, "The operation canceled exception should be considered as retriable by the TrackOne.RetryPolicy.");
             Assert.That(retryPolicy.GetNextRetryInterval(lastException, TimeSpan.FromSeconds(30), retryCount), Is.Null);
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsLiveTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     /// <remarks>
-    ///   These tests have a depenency on live Azure services and may
+    ///   These tests have a dependency on live Azure services and may
     ///   incur costs for the associated Azure subscription.
     ///
     ///   Every send or receive call will trigger diagnostics events as
@@ -57,7 +57,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         /// <param name="listener">The <see cref="IObserver{T}" /> that will subscribe to the Azure.Messaging.EventHubs <see cref="DiagnosticListener" />.</param>
         ///
-        /// <returns>An <see cref="IDisposable" /> subscription. The subscription can be cancelled by disposing of it.</returns>
+        /// <returns>An <see cref="IDisposable" /> subscription. The subscription can be canceled by disposing of it.</returns>
         ///
         private static IDisposable SubscribeToEvents(IObserver<DiagnosticListener> listener) =>
             DiagnosticListener.AllListeners.Subscribe(listener);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     /// <remarks>
-    ///   These tests have a depenency on live Azure services and may
+    ///   These tests have a dependency on live Azure services and may
     ///   incur costs for the associated Azure subscription.
     /// </remarks>
     ///
@@ -189,7 +189,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     Assert.That(partitionProperties.Id, Is.EqualTo(partition), "The partition identifier should match.");
                     Assert.That(partitionProperties.EventHubPath, Is.EqualTo(connectionProperties.EventHubPath).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
                     Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(Int64)), "The beginning sequence number should have been populated.");
-                    Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(Int64)), "The last sequance number should have been populated.");
+                    Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(Int64)), "The last sequence number should have been populated.");
                     Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(Int64)), "The last offset should have been populated.");
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
@@ -120,8 +120,8 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorDoesNotRequireEventHubInConnectionStringWhenPassedSeparate()
         {
             var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real]";
-            Assert.That(() => new EventHubClient(fakeConnection, "eventHub"), Throws.Nothing, "The constructor without options should not require the conection string event hub");
-            Assert.That(() => new EventHubClient(fakeConnection, "eventHub", new EventHubClientOptions()), Throws.Nothing, "The constructor with options should not require the conection string event hub");
+            Assert.That(() => new EventHubClient(fakeConnection, "eventHub"), Throws.Nothing, "The constructor without options should not require the connection string event hub");
+            Assert.That(() => new EventHubClient(fakeConnection, "eventHub", new EventHubClientOptions()), Throws.Nothing, "The constructor with options should not require the connection string event hub");
         }
 
         /// <summary>
@@ -275,7 +275,7 @@ namespace Azure.Messaging.EventHubs.Tests
         public void ConstructorWithExpandedArgumentsValidatesOptions()
         {
             var invalidOptions = new EventHubClientOptions { TransportType = TransportType.AmqpTcp, Proxy = Mock.Of<IWebProxy>() };
-            Assert.That(() => new EventHubClient("host", "path", Mock.Of<TokenCredential>(), invalidOptions), Throws.ArgumentException, "The cexpanded argument onstructor should validate client options");
+            Assert.That(() => new EventHubClient("host", "path", Mock.Of<TokenCredential>(), invalidOptions), Throws.ArgumentException, "The expanded argument constructor should validate client options");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventDataBatchTests.cs
@@ -90,7 +90,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var batch = new EventDataBatch(mockBatch, new SendOptions());
 
             batch.AsEnumerable<String>();
-            Assert.That(mockBatch.AsEnumerableCalledWith, Is.EqualTo(typeof(String)), "The enumerable should delegated the requestd type parameter.");
+            Assert.That(mockBatch.AsEnumerableCalledWith, Is.EqualTo(typeof(String)), "The enumerable should delegated the requested type parameter.");
         }
 
         /// <summary>
@@ -112,7 +112,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///   using its private accessor.
         /// </summary>
         ///
-        /// <param name="batch">The batch to retrive the inner transport batch from.</param>
+        /// <param name="batch">The batch to retrieve the inner transport batch from.</param>
         ///
         /// <returns>The inner transport batch.</returns>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -20,7 +20,7 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     /// <remarks>
-    ///   These tests have a depenency on live Azure services and may
+    ///   These tests have a dependency on live Azure services and may
     ///   incur costs for the associated Azure subscription.
     /// </remarks>
     ///
@@ -217,7 +217,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     foreach (var eventData in events)
                     {
-                        Assert.That(() => batch.TryAdd(eventData), Is.True, "An event was rejected by the batch; all eveny should be accepted.");
+                        Assert.That(() => batch.TryAdd(eventData), Is.True, "An event was rejected by the batch; all events should be accepted.");
                     }
 
                     Assert.That(async () => await producer.SendAsync(batch), Throws.Nothing);
@@ -240,7 +240,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 await using (var client = new EventHubClient(connectionString))
                 await using (var producer = client.CreateProducer())
                 {
-                    var singleEvent = new EventData(new byte[0]);
+                    var singleEvent = new EventData(Array.Empty<byte>());
                     var eventSet = new[] { new EventData(new byte[0]) };
 
                     Assert.That(async () => await producer.SendAsync(singleEvent), Throws.Nothing);
@@ -343,9 +343,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     var events = new[]
                     {
-                        new EventData(new byte[0]),
-                        new EventData(new byte[0]),
-                        new EventData(new byte[0])
+                        new EventData(Array.Empty<byte>()),
+                        new EventData(Array.Empty<byte>()),
+                        new EventData(Array.Empty<byte>())
                     };
 
                     Assert.That(async () => await producer.SendAsync(events), Throws.Nothing);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerTests.cs
@@ -142,7 +142,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -155,7 +155,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -168,7 +168,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -186,7 +186,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -204,7 +204,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -217,7 +217,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -230,7 +230,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -243,7 +243,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -258,7 +258,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -273,7 +273,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -288,7 +288,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -303,7 +303,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -322,7 +322,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -342,7 +342,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.SendAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.SendAsync"/>
         /// </summary>
         ///
         [Test]
@@ -358,7 +358,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
         /// </summary>
         ///
         [Test]
@@ -372,7 +372,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
         /// </summary>
         ///
         [Test]
@@ -391,7 +391,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
         /// </summary>
         ///
         [Test]
@@ -410,7 +410,7 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
-        ///   Verifies finctionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
+        ///   Verifies functionality of the <see cref="EventHubProducer.CreateBatchAsync"/>
         /// </summary>
         ///
         [Test]

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -32,7 +32,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         /// <summary>The number of seconds to use as the basis for backing off on retry attempts.</summary>
         private const double RetryExponentialBackoffSeconds = 0.5;
 
-        /// <summary>The number of seconds to use as the basis for applying jitter to retry backoff calculations.</summary>
+        /// <summary>The number of seconds to use as the basis for applying jitter to retry back-off calculations.</summary>
         private const double RetryBaseJitterSeconds = 3.0;
 
         /// <summary>The buffer to apply when considering refreshing; credentials that expire less than this duration will be refreshed.</summary>
@@ -47,7 +47,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         /// <summary>The token credential to be used with the Event Hubs management client.</summary>
         private static ManagementToken s_managementToken;
 
-        /// <summary>Serves as a sentinal flag to denote when the instance has been disposed.</summary>
+        /// <summary>Serves as a sentinel flag to denote when the instance has been disposed.</summary>
         private bool _disposed = false;
 
         /// <summary>
@@ -182,7 +182,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         ///
         /// <param name="maxRetryAttempts">The maximum retry attempts to allow.</param>
         /// <param name="exponentialBackoffSeconds">The number of seconds to use as the basis for backing off on retry attempts.</param>
-        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry backoff calculations.</param>
+        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry back-off calculations.</param>
         ///
         /// <returns>The retry policy in which to execute the management operation.</returns>
         ///
@@ -197,7 +197,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         ///
         /// <param name="maxRetryAttempts">The maximum retry attempts to allow.</param>
         /// <param name="exponentialBackoffSeconds">The number of seconds to use as the basis for backing off on retry attempts.</param>
-        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry backoff calculations.</param>
+        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry back-off calculations.</param>
         ///
         /// <returns>The retry policy in which to execute the management operation.</returns>
         ///
@@ -226,8 +226,8 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         ///   Calculates the retry delay to use for management-related operations.
         /// </summary>
         ///
-        /// <param name="attempt">The current attempt numner.</param>
-        /// <param name="exponentialBackoffSeconds">The exponential backoff amount,, in seconds.</param>
+        /// <param name="attempt">The current attempt number.</param>
+        /// <param name="exponentialBackoffSeconds">The exponential back-off amount,, in seconds.</param>
         /// <param name="baseJitterSeconds">The amount of base jitter to include, in seconds.</param>
         ///
         /// <returns>The interval to wait before retrying the attempted operation.</returns>
@@ -236,7 +236,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
             TimeSpan.FromSeconds((Math.Pow(2, attempt) * exponentialBackoffSeconds) + (RandomNumberGenerator.Value.NextDouble() * baseJitterSeconds));
 
         /// <summary>
-        ///   Aquires a JWT token for use with the Event Hubs management client.
+        ///   Acquires a JWT token for use with the Event Hubs management client.
         /// </summary>
         ///
         /// <returns>The token to use for management operations against the Event Hubs Live test namespace.</returns>
@@ -247,7 +247,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
 
             // If there was no current token, or it is within the buffer for expiration, request a new token.
             // There is a benign race condition here, where there may be multiple requests in-flight for a new token.  Since
-            // this is test infrastructure, just allow the aquired token to replace the current one without attempting to
+            // this is test infrastructure, just allow the acquired token to replace the current one without attempting to
             // coordinate or ensure that the most recent is kept.
 
             if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
@@ -258,7 +258,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
 
                 if ((String.IsNullOrEmpty(result?.AccessToken)))
                 {
-                    throw new AuthenticationException("Unable to aquire an Active Directory token for the Event Hubs management client.");
+                    throw new AuthenticationException("Unable to acquire an Active Directory token for the Event Hubs management client.");
                 }
 
                 token = new ManagementToken(result.AccessToken, result.ExpiresOn);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestEnvironment.cs
@@ -30,7 +30,7 @@ namespace Azure.Messaging.EventHubs.Tests
         private static readonly Lazy<string> EventHubsNamespaceInstance =
             new Lazy<string>(() => ReadAndVerifyEnvironmentVariable("EVENT_HUBS_NAMESPACE"), LazyThreadSafetyMode.PublicationOnly);
 
-        /// <summary>The environment variable value for the Azure Active Directory tenent that holds the service principal, lazily evaluated.</summary>
+        /// <summary>The environment variable value for the Azure Active Directory tenant that holds the service principal, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsTenantInstance =
             new Lazy<string>(() => ReadAndVerifyEnvironmentVariable("EVENT_HUBS_TENANT"), LazyThreadSafetyMode.PublicationOnly);
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
@@ -17,7 +17,7 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     /// <remarks>
-    ///   These tests have a depenency on live Azure services and may
+    ///   These tests have a dependency on live Azure services and may
     ///   incur costs for the associated Azure subscription.
     /// </remarks>
     ///


### PR DESCRIPTION
# Summary

The intent of these changes is to perform some minor clean up and formatting.

### Goals

- Spellcheck comments and strings for the project, fixing errors.

- Perform an automated formatting run over the solution.

- Convert `new byte[0]` calls to `Array.Empty<byte>()` in event translation areas to reduce unnecessary allocations.

# Last Upstream Rebase

Thursday, July 25, 2019  8:43am (EDT)

# Resources

- [Azure Messaging Exception Documentation](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions)
- [.NET Event Hubs Client: Second Preview Design Proposal](https://github.com/jsquire/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-second-preview.md)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 2](https://github.com/Azure/azure-sdk-for-net/issues/6752) (#6752)