### PR TITLE
[Azure Search] Bump SDK version to 9.1.0 to prepare for a release

### DIFF
--- a/sdk/search/Directory.Build.props
+++ b/sdk/search/Directory.Build.props
@@ -3,7 +3,7 @@
   <Choose>
     <When Condition="'$(IsDataPlaneProject)' == 'true'">
       <PropertyGroup>
-        <VersionPrefix>9.0.2</VersionPrefix>
+        <VersionPrefix>9.1.0</VersionPrefix>
       </PropertyGroup>
     </When>
   </Choose>


### PR DESCRIPTION
Increment Azure Search SDK's version to 9.1.0 to conform with .NET versioning and to prepare for a release.