### PR TITLE
Track One Event Hubs Tests Infrastructure, Processor and Client Live Tests Updates

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -31,7 +31,6 @@
     <PackageReference Update="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Update="Microsoft.Azure.Test.HttpRecorder" Version="[1.13.1, 2.0.0)" />
     <PackageReference Update="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview3.19128.7" />
-    <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0-preview6.19303.8" />
     <PackageReference Update="Microsoft.Build.Tasks.Core" Version="15.5.180" />
     <PackageReference Update="Microsoft.Build" Version="15.5.180" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -31,6 +31,7 @@
     <PackageReference Update="Microsoft.Azure.Storage.Blob" Version="9.4.2" />
     <PackageReference Update="Microsoft.Azure.Test.HttpRecorder" Version="[1.13.1, 2.0.0)" />
     <PackageReference Update="Microsoft.Bcl.Json.Sources" Version="4.6.0-preview3.19128.7" />
+    <PackageReference Update="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0-preview6.19303.8" />
     <PackageReference Update="Microsoft.Build.Tasks.Core" Version="15.5.180" />
     <PackageReference Update="Microsoft.Build" Version="15.5.180" />
     <PackageReference Update="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.6.1" />

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
@@ -24,7 +24,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Management.EventHub"  />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/src/Microsoft.Azure.EventHubs.csproj
@@ -24,6 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Management.EventHub"  />
     <PackageReference Include="Microsoft.Azure.Amqp" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" />

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ClientNegativeCases.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ClientNegativeCases.cs
@@ -16,69 +16,72 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task NonexistentEntity()
         {
-            PartitionReceiver receiver = null;
-
-            // Rebuild connection string with a nonexistent entity.
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            csb.EntityPath = Guid.NewGuid().ToString();
-            var ehClient = EventHubClient.CreateFromConnectionString(csb.ToString());
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                // GetRuntimeInformationAsync on a nonexistent entity.
-                await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
-                {
-                    TestUtility.Log("Getting entity information from a nonexistent entity.");
-                    await ehClient.GetRuntimeInformationAsync();
-                });
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                PartitionReceiver receiver = null;
+                // Rebuild connection string with a nonexistent entity.
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
+                csb.EntityPath = Guid.NewGuid().ToString();
+                var ehClient = EventHubClient.CreateFromConnectionString(csb.ToString());
 
-                // GetPartitionRuntimeInformationAsync on a nonexistent entity.
-                await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                try
                 {
-                    TestUtility.Log("Getting partition information from a nonexistent entity.");
-                    await ehClient.GetPartitionRuntimeInformationAsync("0");
-                });
+                    // GetRuntimeInformationAsync on a nonexistent entity.
+                    await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                    {
+                        TestUtility.Log("Getting entity information from a nonexistent entity.");
+                        await ehClient.GetRuntimeInformationAsync();
+                    });
 
-                // Try sending.
-                PartitionSender sender = null;
-                await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                    // GetPartitionRuntimeInformationAsync on a nonexistent entity.
+                    await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                    {
+                        TestUtility.Log("Getting partition information from a nonexistent entity.");
+                        await ehClient.GetPartitionRuntimeInformationAsync("0");
+                    });
+
+                    // Try sending.
+                    PartitionSender sender = null;
+                    await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                    {
+                        TestUtility.Log("Sending an event to nonexistent entity.");
+                        sender = ehClient.CreatePartitionSender("0");
+                        await sender.SendAsync(new EventData(Encoding.UTF8.GetBytes("this send should fail.")));
+                    });
+                    await sender.CloseAsync();
+
+                    // Try receiving.
+                    await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                    {
+                        TestUtility.Log("Receiving from nonexistent entity.");
+                        receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                        await receiver.ReceiveAsync(1);
+                    });
+                    await receiver.CloseAsync();
+                }
+                finally
                 {
-                    TestUtility.Log("Sending an event to nonexistent entity.");
-                    sender = ehClient.CreatePartitionSender("0");
-                    await sender.SendAsync(new EventData(Encoding.UTF8.GetBytes("this send should fail.")));
-                });
-                await sender.CloseAsync();
+                    await ehClient.CloseAsync();
+                }
 
-                // Try receiving.
-                await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                // Try receiving on an nonexistent consumer group.
+                ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
+                try
                 {
-                    TestUtility.Log("Receiving from nonexistent entity.");
-                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-                    await receiver.ReceiveAsync(1);
-                });
-                await receiver.CloseAsync();
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
-            }
-
-            // Try receiving on an nonexistent consumer group.
-            ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            try
-            {
-                await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                    await Assert.ThrowsAsync<MessagingEntityNotFoundException>(async () =>
+                    {
+                        TestUtility.Log("Receiving from nonexistent consumer group.");
+                        receiver = ehClient.CreateReceiver(Guid.NewGuid().ToString(), "0", EventPosition.FromStart());
+                        await receiver.ReceiveAsync(1);
+                    });
+                    await receiver.CloseAsync();
+                }
+                finally
                 {
-                    TestUtility.Log("Receiving from nonexistent consumer group.");
-                    receiver = ehClient.CreateReceiver(Guid.NewGuid().ToString(), "0", EventPosition.FromStart());
-                    await receiver.ReceiveAsync(1);
-                });
-                await receiver.CloseAsync();
-            }
-            finally
-            {
-              await ehClient.CloseAsync();
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -87,40 +90,44 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task ReceiveFromInvalidPartition()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            PartitionReceiver receiver = null;
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                // Some invalid partition values. These will fail on the service side.
-                var invalidPartitions = new List<string>() { "XYZ", "-1", "1000", "-" };
-                foreach (var invalidPartitionId in invalidPartitions)
-                {
-                    await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
-                    {
-                        TestUtility.Log($"Receiving from invalid partition {invalidPartitionId}");
-                        receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, invalidPartitionId, EventPosition.FromStart());
-                        await receiver.ReceiveAsync(1);
-                    });
-                    await receiver.CloseAsync();
-                }
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                PartitionReceiver receiver = null;
 
-                // Some invalid partition values. These will fail on the client side.
-                invalidPartitions = new List<string>() { " ", null, "" };
-                foreach (var invalidPartitionId in invalidPartitions)
+                try
                 {
-                    await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    // Some invalid partition values. These will fail on the service side.
+                    var invalidPartitions = new List<string>() { "XYZ", "-1", "1000", "-" };
+                    foreach (var invalidPartitionId in invalidPartitions)
                     {
-                        TestUtility.Log($"Receiving from invalid partition {invalidPartitionId}");
-                        receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, invalidPartitionId, EventPosition.FromStart());
-                        await receiver.ReceiveAsync(1);
-                    });
-                    await receiver.CloseAsync();
+                        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                        {
+                            TestUtility.Log($"Receiving from invalid partition {invalidPartitionId}");
+                            receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, invalidPartitionId, EventPosition.FromStart());
+                            await receiver.ReceiveAsync(1);
+                        });
+                        await receiver.CloseAsync();
+                    }
+
+                    // Some invalid partition values. These will fail on the client side.
+                    invalidPartitions = new List<string>() { " ", null, "" };
+                    foreach (var invalidPartitionId in invalidPartitions)
+                    {
+                        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                        {
+                            TestUtility.Log($"Receiving from invalid partition {invalidPartitionId}");
+                            receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, invalidPartitionId, EventPosition.FromStart());
+                            await receiver.ReceiveAsync(1);
+                        });
+                        await receiver.CloseAsync();
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -129,41 +136,45 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendToInvalidPartition()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            PartitionSender sender = null;
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                // Some invalid partition values.
-                var invalidPartitions = new List<string>() { "XYZ", "-1", "1000", "-" };
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                PartitionSender sender = null;
 
-                foreach (var invalidPartitionId in invalidPartitions)
+                try
                 {
-                    await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
-                    {
-                        TestUtility.Log($"Sending to invalid partition {invalidPartitionId}");
-                        sender = ehClient.CreatePartitionSender(invalidPartitionId);
-                        await sender.SendAsync(new EventData(new byte[1]));
-                    });
-                    await sender.CloseAsync();
-                }
+                    // Some invalid partition values.
+                    var invalidPartitions = new List<string>() { "XYZ", "-1", "1000", "-" };
 
-                // Some other invalid partition values. These will fail on the client side.
-                invalidPartitions = new List<string>() { "", " ", null };
-                foreach (var invalidPartitionId in invalidPartitions)
-                {
-                    await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                    foreach (var invalidPartitionId in invalidPartitions)
                     {
-                        TestUtility.Log($"Sending to invalid partition {invalidPartitionId}");
-                        sender = ehClient.CreatePartitionSender(invalidPartitionId);
-                        await sender.SendAsync(new EventData(new byte[1]));
-                    });
-                    await sender.CloseAsync();
+                        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                        {
+                            TestUtility.Log($"Sending to invalid partition {invalidPartitionId}");
+                            sender = ehClient.CreatePartitionSender(invalidPartitionId);
+                            await sender.SendAsync(new EventData(new byte[1]));
+                        });
+                        await sender.CloseAsync();
+                    }
+
+                    // Some other invalid partition values. These will fail on the client side.
+                    invalidPartitions = new List<string>() { "", " ", null };
+                    foreach (var invalidPartitionId in invalidPartitions)
+                    {
+                        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                        {
+                            TestUtility.Log($"Sending to invalid partition {invalidPartitionId}");
+                            sender = ehClient.CreatePartitionSender(invalidPartitionId);
+                            await sender.SendAsync(new EventData(new byte[1]));
+                        });
+                        await sender.CloseAsync();
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -172,53 +183,57 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task GetPartitionRuntimeInformationFromInvalidPartition()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                // Some invalid partition values. These will fail on the service side.
-                var invalidPartitions = new List<string>() { "XYZ", "-1", "1000", "-" };
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-                foreach (var invalidPartitionId in invalidPartitions)
+                try
                 {
-                    await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
-                    {
-                        TestUtility.Log($"Getting partition information from invalid partition {invalidPartitionId}");
-                        await ehClient.GetPartitionRuntimeInformationAsync(invalidPartitionId);
-                    });
-                }
+                    // Some invalid partition values. These will fail on the service side.
+                    var invalidPartitions = new List<string>() { "XYZ", "-1", "1000", "-" };
 
-                // Some other invalid partition values. These will fail on the client side.
-                invalidPartitions = new List<string>() { "", " ", null };
-                foreach (var invalidPartitionId in invalidPartitions)
-                {
-                    await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                    foreach (var invalidPartitionId in invalidPartitions)
                     {
-                        TestUtility.Log($"Getting partition information from invalid partition {invalidPartitionId}");
-                        await ehClient.GetPartitionRuntimeInformationAsync(invalidPartitionId);
-                    });
+                        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(async () =>
+                        {
+                            TestUtility.Log($"Getting partition information from invalid partition {invalidPartitionId}");
+                            await ehClient.GetPartitionRuntimeInformationAsync(invalidPartitionId);
+                        });
+                    }
+
+                    // Some other invalid partition values. These will fail on the client side.
+                    invalidPartitions = new List<string>() { "", " ", null };
+                    foreach (var invalidPartitionId in invalidPartitions)
+                    {
+                        await Assert.ThrowsAsync<ArgumentNullException>(async () =>
+                        {
+                            TestUtility.Log($"Getting partition information from invalid partition {invalidPartitionId}");
+                            await ehClient.GetPartitionRuntimeInformationAsync(invalidPartitionId);
+                        });
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public async Task CreateClientWithoutEntityPathShouldFail()
         {
-            // Remove entity path from connection string.
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            csb.EntityPath = null;
+           // Remove entity path from connection string.
+           var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
+           csb.EntityPath = null;
 
-            await Assert.ThrowsAsync<ArgumentNullException>(() =>
-            {
-                EventHubClient.CreateFromConnectionString(csb.ToString());
-                throw new Exception("Entity path wasn't provided in the connection string and this new call was supposed to fail");
-            });
+           await Assert.ThrowsAsync<ArgumentNullException>(() =>
+           {
+           EventHubClient.CreateFromConnectionString(csb.ToString());
+           throw new Exception("Entity path wasn't provided in the connection string and this new call was supposed to fail");
+           });
+            
         }
 
         [Fact]
@@ -226,25 +241,28 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task MessageSizeExceededException()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-            try
-            {
-                await Assert.ThrowsAsync<MessageSizeExceededException>(async () =>
+                try
                 {
-                    TestUtility.Log("Sending large event via EventHubClient.SendAsync(EventData)");
-                    var eventData = new EventData(new byte[1100000]);
-                    await ehClient.SendAsync(eventData);
-                });
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                    await Assert.ThrowsAsync<MessageSizeExceededException>(async () =>
+                    {
+                        TestUtility.Log("Sending large event via EventHubClient.SendAsync(EventData)");
+                        var eventData = new EventData(new byte[1100000]);
+                        await ehClient.SendAsync(eventData);
+                    });
+                }
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public async Task NullBodyShouldFail()
         {
@@ -260,30 +278,34 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task InvalidPrefetchCount()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var receiver =ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+
+                try
                 {
-                    receiver.PrefetchCount = 3;
-                    throw new Exception("Setting PrefetchCount to 3 didn't fail.");
-                });
+                    await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+                    {
+                        receiver.PrefetchCount = 3;
+                        throw new Exception("Setting PrefetchCount to 3 didn't fail.");
+                    });
 
-                TestUtility.Log("Setting PrefetchCount to 10.");
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-                receiver.PrefetchCount = 10;
+                    TestUtility.Log("Setting PrefetchCount to 10.");
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                    receiver.PrefetchCount = 10;
 
-                TestUtility.Log("Setting PrefetchCount to int.MaxValue.");
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-                receiver.PrefetchCount = int.MaxValue;
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    receiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                    TestUtility.Log("Setting PrefetchCount to int.MaxValue.");
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                    receiver.PrefetchCount = int.MaxValue;
+                }
+                finally
+                {
+                    await Task.WhenAll(
+                        receiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
     }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ClientNegativeCases.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ClientNegativeCases.cs
@@ -221,6 +221,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 
         [Fact]
+        [LiveTest]
         [DisplayTestMethodName]
         public async Task CreateClientWithoutEntityPathShouldFail()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ClientNegativeCases.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ClientNegativeCases.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task NonexistentEntity()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 PartitionReceiver receiver = null;
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task ReceiveFromInvalidPartition()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendToInvalidPartition()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task GetPartitionRuntimeInformationFromInvalidPartition()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -221,7 +221,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public async Task CreateClientWithoutEntityPathShouldFail()
         {
@@ -242,7 +241,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task MessageSizeExceededException()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -279,7 +278,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task InvalidPrefetchCount()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             Assert.True(csbNew.EntityPath == csb.EntityPath, $"Original and New CSB mismatch at EntityPath. Original: {csb.EntityPath} New: {csbNew.EntityPath}");
         }
 
-        [Fact]   
+        [Fact]
         [DisplayTestMethodName]
         public void InvalidConnectionStrings()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     public class ConnectionStringBuilderTests
     {
         [Fact]
+        [LiveTest]
         [DisplayTestMethodName]
         public void ParseAndBuild()
         {
@@ -82,7 +83,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             Assert.True(csbNew.EntityPath == csb.EntityPath, $"Original and New CSB mismatch at EntityPath. Original: {csb.EntityPath} New: {csbNew.EntityPath}");
         }
 
-        [Fact]
+        [Fact]   
         [DisplayTestMethodName]
         public void InvalidConnectionStrings()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     public class ConnectionStringBuilderTests
     {
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public void ParseAndBuild()
         {
@@ -119,39 +118,43 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task UseSharedAccessSignatureApi()
         {
-            // Generate shared access token.
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(csb.SasKeyName, csb.SasKey);
-            var token = await tokenProvider.GetTokenAsync(csb.Endpoint.ToString(), TimeSpan.FromSeconds(120));
-            var sharedAccessSignature = token.TokenValue.ToString();
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Generate shared access token.
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
+                var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(csb.SasKeyName, csb.SasKey);
+                var token = await tokenProvider.GetTokenAsync(csb.Endpoint.ToString(), TimeSpan.FromSeconds(120));
+                var sharedAccessSignature = token.TokenValue.ToString();
 
-            // Create connection string builder by SharedAccessSignature overload.
-            var csbNew = new EventHubsConnectionStringBuilder(csb.Endpoint, csb.EntityPath, sharedAccessSignature, TimeSpan.FromSeconds(60));
+                // Create connection string builder by SharedAccessSignature overload.
+                var csbNew = new EventHubsConnectionStringBuilder(csb.Endpoint, csb.EntityPath, sharedAccessSignature, TimeSpan.FromSeconds(60));
 
-            // Create new client with updated connection string.
-            var ehClient = EventHubClient.CreateFromConnectionString(csbNew.ToString());
+                // Create new client with updated connection string.
+                var ehClient = EventHubClient.CreateFromConnectionString(csbNew.ToString());
 
-            // Send one event
-            TestUtility.Log("Sending one message.");
-            var ehSender = ehClient.CreatePartitionSender("0");
-            var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!"));
-            await ehSender.SendAsync(eventData);
+                // Send one event
+                TestUtility.Log("Sending one message.");
+                var ehSender = ehClient.CreatePartitionSender("0");
+                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!"));
+                await ehSender.SendAsync(eventData);
 
-            // Receive event.
-            TestUtility.Log("Receiving one message.");
-            var ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-            var msg = await ehReceiver.ReceiveAsync(1);
-            Assert.True(msg != null, "Failed to receive message.");
+                // Receive event.
+                TestUtility.Log("Receiving one message.");
+                var ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                var msg = await ehReceiver.ReceiveAsync(1);
+                Assert.True(msg != null, "Failed to receive message.");
 
-            // Get EH runtime information.
-            TestUtility.Log("Getting Event Hub runtime information.");
-            var ehInfo = await ehClient.GetRuntimeInformationAsync();
-            Assert.True(ehInfo != null, "Failed to get runtime information.");
+                // Get EH runtime information.
+                TestUtility.Log("Getting Event Hub runtime information.");
+                var ehInfo = await ehClient.GetRuntimeInformationAsync();
+                Assert.True(ehInfo != null, "Failed to get runtime information.");
 
-            // Get EH partition runtime information.
-            TestUtility.Log("Getting Event Hub partition '0' runtime information.");
-            var partitionInfo = await ehClient.GetPartitionRuntimeInformationAsync("0");
-            Assert.True(ehInfo != null, "Failed to get runtime partition information.");
+                // Get EH partition runtime information.
+                TestUtility.Log("Getting Event Hub partition '0' runtime information.");
+                var partitionInfo = await ehClient.GetPartitionRuntimeInformationAsync("0");
+                Assert.True(ehInfo != null, "Failed to get runtime partition information.");
+            }
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     public class ConnectionStringBuilderTests
     {
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public void ParseAndBuild()
         {
@@ -119,7 +118,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task UseSharedAccessSignatureApi()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Generate shared access token.

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ConnectionStringBuilderTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     public class ConnectionStringBuilderTests
     {
         [Fact]
+        [LiveTest]
         [DisplayTestMethodName]
         public void ParseAndBuild()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/DataBatchTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/DataBatchTests.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendingPartitionKeyBatchOnPartitionSenderShouldFail()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreatingPartitionKeyBatchOnPartitionSenderShouldFail()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             int maxPayloadSize = 1024,
             int minimumNumberOfMessagesToSend = 1000)
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/DataBatchTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/DataBatchTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task AllowFirstMessageInBatch()
         {
-            await SendWithEventDataBatch(maxPayloadSize: 900 * 1024 , minimumNumberOfMessagesToSend: 1);
+            await SendWithEventDataBatch(maxPayloadSize: 900 * 1024, minimumNumberOfMessagesToSend: 1);
         }
 
         /// <summary>
@@ -75,30 +75,33 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendingPartitionKeyBatchOnPartitionSenderShouldFail()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionSender = ehClient.CreatePartitionSender("0");
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                var batchOptions = new BatchOptions()
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionSender = ehClient.CreatePartitionSender("0");
+                try
                 {
-                    PartitionKey = "this is the partition key"
-                };
-                var batcher = ehClient.CreateBatch(batchOptions);
+                    var batchOptions = new BatchOptions()
+                    {
+                        PartitionKey = "this is the partition key"
+                    };
+                    var batcher = ehClient.CreateBatch(batchOptions);
 
-                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    {
+                        TestUtility.Log("Attempting to send a partition-key batch on partition sender. This should fail.");
+                        await partitionSender.SendAsync(batcher);
+                    });
+                }
+                finally
                 {
-                    TestUtility.Log("Attempting to send a partition-key batch on partition sender. This should fail.");
-                    await partitionSender.SendAsync(batcher);
-                });
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    partitionSender.CloseAsync(),
-                    ehClient.CloseAsync());
+                    await Task.WhenAll(
+                        partitionSender.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
-
         /// <summary>
         /// PartitionSender should not allow to create a batch with partition key defined.
         /// </summary>
@@ -107,25 +110,29 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreatingPartitionKeyBatchOnPartitionSenderShouldFail()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionSender = ehClient.CreatePartitionSender("0");
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionSender = ehClient.CreatePartitionSender("0");
 
-            try
-            {
-                Assert.Throws<InvalidOperationException>(() =>
+                try
                 {
-                    TestUtility.Log("Attempting to create a partition-key batch on partition sender. This should fail.");
-                    partitionSender.CreateBatch(new BatchOptions()
+                    Assert.Throws<InvalidOperationException>(() =>
                     {
-                        PartitionKey = "this is the key to fail"
+                        TestUtility.Log("Attempting to create a partition-key batch on partition sender. This should fail.");
+                        partitionSender.CreateBatch(new BatchOptions()
+                        {
+                            PartitionKey = "this is the key to fail"
+                        });
                     });
-                });
-            }
-            finally
-            {
-               await Task.WhenAll(
-                   partitionSender.CloseAsync(),
-                   ehClient.CloseAsync());
+                }
+                finally
+                {
+                    await Task.WhenAll(
+                        partitionSender.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -134,91 +141,95 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             int maxPayloadSize = 1024,
             int minimumNumberOfMessagesToSend = 1000)
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitions = await this.GetPartitionsAsync(ehClient);
-            var receivers = new List<PartitionReceiver>();
-
-            // Create partition receivers starting from the end of the stream.
-            TestUtility.Log("Discovering end of stream on each partition.");
-            foreach (var partitionId in partitions)
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                var lastEvent = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
-                receivers.Add(ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(lastEvent.LastEnqueuedOffset)));
-            }
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitions = await this.GetPartitionsAsync(ehClient);
+                var receivers = new List<PartitionReceiver>();
 
-            try
-            {
-                // Start receicing messages now.
-                var receiverTasks = new List<Task<List<EventData>>>();
-                foreach (var receiver in receivers)
+                // Create partition receivers starting from the end of the stream.
+                TestUtility.Log("Discovering end of stream on each partition.");
+                foreach (var partitionId in partitions)
                 {
-                    receiverTasks.Add(ReceiveAllMessagesAsync(receiver));
+                    var lastEvent = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                    receivers.Add(ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(lastEvent.LastEnqueuedOffset)));
                 }
 
-                // Create initial batcher.
-                EventDataBatch batcher = null;
-
-                // We will send a thousand messages where each message is 1K.
-                var totalSent = 0;
-                var rnd = new Random();
-                TestUtility.Log("Starting to send.");
-                do
+                try
                 {
-                    if (batcher == null)
+                    // Start receicing messages now.
+                    var receiverTasks = new List<Task<List<EventData>>>();
+                    foreach (var receiver in receivers)
                     {
-                        // Exercise both CreateBatch overloads.
-                        if (partitionKey != null)
+                        receiverTasks.Add(ReceiveAllMessagesAsync(receiver));
+                    }
+
+                    // Create initial batcher.
+                    EventDataBatch batcher = null;
+
+                    // We will send a thousand messages where each message is 1K.
+                    var totalSent = 0;
+                    var rnd = new Random();
+                    TestUtility.Log("Starting to send.");
+                    do
+                    {
+                        if (batcher == null)
                         {
-                            batcher = ehClient.CreateBatch(new BatchOptions()
+                            // Exercise both CreateBatch overloads.
+                            if (partitionKey != null)
                             {
-                                PartitionKey = partitionKey
-                            });
+                                batcher = ehClient.CreateBatch(new BatchOptions()
+                                {
+                                    PartitionKey = partitionKey
+                                });
+                            }
+                            else
+                            {
+                                batcher = ehClient.CreateBatch();
+                            }
                         }
-                        else
+
+                        // Send random body size.
+                        var ed = new EventData(new byte[rnd.Next(0, maxPayloadSize)]);
+                        if (!batcher.TryAdd(ed) || totalSent + batcher.Count >= minimumNumberOfMessagesToSend)
                         {
-                            batcher = ehClient.CreateBatch();
+                            await ehClient.SendAsync(batcher);
+                            totalSent += batcher.Count;
+                            TestUtility.Log($"Sent {batcher.Count} messages in the batch.");
+                            batcher = null;
                         }
-                    }
+                    } while (totalSent < minimumNumberOfMessagesToSend);
 
-                    // Send random body size.
-                    var ed = new EventData(new byte[rnd.Next(0, maxPayloadSize)]);
-                    if (!batcher.TryAdd(ed) || totalSent + batcher.Count >= minimumNumberOfMessagesToSend)
+                    TestUtility.Log($"{totalSent} messages sent in total.");
+
+                    var pReceived = await Task.WhenAll(receiverTasks);
+                    var totalReceived = pReceived.Sum(p => p.Count);
+                    TestUtility.Log($"{totalReceived} messages received in total.");
+
+                    // Sent at least a message?
+                    Assert.True(totalSent > 0, $"Client was not able to send any messages.");
+
+                    // All messages received?
+                    Assert.True(totalReceived == totalSent, $"Sent {totalSent}, but received {totalReceived} messages.");
+
+                    if (partitionKey != null)
                     {
-                        await ehClient.SendAsync(batcher);
-                        totalSent += batcher.Count;
-                        TestUtility.Log($"Sent {batcher.Count} messages in the batch.");
-                        batcher = null;
+                        // Partition key is set then we expect all messages from the same partition.
+                        Assert.True(pReceived.Count(p => p.Count > 0) == 1, "Received messsages from multiple partitions.");
+
+                        // Find target partition.
+                        var targetPartition = pReceived.Single(p => p.Count > 0);
+
+                        // Validate partition key is delivered on all messages.
+                        Assert.True(!targetPartition.Any(p => p.SystemProperties.PartitionKey != partitionKey), "Identified at least one event with a different partition key value.");
                     }
-                } while (totalSent < minimumNumberOfMessagesToSend);
-
-                TestUtility.Log($"{totalSent} messages sent in total.");
-
-                var pReceived = await Task.WhenAll(receiverTasks);
-                var totalReceived = pReceived.Sum(p => p.Count);
-                TestUtility.Log($"{totalReceived} messages received in total.");
-
-                // Sent at least a message?
-                Assert.True(totalSent > 0, $"Client was not able to send any messages.");
-
-                // All messages received?
-                Assert.True(totalReceived == totalSent, $"Sent {totalSent}, but received {totalReceived} messages.");
-
-                if (partitionKey != null)
-                {
-                    // Partition key is set then we expect all messages from the same partition.
-                    Assert.True(pReceived.Count(p => p.Count > 0) == 1, "Received messsages from multiple partitions.");
-
-                    // Find target partition.
-                    var targetPartition = pReceived.Single(p => p.Count > 0);
-
-                    // Validate partition key is delivered on all messages.
-                    Assert.True(!targetPartition.Any(p => p.SystemProperties.PartitionKey != partitionKey), "Identified at least one event with a different partition key value.");
                 }
-            }
-            finally
-            {
-                await Task.WhenAll(receivers.Select(r => r.CloseAsync()));
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await Task.WhenAll(receivers.Select(r => r.CloseAsync()));
+                    await ehClient.CloseAsync();
+                }
             }
         }
     }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/DiagnosticsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/DiagnosticsTests.cs
@@ -80,51 +80,55 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendFiresEvents()
         {
-            var partitionKey = "SomePartitionKeyHere";
-            var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
-            var eventQueue = this.CreateEventQueue();
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            TestUtility.Log("Sending single Event via EventHubClient produces diagnostic events");
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                using (var listener = this.CreateEventListener(null, eventQueue))
-                using (var subscription = this.SubscribeToEvents(listener))
-                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!")))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var partitionKey = "SomePartitionKeyHere";
+                var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
+                var eventQueue = this.CreateEventQueue();
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
+                TestUtility.Log("Sending single Event via EventHubClient produces diagnostic events");
+
+                try
                 {
-                    // enable Send .Start & .Stop events
-                    listener.Enable((name, queueName, arg) => name.Contains("Send") && !name.EndsWith(".Exception"));
+                    using (var listener = this.CreateEventListener(null, eventQueue))
+                    using (var subscription = this.SubscribeToEvents(listener))
+                    using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!")))
+                    {
+                        // enable Send .Start & .Stop events
+                        listener.Enable((name, queueName, arg) => name.Contains("Send") && !name.EndsWith(".Exception"));
 
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
 
-                    parentActivity.Start();
+                        parentActivity.Start();
 
-                    await ehClient.SendAsync(eventData, partitionKey);
+                        await ehClient.SendAsync(eventData, partitionKey);
 
-                    parentActivity.Stop();
+                        parentActivity.Stop();
 
-                    // check Diagnostic-Id injection
-                    Assert.True(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        // check Diagnostic-Id injection
+                        Assert.True(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
 
-                    // check Correlation-Context injection
-                    Assert.True(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
-                    Assert.Equal(EventHubsDiagnosticSource.SerializeCorrelationContext(parentActivity.Baggage.ToList()), eventData.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName]);
+                        // check Correlation-Context injection
+                        Assert.True(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+                        Assert.Equal(EventHubsDiagnosticSource.SerializeCorrelationContext(parentActivity.Baggage.ToList()), eventData.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName]);
 
-                    Assert.True(eventQueue.TryDequeue(out var sendStart));
-                    AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, parentActivity, partitionKey, ehClient.ConnectionStringBuilder);
+                        Assert.True(eventQueue.TryDequeue(out var sendStart));
+                        AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, parentActivity, partitionKey, ehClient.ConnectionStringBuilder);
 
-                    Assert.True(eventQueue.TryDequeue(out var sendStop));
-                    AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity, partitionKey, ehClient.ConnectionStringBuilder);
+                        Assert.True(eventQueue.TryDequeue(out var sendStop));
+                        AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity, partitionKey, ehClient.ConnectionStringBuilder);
 
-                    // no more events
-                    Assert.False(eventQueue.TryDequeue(out var evnt));
+                        // no more events
+                        Assert.False(eventQueue.TryDequeue(out var evnt));
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -133,98 +137,104 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendDoesNotInjectContextWhenNoListeners()
         {
-            var partitionKey = "SomePartitionKeyHere";
-            var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
-            var eventQueue = this.CreateEventQueue();
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            TestUtility.Log("Sending single Event via EventHubClient produces diagnostic events");
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                using (var listener = this.CreateEventListener(null, eventQueue))
-                using (var subscription = this.SubscribeToEvents(listener))
-                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!")))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var partitionKey = "SomePartitionKeyHere";
+                var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
+                var eventQueue = this.CreateEventQueue();
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
+                TestUtility.Log("Sending single Event via EventHubClient produces diagnostic events");
+
+                try
                 {
-                    // disable all events
-                    listener.Enable((name, queueName, arg) => false);
+                    using (var listener = this.CreateEventListener(null, eventQueue))
+                    using (var subscription = this.SubscribeToEvents(listener))
+                    using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!")))
+                    {
+                        // disable all events
+                        listener.Enable((name, queueName, arg) => false);
 
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
 
-                    parentActivity.Start();
+                        parentActivity.Start();
 
-                    await ehClient.SendAsync(eventData, partitionKey);
+                        await ehClient.SendAsync(eventData, partitionKey);
 
-                    parentActivity.Stop();
+                        parentActivity.Stop();
 
-                    // check Diagnostic-Id not injected
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        // check Diagnostic-Id not injected
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
 
-                    // check Correlation-Context not injected
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+                        // check Correlation-Context not injected
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
 
-                    // no events
-                    Assert.False(eventQueue.TryDequeue(out var evnt));
+                        // no events
+                        Assert.False(eventQueue.TryDequeue(out var evnt));
+                    }
+                }
+                finally
+                {
+                    await ehClient.CloseAsync();
                 }
             }
-            finally
-            {
-                await ehClient.CloseAsync();
-            }
         }
-
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task SendFiresExceptionEvents()
         {
-            var partitionKey = "SomePartitionKeyHere";
-            var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
-            var eventQueue = this.CreateEventQueue();
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            TestUtility.Log("Sending single Event via EventHubClient produces diagnostic events for exception");
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                using (var listener = this.CreateEventListener(null, eventQueue))
-                using (var subscription = this.SubscribeToEvents(listener))
-                using (var eventData = new EventData(new byte[300 * 1024 * 1024]))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var partitionKey = "SomePartitionKeyHere";
+                var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
+                var eventQueue = this.CreateEventQueue();
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
+                TestUtility.Log("Sending single Event via EventHubClient produces diagnostic events for exception");
+
+                try
                 {
-                    // enable Send .Exception & .Stop events
-                    listener.Enable((name, queueName, arg) => name.Contains("Send") && !name.EndsWith(".Start"));
-                    parentActivity.Start();
-
-                    // Events data size limit is 256kb - larger one will results in exception from within Send method
-                    try
+                    using (var listener = this.CreateEventListener(null, eventQueue))
+                    using (var subscription = this.SubscribeToEvents(listener))
+                    using (var eventData = new EventData(new byte[300 * 1024 * 1024]))
                     {
-                        await ehClient.SendAsync(eventData, partitionKey);
-                        Assert.True(false, "Exception was expected but not thrown");
+                        // enable Send .Exception & .Stop events
+                        listener.Enable((name, queueName, arg) => name.Contains("Send") && !name.EndsWith(".Start"));
+                        parentActivity.Start();
+
+                        // Events data size limit is 256kb - larger one will results in exception from within Send method
+                        try
+                        {
+                            await ehClient.SendAsync(eventData, partitionKey);
+                            Assert.True(false, "Exception was expected but not thrown");
+                        }
+                        catch (Exception)
+                        { }
+
+                        parentActivity.Stop();
+
+                        Assert.True(eventQueue.TryDequeue(out var exception));
+                        AssertSendException(exception.eventName, exception.payload, exception.activity, null, partitionKey, ehClient.ConnectionStringBuilder);
+
+                        Assert.True(eventQueue.TryDequeue(out var sendStop));
+                        AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, null, partitionKey, ehClient.ConnectionStringBuilder, isFaulted: true);
+
+                        Assert.Equal(sendStop.activity, exception.activity);
+
+                        // no more events
+                        Assert.False(eventQueue.TryDequeue(out var evnt));
                     }
-                    catch (Exception)
-                    { }
-
-                    parentActivity.Stop();
-
-                    Assert.True(eventQueue.TryDequeue(out var exception));
-                    AssertSendException(exception.eventName, exception.payload, exception.activity, null, partitionKey, ehClient.ConnectionStringBuilder);
-
-                    Assert.True(eventQueue.TryDequeue(out var sendStop));
-                    AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, null, partitionKey, ehClient.ConnectionStringBuilder, isFaulted: true);
-
-                    Assert.Equal(sendStop.activity, exception.activity);
-
-                    // no more events
-                    Assert.False(eventQueue.TryDequeue(out var evnt));
+                }
+                finally
+                {
+                    await ehClient.CloseAsync();
                 }
             }
-            finally
-            {
-                await ehClient.CloseAsync();
-            }
         }
-
         #endregion Send
 
         #region Partition Sender
@@ -234,61 +244,65 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionSenderSendFiresEvents()
         {
-            var partitionKey = "1";
-            var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
-            var eventQueue = this.CreateEventQueue();
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionSender1 = default(PartitionSender);
-
-            TestUtility.Log("Sending single Event via PartitionSender produces diagnostic events");
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                using (var listener = this.CreateEventListener(null, eventQueue))
-                using (var subscription = this.SubscribeToEvents(listener))
-                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello again EventHub Partition 1!")))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var partitionKey = "1";
+                var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
+                var eventQueue = this.CreateEventQueue();
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionSender1 = default(PartitionSender);
+
+                TestUtility.Log("Sending single Event via PartitionSender produces diagnostic events");
+
+                try
                 {
-                    partitionSender1 = ehClient.CreatePartitionSender(partitionKey);
-
-                    // enable Send .Start & .Stop events
-                    listener.Enable((name, queueName, arg) => name.Contains("Send") && !name.EndsWith(".Exception"));
-
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
-
-                    parentActivity.Start();
-
-                    try
+                    using (var listener = this.CreateEventListener(null, eventQueue))
+                    using (var subscription = this.SubscribeToEvents(listener))
+                    using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello again EventHub Partition 1!")))
                     {
-                        await partitionSender1.SendAsync(eventData);
+                        partitionSender1 = ehClient.CreatePartitionSender(partitionKey);
+
+                        // enable Send .Start & .Stop events
+                        listener.Enable((name, queueName, arg) => name.Contains("Send") && !name.EndsWith(".Exception"));
+
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+
+                        parentActivity.Start();
+
+                        try
+                        {
+                            await partitionSender1.SendAsync(eventData);
+                        }
+                        finally
+                        {
+                            await partitionSender1.CloseAsync();
+                        }
+
+                        parentActivity.Stop();
+
+                        // check Diagnostic-Id injection
+                        Assert.True(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+
+                        // check Correlation-Context injection
+                        Assert.True(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+                        Assert.Equal(EventHubsDiagnosticSource.SerializeCorrelationContext(parentActivity.Baggage.ToList()), eventData.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName]);
+
+                        Assert.True(eventQueue.TryDequeue(out var sendStart));
+                        AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, parentActivity, partitionKey, ehClient.ConnectionStringBuilder);
+
+                        Assert.True(eventQueue.TryDequeue(out var sendStop));
+                        AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity, partitionKey, ehClient.ConnectionStringBuilder);
+
+                        // no more events
+                        Assert.False(eventQueue.TryDequeue(out var evnt));
                     }
-                    finally
-                    {
-                        await partitionSender1.CloseAsync();
-                    }
-
-                    parentActivity.Stop();
-
-                    // check Diagnostic-Id injection
-                    Assert.True(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-
-                    // check Correlation-Context injection
-                    Assert.True(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
-                    Assert.Equal(EventHubsDiagnosticSource.SerializeCorrelationContext(parentActivity.Baggage.ToList()), eventData.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName]);
-
-                    Assert.True(eventQueue.TryDequeue(out var sendStart));
-                    AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, parentActivity, partitionKey, ehClient.ConnectionStringBuilder);
-
-                    Assert.True(eventQueue.TryDequeue(out var sendStop));
-                    AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity, partitionKey, ehClient.ConnectionStringBuilder);
-
-                    // no more events
-                    Assert.False(eventQueue.TryDequeue(out var evnt));
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -297,54 +311,58 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionSenderSendDoesNotInjectContextWhenNoListeners()
         {
-            var partitionKey = "1";
-            var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
-            var eventQueue = this.CreateEventQueue();
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionSender1 = default(PartitionSender);
-
-            TestUtility.Log("Sending single Event via PartitionSender produces diagnostic events");
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                using (var listener = this.CreateEventListener(null, eventQueue))
-                using (var subscription = this.SubscribeToEvents(listener))
-                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello again EventHub Partition 1!")))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var partitionKey = "1";
+                var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
+                var eventQueue = this.CreateEventQueue();
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionSender1 = default(PartitionSender);
+
+                TestUtility.Log("Sending single Event via PartitionSender produces diagnostic events");
+
+                try
                 {
-                    partitionSender1 = ehClient.CreatePartitionSender(partitionKey);
-
-                    // disable all events
-                    listener.Enable((name, queueName, arg) => false);
-
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
-
-                    parentActivity.Start();
-
-                    try
+                    using (var listener = this.CreateEventListener(null, eventQueue))
+                    using (var subscription = this.SubscribeToEvents(listener))
+                    using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello again EventHub Partition 1!")))
                     {
-                        await partitionSender1.SendAsync(eventData);
+                        partitionSender1 = ehClient.CreatePartitionSender(partitionKey);
+
+                        // disable all events
+                        listener.Enable((name, queueName, arg) => false);
+
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+
+                        parentActivity.Start();
+
+                        try
+                        {
+                            await partitionSender1.SendAsync(eventData);
+                        }
+                        finally
+                        {
+                            await partitionSender1.CloseAsync();
+                        }
+
+                        parentActivity.Stop();
+
+                        // check Diagnostic-Id not injected
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+
+                        // check Correlation-Context not injected
+                        Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+
+                        // no events
+                        Assert.False(eventQueue.TryDequeue(out var evnt));
                     }
-                    finally
-                    {
-                        await partitionSender1.CloseAsync();
-                    }
-
-                    parentActivity.Stop();
-
-                    // check Diagnostic-Id not injected
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-
-                    // check Correlation-Context not injected
-                    Assert.False(eventData.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
-
-                    // no events
-                    Assert.False(eventQueue.TryDequeue(out var evnt));
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -353,56 +371,59 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionSenderSendFiresExceptionEvents()
         {
-            var partitionKey = "1";
-            var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
-            var eventQueue = this.CreateEventQueue();
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionSender1 = default(PartitionSender);
-
-            TestUtility.Log("Sending single Event via PartitionSender produces diagnostic events for exception");
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                using (var listener = this.CreateEventListener(null, eventQueue))
-                using (var subscription = this.SubscribeToEvents(listener))
-                using (var eventData = new EventData(new byte[300 * 1024 * 1024]))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var partitionKey = "1";
+                var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
+                var eventQueue = this.CreateEventQueue();
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionSender1 = default(PartitionSender);
+
+                TestUtility.Log("Sending single Event via PartitionSender produces diagnostic events for exception");
+
+                try
                 {
-                    partitionSender1 = ehClient.CreatePartitionSender(partitionKey);
-
-                    // enable Send .Exception & .Stop events
-                    listener.Enable((name, queueName, arg) => name.Contains("Send") && !name.EndsWith(".Start"));
-                    parentActivity.Start();
-
-                    try
+                    using (var listener = this.CreateEventListener(null, eventQueue))
+                    using (var subscription = this.SubscribeToEvents(listener))
+                    using (var eventData = new EventData(new byte[300 * 1024 * 1024]))
                     {
-                        // Events data size limit is 256kb - larger one will results in exception from within Send method
-                        await Assert.ThrowsAsync<MessageSizeExceededException>( () => partitionSender1.SendAsync(eventData));
+                        partitionSender1 = ehClient.CreatePartitionSender(partitionKey);
+
+                        // enable Send .Exception & .Stop events
+                        listener.Enable((name, queueName, arg) => name.Contains("Send") && !name.EndsWith(".Start"));
+                        parentActivity.Start();
+
+                        try
+                        {
+                            // Events data size limit is 256kb - larger one will results in exception from within Send method
+                            await Assert.ThrowsAsync<MessageSizeExceededException>(() => partitionSender1.SendAsync(eventData));
+                        }
+                        finally
+                        {
+                            await partitionSender1.CloseAsync();
+                        }
+
+                        parentActivity.Stop();
+
+                        Assert.True(eventQueue.TryDequeue(out var exception));
+                        AssertSendException(exception.eventName, exception.payload, exception.activity, null, partitionKey, ehClient.ConnectionStringBuilder);
+
+                        Assert.True(eventQueue.TryDequeue(out var sendStop));
+                        AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, null, partitionKey, ehClient.ConnectionStringBuilder, isFaulted: true);
+
+                        Assert.Equal(sendStop.activity, exception.activity);
+
+                        // no more events
+                        Assert.False(eventQueue.TryDequeue(out var evnt));
                     }
-                    finally
-                    {
-                        await partitionSender1.CloseAsync();
-                    }
-
-                    parentActivity.Stop();
-
-                    Assert.True(eventQueue.TryDequeue(out var exception));
-                    AssertSendException(exception.eventName, exception.payload, exception.activity, null, partitionKey, ehClient.ConnectionStringBuilder);
-
-                    Assert.True(eventQueue.TryDequeue(out var sendStop));
-                    AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, null, partitionKey, ehClient.ConnectionStringBuilder, isFaulted: true);
-
-                    Assert.Equal(sendStop.activity, exception.activity);
-
-                    // no more events
-                    Assert.False(eventQueue.TryDequeue(out var evnt));
+                }
+                finally
+                {
+                    await ehClient.CloseAsync();
                 }
             }
-            finally
-            {
-                await ehClient.CloseAsync();
-            }
         }
-
         #endregion Partition Sender
 
         #region Partition Receiver
@@ -412,75 +433,79 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionReceiverReceiveFiresEvents()
         {
-            var partitionKey = "2";
-            var payloadString = "Hello EventHub!";
-            var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
-            var eventQueue = this.CreateEventQueue();
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            TestUtility.Log("Receiving Events via PartitionReceiver produces diagnostic events");
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                using (var listener = this.CreateEventListener(null, eventQueue))
-                using (var subscription = this.SubscribeToEvents(listener))
-                using (var sendEvent = new EventData(Encoding.UTF8.GetBytes(payloadString)))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var partitionKey = "2";
+                var payloadString = "Hello EventHub!";
+                var parentActivity = new Activity("test").AddBaggage("k1", "v1").AddBaggage("k2", "v2");
+                var eventQueue = this.CreateEventQueue();
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
+                TestUtility.Log("Receiving Events via PartitionReceiver produces diagnostic events");
+
+                try
                 {
-                    // enable Send & Receive .Start & .Stop events
-                    listener.Enable((name, queueName, arg) => !name.EndsWith(".Exception"));
+                    using (var listener = this.CreateEventListener(null, eventQueue))
+                    using (var subscription = this.SubscribeToEvents(listener))
+                    using (var sendEvent = new EventData(Encoding.UTF8.GetBytes(payloadString)))
+                    {
+                        // enable Send & Receive .Start & .Stop events
+                        listener.Enable((name, queueName, arg) => !name.EndsWith(".Exception"));
 
-                    // send to have some data to receive
-                    Assert.False(sendEvent.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-                    Assert.False(sendEvent.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+                        // send to have some data to receive
+                        Assert.False(sendEvent.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        Assert.False(sendEvent.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
 
-                    parentActivity.Start();
+                        parentActivity.Start();
 
-                    // Mark end of stream before sending.
-                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionKey);
+                        // Mark end of stream before sending.
+                        var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionKey);
 
-                    await TestUtility.SendToPartitionAsync(ehClient, partitionKey, sendEvent, 1);
+                        await TestUtility.SendToPartitionAsync(ehClient, partitionKey, sendEvent, 1);
 
-                    // Create receiver from marked offset.
-                    var receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionKey, EventPosition.FromOffset(pInfo.LastEnqueuedOffset));
-                    var messages = await receiver.ReceiveAsync(10);
+                        // Create receiver from marked offset.
+                        var receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionKey, EventPosition.FromOffset(pInfo.LastEnqueuedOffset));
+                        var messages = await receiver.ReceiveAsync(10);
 
-                    Assert.True(messages.Count() == 1, $"Received {messages.Count()} messages whereas 1 expected.");
-                    var receivedEvent = messages.First();
+                        Assert.True(messages.Count() == 1, $"Received {messages.Count()} messages whereas 1 expected.");
+                        var receivedEvent = messages.First();
 
-                    Assert.True(Encoding.UTF8.GetString(receivedEvent.Body.Array) == payloadString, "Received payload string isn't the same as sent payload string.");
+                        Assert.True(Encoding.UTF8.GetString(receivedEvent.Body.Array) == payloadString, "Received payload string isn't the same as sent payload string.");
 
-                    parentActivity.Stop();
+                        parentActivity.Stop();
 
-                    // check Diagnostic-Id injection
-                    Assert.True(sendEvent.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-                    Assert.True(receivedEvent.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
-                    Assert.Equal(sendEvent.Properties[EventHubsDiagnosticSource.ActivityIdPropertyName], receivedEvent.Properties[EventHubsDiagnosticSource.ActivityIdPropertyName]);
+                        // check Diagnostic-Id injection
+                        Assert.True(sendEvent.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        Assert.True(receivedEvent.Properties.ContainsKey(EventHubsDiagnosticSource.ActivityIdPropertyName));
+                        Assert.Equal(sendEvent.Properties[EventHubsDiagnosticSource.ActivityIdPropertyName], receivedEvent.Properties[EventHubsDiagnosticSource.ActivityIdPropertyName]);
 
-                    // check Correlation-Context injection
-                    Assert.True(sendEvent.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
-                    Assert.True(receivedEvent.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
-                    Assert.Equal(sendEvent.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName], receivedEvent.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName]);
-                    Assert.Equal(EventHubsDiagnosticSource.SerializeCorrelationContext(parentActivity.Baggage.ToList()), sendEvent.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName]);
+                        // check Correlation-Context injection
+                        Assert.True(sendEvent.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+                        Assert.True(receivedEvent.Properties.ContainsKey(EventHubsDiagnosticSource.CorrelationContextPropertyName));
+                        Assert.Equal(sendEvent.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName], receivedEvent.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName]);
+                        Assert.Equal(EventHubsDiagnosticSource.SerializeCorrelationContext(parentActivity.Baggage.ToList()), sendEvent.Properties[EventHubsDiagnosticSource.CorrelationContextPropertyName]);
 
-                    Assert.True(eventQueue.TryDequeue(out var sendStart));
-                    AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, parentActivity, partitionKey, ehClient.ConnectionStringBuilder);
+                        Assert.True(eventQueue.TryDequeue(out var sendStart));
+                        AssertSendStart(sendStart.eventName, sendStart.payload, sendStart.activity, parentActivity, partitionKey, ehClient.ConnectionStringBuilder);
 
-                    Assert.True(eventQueue.TryDequeue(out var sendStop));
-                    AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity, partitionKey, ehClient.ConnectionStringBuilder);
+                        Assert.True(eventQueue.TryDequeue(out var sendStop));
+                        AssertSendStop(sendStop.eventName, sendStop.payload, sendStop.activity, sendStart.activity, partitionKey, ehClient.ConnectionStringBuilder);
 
-                    Assert.True(eventQueue.TryDequeue(out var receiveStart));
-                    AssertReceiveStart(receiveStart.eventName, receiveStart.payload, receiveStart.activity, partitionKey, ehClient.ConnectionStringBuilder);
+                        Assert.True(eventQueue.TryDequeue(out var receiveStart));
+                        AssertReceiveStart(receiveStart.eventName, receiveStart.payload, receiveStart.activity, partitionKey, ehClient.ConnectionStringBuilder);
 
-                    Assert.True(eventQueue.TryDequeue(out var receiveStop));
-                    AssertReceiveStop(receiveStop.eventName, receiveStop.payload, receiveStop.activity, receiveStart.activity, partitionKey, ehClient.ConnectionStringBuilder, relatedId: sendStop.activity.Id);
+                        Assert.True(eventQueue.TryDequeue(out var receiveStop));
+                        AssertReceiveStop(receiveStop.eventName, receiveStop.payload, receiveStop.activity, receiveStart.activity, partitionKey, ehClient.ConnectionStringBuilder, relatedId: sendStop.activity.Id);
 
-                    // no more events
-                    Assert.False(eventQueue.TryDequeue(out var evnt));
+                        // no more events
+                        Assert.False(eventQueue.TryDequeue(out var evnt));
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -489,7 +514,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         #region Extract Activity
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public void ExtractsActivityWithIdAndNoContext()
         {
@@ -507,7 +531,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public void ExtractsActivityWithIdAndSingleContext()
         {
@@ -529,7 +552,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public void ExtractsActivityWithIdAndMultiContext()
         {
@@ -555,7 +577,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 
         [Fact]
-        [LiveTest]
         [DisplayTestMethodName]
         public void ExtractActivityWithAlternateName()
         {
@@ -572,7 +593,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [InlineData("")]
         [InlineData("not valid context")]
         [InlineData("not,valid,context")]
-        [LiveTest]
         [DisplayTestMethodName]
         public void ExtractsActivityWithIdAndInvalidContext(string context)
         {
@@ -593,7 +613,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        [LiveTest]
         [DisplayTestMethodName]
         public void ExtractsActivityWithoutIdAsRoot(string id)
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/DiagnosticsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/DiagnosticsTests.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendFiresEvents()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var partitionKey = "SomePartitionKeyHere";
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendDoesNotInjectContextWhenNoListeners()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var partitionKey = "SomePartitionKeyHere";
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendFiresExceptionEvents()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var partitionKey = "SomePartitionKeyHere";
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionSenderSendFiresEvents()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var partitionKey = "1";
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionSenderSendDoesNotInjectContextWhenNoListeners()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var partitionKey = "1";
@@ -371,7 +371,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionSenderSendFiresExceptionEvents()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var partitionKey = "1";
@@ -433,7 +433,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionReceiverReceiveFiresEvents()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(3))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var partitionKey = "2";

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MiscTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MiscTests.cs
@@ -17,79 +17,83 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionKeyValidation()
         {
-            var NumberOfMessagesToSend = 100;
-            var totalReceived = 0;
-            var partitionOffsets = new Dictionary<string, string>();
-            var receivers = new List<PartitionReceiver>();
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitions = await this.GetPartitionsAsync(ehClient);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                // Discover the end of stream on each partition.
-                TestUtility.Log("Discovering end of stream on each partition.");
-                foreach (var partitionId in partitions)
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var NumberOfMessagesToSend = 100;
+                var totalReceived = 0;
+                var partitionOffsets = new Dictionary<string, string>();
+                var receivers = new List<PartitionReceiver>();
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitions = await this.GetPartitionsAsync(ehClient);
+
+                try
                 {
-                    var lastEvent = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
-                    partitionOffsets.Add(partitionId, lastEvent.LastEnqueuedOffset);
-                    TestUtility.Log($"Partition {partitionId} has last message with offset {lastEvent.LastEnqueuedOffset}");
-                }
-
-                // Now send a set of messages with different partition keys.
-                TestUtility.Log($"Sending {NumberOfMessagesToSend} messages.");
-                Random rnd = new Random();
-                for (int i = 0; i < NumberOfMessagesToSend; i++)
-                {
-                    var partitionKey = rnd.Next(10);
-                    await ehClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")), partitionKey.ToString());
-                }
-
-                // It is time to receive all messages that we just sent.
-                // Prepare partition key to partition map while receiving.
-                // Validation: All messages of a partition key should be received from a single partition.
-                TestUtility.Log("Starting to receive all messages from each partition.");
-                var receiveTasks = new Dictionary<string, Task<List<EventData>>>();
-
-                foreach (var partitionId in partitions)
-                {
-                    var receiver = ehClient.CreateReceiver(
-                        PartitionReceiver.DefaultConsumerGroupName,
-                        partitionId,
-                        EventPosition.FromOffset(partitionOffsets[partitionId]));
-
-                    receivers.Add(receiver);
-                    receiveTasks.Add(partitionId, ReceiveAllMessagesAsync(receiver));
-                }
-
-                var partitionMap = new Dictionary<string, string>();
-
-                foreach (var receiveTask in receiveTasks)
-                {
-                    var partitionId = receiveTask.Key;
-                    var messagesFromPartition = await receiveTask.Value;
-                    totalReceived += messagesFromPartition.Count;
-
-                    TestUtility.Log($"Received {messagesFromPartition.Count} messages from partition {partitionId}.");
-                    foreach (var ed in messagesFromPartition)
+                    // Discover the end of stream on each partition.
+                    TestUtility.Log("Discovering end of stream on each partition.");
+                    foreach (var partitionId in partitions)
                     {
-                        var pk = ed.SystemProperties.PartitionKey;
-                        if (partitionMap.ContainsKey(pk) && partitionMap[pk] != partitionId)
-                        {
-                            throw new Exception($"Received a message from partition {partitionId} with partition key {pk}, whereas the same key was observed on partition {partitionMap[pk]} before.");
-                        }
+                        var lastEvent = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                        partitionOffsets.Add(partitionId, lastEvent.LastEnqueuedOffset);
+                        TestUtility.Log($"Partition {partitionId} has last message with offset {lastEvent.LastEnqueuedOffset}");
+                    }
 
-                        partitionMap[pk] = partitionId;
+                    // Now send a set of messages with different partition keys.
+                    TestUtility.Log($"Sending {NumberOfMessagesToSend} messages.");
+                    Random rnd = new Random();
+                    for (int i = 0; i < NumberOfMessagesToSend; i++)
+                    {
+                        var partitionKey = rnd.Next(10);
+                        await ehClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")), partitionKey.ToString());
+                    }
+
+                    // It is time to receive all messages that we just sent.
+                    // Prepare partition key to partition map while receiving.
+                    // Validation: All messages of a partition key should be received from a single partition.
+                    TestUtility.Log("Starting to receive all messages from each partition.");
+                    var receiveTasks = new Dictionary<string, Task<List<EventData>>>();
+
+                    foreach (var partitionId in partitions)
+                    {
+                        var receiver = ehClient.CreateReceiver(
+                            PartitionReceiver.DefaultConsumerGroupName,
+                            partitionId,
+                            EventPosition.FromOffset(partitionOffsets[partitionId]));
+
+                        receivers.Add(receiver);
+                        receiveTasks.Add(partitionId, ReceiveAllMessagesAsync(receiver));
+                    }
+
+                    var partitionMap = new Dictionary<string, string>();
+
+                    foreach (var receiveTask in receiveTasks)
+                    {
+                        var partitionId = receiveTask.Key;
+                        var messagesFromPartition = await receiveTask.Value;
+                        totalReceived += messagesFromPartition.Count;
+
+                        TestUtility.Log($"Received {messagesFromPartition.Count} messages from partition {partitionId}.");
+                        foreach (var ed in messagesFromPartition)
+                        {
+                            var pk = ed.SystemProperties.PartitionKey;
+                            if (partitionMap.ContainsKey(pk) && partitionMap[pk] != partitionId)
+                            {
+                                throw new Exception($"Received a message from partition {partitionId} with partition key {pk}, whereas the same key was observed on partition {partitionMap[pk]} before.");
+                            }
+
+                            partitionMap[pk] = partitionId;
+                        }
                     }
                 }
-            }
-            finally
-            {
-                await Task.WhenAll(receivers.Select(receiver => receiver.CloseAsync()));
-                await ehClient.CloseAsync();
-            }
+                finally
+                {
+                    await Task.WhenAll(receivers.Select(receiver => receiver.CloseAsync()));
+                    await ehClient.CloseAsync();
+                }
 
-            Assert.True(totalReceived == NumberOfMessagesToSend,
-                $"Didn't receive the same number of messages that we sent. Sent: {NumberOfMessagesToSend}, Received: {totalReceived}");
+                Assert.True(totalReceived == NumberOfMessagesToSend,
+                    $"Didn't receive the same number of messages that we sent. Sent: {NumberOfMessagesToSend}, Received: {totalReceived}");
+            }
         }
 
         [Fact]
@@ -97,24 +101,28 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendAndReceiveLargeMessage()
         {
-            var bodySize = 250 * 1024;
-            var targetPartition = "0";
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                using (var edToSend = new EventData(new byte[bodySize]))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var bodySize = 250 * 1024;
+                var targetPartition = "0";
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
+                try
                 {
-                    TestUtility.Log($"Sending one message with body size {bodySize} bytes.");
-                    var edReceived = await SendAndReceiveEventAsync(targetPartition, edToSend, ehClient);
+                    using (var edToSend = new EventData(new byte[bodySize]))
+                    {
+                        TestUtility.Log($"Sending one message with body size {bodySize} bytes.");
+                        var edReceived = await SendAndReceiveEventAsync(targetPartition, edToSend, ehClient);
 
-                    // Validate body size.
-                    Assert.True(edReceived.Body.Count == bodySize, $"Sent {bodySize} bytes and received {edReceived.Body.Count}");
+                        // Validate body size.
+                        Assert.True(edReceived.Body.Count == bodySize, $"Sent {bodySize} bytes and received {edReceived.Body.Count}");
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
     }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MiscTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MiscTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task PartitionKeyValidation()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var NumberOfMessagesToSend = 100;
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendAndReceiveLargeMessage()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var bodySize = 250 * 1024;

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/PartitionPumpTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/PartitionPumpTests.cs
@@ -18,75 +18,79 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendReceiveBasic()
         {
-            TestUtility.Log("Receiving Events via PartitionReceiver.SetReceiveHandler()");
-
-            var partitionId = "1";
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(-10)));
-            var partitionSender = ehClient.CreatePartitionSender(partitionId);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                string uniqueEventId = Guid.NewGuid().ToString();
-                TestUtility.Log($"Sending an event to Partition {partitionId} with custom property EventId {uniqueEventId}");
-                var sendEvent = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-                sendEvent.Properties["EventId"] = uniqueEventId;
-                await partitionSender.SendAsync(sendEvent);
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                TestUtility.Log("Receiving Events via PartitionReceiver.SetReceiveHandler()");
 
-                EventWaitHandle dataReceivedEvent = new EventWaitHandle(false, EventResetMode.ManualReset);
-                var handler = new TestPartitionReceiveHandler();
+                var partitionId = "1";
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(-10)));
+                var partitionSender = ehClient.CreatePartitionSender(partitionId);
 
-                // Not expecting any errors.
-                handler.ErrorReceived += (s, e) =>
+                try
                 {
-                    throw new Exception($"TestPartitionReceiveHandler.ProcessError {e.GetType().Name}: {e.Message}");
-                };
+                    string uniqueEventId = Guid.NewGuid().ToString();
+                    TestUtility.Log($"Sending an event to Partition {partitionId} with custom property EventId {uniqueEventId}");
+                    var sendEvent = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
+                    sendEvent.Properties["EventId"] = uniqueEventId;
+                    await partitionSender.SendAsync(sendEvent);
 
-                handler.EventsReceived += (s, eventDatas) =>
-                {
-                    int count = eventDatas != null ? eventDatas.Count() : 0;
-                    TestUtility.Log($"Received {count} event(s):");
+                    EventWaitHandle dataReceivedEvent = new EventWaitHandle(false, EventResetMode.ManualReset);
+                    var handler = new TestPartitionReceiveHandler();
 
-                    if (eventDatas != null)
+                    // Not expecting any errors.
+                    handler.ErrorReceived += (s, e) =>
                     {
-                        foreach (var eventData in eventDatas)
+                        throw new Exception($"TestPartitionReceiveHandler.ProcessError {e.GetType().Name}: {e.Message}");
+                    };
+
+                    handler.EventsReceived += (s, eventDatas) =>
+                    {
+                        int count = eventDatas != null ? eventDatas.Count() : 0;
+                        TestUtility.Log($"Received {count} event(s):");
+
+                        if (eventDatas != null)
                         {
-                            object objectValue;
-                            if (eventData.Properties != null && eventData.Properties.TryGetValue("EventId", out objectValue))
+                            foreach (var eventData in eventDatas)
                             {
-                                TestUtility.Log($"Received message with EventId {objectValue}");
-                                string receivedId = objectValue.ToString();
-                                if (receivedId == uniqueEventId)
+                                object objectValue;
+                                if (eventData.Properties != null && eventData.Properties.TryGetValue("EventId", out objectValue))
                                 {
-                                    TestUtility.Log("Success");
-                                    dataReceivedEvent.Set();
-                                    break;
+                                    TestUtility.Log($"Received message with EventId {objectValue}");
+                                    string receivedId = objectValue.ToString();
+                                    if (receivedId == uniqueEventId)
+                                    {
+                                        TestUtility.Log("Success");
+                                        dataReceivedEvent.Set();
+                                        break;
+                                    }
                                 }
                             }
                         }
+                    };
+
+                    partitionReceiver.SetReceiveHandler(handler);
+
+                    await Task.Delay(TimeSpan.FromSeconds(60));
+
+                    if (!dataReceivedEvent.WaitOne(TimeSpan.FromSeconds(20)))
+                    {
+                        throw new InvalidOperationException("Data Received Event was not signaled.");
                     }
-                };
-
-                partitionReceiver.SetReceiveHandler(handler);
-
-                await Task.Delay(TimeSpan.FromSeconds(60));
-
-                if (!dataReceivedEvent.WaitOne(TimeSpan.FromSeconds(20)))
-                {
-                    throw new InvalidOperationException("Data Received Event was not signaled.");
                 }
-            }
-            finally
-            {
-                // Unregister handler.
-                partitionReceiver.SetReceiveHandler(null);
+                finally
+                {
+                    // Unregister handler.
+                    partitionReceiver.SetReceiveHandler(null);
 
-                // Close clients.
+                    // Close clients.
 
-                await Task.WhenAll(
-                    partitionSender.CloseAsync(),
-                    partitionReceiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                    await Task.WhenAll(
+                        partitionSender.CloseAsync(),
+                        partitionReceiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -95,69 +99,73 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task ReceiveHandlerReregister()
         {
-            var totalNumberOfMessagesToSend = 100;
-            var partitionId = "0";
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
-            var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset));
-
-            await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.", totalNumberOfMessagesToSend);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                var handler = new TestPartitionReceiveHandler();
-                handler.MaxBatchSize = 1;
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var totalNumberOfMessagesToSend = 100;
+                var partitionId = "0";
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset));
 
-                // Not expecting any errors.
-                handler.ErrorReceived += (s, e) =>
-                {
-                    // SetReceiveHandler will ignore any exception thrown so log here for output.
-                    TestUtility.Log($"TestPartitionReceiveHandler.ProcessError {e.GetType().Name}: {e.Message}");
-                    throw new Exception($"TestPartitionReceiveHandler.ProcessError {e.GetType().Name}: {e.Message}");
-                };
-
-                int totalnumberOfMessagesReceived = 0;
-                handler.EventsReceived += (s, eventDatas) =>
-                {
-                    int count = eventDatas != null ? eventDatas.Count() : 0;
-                    Interlocked.Add(ref totalnumberOfMessagesReceived, count);
-                    TestUtility.Log($"Received {count} event(s).");
-                };
-
-                TestUtility.Log("Registering");
-                partitionReceiver.SetReceiveHandler(handler);
-                TestUtility.Log("Unregistering");
-                partitionReceiver.SetReceiveHandler(null);
-                TestUtility.Log("Registering");
-                partitionReceiver.SetReceiveHandler(handler);
-                await Task.Delay(3000);
-
-                // Second register call will trigger error handler but throw from handler should be ignored
-                // so below register call should not fail.
-                TestUtility.Log("Registering when already registered");
-                partitionReceiver.SetReceiveHandler(handler);
-
-                TestUtility.Log("All register calls done.");
-
-                // Send another set of messages.
-                // Since handler is still registered we should be able to receive these messages just fine.
                 await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.", totalNumberOfMessagesToSend);
 
-                // Allow 1 minute to receive all messages.
-                await Task.Delay(TimeSpan.FromSeconds(60));
-                TestUtility.Log($"Received {totalnumberOfMessagesReceived}.");
-                Assert.True(totalnumberOfMessagesReceived == totalNumberOfMessagesToSend * 2, $"Did not receive {totalNumberOfMessagesToSend * 2} messages, received {totalnumberOfMessagesReceived}.");
-            }
-            finally
-            {
-                // Unregister handler.
-                partitionReceiver.SetReceiveHandler(null);
+                try
+                {
+                    var handler = new TestPartitionReceiveHandler();
+                    handler.MaxBatchSize = 1;
 
-                // Close clients.
+                    // Not expecting any errors.
+                    handler.ErrorReceived += (s, e) =>
+                    {
+                    // SetReceiveHandler will ignore any exception thrown so log here for output.
+                    TestUtility.Log($"TestPartitionReceiveHandler.ProcessError {e.GetType().Name}: {e.Message}");
+                        throw new Exception($"TestPartitionReceiveHandler.ProcessError {e.GetType().Name}: {e.Message}");
+                    };
 
-                await Task.WhenAll(
-                    partitionReceiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                    int totalnumberOfMessagesReceived = 0;
+                    handler.EventsReceived += (s, eventDatas) =>
+                    {
+                        int count = eventDatas != null ? eventDatas.Count() : 0;
+                        Interlocked.Add(ref totalnumberOfMessagesReceived, count);
+                        TestUtility.Log($"Received {count} event(s).");
+                    };
+
+                    TestUtility.Log("Registering");
+                    partitionReceiver.SetReceiveHandler(handler);
+                    TestUtility.Log("Unregistering");
+                    partitionReceiver.SetReceiveHandler(null);
+                    TestUtility.Log("Registering");
+                    partitionReceiver.SetReceiveHandler(handler);
+                    await Task.Delay(3000);
+
+                    // Second register call will trigger error handler but throw from handler should be ignored
+                    // so below register call should not fail.
+                    TestUtility.Log("Registering when already registered");
+                    partitionReceiver.SetReceiveHandler(handler);
+
+                    TestUtility.Log("All register calls done.");
+
+                    // Send another set of messages.
+                    // Since handler is still registered we should be able to receive these messages just fine.
+                    await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.", totalNumberOfMessagesToSend);
+
+                    // Allow 1 minute to receive all messages.
+                    await Task.Delay(TimeSpan.FromSeconds(60));
+                    TestUtility.Log($"Received {totalnumberOfMessagesReceived}.");
+                    Assert.True(totalnumberOfMessagesReceived == totalNumberOfMessagesToSend * 2, $"Did not receive {totalNumberOfMessagesToSend * 2} messages, received {totalnumberOfMessagesReceived}.");
+                }
+                finally
+                {
+                    // Unregister handler.
+                    partitionReceiver.SetReceiveHandler(null);
+
+                    // Close clients.
+
+                    await Task.WhenAll(
+                        partitionReceiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -166,84 +174,91 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task InvokeOnNull()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromEnd());
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var handler = new TestPartitionReceiveHandler();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromEnd());
 
-                handler.EventsReceived += (s, eventDatas) =>
+                try
                 {
-                    if (eventDatas == null)
+                    var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var handler = new TestPartitionReceiveHandler();
+
+                    handler.EventsReceived += (s, eventDatas) =>
                     {
-                        TestUtility.Log("Received null.");
-                        tcs.TrySetResult(true);
-                    }
-                };
+                        if (eventDatas == null)
+                        {
+                            TestUtility.Log("Received null.");
+                            tcs.TrySetResult(true);
+                        }
+                    };
 
-                partitionReceiver.SetReceiveHandler(handler, true);
-                await tcs.Task.WithTimeout(TimeSpan.FromSeconds(120));
-            }
-            finally
-            {
-                // Unregister handler.
-                partitionReceiver.SetReceiveHandler(null);
+                    partitionReceiver.SetReceiveHandler(handler, true);
+                    await tcs.Task.WithTimeout(TimeSpan.FromSeconds(120));
+                }
+                finally
+                {
+                    // Unregister handler.
+                    partitionReceiver.SetReceiveHandler(null);
 
-                // Close clients.
+                    // Close clients.
 
-                await Task.WhenAll(
-                    partitionReceiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                    await Task.WhenAll(
+                        partitionReceiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
-
 
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task DefaultBehaviorNoInvokeOnNull()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromEnd());
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                var nullCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var dataCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
-                var handler = new TestPartitionReceiveHandler();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromEnd());
 
-                handler.EventsReceived += (s, eventDatas) =>
+                try
                 {
-                    if (eventDatas == null)
+                    var nullCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var dataCompletionSource = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                    var handler = new TestPartitionReceiveHandler();
+
+                    handler.EventsReceived += (s, eventDatas) =>
                     {
-                        TestUtility.Log("Received null.");
-                        nullCompletionSource.TrySetResult(true);
-                    }
-                    else
-                    {
-                        TestUtility.Log("Received message.");
-                        dataCompletionSource.TrySetResult(true);
-                    }
-                };
+                        if (eventDatas == null)
+                        {
+                            TestUtility.Log("Received null.");
+                            nullCompletionSource.TrySetResult(true);
+                        }
+                        else
+                        {
+                            TestUtility.Log("Received message.");
+                            dataCompletionSource.TrySetResult(true);
+                        }
+                    };
 
-                partitionReceiver.SetReceiveHandler(handler);
-                await Assert.ThrowsAsync<TimeoutException>(() => nullCompletionSource.Task.WithTimeout(TimeSpan.FromSeconds(120)));
+                    partitionReceiver.SetReceiveHandler(handler);
+                    await Assert.ThrowsAsync<TimeoutException>(() => nullCompletionSource.Task.WithTimeout(TimeSpan.FromSeconds(120)));
 
-                // Send one message. Pump should receive this.
-                await TestUtility.SendToPartitionAsync(ehClient, "0", "new event");
-                await dataCompletionSource.Task.WithTimeout(TimeSpan.FromSeconds(60), timeoutCallback: () => throw new TimeoutException("The data event was not received"));
-            }
-            finally
-            {
-                // Unregister handler.
-                partitionReceiver.SetReceiveHandler(null);
+                    // Send one message. Pump should receive this.
+                    await TestUtility.SendToPartitionAsync(ehClient, "0", "new event");
+                    await dataCompletionSource.Task.WithTimeout(TimeSpan.FromSeconds(60), timeoutCallback: () => throw new TimeoutException("The data event was not received"));
+                }
+                finally
+                {
+                    // Unregister handler.
+                    partitionReceiver.SetReceiveHandler(null);
 
-                // Close clients.
-                await Task.WhenAll(
-                    partitionReceiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                    // Close clients.
+                    await Task.WhenAll(
+                        partitionReceiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/PartitionPumpTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/PartitionPumpTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task SendReceiveBasic()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 TestUtility.Log("Receiving Events via PartitionReceiver.SetReceiveHandler()");
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task ReceiveHandlerReregister()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var totalNumberOfMessagesToSend = 100;
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task InvokeOnNull()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task DefaultBehaviorNoInvokeOnNull()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/PluginTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/PluginTests.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using Microsoft.Azure.EventHubs.Core;
     using Xunit;
 
-
     public class PluginTests
     {
         protected EventHubClient EventHubClient;
@@ -19,7 +18,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Registering_plugin_multiple_times_should_throw()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -37,7 +36,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Unregistering_plugin_should_complete_with_plugin_set()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -54,7 +53,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Unregistering_plugin_should_complete_without_plugin_set()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -68,10 +67,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Plugin_without_ShouldContinueOnException_should_throw()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
+
                 try
                 {
                     var plugin = new ExceptionPlugin();
@@ -92,10 +92,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Plugin_with_ShouldContinueOnException_should_continue()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
+
                 try
                 {
                     var plugin = new ShouldCompleteAnywayExceptionPlugin();

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/PluginTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/PluginTests.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using Microsoft.Azure.EventHubs.Core;
     using Xunit;
 
+
     public class PluginTests
     {
         protected EventHubClient EventHubClient;
@@ -18,13 +19,17 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Registering_plugin_multiple_times_should_throw()
         {
-            this.EventHubClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var firstPlugin = new SamplePlugin();
-            var secondPlugin = new SamplePlugin();
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var firstPlugin = new SamplePlugin();
+                var secondPlugin = new SamplePlugin();
 
-            this.EventHubClient.RegisterPlugin(firstPlugin);
-            Assert.Throws<ArgumentException>(() => EventHubClient.RegisterPlugin(secondPlugin));
-            await EventHubClient.CloseAsync();
+                this.EventHubClient.RegisterPlugin(firstPlugin);
+                Assert.Throws<ArgumentException>(() => EventHubClient.RegisterPlugin(secondPlugin));
+                await EventHubClient.CloseAsync();
+            }
         }
 
         [Fact]
@@ -32,12 +37,16 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Unregistering_plugin_should_complete_with_plugin_set()
         {
-            this.EventHubClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var firstPlugin = new SamplePlugin();
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var firstPlugin = new SamplePlugin();
 
-            this.EventHubClient.RegisterPlugin(firstPlugin);
-            this.EventHubClient.UnregisterPlugin(firstPlugin.Name);
-            await this.EventHubClient.CloseAsync();
+                this.EventHubClient.RegisterPlugin(firstPlugin);
+                this.EventHubClient.UnregisterPlugin(firstPlugin.Name);
+                await this.EventHubClient.CloseAsync();
+            }
         }
 
         [Fact]
@@ -45,9 +54,13 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Unregistering_plugin_should_complete_without_plugin_set()
         {
-            this.EventHubClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            this.EventHubClient.UnregisterPlugin("Non-existant plugin");
-            await this.EventHubClient.CloseAsync();
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
+                this.EventHubClient.UnregisterPlugin("Non-existant plugin");
+                await this.EventHubClient.CloseAsync();
+            }
         }
 
         [Fact]
@@ -55,18 +68,22 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Plugin_without_ShouldContinueOnException_should_throw()
         {
-            this.EventHubClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                var plugin = new ExceptionPlugin();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
+                try
+                {
+                    var plugin = new ExceptionPlugin();
 
-                this.EventHubClient.RegisterPlugin(plugin);
-                var testEvent = new EventData(Encoding.UTF8.GetBytes("Test message"));
-                await Assert.ThrowsAsync<NotImplementedException>(() => this.EventHubClient.SendAsync(testEvent));
-            }
-            finally
-            {
-                await this.EventHubClient.CloseAsync();
+                    this.EventHubClient.RegisterPlugin(plugin);
+                    var testEvent = new EventData(Encoding.UTF8.GetBytes("Test message"));
+                    await Assert.ThrowsAsync<NotImplementedException>(() => this.EventHubClient.SendAsync(testEvent));
+                }
+                finally
+                {
+                    await this.EventHubClient.CloseAsync();
+                }
             }
         }
 
@@ -75,19 +92,23 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task Plugin_with_ShouldContinueOnException_should_continue()
         {
-            this.EventHubClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                var plugin = new ShouldCompleteAnywayExceptionPlugin();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                this.EventHubClient = EventHubClient.CreateFromConnectionString(connectionString);
+                try
+                {
+                    var plugin = new ShouldCompleteAnywayExceptionPlugin();
 
-                this.EventHubClient.RegisterPlugin(plugin);
+                    this.EventHubClient.RegisterPlugin(plugin);
 
-                var testEvent = new EventData(Encoding.UTF8.GetBytes("Test message"));
-                await this.EventHubClient.SendAsync(testEvent);
-            }
-            finally
-            {
-                await this.EventHubClient.CloseAsync();
+                    var testEvent = new EventData(Encoding.UTF8.GetBytes("Test message"));
+                    await this.EventHubClient.SendAsync(testEvent);
+                }
+                finally
+                {
+                    await this.EventHubClient.CloseAsync();
+                }
             }
         }
     }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverRuntimeMetricsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverRuntimeMetricsTests.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
-
     public class ReceiverRuntimeMetricsTests : ClientTestBase
     {
         string targetPartitionId = "1";
@@ -23,6 +22,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
                 var partitionReceiver = default(PartitionReceiver);
+
                 try
                 {
                     // Send some number of messages to target partition.
@@ -51,7 +51,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
         }
 
-
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -62,6 +61,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
                 var partitionReceiver = default(PartitionReceiver);
+
                 try
                 {
                     // Send single event
@@ -80,7 +80,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
         }
 
-
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -91,6 +90,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
                 var partitionReceiver = default(PartitionReceiver);
+
                 try
                 {
                     // Send single event
@@ -129,6 +129,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
                 var partitionReceiver1 = default(PartitionReceiver);
                 var partitionReceiver2 = default(PartitionReceiver);
+
                 try
                 {
                     // Send some number of messages to target partition.

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverTests.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
-   public class ReceiverTests : ClientTestBase
+
+    public class ReceiverTests : ClientTestBase
     {
         [Fact]
         [LiveTest]
@@ -20,22 +21,26 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var partitionId = "1";
             var payloadString = "Hello EventHub!";
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log("Receiving Events via PartitionReceiver.ReceiveAsync");
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-                using (var sendEvent = new EventData(Encoding.UTF8.GetBytes(payloadString)))
-                using (var receivedEvent = await SendAndReceiveEventAsync(partitionId, sendEvent, ehClient))
+                try
                 {
-                    Assert.True(Encoding.UTF8.GetString(receivedEvent.Body.Array) == payloadString, "Received payload string isn't the same as sent payload string.");
-                }
+                    TestUtility.Log("Receiving Events via PartitionReceiver.ReceiveAsync");
 
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                    using (var sendEvent = new EventData(Encoding.UTF8.GetBytes(payloadString)))
+                    using (var receivedEvent = await SendAndReceiveEventAsync(partitionId, sendEvent, ehClient))
+                    {
+                        Assert.True(Encoding.UTF8.GetString(receivedEvent.Body.Array) == payloadString, "Received payload string isn't the same as sent payload string.");
+                    }
+
+                }
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -46,63 +51,66 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var receiver = default(PartitionReceiver);
             var partitionSender = default(PartitionSender);
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Randomly pick one of the available partitons.
-                var partitions = await this.GetPartitionsAsync(ehClient);
-                var partitionId = partitions[new Random().Next(partitions.Length)];
-                TestUtility.Log($"Randomly picked partition {partitionId}");
-
-                partitionSender = ehClient.CreatePartitionSender(partitionId);
-
-                // Send couple of messages before creating an EndOfStream receiver.
-                // We are not expecting to receive these messages would be sent before receiver creation.
-                for (int i = 0; i < 10; i++)
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                try
                 {
-                    var ed = new EventData(new byte[1]);
-                    await partitionSender.SendAsync(ed);
+                    // Randomly pick one of the available partitons.
+                    var partitions = await this.GetPartitionsAsync(ehClient);
+                    var partitionId = partitions[new Random().Next(partitions.Length)];
+                    TestUtility.Log($"Randomly picked partition {partitionId}");
+
+                    partitionSender = ehClient.CreatePartitionSender(partitionId);
+
+                    // Send couple of messages before creating an EndOfStream receiver.
+                    // We are not expecting to receive these messages would be sent before receiver creation.
+                    for (int i = 0; i < 10; i++)
+                    {
+                        var ed = new EventData(new byte[1]);
+                        await partitionSender.SendAsync(ed);
+                    }
+
+                    // Create a new receiver which will start reading from the end of the stream.
+                    TestUtility.Log($"Creating a new receiver with offset EndOFStream");
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnd());
+
+
+                    // Attemp to receive the message. This should return only 1 message.
+                    var receiveTask = receiver.ReceiveAsync(100);
+
+                    // Send a new message which is expected to go to the end of stream.
+                    // We are expecting to receive only this message.
+                    // Wait 5 seconds before sending to avoid race.
+                    await Task.Delay(5000);
+                    var eventToReceive = new EventData(new byte[1]);
+                    eventToReceive.Properties["stamp"] = Guid.NewGuid().ToString();
+                    await partitionSender.SendAsync(eventToReceive);
+
+                    // Complete asyncy receive task.
+                    var receivedMessages = await receiveTask;
+
+                    // We should have received only 1 message from this call.
+                    Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
+
+                    // Check stamp.
+                    Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventToReceive.Properties["stamp"].ToString()
+                        , "Stamps didn't match on the message sent and received!");
+
+                    TestUtility.Log("Received correct message as expected.");
+
+                    // Next receive on this partition shouldn't return any more messages.
+                    receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
+                    Assert.True(receivedMessages == null, $"Received messages at the end.");
                 }
-
-                // Create a new receiver which will start reading from the end of the stream.
-                TestUtility.Log($"Creating a new receiver with offset EndOFStream");
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnd());
-
-
-                // Attemp to receive the message. This should return only 1 message.
-                var receiveTask = receiver.ReceiveAsync(100);
-
-                // Send a new message which is expected to go to the end of stream.
-                // We are expecting to receive only this message.
-                // Wait 5 seconds before sending to avoid race.
-                await Task.Delay(5000);
-                var eventToReceive = new EventData(new byte[1]);
-                eventToReceive.Properties["stamp"] = Guid.NewGuid().ToString();
-                await partitionSender.SendAsync(eventToReceive);
-
-                // Complete asyncy receive task.
-                var receivedMessages = await receiveTask;
-
-                // We should have received only 1 message from this call.
-                Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
-
-                // Check stamp.
-                Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventToReceive.Properties["stamp"].ToString()
-                    , "Stamps didn't match on the message sent and received!");
-
-                TestUtility.Log("Received correct message as expected.");
-
-                // Next receive on this partition shouldn't return any more messages.
-                receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
-                Assert.True(receivedMessages == null, $"Received messages at the end.");
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    partitionSender.CloseAsync(),
-                    receiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                finally
+                {
+                    await Task.WhenAll(
+                        partitionSender.CloseAsync(),
+                        receiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -112,47 +120,52 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task CreateReceiverWithOffset()
         {
             var receiver = default(PartitionReceiver);
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Randomly pick one of the available partitons.
-                var partitions = await this.GetPartitionsAsync(ehClient);
-                var partitionId = partitions[new Random().Next(partitions.Length)];
-                TestUtility.Log($"Randomly picked partition {partitionId}");
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-                // Send and receive a message to identify the end of stream.
-                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                try
+                {
+                    // Randomly pick one of the available partitons.
+                    var partitions = await this.GetPartitionsAsync(ehClient);
+                    var partitionId = partitions[new Random().Next(partitions.Length)];
+                    TestUtility.Log($"Randomly picked partition {partitionId}");
 
-                // Send a new message which is expected to go to the end of stream.
-                // We are expecting to receive only this message.
-                var eventSent = new EventData(new byte[1]);
-                eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
-                await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
+                    // Send and receive a message to identify the end of stream.
+                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
 
-                // Create a new receiver which will start reading from the last message on the stream.
-                TestUtility.Log($"Creating a new receiver with offset {pInfo.LastEnqueuedOffset}");
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset));
-                var receivedMessages = await receiver.ReceiveAsync(100);
+                    // Send a new message which is expected to go to the end of stream.
+                    // We are expecting to receive only this message.
+                    var eventSent = new EventData(new byte[1]);
+                    eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
+                    await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
 
-                // We should have received only 1 message from this call.
-                Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
+                    // Create a new receiver which will start reading from the last message on the stream.
+                    TestUtility.Log($"Creating a new receiver with offset {pInfo.LastEnqueuedOffset}");
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset));
+                    var receivedMessages = await receiver.ReceiveAsync(100);
 
-                // Check stamp.
-                Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventSent.Properties["stamp"].ToString()
-                    , "Stamps didn't match on the message sent and received!");
+                    // We should have received only 1 message from this call.
+                    Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
 
-                TestUtility.Log("Received correct message as expected.");
+                    // Check stamp.
+                    Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventSent.Properties["stamp"].ToString()
+                        , "Stamps didn't match on the message sent and received!");
 
-                // Next receive on this partition shouldn't return any more messages.
-                receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
-                Assert.True(receivedMessages == null, $"Received messages at the end.");
-            }
-            finally
-            {
-                await Task.WhenAll(
-                     receiver.CloseAsync(),
-                     ehClient.CloseAsync());
+                    TestUtility.Log("Received correct message as expected.");
+
+                    // Next receive on this partition shouldn't return any more messages.
+                    receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
+                    Assert.True(receivedMessages == null, $"Received messages at the end.");
+                }
+                finally
+                {
+                    await Task.WhenAll(
+                         receiver.CloseAsync(),
+                         ehClient.CloseAsync());
+                }
             }
         }
 
@@ -162,41 +175,46 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task CreateReceiverWithInclusiveOffset()
         {
             var receiver = default(PartitionReceiver);
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Randomly pick one of the available partitons.
-                var partitions = await this.GetPartitionsAsync(ehClient);
-                var partitionId = partitions[new Random().Next(partitions.Length)];
-                TestUtility.Log($"Randomly picked partition {partitionId}");
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-                await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
+                try
+                {
+                    // Randomly pick one of the available partitons.
+                    var partitions = await this.GetPartitionsAsync(ehClient);
+                    var partitionId = partitions[new Random().Next(partitions.Length)];
+                    TestUtility.Log($"Randomly picked partition {partitionId}");
 
-                // Find out where to start reading on the partition.
-                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                    await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
 
-                // Send a message which is expected to go to the end of stream.
-                // We are expecting to receive this message as well.
-                await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
+                    // Find out where to start reading on the partition.
+                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
 
-                // Create a new receiver which will start reading from the last message on the stream.
-                TestUtility.Log($"Creating a new receiver with offset {pInfo.LastEnqueuedOffset}");
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset, true));
-                var receivedMessages =  await ReceiveAllMessagesAsync(receiver);
+                    // Send a message which is expected to go to the end of stream.
+                    // We are expecting to receive this message as well.
+                    await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
 
-                // We should have received only 1 message from this call.
-                Assert.True(receivedMessages.Count() == 2, $"Didn't receive 2 messages. Received {receivedMessages.Count()} messages(s).");
+                    // Create a new receiver which will start reading from the last message on the stream.
+                    TestUtility.Log($"Creating a new receiver with offset {pInfo.LastEnqueuedOffset}");
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromOffset(pInfo.LastEnqueuedOffset, true));
+                    var receivedMessages = await ReceiveAllMessagesAsync(receiver);
 
-                // Next receive on this partition shouldn't return any more messages.
-                var expectNull = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
-                Assert.True(expectNull == null, $"Received messages at the end.");
-            }
-            finally
-            {
-                await Task.WhenAll(
-                     receiver.CloseAsync(),
-                     ehClient.CloseAsync());
+                    // We should have received only 1 message from this call.
+                    Assert.True(receivedMessages.Count() == 2, $"Didn't receive 2 messages. Received {receivedMessages.Count()} messages(s).");
+
+                    // Next receive on this partition shouldn't return any more messages.
+                    var expectNull = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
+                    Assert.True(expectNull == null, $"Received messages at the end.");
+                }
+                finally
+                {
+                    await Task.WhenAll(
+                         receiver.CloseAsync(),
+                         ehClient.CloseAsync());
+                }
             }
         }
 
@@ -206,47 +224,52 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task CreateReceiverWithDateTime()
         {
             var receiver = default(PartitionReceiver);
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Randomly pick one of the available partitons.
-                var partitions = await this.GetPartitionsAsync(ehClient);
-                var partitionId = partitions[new Random().Next(partitions.Length)];
-                TestUtility.Log($"Randomly picked partition {partitionId}");
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-                // Send and receive a message to identify the end of stream.
-                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                try
+                {
+                    // Randomly pick one of the available partitons.
+                    var partitions = await this.GetPartitionsAsync(ehClient);
+                    var partitionId = partitions[new Random().Next(partitions.Length)];
+                    TestUtility.Log($"Randomly picked partition {partitionId}");
 
-                // Send a new message which is expected to go to the end of stream.
-                // We are expecting to receive only this message.
-                var eventSent = new EventData(new byte[1]);
-                eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
-                await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
+                    // Send and receive a message to identify the end of stream.
+                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
 
-                // Create a new receiver which will start reading from the last message on the stream.
-                TestUtility.Log($"Creating a new receiver with date-time {pInfo.LastEnqueuedTimeUtc}");
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(pInfo.LastEnqueuedTimeUtc));
-                var receivedMessages = await receiver.ReceiveAsync(100);
+                    // Send a new message which is expected to go to the end of stream.
+                    // We are expecting to receive only this message.
+                    var eventSent = new EventData(new byte[1]);
+                    eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
+                    await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
 
-                // We should have received only 1 message from this call.
-                Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
+                    // Create a new receiver which will start reading from the last message on the stream.
+                    TestUtility.Log($"Creating a new receiver with date-time {pInfo.LastEnqueuedTimeUtc}");
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(pInfo.LastEnqueuedTimeUtc));
+                    var receivedMessages = await receiver.ReceiveAsync(100);
 
-                // Check stamp.
-                Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventSent.Properties["stamp"].ToString()
-                    , "Stamps didn't match on the message sent and received!");
+                    // We should have received only 1 message from this call.
+                    Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
 
-                TestUtility.Log("Received correct message as expected.");
+                    // Check stamp.
+                    Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventSent.Properties["stamp"].ToString()
+                        , "Stamps didn't match on the message sent and received!");
 
-                // Next receive on this partition shouldn't return any more messages.
-                receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
-                Assert.True(receivedMessages == null, $"Received messages at the end.");
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    receiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                    TestUtility.Log("Received correct message as expected.");
+
+                    // Next receive on this partition shouldn't return any more messages.
+                    receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
+                    Assert.True(receivedMessages == null, $"Received messages at the end.");
+                }
+                finally
+                {
+                    await Task.WhenAll(
+                        receiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -256,47 +279,51 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task CreateReceiverWithSequenceNumber()
         {
             var receiver = default(PartitionReceiver);
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Randomly pick one of the available partitons.
-                var partitions = await this.GetPartitionsAsync(ehClient);
-                var partitionId = partitions[new Random().Next(partitions.Length)];
-                TestUtility.Log($"Randomly picked partition {partitionId}");
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                try
+                {
+                    // Randomly pick one of the available partitons.
+                    var partitions = await this.GetPartitionsAsync(ehClient);
+                    var partitionId = partitions[new Random().Next(partitions.Length)];
+                    TestUtility.Log($"Randomly picked partition {partitionId}");
 
-                // Send and receive a message to identify the end of stream.
-                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                    // Send and receive a message to identify the end of stream.
+                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
 
-                // Send a new message which is expected to go to the end of stream.
-                // We are expecting to receive only this message.
-                var eventSent = new EventData(new byte[1]);
-                eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
-                await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
+                    // Send a new message which is expected to go to the end of stream.
+                    // We are expecting to receive only this message.
+                    var eventSent = new EventData(new byte[1]);
+                    eventSent.Properties["stamp"] = Guid.NewGuid().ToString();
+                    await ehClient.CreatePartitionSender(partitionId).SendAsync(eventSent);
 
-                // Create a new receiver which will start reading from the last message on the stream.
-                TestUtility.Log($"Creating a new receiver with sequence number {pInfo.LastEnqueuedSequenceNumber}");
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromSequenceNumber(pInfo.LastEnqueuedSequenceNumber));
-                var receivedMessages = await receiver.ReceiveAsync(100);
+                    // Create a new receiver which will start reading from the last message on the stream.
+                    TestUtility.Log($"Creating a new receiver with sequence number {pInfo.LastEnqueuedSequenceNumber}");
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromSequenceNumber(pInfo.LastEnqueuedSequenceNumber));
+                    var receivedMessages = await receiver.ReceiveAsync(100);
 
-                // We should have received only 1 message from this call.
-                Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
+                    // We should have received only 1 message from this call.
+                    Assert.True(receivedMessages.Count() == 1, $"Didn't receive 1 message. Received {receivedMessages.Count()} messages(s).");
 
-                // Check stamp.
-                Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventSent.Properties["stamp"].ToString()
-                    , "Stamps didn't match on the message sent and received!");
+                    // Check stamp.
+                    Assert.True(receivedMessages.Single().Properties["stamp"].ToString() == eventSent.Properties["stamp"].ToString()
+                        , "Stamps didn't match on the message sent and received!");
 
-                TestUtility.Log("Received correct message as expected.");
+                    TestUtility.Log("Received correct message as expected.");
 
-                // Next receive on this partition shouldn't return any more messages.
-                receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
-                Assert.True(receivedMessages == null, $"Received messages at the end.");
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    receiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                    // Next receive on this partition shouldn't return any more messages.
+                    receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
+                    Assert.True(receivedMessages == null, $"Received messages at the end.");
+                }
+                finally
+                {
+                    await Task.WhenAll(
+                        receiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -306,41 +333,45 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task CreateReceiverWithInclusiveSequenceNumber()
         {
             var receiver = default(PartitionReceiver);
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Randomly pick one of the available partitons.
-                var partitions = await this.GetPartitionsAsync(ehClient);
-                var partitionId = partitions[new Random().Next(partitions.Length)];
-                TestUtility.Log($"Randomly picked partition {partitionId}");
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                try
+                {
+                    // Randomly pick one of the available partitons.
+                    var partitions = await this.GetPartitionsAsync(ehClient);
+                    var partitionId = partitions[new Random().Next(partitions.Length)];
+                    TestUtility.Log($"Randomly picked partition {partitionId}");
 
-                await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
+                    await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
 
-                // Find out where to start reading on the partition.
-                var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
+                    // Find out where to start reading on the partition.
+                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(partitionId);
 
-                // Send a message which is expected to go to the end of stream.
-                // We are expecting to receive this message as well.
-                await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
+                    // Send a message which is expected to go to the end of stream.
+                    // We are expecting to receive this message as well.
+                    await TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event.");
 
-                // Create a new receiver which will start reading from the last message on the stream.
-                TestUtility.Log($"Creating a new receiver with sequence number {pInfo.LastEnqueuedSequenceNumber}");
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromSequenceNumber(pInfo .LastEnqueuedSequenceNumber, true));
-                var receivedMessages = await receiver.ReceiveAsync(100);
+                    // Create a new receiver which will start reading from the last message on the stream.
+                    TestUtility.Log($"Creating a new receiver with sequence number {pInfo.LastEnqueuedSequenceNumber}");
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromSequenceNumber(pInfo.LastEnqueuedSequenceNumber, true));
+                    var receivedMessages = await receiver.ReceiveAsync(100);
 
-                // We should have received only 1 message from this call.
-                Assert.True(receivedMessages.Count() == 2, $"Didn't receive 2 messages. Received {receivedMessages.Count()} messages(s).");
+                    // We should have received only 1 message from this call.
+                    Assert.True(receivedMessages.Count() == 2, $"Didn't receive 2 messages. Received {receivedMessages.Count()} messages(s).");
 
-                // Next receive on this partition shouldn't return any more messages.
-                receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
-                Assert.True(receivedMessages == null, $"Received messages at the end.");
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    receiver.CloseAsync(),
-                    ehClient.CloseAsync());
+                    // Next receive on this partition shouldn't return any more messages.
+                    receivedMessages = await receiver.ReceiveAsync(100, TimeSpan.FromSeconds(15));
+                    Assert.True(receivedMessages == null, $"Received messages at the end.");
+                }
+                finally
+                {
+                    await Task.WhenAll(
+                        receiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -353,44 +384,48 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             TestUtility.Log("Receiving Events via PartitionReceiver.ReceiveAsync(BatchSize)");
             const string partitionId = "0";
 
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionSender = ehClient.CreatePartitionSender(partitionId);
-            var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(-10)));
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                int eventCount = 20;
-                TestUtility.Log($"Sending {eventCount} events to Partition {partitionId}");
-                var sendEvents = new List<EventData>(eventCount);
-                for (int i = 0; i < eventCount; i++)
-                {
-                    sendEvents.Add(new EventData(Encoding.UTF8.GetBytes($"Hello EventHub! Message {i}")));
-                }
-                await partitionSender.SendAsync(sendEvents);
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionSender = ehClient.CreatePartitionSender(partitionId);
+                var partitionReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(-10)));
 
-                int maxReceivedBatchSize = 0;
-                while (true)
+                try
                 {
-                    IEnumerable<EventData> partition1Events = await partitionReceiver.ReceiveAsync(MaxBatchSize);
-                    int receivedEventCount = partition1Events != null ? partition1Events.Count() : 0;
-                    TestUtility.Log($"Received {receivedEventCount} event(s)");
-
-                    if (partition1Events == null)
+                    int eventCount = 20;
+                    TestUtility.Log($"Sending {eventCount} events to Partition {partitionId}");
+                    var sendEvents = new List<EventData>(eventCount);
+                    for (int i = 0; i < eventCount; i++)
                     {
-                        break;
+                        sendEvents.Add(new EventData(Encoding.UTF8.GetBytes($"Hello EventHub! Message {i}")));
+                    }
+                    await partitionSender.SendAsync(sendEvents);
+
+                    int maxReceivedBatchSize = 0;
+                    while (true)
+                    {
+                        IEnumerable<EventData> partition1Events = await partitionReceiver.ReceiveAsync(MaxBatchSize);
+                        int receivedEventCount = partition1Events != null ? partition1Events.Count() : 0;
+                        TestUtility.Log($"Received {receivedEventCount} event(s)");
+
+                        if (partition1Events == null)
+                        {
+                            break;
+                        }
+
+                        maxReceivedBatchSize = Math.Max(maxReceivedBatchSize, receivedEventCount);
                     }
 
-                    maxReceivedBatchSize = Math.Max(maxReceivedBatchSize, receivedEventCount);
+                    Assert.True(maxReceivedBatchSize == MaxBatchSize, $"A max batch size of {MaxBatchSize} events was not honored! Actual {maxReceivedBatchSize}.");
                 }
-
-                Assert.True(maxReceivedBatchSize == MaxBatchSize, $"A max batch size of {MaxBatchSize} events was not honored! Actual {maxReceivedBatchSize}.");
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    partitionReceiver.CloseAsync(),
-                    partitionSender.CloseAsync(),
-                    ehClient.CloseAsync());
+                finally
+                {
+                    await Task.WhenAll(
+                        partitionReceiver.CloseAsync(),
+                        partitionSender.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -400,55 +435,60 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task PartitionReceiverEpochReceive()
         {
             TestUtility.Log("Testing EpochReceiver semantics");
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var epochReceiver1 = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
-            var epochReceiver2 = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 2);
-            try
+
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Read the events from Epoch 1 Receiver until we're at the end of the stream
-                TestUtility.Log("Starting epoch 1 receiver");
-                IEnumerable<EventData> events;
-                do
-                {
-                    events = await epochReceiver1.ReceiveAsync(10);
-                    var count = events?.Count() ?? 0;
-                }
-                while (events != null);
-
-                TestUtility.Log("Starting epoch 2 receiver");
-                var epoch2ReceiveTask = epochReceiver2.ReceiveAsync(10);
-
-                DateTime stopTime = DateTime.UtcNow.AddSeconds(30);
-                do
-                {
-                    events = await epochReceiver1.ReceiveAsync(10);
-                    var count = events?.Count() ?? 0;
-                    TestUtility.Log($"Epoch 1 receiver got {count} event(s)");
-                }
-                while (DateTime.UtcNow < stopTime);
-
-                throw new InvalidOperationException("Epoch 1 receiver should have encountered an exception by now!");
-            }
-            catch (ReceiverDisconnectedException disconnectedException)
-            {
-                TestUtility.Log($"Received expected exception {disconnectedException.GetType()}: {disconnectedException.Message}");
-
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var epochReceiver1 = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
+                var epochReceiver2 = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 2);
                 try
                 {
-                    await epochReceiver1.ReceiveAsync(10);
-                    throw new InvalidOperationException("Epoch 1 receiver should throw ReceiverDisconnectedException here too!");
+                    // Read the events from Epoch 1 Receiver until we're at the end of the stream
+                    TestUtility.Log("Starting epoch 1 receiver");
+                    IEnumerable<EventData> events;
+                    do
+                    {
+                        events = await epochReceiver1.ReceiveAsync(10);
+                        var count = events?.Count() ?? 0;
+                    }
+                    while (events != null);
+
+                    TestUtility.Log("Starting epoch 2 receiver");
+                    var epoch2ReceiveTask = epochReceiver2.ReceiveAsync(10);
+
+                    DateTime stopTime = DateTime.UtcNow.AddSeconds(30);
+                    do
+                    {
+                        events = await epochReceiver1.ReceiveAsync(10);
+                        var count = events?.Count() ?? 0;
+                        TestUtility.Log($"Epoch 1 receiver got {count} event(s)");
+                    }
+                    while (DateTime.UtcNow < stopTime);
+
+                    throw new InvalidOperationException("Epoch 1 receiver should have encountered an exception by now!");
                 }
-                catch (ReceiverDisconnectedException e)
+                catch (ReceiverDisconnectedException disconnectedException)
                 {
-                    TestUtility.Log($"Received expected exception {e.GetType()}");
+                    TestUtility.Log($"Received expected exception {disconnectedException.GetType()}: {disconnectedException.Message}");
+
+                    try
+                    {
+                        await epochReceiver1.ReceiveAsync(10);
+                        throw new InvalidOperationException("Epoch 1 receiver should throw ReceiverDisconnectedException here too!");
+                    }
+                    catch (ReceiverDisconnectedException e)
+                    {
+                        TestUtility.Log($"Received expected exception {e.GetType()}");
+                    }
                 }
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    epochReceiver1.CloseAsync(),
-                    epochReceiver2.CloseAsync(),
-                    ehClient.CloseAsync());
+                finally
+                {
+                    await Task.WhenAll(
+                        epochReceiver1.CloseAsync(),
+                        epochReceiver2.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -457,34 +497,39 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateNonEpochReceiverAfterEpochReceiver()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var epochReceiver = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
-            var nonEpochReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log("Starting epoch receiver");
-                await epochReceiver.ReceiveAsync(10);
-
-                await Task.Delay(TimeSpan.FromSeconds(10));
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var epochReceiver = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
+                var nonEpochReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
 
                 try
                 {
-                    TestUtility.Log("Starting nonepoch receiver, this should fail");
-                    await nonEpochReceiver.ReceiveAsync(10);
-                    throw new InvalidOperationException("Non-Epoch receiver should have encountered an exception by now!");
+                    TestUtility.Log("Starting epoch receiver");
+                    await epochReceiver.ReceiveAsync(10);
+
+                    await Task.Delay(TimeSpan.FromSeconds(10));
+
+                    try
+                    {
+                        TestUtility.Log("Starting nonepoch receiver, this should fail");
+                        await nonEpochReceiver.ReceiveAsync(10);
+                        throw new InvalidOperationException("Non-Epoch receiver should have encountered an exception by now!");
+                    }
+                    catch (ReceiverDisconnectedException ex) when (ex.Message.Contains("non-epoch receiver is not allowed"))
+                    {
+                        TestUtility.Log($"Received expected exception {ex.GetType()}: {ex.Message}");
+                    }
                 }
-                catch (ReceiverDisconnectedException ex) when (ex.Message.Contains("non-epoch receiver is not allowed"))
+                finally
                 {
-                    TestUtility.Log($"Received expected exception {ex.GetType()}: {ex.Message}");
+                    await Task.WhenAll(
+                        epochReceiver.CloseAsync(),
+                        nonEpochReceiver.CloseAsync(),
+                        ehClient.CloseAsync());
                 }
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    epochReceiver.CloseAsync(),
-                    nonEpochReceiver.CloseAsync(),
-                    ehClient.CloseAsync());
             }
         }
 
@@ -493,39 +538,44 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateEpochReceiverAfterNonEpochReceiver()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var nonEpochReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
-            var epochReceiver = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log("Starting nonepoch receiver");
-                await nonEpochReceiver.ReceiveAsync(10);
-
-                await Task.Delay(TimeSpan.FromSeconds(10));
-
-                TestUtility.Log("Starting epoch receiver");
-                await epochReceiver.ReceiveAsync(10);
-
-                await Task.Delay(TimeSpan.FromSeconds(10));
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var nonEpochReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
+                var epochReceiver = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(), 1);
 
                 try
                 {
-                    TestUtility.Log("Restarting nonepoch receiver, this should fail");
+                    TestUtility.Log("Starting nonepoch receiver");
                     await nonEpochReceiver.ReceiveAsync(10);
-                    throw new InvalidOperationException("Non-Epoch receiver should have encountered an exception by now!");
+
+                    await Task.Delay(TimeSpan.FromSeconds(10));
+
+                    TestUtility.Log("Starting epoch receiver");
+                    await epochReceiver.ReceiveAsync(10);
+
+                    await Task.Delay(TimeSpan.FromSeconds(10));
+
+                    try
+                    {
+                        TestUtility.Log("Restarting nonepoch receiver, this should fail");
+                        await nonEpochReceiver.ReceiveAsync(10);
+                        throw new InvalidOperationException("Non-Epoch receiver should have encountered an exception by now!");
+                    }
+                    catch (ReceiverDisconnectedException ex) when (ex.Message.Contains("non-epoch receiver is not allowed"))
+                    {
+                        TestUtility.Log($"Received expected exception {ex.GetType()}: {ex.Message}");
+                    }
                 }
-                catch (ReceiverDisconnectedException ex) when (ex.Message.Contains("non-epoch receiver is not allowed"))
+                finally
                 {
-                    TestUtility.Log($"Received expected exception {ex.GetType()}: {ex.Message}");
+                    await Task.WhenAll(
+                        epochReceiver.CloseAsync(),
+                        nonEpochReceiver.CloseAsync(),
+                        ehClient.CloseAsync());
                 }
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    epochReceiver.CloseAsync(),
-                    nonEpochReceiver.CloseAsync(),
-                    ehClient.CloseAsync());
             }
         }
 
@@ -534,33 +584,38 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CloseReceiverClient()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var pSender = ehClient.CreatePartitionSender("0");
-            var pReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log("Sending single event to partition 0");
-                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-                await pSender.SendAsync(eventData);
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var pSender = ehClient.CreatePartitionSender("0");
+                var pReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
 
-                TestUtility.Log("Receiving the event.");
-                var events = await pReceiver.ReceiveAsync(1);
-                Assert.True(events != null && events.Count() == 1, "Failed to receive 1 event");
+                try
+                {
+                    TestUtility.Log("Sending single event to partition 0");
+                    var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
+                    await pSender.SendAsync(eventData);
+
+                    TestUtility.Log("Receiving the event.");
+                    var events = await pReceiver.ReceiveAsync(1);
+                    Assert.True(events != null && events.Count() == 1, "Failed to receive 1 event");
+                }
+                finally
+                {
+                    TestUtility.Log("Closing partition receiver");
+                    await Task.WhenAll(
+                        pReceiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
+
+                await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+                {
+                    TestUtility.Log("Receiving another event from partition 0 on the closed receiver, this should fail");
+                    await pReceiver.ReceiveAsync(1);
+                });
             }
-            finally
-            {
-                TestUtility.Log("Closing partition receiver");
-                await Task.WhenAll(
-                    pReceiver.CloseAsync(),
-                    ehClient.CloseAsync());
-            }
-
-            await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
-            {
-                TestUtility.Log("Receiving another event from partition 0 on the closed receiver, this should fail");
-                await pReceiver.ReceiveAsync(1);
-            });
         }
 
         [Fact]
@@ -568,49 +623,54 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task ReceiverIdentifier()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var receivers = new List<PartitionReceiver>();
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                for (int i=0; i < 5; i++)
-                {
-                    TestUtility.Log($"Creating receiver {i}");
-                    var newReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(),
-                        new ReceiverOptions()
-                        {
-                            Identifier = $"receiver{i}"
-                        });
-
-                    // Issue a receive call so link will become active.
-                    await newReceiver.ReceiveAsync(10);
-                    receivers.Add(newReceiver);
-                }
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var receivers = new List<PartitionReceiver>();
 
                 try
                 {
-                    // Attempt to create 6th receiver. This should fail.
-                    var failReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
-                    await failReceiver.ReceiveAsync(10);
-                    throw new InvalidOperationException("6th receiver should have encountered QuotaExceededException.");
-                }
-                catch (QuotaExceededException ex)
-                {
-                    TestUtility.Log($"Received expected exception {ex.GetType()}: {ex.Message}");
-                    foreach (var receiver in receivers)
+                    for (int i = 0; i < 5; i++)
                     {
-                        Assert.True(ex.Message.Contains(receiver.Identifier), $"QuotaExceededException message is missing receiver identifier '{receiver.Identifier}'");
+                        TestUtility.Log($"Creating receiver {i}");
+                        var newReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart(),
+                            new ReceiverOptions()
+                            {
+                                Identifier = $"receiver{i}"
+                            });
+
+                        // Issue a receive call so link will become active.
+                        await newReceiver.ReceiveAsync(10);
+                        receivers.Add(newReceiver);
+                    }
+
+                    try
+                    {
+                        // Attempt to create 6th receiver. This should fail.
+                        var failReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "1", EventPosition.FromStart());
+                        await failReceiver.ReceiveAsync(10);
+                        throw new InvalidOperationException("6th receiver should have encountered QuotaExceededException.");
+                    }
+                    catch (QuotaExceededException ex)
+                    {
+                        TestUtility.Log($"Received expected exception {ex.GetType()}: {ex.Message}");
+                        foreach (var receiver in receivers)
+                        {
+                            Assert.True(ex.Message.Contains(receiver.Identifier), $"QuotaExceededException message is missing receiver identifier '{receiver.Identifier}'");
+                        }
                     }
                 }
-            }
-            finally
-            {
-                // Close all receivers.
-                foreach (var receiver in receivers)
+                finally
                 {
-                    await Task.WhenAll(
-                        receiver.CloseAsync(),
-                        ehClient.CloseAsync());
+                    // Close all receivers.
+                    foreach (var receiver in receivers)
+                    {
+                        await Task.WhenAll(
+                            receiver.CloseAsync(),
+                            ehClient.CloseAsync());
+                    }
                 }
             }
         }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/ReceiverTests.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
-
     public class ReceiverTests : ClientTestBase
     {
         [Fact]
@@ -21,6 +20,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var partitionId = "1";
             var payloadString = "Hello EventHub!";
+
             await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
@@ -51,10 +51,12 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var receiver = default(PartitionReceiver);
             var partitionSender = default(PartitionSender);
-            await using (var scope = await EventHubScope.CreateAsync(2))
+
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
                 try
                 {
                     // Randomly pick one of the available partitons.
@@ -75,7 +77,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                     // Create a new receiver which will start reading from the end of the stream.
                     TestUtility.Log($"Creating a new receiver with offset EndOFStream");
                     receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, partitionId, EventPosition.FromEnd());
-
 
                     // Attemp to receive the message. This should return only 1 message.
                     var receiveTask = receiver.ReceiveAsync(100);
@@ -121,7 +122,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var receiver = default(PartitionReceiver);
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -176,7 +177,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var receiver = default(PartitionReceiver);
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -225,7 +226,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var receiver = default(PartitionReceiver);
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -280,10 +281,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var receiver = default(PartitionReceiver);
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
                 try
                 {
                     // Randomly pick one of the available partitons.
@@ -334,10 +336,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var receiver = default(PartitionReceiver);
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
                 try
                 {
                     // Randomly pick one of the available partitons.
@@ -384,7 +387,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             TestUtility.Log("Receiving Events via PartitionReceiver.ReceiveAsync(BatchSize)");
             const string partitionId = "0";
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -497,7 +500,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateNonEpochReceiverAfterEpochReceiver()
         {
-
             await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
@@ -538,7 +540,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CreateEpochReceiverAfterNonEpochReceiver()
         {
-
             await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
@@ -584,8 +585,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CloseReceiverClient()
         {
-
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -623,7 +623,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task ReceiverIdentifier()
         {
-
             await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/RetryTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/RetryTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var testMaxRetryCount = 99;
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/RetryTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/RetryTests.cs
@@ -5,6 +5,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 {
     using System;
     using Xunit;
+    using System.Threading;
+    using System.Threading.Tasks;
 
     public class RetryTests
     {
@@ -91,24 +93,28 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
-        public void ChildEntityShouldInheritRetryPolicyFromParent()
+        public async Task ChildEntityShouldInheritRetryPolicyFromParent()
         {
             var testMaxRetryCount = 99;
 
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            ehClient.RetryPolicy = new RetryPolicyCustom(testMaxRetryCount);
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                ehClient.RetryPolicy = new RetryPolicyCustom(testMaxRetryCount);
 
-            // Validate partition sender inherits.
-            var sender = ehClient.CreateEventSender("0");
-            Assert.True(sender.RetryPolicy is RetryPolicyCustom, "Sender failed to inherit parent client's RetryPolicy setting.");
-            Assert.True((sender.RetryPolicy as RetryPolicyCustom).maximumRetryCount == testMaxRetryCount,
-                $"Retry policy on the sender shows testMaxRetryCount as {(sender.RetryPolicy as RetryPolicyCustom).maximumRetryCount}");
+                // Validate partition sender inherits.
+                var sender = ehClient.CreateEventSender("0");
+                Assert.True(sender.RetryPolicy is RetryPolicyCustom, "Sender failed to inherit parent client's RetryPolicy setting.");
+                Assert.True((sender.RetryPolicy as RetryPolicyCustom).maximumRetryCount == testMaxRetryCount,
+                    $"Retry policy on the sender shows testMaxRetryCount as {(sender.RetryPolicy as RetryPolicyCustom).maximumRetryCount}");
 
-            // Validate partition receiver inherits.
-            var receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-            Assert.True(receiver.RetryPolicy is RetryPolicyCustom, "Receiver failed to inherit parent client's RetryPolicy setting.");
-            Assert.True((receiver.RetryPolicy as RetryPolicyCustom).maximumRetryCount == testMaxRetryCount,
-                $"Retry policy on the receiver shows testMaxRetryCount as {(receiver.RetryPolicy as RetryPolicyCustom).maximumRetryCount}");
+                // Validate partition receiver inherits.
+                var receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                Assert.True(receiver.RetryPolicy is RetryPolicyCustom, "Receiver failed to inherit parent client's RetryPolicy setting.");
+                Assert.True((receiver.RetryPolicy as RetryPolicyCustom).maximumRetryCount == testMaxRetryCount,
+                    $"Retry policy on the receiver shows testMaxRetryCount as {(receiver.RetryPolicy as RetryPolicyCustom).maximumRetryCount}");
+            }
         }
 
         public sealed class RetryPolicyCustom : RetryPolicy

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/RuntimeInformationTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/RuntimeInformationTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
+
     public class RuntimeInformationTests : ClientTestBase
     {
         [Fact]
@@ -17,26 +18,31 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task GetEventHubRuntimeInformation()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log("Getting  EventHubRuntimeInformation");
-                var eventHubRuntimeInformation = await ehClient.GetRuntimeInformationAsync();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-                Assert.True(eventHubRuntimeInformation != null, "eventHubRuntimeInformation was null!");
-                Assert.True(eventHubRuntimeInformation.PartitionIds != null, "eventHubRuntimeInformation.PartitionIds was null!");
-                Assert.True(eventHubRuntimeInformation.PartitionIds.Length != 0, "eventHubRuntimeInformation.PartitionIds.Length was 0!");
-
-                TestUtility.Log("Found partitions:");
-                foreach (string partitionId in eventHubRuntimeInformation.PartitionIds)
+                try
                 {
-                    TestUtility.Log(partitionId);
+                    TestUtility.Log("Getting  EventHubRuntimeInformation");
+                    var eventHubRuntimeInformation = await ehClient.GetRuntimeInformationAsync();
+
+                    Assert.True(eventHubRuntimeInformation != null, "eventHubRuntimeInformation was null!");
+                    Assert.True(eventHubRuntimeInformation.PartitionIds != null, "eventHubRuntimeInformation.PartitionIds was null!");
+                    Assert.True(eventHubRuntimeInformation.PartitionIds.Length != 0, "eventHubRuntimeInformation.PartitionIds.Length was 0!");
+
+                    TestUtility.Log("Found partitions:");
+                    foreach (string partitionId in eventHubRuntimeInformation.PartitionIds)
+                    {
+                        TestUtility.Log(partitionId);
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -45,52 +51,58 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task GetEventHubPartitionRuntimeInformation()
         {
-            var cbs = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitions = await this.GetPartitionsAsync(ehClient);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log("Getting EventHubPartitionRuntimeInformation on each partition in parallel");
-                var tasks = partitions.Select(async (pid) =>
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
+                var ehClient = EventHubClient.CreateFromConnectionString(csb.ToString());
+                var partitions = await this.GetPartitionsAsync(ehClient);
+
+                try
                 {
-                    // Send some messages so we can have meaningful data returned from service call.
-                    PartitionSender partitionSender = ehClient.CreatePartitionSender(pid);
-
-                    try
+                    TestUtility.Log("Getting EventHubPartitionRuntimeInformation on each partition in parallel");
+                    var tasks = partitions.Select(async (pid) =>
                     {
-                        TestUtility.Log($"Sending single event to partition {pid}");
-                        var eDataToSend = new EventData(new byte[1]);
-                        await partitionSender.SendAsync(eDataToSend);
+                        // Send some messages so we can have meaningful data returned from service call.
+                        PartitionSender partitionSender = ehClient.CreatePartitionSender(pid);
 
-                        TestUtility.Log($"Getting partition runtime information on partition {pid}");
-                        var partition = await ehClient.GetPartitionRuntimeInformationAsync(pid);
-                        TestUtility.Log($"Path:{partition.Path} PartitionId:{partition.PartitionId} BeginSequenceNumber:{partition.BeginSequenceNumber} LastEnqueuedOffset:{partition.LastEnqueuedOffset} LastEnqueuedTimeUtc:{partition.LastEnqueuedTimeUtc} LastEnqueuedSequenceNumber:{partition.LastEnqueuedSequenceNumber}");
+                        try
+                        {
+                            TestUtility.Log($"Sending single event to partition {pid}");
+                            var eDataToSend = new EventData(new byte[1]);
+                            await partitionSender.SendAsync(eDataToSend);
 
-                        // Validations.
-                        Assert.True(partition.Path == cbs.EntityPath, $"Returned path {partition.Path} is different than {cbs.EntityPath}");
-                        Assert.True(partition.PartitionId == pid, $"Returned partition id {partition.PartitionId} is different than {pid}");
-                        Assert.True(partition.LastEnqueuedOffset != null, "Returned LastEnqueuedOffset is null");
-                        Assert.True(partition.LastEnqueuedTimeUtc != null, "Returned LastEnqueuedTimeUtc is null");
+                            TestUtility.Log($"Getting partition runtime information on partition {pid}");
+                            var partition = await ehClient.GetPartitionRuntimeInformationAsync(pid);
+                            TestUtility.Log($"Path:{partition.Path} PartitionId:{partition.PartitionId} BeginSequenceNumber:{partition.BeginSequenceNumber} LastEnqueuedOffset:{partition.LastEnqueuedOffset} LastEnqueuedTimeUtc:{partition.LastEnqueuedTimeUtc} LastEnqueuedSequenceNumber:{partition.LastEnqueuedSequenceNumber}");
 
-                        // Validate returned data regarding recently sent event.
-                        // Account 60 seconds of max clock skew.
-                        Assert.True(partition.LastEnqueuedOffset != "-1", $"Returned LastEnqueuedOffset is {partition.LastEnqueuedOffset}");
-                        Assert.True(partition.BeginSequenceNumber >= 0, $"Returned BeginSequenceNumber is {partition.BeginSequenceNumber}");
-                        Assert.True(partition.LastEnqueuedSequenceNumber >= 0, $"Returned LastEnqueuedSequenceNumber is {partition.LastEnqueuedSequenceNumber}");
-                        Assert.True(partition.LastEnqueuedTimeUtc >= DateTime.UtcNow.AddSeconds(-60), $"Returned LastEnqueuedTimeUtc is {partition.LastEnqueuedTimeUtc}");
-                    }
-                    finally
-                    {
-                        await partitionSender.CloseAsync();
-                    }
-                });
+                            // Validations.
+                            Assert.True(partition.Path == csb.EntityPath, $"Returned path {partition.Path} is different than {csb.EntityPath}");
+                            Assert.True(partition.PartitionId == pid, $"Returned partition id {partition.PartitionId} is different than {pid}");
+                            Assert.True(partition.LastEnqueuedOffset != null, "Returned LastEnqueuedOffset is null");
+                            Assert.True(partition.LastEnqueuedTimeUtc != null, "Returned LastEnqueuedTimeUtc is null");
 
-                await Task.WhenAll(tasks);
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                            // Validate returned data regarding recently sent event.
+                            // Account 60 seconds of max clock skew.
+                            Assert.True(partition.LastEnqueuedOffset != "-1", $"Returned LastEnqueuedOffset is {partition.LastEnqueuedOffset}");
+                            Assert.True(partition.BeginSequenceNumber >= 0, $"Returned BeginSequenceNumber is {partition.BeginSequenceNumber}");
+                            Assert.True(partition.LastEnqueuedSequenceNumber >= 0, $"Returned LastEnqueuedSequenceNumber is {partition.LastEnqueuedSequenceNumber}");
+                            Assert.True(partition.LastEnqueuedTimeUtc >= DateTime.UtcNow.AddSeconds(-60), $"Returned LastEnqueuedTimeUtc is {partition.LastEnqueuedTimeUtc}");
+                        }
+                        finally
+                        {
+                            await partitionSender.CloseAsync();
+                        }
+                    });
+
+                    await Task.WhenAll(tasks);
+                }
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -104,30 +116,35 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
             TestUtility.Log($"Starting {maxNumberOfClients} GetRuntimeInformationAsync tasks in parallel.");
 
-            var tasks = new List<Task>();
-            for (var i = 0; i < maxNumberOfClients; i++)
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                var task = Task.Run(async () =>
+                var tasks = new List<Task>();
+                for (var i = 0; i < maxNumberOfClients; i++)
                 {
-                    await tcs.Task;
-                    var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-                    try
+                    var task = Task.Run(async () =>
                     {
-                        await ehClient.GetRuntimeInformationAsync();
-                    }
-                    finally
-                    {
-                        await ehClient.CloseAsync();
-                    }
-                });
+                        await tcs.Task;
+                        var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                        var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-                tasks.Add(task);
+                        try
+                        {
+                            await ehClient.GetRuntimeInformationAsync();
+                        }
+                        finally
+                        {
+                            await ehClient.CloseAsync();
+                        }
+
+                    });
+
+                    tasks.Add(task);
+                }
+
+                await Task.Delay(10000);
+                tcs.TrySetResult(true);
+                await Task.WhenAll(tasks);
             }
-
-            await Task.Delay(10000);
-            tcs.TrySetResult(true);
-            await Task.WhenAll(tasks);
 
             TestUtility.Log("All GetRuntimeInformationAsync tasks have completed.");
         }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/RuntimeInformationTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/RuntimeInformationTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
-
     public class RuntimeInformationTests : ClientTestBase
     {
         [Fact]
@@ -18,8 +17,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task GetEventHubRuntimeInformation()
         {
-
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -51,11 +49,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task GetEventHubPartitionRuntimeInformation()
         {
-
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-
                 var csb = new EventHubsConnectionStringBuilder(connectionString);
                 var ehClient = EventHubClient.CreateFromConnectionString(csb.ToString());
                 var partitions = await this.GetPartitionsAsync(ehClient);
@@ -116,9 +112,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
             TestUtility.Log($"Starting {maxNumberOfClients} GetRuntimeInformationAsync tasks in parallel.");
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var tasks = new List<Task>();
+
                 for (var i = 0; i < maxNumberOfClients; i++)
                 {
                     var task = Task.Run(async () =>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
+
     public class SendTests : ClientTestBase
     {
         [Fact]
@@ -19,21 +20,26 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task SendAndReceiveZeroLengthBody()
         {
             var targetPartition = "0";
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                using (var zeroBodyEventData = new EventData(new byte[0]))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
+                try
                 {
-                    var edReceived = await SendAndReceiveEventAsync(targetPartition, zeroBodyEventData, ehClient);
+                    using (var zeroBodyEventData = new EventData(new byte[0]))
+                    {
+                        var edReceived = await SendAndReceiveEventAsync(targetPartition, zeroBodyEventData, ehClient);
 
-                    // Validate body.
-                    Assert.True(edReceived.Body.Count == 0, $"Received event's body isn't zero byte long.");
+                        // Validate body.
+                        Assert.True(edReceived.Body.Count == 0, $"Received event's body isn't zero byte long.");
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -44,18 +50,22 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             TestUtility.Log("Sending single Event via EventHubClient.SendAsync(EventData, string)");
 
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-            try
-            {
-                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!")))
+                try
                 {
-                    await ehClient.SendAsync(eventData, "SomePartitionKeyHere");
+                    using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub by partitionKey!")))
+                    {
+                        await ehClient.SendAsync(eventData, "SomePartitionKeyHere");
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -66,20 +76,24 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             TestUtility.Log("Sending multiple Events via EventHubClient.SendAsync(IEnumerable<EventData>)");
 
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-            try
-            {
-                using (var eventData1 = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
-                using (var eventData2 = new EventData(Encoding.UTF8.GetBytes("This is another message in the batch!")))
+                try
                 {
-                    eventData2.Properties["ContosoEventType"] = "some value here";
-                    await ehClient.SendAsync(new[] { eventData1, eventData2 });
+                    using (var eventData1 = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
+                    using (var eventData2 = new EventData(Encoding.UTF8.GetBytes("This is another message in the batch!")))
+                    {
+                        eventData2.Properties["ContosoEventType"] = "some value here";
+                        await ehClient.SendAsync(new[] { eventData1, eventData2 });
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -90,21 +104,25 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             TestUtility.Log("Sending single Event via PartitionSender.SendAsync(EventData)");
 
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionSender1 = ehClient.CreatePartitionSender("1");
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionSender1 = ehClient.CreatePartitionSender("1");
 
-            try
-            {
-                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello again EventHub Partition 1!")))
+                try
                 {
-                    await partitionSender1.SendAsync(eventData);
+                    using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello again EventHub Partition 1!")))
+                    {
+                        await partitionSender1.SendAsync(eventData);
+                    }
                 }
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    partitionSender1?.CloseAsync(),
-                    ehClient.CloseAsync());
+                finally
+                {
+                    await Task.WhenAll(
+                        partitionSender1?.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -115,23 +133,27 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             TestUtility.Log("Sending single Event via PartitionSender.SendAsync(IEnumerable<EventData>)");
 
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var partitionSender1 = ehClient.CreatePartitionSender("1");
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var partitionSender1 = ehClient.CreatePartitionSender("1");
 
-            try
-            {
-                using (var eventData1 = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
-                using (var eventData2 = new EventData(Encoding.UTF8.GetBytes("This is another message in the batch!")))
+                try
                 {
-                    eventData2.Properties["ContosoEventType"] = "some value here";
-                    await partitionSender1.SendAsync(new[] { eventData1, eventData2 });
+                    using (var eventData1 = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
+                    using (var eventData2 = new EventData(Encoding.UTF8.GetBytes("This is another message in the batch!")))
+                    {
+                        eventData2.Properties["ContosoEventType"] = "some value here";
+                        await partitionSender1.SendAsync(new[] { eventData1, eventData2 });
+                    }
                 }
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    partitionSender1?.CloseAsync(),
-                    ehClient.CloseAsync());
+                finally
+                {
+                    await Task.WhenAll(
+                        partitionSender1?.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -142,21 +164,26 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var targetPartition = "0";
             var byteArr = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                using (var edToSend = new EventData(new ArraySegment<byte>(byteArr)))
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+
+                try
                 {
-                    var edReceived = await SendAndReceiveEventAsync(targetPartition, edToSend, ehClient);
+                    using (var edToSend = new EventData(new ArraySegment<byte>(byteArr)))
+                    {
+                        var edReceived = await SendAndReceiveEventAsync(targetPartition, edToSend, ehClient);
 
-                    // Validate array segment count.
-                    Assert.True(edReceived.Body.Count == byteArr.Count(), $"Sent {byteArr.Count()} bytes and received {edReceived.Body.Count}");
+                        // Validate array segment count.
+                        Assert.True(edReceived.Body.Count == byteArr.Count(), $"Sent {byteArr.Count()} bytes and received {edReceived.Body.Count}");
+                    }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -170,31 +197,35 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
             TestUtility.Log($"Starting {maxNumberOfClients} SendAsync tasks in parallel.");
 
-            var tasks = new List<Task>();
-            for (var i = 0; i < maxNumberOfClients; i++)
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                var task = Task.Run(async () =>
+                var tasks = new List<Task>();
+                for (var i = 0; i < maxNumberOfClients; i++)
                 {
-                    await startGate.Task;
-                    var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-                    try
+                    var task = Task.Run(async () =>
                     {
-                        await ehClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")));
-                    }
-                    finally
-                    {
-                        await ehClient.CloseAsync();
-                    }
-                });
+                        await startGate.Task;
+                        var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                        var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
 
-                tasks.Add(task);
+                        try
+                        {
+                            await ehClient.SendAsync(new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")));
+                        }
+                        finally
+                        {
+                            await ehClient.CloseAsync();
+                        }
+                    });
+
+                    tasks.Add(task);
+                }
+
+
+                await Task.Delay(10000);
+                startGate.TrySetResult(true);
+                await Task.WhenAll(tasks);
             }
-
-            await Task.Delay(10000);
-            startGate.TrySetResult(true);
-            await Task.WhenAll(tasks);
-
             TestUtility.Log("All Send tasks have completed.");
         }
 
@@ -203,34 +234,39 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task CloseSenderClient()
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var pSender = ehClient.CreatePartitionSender("0");
-            var pReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log("Sending single event to partition 0");
-                using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
-                {
-                    await pSender.SendAsync(eventData);
-                    TestUtility.Log("Closing partition sender");
-                    await pSender.CloseAsync();
-                }
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var pSender = ehClient.CreatePartitionSender("0");
+                var pReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
 
-                await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+                try
                 {
-                    TestUtility.Log("Sending another event to partition 0 on the closed sender, this should fail");
+                    TestUtility.Log("Sending single event to partition 0");
                     using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
                     {
                         await pSender.SendAsync(eventData);
+                        TestUtility.Log("Closing partition sender");
+                        await pSender.CloseAsync();
                     }
-                });
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    pReceiver.CloseAsync(),
-                    ehClient.CloseAsync());
+
+                    await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+                    {
+                        TestUtility.Log("Sending another event to partition 0 on the closed sender, this should fail");
+                        using (var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!")))
+                        {
+                            await pSender.SendAsync(eventData);
+                        }
+                    });
+                }
+                finally
+                {
+                    await Task.WhenAll(
+                        pReceiver.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
 
@@ -241,55 +277,59 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             string targetPartitionKey = "this is the partition key";
 
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var receiver = default(PartitionReceiver);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Mark end of each partition so that we can start reading from there.
-                var partitionIds = await this.GetPartitionsAsync(ehClient);
-                var partitions = await TestUtility.DiscoverEndOfStreamForPartitionsAsync(ehClient, partitionIds);
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var receiver = default(PartitionReceiver);
 
-                // Send a batch of 2 messages.
-                using (var eventData1 = new EventData(Guid.NewGuid().ToByteArray()))
-                using (var eventData2 = new EventData(Guid.NewGuid().ToByteArray()))
+                try
                 {
-                    await ehClient.SendAsync(new[] { eventData1, eventData2 }, targetPartitionKey);
-                }
+                    // Mark end of each partition so that we can start reading from there.
+                    var partitionIds = await this.GetPartitionsAsync(ehClient);
+                    var partitions = await TestUtility.DiscoverEndOfStreamForPartitionsAsync(ehClient, partitionIds);
 
-                // Now find out the partition where our messages landed.
-                var targetPartition = "";
-                foreach (var pId in partitionIds)
-                {
-                    var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(pId);
-                    if (pInfo.LastEnqueuedOffset != partitions[pId])
+                    // Send a batch of 2 messages.
+                    using (var eventData1 = new EventData(Guid.NewGuid().ToByteArray()))
+                    using (var eventData2 = new EventData(Guid.NewGuid().ToByteArray()))
                     {
-                        targetPartition = pId;
-                        TestUtility.Log($"Batch landed on partition {targetPartition}");
+                        await ehClient.SendAsync(new[] { eventData1, eventData2 }, targetPartitionKey);
                     }
+
+                    // Now find out the partition where our messages landed.
+                    var targetPartition = "";
+                    foreach (var pId in partitionIds)
+                    {
+                        var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(pId);
+                        if (pInfo.LastEnqueuedOffset != partitions[pId])
+                        {
+                            targetPartition = pId;
+                            TestUtility.Log($"Batch landed on partition {targetPartition}");
+                        }
+                    }
+
+                    // Confirm that we identified the partition with our messages.
+                    Assert.True(targetPartition != "", "None of the partition offsets moved.");
+
+                    // Receive all messages from target partition.
+                    receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartition, EventPosition.FromOffset(partitions[targetPartition]));
+                    var messages = await ReceiveAllMessagesAsync(receiver);
+
+                    // Validate 2 messages received.
+                    Assert.True(messages.Count == 2, $"Received {messages.Count} messages instead of 2.");
+
+                    // Validate both messages carry correct partition id.
+                    Assert.True(messages[0].SystemProperties.PartitionKey == targetPartitionKey,
+                        $"First message returned partition key value '{messages[0].SystemProperties.PartitionKey}'");
+                    Assert.True(messages[1].SystemProperties.PartitionKey == targetPartitionKey,
+                        $"Second message returned partition key value '{messages[1].SystemProperties.PartitionKey}'");
                 }
-
-                // Confirm that we identified the partition with our messages.
-                Assert.True(targetPartition != "", "None of the partition offsets moved.");
-
-                // Receive all messages from target partition.
-                receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, targetPartition, EventPosition.FromOffset(partitions[targetPartition]));
-                var messages = await ReceiveAllMessagesAsync(receiver);
-
-                // Validate 2 messages received.
-                Assert.True(messages.Count == 2, $"Received {messages.Count} messages instead of 2.");
-
-                // Validate both messages carry correct partition id.
-                Assert.True(messages[0].SystemProperties.PartitionKey == targetPartitionKey,
-                    $"First message returned partition key value '{messages[0].SystemProperties.PartitionKey}'");
-                Assert.True(messages[1].SystemProperties.PartitionKey == targetPartitionKey,
-                    $"Second message returned partition key value '{messages[1].SystemProperties.PartitionKey}'");
-            }
-            finally
-            {
-                await Task.WhenAll(
-                    receiver?.CloseAsync(),
-                    ehClient.CloseAsync());
+                finally
+                {
+                    await Task.WhenAll(
+                        receiver?.CloseAsync(),
+                        ehClient.CloseAsync());
+                }
             }
         }
     }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/SendTests.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
-
     public class SendTests : ClientTestBase
     {
         [Fact]
@@ -21,7 +20,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var targetPartition = "0";
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -50,7 +49,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             TestUtility.Log("Sending single Event via EventHubClient.SendAsync(EventData, string)");
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -76,7 +75,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             TestUtility.Log("Sending multiple Events via EventHubClient.SendAsync(IEnumerable<EventData>)");
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -133,11 +132,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             TestUtility.Log("Sending single Event via PartitionSender.SendAsync(IEnumerable<EventData>)");
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
-                var partitionSender1 = ehClient.CreatePartitionSender("1");
+                var partitionSender1 = ehClient.CreatePartitionSender("0");
 
                 try
                 {
@@ -165,7 +164,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             var targetPartition = "0";
             var byteArr = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -197,9 +196,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
             TestUtility.Log($"Starting {maxNumberOfClients} SendAsync tasks in parallel.");
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var tasks = new List<Task>();
+
                 for (var i = 0; i < maxNumberOfClients; i++)
                 {
                     var task = Task.Run(async () =>
@@ -221,11 +221,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                     tasks.Add(task);
                 }
 
-
                 await Task.Delay(10000);
                 startGate.TrySetResult(true);
                 await Task.WhenAll(tasks);
             }
+
             TestUtility.Log("All Send tasks have completed.");
         }
 
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task CloseSenderClient()
         {
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
@@ -277,7 +277,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             string targetPartitionKey = "this is the partition key";
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TimeoutTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TimeoutTests.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
-
     public class TimeoutTests : ClientTestBase
     {
         [Fact]
@@ -18,11 +17,12 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         {
             var testValues = new[] { 30, 60, 120 };
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
                 var receiver = default(PartitionReceiver);
+
                 try
                 {
                     foreach (var receiveTimeoutInSeconds in testValues)
@@ -74,12 +74,14 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             // Issue receives with 1 second so that some of the Receive calls will timeout while creating AMQP link.
             // Even those Receive calls should return NULL instead of bubbling the exception up.
             var receiveTimeoutInSeconds = 1;
-            await using (var scope = await EventHubScope.CreateAsync(2))
+
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var tasks = Enumerable.Range(0, maxClients)
                 .Select(async i =>
                 {
                     PartitionReceiver receiver = null;
+
                     try
                     {
                         TestUtility.Log($"Testing with {receiveTimeoutInSeconds} seconds on client {i}.");

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TimeoutTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TimeoutTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
+
     public class TimeoutTests : ClientTestBase
     {
         [Fact]
@@ -16,41 +17,45 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task ReceiveTimeout()
         {
             var testValues = new[] { 30, 60, 120 };
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-            var receiver = default(PartitionReceiver);
 
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                foreach (var receiveTimeoutInSeconds in testValues)
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                var receiver = default(PartitionReceiver);
+                try
                 {
-                    TestUtility.Log($"Testing with {receiveTimeoutInSeconds} seconds.");
-
-                    try
+                    foreach (var receiveTimeoutInSeconds in testValues)
                     {
-                        // Start receiving from a future time so that Receive call won't be able to fetch any events.
-                        receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(1)));
+                        TestUtility.Log($"Testing with {receiveTimeoutInSeconds} seconds.");
 
-                        var startTime = DateTime.Now;
-                        await receiver.ReceiveAsync(1, TimeSpan.FromSeconds(receiveTimeoutInSeconds));
+                        try
+                        {
+                            // Start receiving from a future time so that Receive call won't be able to fetch any events.
+                            receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(1)));
 
-                        // Receive call should have waited more than receive timeout.
-                        // Give 100 milliseconds of buffer.
-                        var diff = DateTime.Now.Subtract(startTime).TotalSeconds;
-                        Assert.True(diff >= receiveTimeoutInSeconds - 0.1, $"Hit timeout {diff} seconds into Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
+                            var startTime = DateTime.Now;
+                            await receiver.ReceiveAsync(1, TimeSpan.FromSeconds(receiveTimeoutInSeconds));
 
-                        // Timeout should not be late more than 5 seconds.
-                        // This is just a logical buffer for timeout behavior validation.
-                        Assert.True(diff < receiveTimeoutInSeconds + 5, $"Hit timeout {diff} seconds into Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
-                    }
-                    finally
-                    {
-                        await receiver.CloseAsync();
+                            // Receive call should have waited more than receive timeout.
+                            // Give 100 milliseconds of buffer.
+                            var diff = DateTime.Now.Subtract(startTime).TotalSeconds;
+                            Assert.True(diff >= receiveTimeoutInSeconds - 0.1, $"Hit timeout {diff} seconds into Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
+
+                            // Timeout should not be late more than 5 seconds.
+                            // This is just a logical buffer for timeout behavior validation.
+                            Assert.True(diff < receiveTimeoutInSeconds + 5, $"Hit timeout {diff} seconds into Receive call while testing {receiveTimeoutInSeconds} seconds timeout.");
+                        }
+                        finally
+                        {
+                            await receiver.CloseAsync();
+                        }
                     }
                 }
-            }
-            finally
-            {
-                await ehClient.CloseAsync();
+                finally
+                {
+                    await ehClient.CloseAsync();
+                }
             }
         }
 
@@ -62,25 +67,25 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
-       public  async Task SmallReceiveTimeout()
+        public async Task SmallReceiveTimeout()
         {
             var maxClients = 4;
 
             // Issue receives with 1 second so that some of the Receive calls will timeout while creating AMQP link.
             // Even those Receive calls should return NULL instead of bubbling the exception up.
             var receiveTimeoutInSeconds = 1;
-
-            var tasks = Enumerable.Range(0, maxClients)
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
+                var tasks = Enumerable.Range(0, maxClients)
                 .Select(async i =>
                 {
                     PartitionReceiver receiver = null;
-
                     try
                     {
                         TestUtility.Log($"Testing with {receiveTimeoutInSeconds} seconds on client {i}.");
-
                         // Start receiving from a future time so that Receive call won't be able to fetch any events.
-                        var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+                        var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                        var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
                         receiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromEnqueuedTime(DateTime.UtcNow.AddMinutes(1)));
                         var ed = await receiver.ReceiveAsync(1, TimeSpan.FromSeconds(receiveTimeoutInSeconds));
                         if (ed == null)
@@ -94,7 +99,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                     }
                 });
 
-            await Task.WhenAll(tasks);
+                await Task.WhenAll(tasks);
+            }
         }
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TokenProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TokenProviderTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using Microsoft.IdentityModel.Clients.ActiveDirectory;
     using Xunit;
 
+
     public class TokenProviderTests : ClientTestBase
     {
         [Fact]
@@ -17,50 +18,53 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task UseSharedAccessSignature()
         {
-            // Generate shared access token.
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(csb.SasKeyName, csb.SasKey);
-            var token = await tokenProvider.GetTokenAsync(csb.Endpoint.ToString(), TimeSpan.FromSeconds(120));
-            var sas = token.TokenValue.ToString();
 
-            // Update connection string builder to use shared access signature instead.
-            csb.SasKey = "";
-            csb.SasKeyName = "";
-            csb.SharedAccessSignature = sas;
-
-            // Create new client with updated connection string.
-            var ehClient = EventHubClient.CreateFromConnectionString(csb.ToString());
-
-            // Send one event
-            TestUtility.Log($"Sending one message.");
-            var ehSender = ehClient.CreatePartitionSender("0");
-            var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-            await ehSender.SendAsync(eventData);
-
-            // Receive event.
-            // Receive event.
-            PartitionReceiver ehReceiver = null;
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log($"Receiving one message.");
-                ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-                var msg = await ehReceiver.ReceiveAsync(1);
-                Assert.True(msg != null, "Failed to receive message.");
-            }
-            finally
-            {
-                await ehReceiver?.CloseAsync();
-            }
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
+                var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(csb.SasKeyName, csb.SasKey);
+                var token = await tokenProvider.GetTokenAsync(csb.Endpoint.ToString(), TimeSpan.FromSeconds(120));
+                var sas = token.TokenValue.ToString();
 
-            // Get EH runtime information.
-            TestUtility.Log($"Getting Event Hub runtime information.");
-            var ehInfo = await ehClient.GetRuntimeInformationAsync();
-            Assert.True(ehInfo != null, "Failed to get runtime information.");
+                // Update connection string builder to use shared access signature instead.
+                csb.SasKey = "";
+                csb.SasKeyName = "";
+                csb.SharedAccessSignature = sas;
 
-            // Get EH partition runtime information.
-            TestUtility.Log($"Getting Event Hub partition '0' runtime information.");
-            var partitionInfo = await ehClient.GetPartitionRuntimeInformationAsync("0");
-            Assert.True(ehInfo != null, "Failed to get runtime partition information.");
+                // Create new client with updated connection string.
+                var ehClient = EventHubClient.CreateFromConnectionString(csb.ToString());
+
+                // Send one event
+                TestUtility.Log($"Sending one message.");
+                var ehSender = ehClient.CreatePartitionSender("0");
+                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
+                await ehSender.SendAsync(eventData);
+
+                // Receive event.
+                PartitionReceiver ehReceiver = null;
+                try
+                {
+                    TestUtility.Log($"Receiving one message.");
+                    ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                    var msg = await ehReceiver.ReceiveAsync(1);
+                    Assert.True(msg != null, "Failed to receive message.");
+                }
+                finally
+                {
+                    await ehReceiver?.CloseAsync();
+                }
+
+                // Get EH runtime information.
+                TestUtility.Log($"Getting Event Hub runtime information.");
+                var ehInfo = await ehClient.GetRuntimeInformationAsync();
+                Assert.True(ehInfo != null, "Failed to get runtime information.");
+
+                // Get EH partition runtime information.
+                TestUtility.Log($"Getting Event Hub partition '0' runtime information.");
+                var partitionInfo = await ehClient.GetPartitionRuntimeInformationAsync("0");
+                Assert.True(ehInfo != null, "Failed to get runtime partition information.");
+            }
         }
 
         [Fact]
@@ -69,41 +73,45 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task UseITokenProviderWithSas()
         {
             // Generate SAS token provider.
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(csb.SasKeyName, csb.SasKey);
-
-            // Create new client with updated connection string.
-            var ehClient = EventHubClient.CreateWithTokenProvider(csb.Endpoint, csb.EntityPath, tokenProvider);
-
-            // Send one event
-            TestUtility.Log($"Sending one message.");
-            var ehSender = ehClient.CreatePartitionSender("0");
-            var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-            await ehSender.SendAsync(eventData);
-
-            // Receive event.
-            PartitionReceiver ehReceiver = null;
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log($"Receiving one message.");
-                ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-                var msg = await ehReceiver.ReceiveAsync(1);
-                Assert.True(msg != null, "Failed to receive message.");
-            }
-            finally
-            {
-                await ehReceiver?.CloseAsync();
-            }
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
+                var tokenProvider = TokenProvider.CreateSharedAccessSignatureTokenProvider(csb.SasKeyName, csb.SasKey);
 
-            // Get EH runtime information.
-            TestUtility.Log($"Getting Event Hub runtime information.");
-            var ehInfo = await ehClient.GetRuntimeInformationAsync();
-            Assert.True(ehInfo != null, "Failed to get runtime information.");
+                // Create new client with updated connection string.
+                var ehClient = EventHubClient.CreateWithTokenProvider(csb.Endpoint, csb.EntityPath, tokenProvider);
 
-            // Get EH partition runtime information.
-            TestUtility.Log($"Getting Event Hub partition '0' runtime information.");
-            var partitionInfo = await ehClient.GetPartitionRuntimeInformationAsync("0");
-            Assert.True(ehInfo != null, "Failed to get runtime partition information.");
+                // Send one event
+                TestUtility.Log($"Sending one message.");
+                var ehSender = ehClient.CreatePartitionSender("0");
+                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
+                await ehSender.SendAsync(eventData);
+
+                // Receive event.
+                PartitionReceiver ehReceiver = null;
+                try
+                {
+                    TestUtility.Log($"Receiving one message.");
+                    ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                    var msg = await ehReceiver.ReceiveAsync(1);
+                    Assert.True(msg != null, "Failed to receive message.");
+                }
+                finally
+                {
+                    await ehReceiver?.CloseAsync();
+                }
+
+                // Get EH runtime information.
+                TestUtility.Log($"Getting Event Hub runtime information.");
+                var ehInfo = await ehClient.GetRuntimeInformationAsync();
+                Assert.True(ehInfo != null, "Failed to get runtime information.");
+
+                // Get EH partition runtime information.
+                TestUtility.Log($"Getting Event Hub partition '0' runtime information.");
+                var partitionInfo = await ehClient.GetPartitionRuntimeInformationAsync("0");
+                Assert.True(ehInfo != null, "Failed to get runtime partition information.");
+            }
         }
 
         /// <summary>
@@ -118,7 +126,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             var aadAppId = "";
             var aadAppSecret = "";
 
-            AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback = 
+            AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback =
                 async (audience, authority, state) =>
                 {
                     var authContext = new AuthenticationContext(authority);
@@ -130,27 +138,31 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             var tokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, appAuthority);
 
             // Create new client with updated connection string.
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            var ehClient = EventHubClient.CreateWithTokenProvider(csb.Endpoint, csb.EntityPath, tokenProvider);
-
-            // Send one event
-            TestUtility.Log($"Sending one message.");
-            var ehSender = ehClient.CreatePartitionSender("0");
-            var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-            await ehSender.SendAsync(eventData);
-
-            // Receive event.
-            PartitionReceiver ehReceiver = null;
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log($"Receiving one message.");
-                ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-                var msg = await ehReceiver.ReceiveAsync(1);
-                Assert.True(msg != null, "Failed to receive message.");
-            }
-            finally
-            {
-                await ehReceiver?.CloseAsync();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
+                var ehClient = EventHubClient.CreateWithTokenProvider(csb.Endpoint, csb.EntityPath, tokenProvider);
+
+                // Send one event
+                TestUtility.Log($"Sending one message.");
+                var ehSender = ehClient.CreatePartitionSender("0");
+                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
+                await ehSender.SendAsync(eventData);
+
+                // Receive event.
+                PartitionReceiver ehReceiver = null;
+                try
+                {
+                    TestUtility.Log($"Receiving one message.");
+                    ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                    var msg = await ehReceiver.ReceiveAsync(1);
+                    Assert.True(msg != null, "Failed to receive message.");
+                }
+                finally
+                {
+                    await ehReceiver?.CloseAsync();
+                }
             }
         }
 
@@ -158,7 +170,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         /// This test is for manual only purpose. Fill in the tenant-id, app-id and app-secret before running.
         /// </summary>
         /// <returns></returns>
-        [Fact (Skip = "Manual run only")]
+        [Fact(Skip = "Manual run only")]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task UseCreateApiWithAad()
@@ -177,27 +189,31 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 };
 
             // Create new client with updated connection string.
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            var ehClient = EventHubClient.CreateWithAzureActiveDirectory(csb.Endpoint, csb.EntityPath, authCallback, appAuthority);
-
-            // Send one event
-            TestUtility.Log($"Sending one message.");
-            var ehSender = ehClient.CreatePartitionSender("0");
-            var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
-            await ehSender.SendAsync(eventData);
-
-            // Receive event.
-            PartitionReceiver ehReceiver = null;
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                TestUtility.Log($"Receiving one message.");
-                ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
-                var msg = await ehReceiver.ReceiveAsync(1);
-                Assert.True(msg != null, "Failed to receive message.");
-            }
-            finally
-            {
-                await ehReceiver?.CloseAsync();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
+                var ehClient = EventHubClient.CreateWithAzureActiveDirectory(csb.Endpoint, csb.EntityPath, authCallback, appAuthority);
+
+                // Send one event
+                TestUtility.Log($"Sending one message.");
+                var ehSender = ehClient.CreatePartitionSender("0");
+                var eventData = new EventData(Encoding.UTF8.GetBytes("Hello EventHub!"));
+                await ehSender.SendAsync(eventData);
+
+                // Receive event.
+                PartitionReceiver ehReceiver = null;
+                try
+                {
+                    TestUtility.Log($"Receiving one message.");
+                    ehReceiver = ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart());
+                    var msg = await ehReceiver.ReceiveAsync(1);
+                    Assert.True(msg != null, "Failed to receive message.");
+                }
+                finally
+                {
+                    await ehReceiver?.CloseAsync();
+                }
             }
         }
     }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TokenProviderTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/TokenProviderTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using Microsoft.IdentityModel.Clients.ActiveDirectory;
     using Xunit;
 
-
     public class TokenProviderTests : ClientTestBase
     {
         [Fact]
@@ -18,8 +17,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         [DisplayTestMethodName]
         public async Task UseSharedAccessSignature()
         {
-
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var csb = new EventHubsConnectionStringBuilder(connectionString);
@@ -73,7 +71,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         public async Task UseITokenProviderWithSas()
         {
             // Generate SAS token provider.
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var csb = new EventHubsConnectionStringBuilder(connectionString);
@@ -138,7 +136,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             var tokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, appAuthority);
 
             // Create new client with updated connection string.
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var csb = new EventHubsConnectionStringBuilder(connectionString);
@@ -189,7 +187,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 };
 
             // Create new client with updated connection string.
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var csb = new EventHubsConnectionStringBuilder(connectionString);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
@@ -132,20 +132,28 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             // Send call should fail.
             await Assert.ThrowsAsync<WebSocketException>(async () =>
             {
-                var ehClient = EventHubClient.CreateFromConnectionString(webSocketConnString);
+                await using (var scope = await EventHubScope.CreateAsync(2))
+                {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
                 ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
                 var edToFail = new EventData(Encoding.UTF8.GetBytes("This is a sample event."));
                 await ehClient.SendAsync(edToFail);
+                }
             });
 
  
 
             // Receive call should fail.
             await Assert.ThrowsAsync<WebSocketException>(async () =>
-            {
-                var ehClient = EventHubClient.CreateFromConnectionString(webSocketConnString);
+            { 
+                await using (var scope = await EventHubScope.CreateAsync(2))
+                {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
                 ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
                 await ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart()).ReceiveAsync(1);
+                }
             });
 
  
@@ -153,16 +161,24 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             // Management link call should fail.
             await Assert.ThrowsAsync<WebSocketException>(async () =>
             {
-                var ehClient = EventHubClient.CreateFromConnectionString(webSocketConnString);
+                await using (var scope = await EventHubScope.CreateAsync(2))
+                {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
                 ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
                 await ehClient.GetRuntimeInformationAsync();
+                }
             });
 
  
 
             // Send/receive should work fine w/o proxy.
-            var ehNoProxyClient = EventHubClient.CreateFromConnectionString(webSocketConnString);
-            var eventData = new EventData(Encoding.UTF8.GetBytes("This is a sample event."));
+              await using (var scope = await EventHubScope.CreateAsync(2))
+             {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var ehNoProxyClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
+                var eventData = new EventData(Encoding.UTF8.GetBytes("This is a sample event."));
+            }
         }
 #endif
     }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
@@ -19,9 +19,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
     public class WebSocketTests : ClientTestBase
     {
-        string webSocketConnString;
+       
 
-        public String WebSocketTest(string ConnectionString)
+        private string getWebSocketConnectionString(string ConnectionString)
         {
 
             // Create connection string builder with web-sockets enabled.
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             csb.OperationTimeout = TimeSpan.FromMinutes(5);
 
             // Confirm connection string has transport-type set as desired.
-            this.webSocketConnString = csb.ToString();
+            string webSocketConnString = csb.ToString();
 
             // Remove secrets.
             csb.SasKey = "XXX";
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(WebSocketTest(connectionString));
+                var ehClient = EventHubClient.CreateFromConnectionString(getWebSocketConnectionString(connectionString));
 
                 TestUtility.Log("Getting  EventHubRuntimeInformation");
                 var eventHubRuntimeInformation = await ehClient.GetRuntimeInformationAsync();
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             {
 
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(WebSocketTest(connectionString));
+                var ehClient = EventHubClient.CreateFromConnectionString(getWebSocketConnectionString(connectionString));
 
                 PartitionSender sender = null;
                 try

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
@@ -1,11 +1,8 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-
-
 namespace Microsoft.Azure.EventHubs.Tests.Client
 {
-
     using System;
     using System.Collections.Generic;
     using System.Linq;
@@ -16,14 +13,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     using System.Threading.Tasks;
     using Xunit;
 
-
     public class WebSocketTests : ClientTestBase
     {
-
-
         private string GetWebSocketConnectionString(string ConnectionString)
         {
-
             // Create connection string builder with web-sockets enabled.
             var csb = new EventHubsConnectionStringBuilder(ConnectionString);
             csb.TransportType = EventHubs.TransportType.AmqpWebSockets;
@@ -41,15 +34,13 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             return webSocketConnString;
         }
 
-
-
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task GetEventHubRuntimeInformation()
         {
 
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
@@ -70,7 +61,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 
 
-
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -79,7 +69,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             string targetPartitionId = "0";
 
             TestUtility.Log("Creating Event Hub client");
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
 
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
@@ -98,8 +88,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
                 {
                     await sender?.CloseAsync();
                 }
-
-
 
                 PartitionReceiver receiver = null;
                 try

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
     {
        
 
-        private string getWebSocketConnectionString(string ConnectionString)
+        private string GetWebSocketConnectionString(string ConnectionString)
         {
 
             // Create connection string builder with web-sockets enabled.
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(getWebSocketConnectionString(connectionString));
+                var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
 
                 TestUtility.Log("Getting  EventHubRuntimeInformation");
                 var eventHubRuntimeInformation = await ehClient.GetRuntimeInformationAsync();
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             {
 
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(getWebSocketConnectionString(connectionString));
+                var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
 
                 PartitionSender sender = null;
                 try

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/WebSocketTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
 
     public class WebSocketTests : ClientTestBase
     {
-       
+
 
         private string GetWebSocketConnectionString(string ConnectionString)
         {
@@ -134,47 +134,47 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             {
                 await using (var scope = await EventHubScope.CreateAsync(2))
                 {
-                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
-                ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
-                var edToFail = new EventData(Encoding.UTF8.GetBytes("This is a sample event."));
-                await ehClient.SendAsync(edToFail);
+                    var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                    var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
+                    ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
+                    var edToFail = new EventData(Encoding.UTF8.GetBytes("This is a sample event."));
+                    await ehClient.SendAsync(edToFail);
                 }
             });
 
- 
+
 
             // Receive call should fail.
             await Assert.ThrowsAsync<WebSocketException>(async () =>
-            { 
+            {
                 await using (var scope = await EventHubScope.CreateAsync(2))
                 {
-                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
-                ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
-                await ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart()).ReceiveAsync(1);
+                    var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                    var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
+                    ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
+                    await ehClient.CreateReceiver(PartitionReceiver.DefaultConsumerGroupName, "0", EventPosition.FromStart()).ReceiveAsync(1);
                 }
             });
 
- 
+
 
             // Management link call should fail.
             await Assert.ThrowsAsync<WebSocketException>(async () =>
             {
                 await using (var scope = await EventHubScope.CreateAsync(2))
                 {
-                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
-                ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
-                await ehClient.GetRuntimeInformationAsync();
+                    var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                    var ehClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
+                    ehClient.WebProxy = new WebProxy("http://1.2.3.4:9999");
+                    await ehClient.GetRuntimeInformationAsync();
                 }
             });
 
- 
+
 
             // Send/receive should work fine w/o proxy.
-              await using (var scope = await EventHubScope.CreateAsync(2))
-             {
+            await using (var scope = await EventHubScope.CreateAsync(2))
+            {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var ehNoProxyClient = EventHubClient.CreateFromConnectionString(GetWebSocketConnectionString(connectionString));
                 var eventData = new EventData(Encoding.UTF8.GetBytes("This is a sample event."));
@@ -182,4 +182,5 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
         }
 #endif
     }
+
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -15,7 +15,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
 using Polly;
 
-
+// Ported from Track Two EventHubScope.cs
 namespace Microsoft.Azure.EventHubs.Tests.Infrastructure
 {
     /// <summary>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -1,0 +1,299 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Runtime.CompilerServices;
+using System.Security.Authentication;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Azure.Management.EventHub;
+using Microsoft.Azure.Management.EventHub.Models;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.Rest;
+using Polly;
+
+
+namespace Microsoft.Azure.EventHubs.Tests.Infrastructure
+{
+    /// <summary>
+    ///  Provides a dynamically created Event Hub instance which exists only in the context
+    ///  of the scope; disposal removes the instance.
+    /// </summary>
+    ///
+    /// <seealso cref="System.IAsyncDisposable" />
+    ///
+    public sealed class EventHubScope : IAsyncDisposable
+    {
+        /// <summary>The maximum number of attempts to retry a management operation.</summary>
+        private const int RetryMaximumAttemps = 8;
+
+        /// <summary>The number of seconds to use as the basis for backing off on retry attempts.</summary>
+        private const double RetryExponentialBackoffSeconds = 0.5;
+
+        /// <summary>The number of seconds to use as the basis for applying jitter to retry backoff calculations.</summary>
+        private const double RetryBaseJitterSeconds = 3.0;
+
+        /// <summary>The buffer to apply when considering refreshing; credentials that expire less than this duration will be refreshed.</summary>
+        private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);
+
+        /// <summary>The random number generator to use for each requesting thread.</summary>
+        private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);
+
+        /// <summary>The seed to use for random number generation.</summary>
+        private static int s_randomSeed = Environment.TickCount;
+
+        /// <summary>The token credential to be used with the Event Hubs management client.</summary>
+        private static ManagementToken s_managementToken;
+
+        /// <summary>Serves as a sentinal flag to denote when the instance has been disposed.</summary>
+        private bool _disposed = false;
+
+        /// <summary>
+        ///  The name of the Event Hub that was created.
+        /// </summary>
+        ///
+        public string EventHubName { get; }
+
+        /// <summary>
+        ///   The consumer groups created and associated with the Event Hub, not including
+        ///   the default consumer group which is created implicitly.
+        /// </summary>
+        ///
+        public IReadOnlyList<string> ConsumerGroups { get; }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventHubScope"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventHubHame">The name of the Event Hub that was created.</param>
+        /// <param name="consumerGroups">The set of consumer groups associated with the Event Hub; the default consumer group is not included, as it is implicitly created.</param>
+        ///
+        private EventHubScope(string eventHubHame,
+                              IReadOnlyList<string> consumerGroups)
+        {
+            EventHubName = eventHubHame;
+            ConsumerGroups = consumerGroups;
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to remove the dynamically created
+        ///   Event Hub.
+        /// </summary>
+        ///
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            var resourceGroup = TestUtility.EventHubsResourceGroup;
+            var eventHubNamespace = TestUtility.EventHubsNamespace;
+            var token = await AquireManagementTokenAsync();
+            var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription };
+
+            try
+            {
+                await CreateRetryPolicy().ExecuteAsync(() => client.EventHubs.DeleteAsync(resourceGroup, eventHubNamespace, EventHubName));
+            }
+            finally
+            {
+                client?.Dispose();
+            }
+
+            _disposed = true;
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to create a new Event Hub instance with the requested
+        ///   partition count and a dynamically assigned unique name.
+        /// </summary>
+        ///
+        /// <param name="partitionCount">The number of partitions that the Event Hub should be configured with.</param>
+        /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
+        ///
+        public static Task<EventHubScope> CreateAsync(int partitionCount,
+                                                      [CallerMemberName] string caller = "") => CreateAsync(partitionCount, Enumerable.Empty<string>(), caller);
+
+        /// <summary>
+        ///   Performs the tasks needed to create a new Event Hub instance with the requested
+        ///   partition count and a dynamically assigned unique name.
+        /// </summary>
+        ///
+        /// <param name="partitionCount">The number of partitions that the Event Hub should be configured with.</param>
+        /// <param name="consumerGroup">The name of a consumer group to create and associate with the Event Hub; the default consumer group should not be specified, as it is implicitly created.</param>
+        /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
+        ///
+        public static Task<EventHubScope> CreateAsync(int partitionCount,
+                                                      string consumerGroup,
+                                                      [CallerMemberName] string caller = "") => CreateAsync(partitionCount, new[] { consumerGroup }, caller);
+
+        /// <summary>
+        ///   Performs the tasks needed to create a new Event Hub instance with the requested
+        ///   partition count and a dynamically assigned unique name.
+        /// </summary>
+        ///
+        /// <param name="partitionCount">The number of partitions that the Event Hub should be configured with.</param>
+        /// <param name="consumerGroups">The set of consumer groups to create and associate with the Event Hub; the default consumer group should not be included, as it is implicitly created.</param>
+        /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
+        ///
+        public static async Task<EventHubScope> CreateAsync(int partitionCount,
+                                                            IEnumerable<string> consumerGroups,
+                                                            [CallerMemberName] string caller = "")
+        {
+            var eventHubName = $"{ caller }-{ Guid.NewGuid().ToString("D").Substring(0, 8) }";
+            var groups = (consumerGroups ?? Enumerable.Empty<string>()).ToList();
+            var resourceGroup = TestUtility.EventHubsResourceGroup;
+            var eventHubNamespace = TestUtility.EventHubsNamespace;
+            var token = await AquireManagementTokenAsync();
+            var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = TestUtility.EventHubsSubscription };
+
+            try
+            {
+                var eventHub = new Eventhub(name: eventHubName, partitionCount: partitionCount);
+                await CreateRetryPolicy<Eventhub>().ExecuteAsync(() => client.EventHubs.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, eventHubName, eventHub));
+
+                var consumerPolicy = CreateRetryPolicy<ConsumerGroup>();
+
+                await Task.WhenAll
+                (
+                    consumerGroups.Select(groupName =>
+                    {
+                        var group = new ConsumerGroup(name: groupName);
+                        return consumerPolicy.ExecuteAsync(() => client.ConsumerGroups.CreateOrUpdateAsync(resourceGroup, eventHubNamespace, eventHubName, groupName, group));
+                    })
+                );
+            }
+            finally
+            {
+                client?.Dispose();
+            }
+
+            return new EventHubScope(eventHubName, groups);
+        }
+
+        /// <summary>
+        ///   Creates the retry policy to apply to a management operation.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The expected type of response from the management operation.</typeparam>
+        ///
+        /// <param name="maxRetryAttempts">The maximum retry attempts to allow.</param>
+        /// <param name="exponentialBackoffSeconds">The number of seconds to use as the basis for backing off on retry attempts.</param>
+        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry backoff calculations.</param>
+        ///
+        /// <returns>The retry policy in which to execute the management operation.</returns>
+        ///
+        private static IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = RetryMaximumAttemps, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
+           Policy<T>
+               .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
+               .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
+
+        /// <summary>
+        ///   Creates the retry policy to apply to a management operation.
+        /// </summary>
+        ///
+        /// <param name="maxRetryAttempts">The maximum retry attempts to allow.</param>
+        /// <param name="exponentialBackoffSeconds">The number of seconds to use as the basis for backing off on retry attempts.</param>
+        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry backoff calculations.</param>
+        ///
+        /// <returns>The retry policy in which to execute the management operation.</returns>
+        ///
+        private static IAsyncPolicy CreateRetryPolicy(int maxRetryAttempts = RetryMaximumAttemps, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
+            Policy
+                .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
+                .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
+
+        /// <summary>
+        ///   Determines whether the specified HTTP status code is considered eligible to retry
+        ///   the associated operation.
+        /// </summary>
+        ///
+        /// <param name="statusCode">The status code to consider.</param>
+        ///
+        /// <returns><c>true</c> if the status code is eligible for retries; otherwise, <c>false</c>.</returns>
+        ///
+        private static bool IsRetriableStatus(HttpStatusCode statusCode) =>
+            ((statusCode == HttpStatusCode.Unauthorized)
+                || (statusCode == HttpStatusCode.InternalServerError)
+                || (statusCode == HttpStatusCode.ServiceUnavailable)
+                || (statusCode == HttpStatusCode.Conflict)
+                || (statusCode == HttpStatusCode.GatewayTimeout));
+
+        /// <summary>
+        ///   Calculates the retry delay to use for management-related operations.
+        /// </summary>
+        ///
+        /// <param name="attempt">The current attempt numner.</param>
+        /// <param name="exponentialBackoffSeconds">The exponential backoff amount,, in seconds.</param>
+        /// <param name="baseJitterSeconds">The amount of base jitter to include, in seconds.</param>
+        ///
+        /// <returns>The interval to wait before retrying the attempted operation.</returns>
+        ///
+        private static TimeSpan CalculateRetryDelay(int attempt, double exponentialBackoffSeconds, double baseJitterSeconds) =>
+            TimeSpan.FromSeconds((Math.Pow(2, attempt) * exponentialBackoffSeconds) + (RandomNumberGenerator.Value.NextDouble() * baseJitterSeconds));
+
+        /// <summary>
+        ///   Aquires a JWT token for use with the Event Hubs management client.
+        /// </summary>
+        ///
+        /// <returns>The token to use for management operations against the Event Hubs Live test namespace.</returns>
+        ///
+        private static async Task<string> AquireManagementTokenAsync()
+        {
+            var token = s_managementToken;
+
+            // If there was no current token, or it is within the buffer for expiration, request a new token.
+            // There is a benign race condition here, where there may be multiple requests in-flight for a new token.  Since
+            // this is test infrastructure, just allow the aquired token to replace the current one without attempting to
+            // coordinate or ensure that the most recent is kept.
+
+            if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
+            {
+                var credential = new ClientCredential(TestUtility.EventHubsClient, TestUtility.EventHubsSecret);
+                var context = new AuthenticationContext($"https://login.windows.net/{ TestUtility.EventHubsTenant }");
+                var result = await context.AcquireTokenAsync("https://management.core.windows.net/", credential);
+
+                if ((String.IsNullOrEmpty(result?.AccessToken)))
+                {
+                    throw new AuthenticationException("Unable to aquire an Active Directory token for the Event Hubs management client.");
+                }
+
+                token = new ManagementToken(result.AccessToken, result.ExpiresOn);
+                Interlocked.Exchange(ref s_managementToken, token);
+            }
+
+            return token.Token;
+        }
+     
+        /// <summary>
+        ///   An internal type for tracking the management access token and
+        ///   its associated expiration.
+        /// </summary>
+        ///
+        private class ManagementToken
+        {
+            /// <summary>The value bearer token to use for authorization.</summary>
+            public readonly string Token;
+
+            /// <summary>The date and time, in UTC, that the token expires.</summary>
+            public readonly DateTimeOffset ExpiresOn;
+
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="ManagementToken"/> class.
+            /// </summary>
+            ///
+            /// <param name="token">The value of the bearer token.</param>
+            /// <param name="expiresOn">The date and time, in UTC, that the token expires on.</param>
+            ///
+            public ManagementToken(string token, DateTimeOffset expiresOn)
+            {
+                Token = token;
+                ExpiresOn = expiresOn;
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -15,9 +15,10 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
 using Polly;
 
-// Ported from Track Two EventHubScope.cs
+
 namespace Microsoft.Azure.EventHubs.Tests.Infrastructure
 {
+    // Ported from Track Two EventHubScope.cs
     /// <summary>
     ///  Provides a dynamically created Event Hub instance which exists only in the context
     ///  of the scope; disposal removes the instance.

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -15,8 +15,8 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
 using Polly;
 
-
-namespace Microsoft.Azure.EventHubs.Tests.Infrastructure
+// Ported from Track Two EventHubScope.cs
+namespace Microsoft.Azure.EventHubs.Tests
 {
     // Ported from Track Two EventHubScope.cs
     /// <summary>

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -18,60 +18,30 @@ using Polly;
 
 namespace Microsoft.Azure.EventHubs.Tests
 {
-    // Ported from Track Two EventHubScope.cs
-    /// <summary>
-    ///  Provides a dynamically created Event Hub instance which exists only in the context
-    ///  of the scope; disposal removes the instance.
-    /// </summary>
-    ///
-    /// <seealso cref="System.IAsyncDisposable" />
-    ///
-    public sealed class EventHubScope : IAsyncDisposable
+    
+    internal sealed class EventHubScope : IAsyncDisposable
     {
-        /// <summary>The maximum number of attempts to retry a management operation.</summary>
+      
         private const int RetryMaximumAttemps = 8;
 
-        /// <summary>The number of seconds to use as the basis for backing off on retry attempts.</summary>
         private const double RetryExponentialBackoffSeconds = 0.5;
 
-        /// <summary>The number of seconds to use as the basis for applying jitter to retry backoff calculations.</summary>
         private const double RetryBaseJitterSeconds = 3.0;
 
-        /// <summary>The buffer to apply when considering refreshing; credentials that expire less than this duration will be refreshed.</summary>
         private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);
 
-        /// <summary>The random number generator to use for each requesting thread.</summary>
         private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);
 
-        /// <summary>The seed to use for random number generation.</summary>
         private static int s_randomSeed = Environment.TickCount;
 
-        /// <summary>The token credential to be used with the Event Hubs management client.</summary>
         private static ManagementToken s_managementToken;
 
-        /// <summary>Serves as a sentinal flag to denote when the instance has been disposed.</summary>
         private bool _disposed = false;
 
-        /// <summary>
-        ///  The name of the Event Hub that was created.
-        /// </summary>
-        ///
-        public string EventHubName { get; }
+        internal string EventHubName { get; }
 
-        /// <summary>
-        ///   The consumer groups created and associated with the Event Hub, not including
-        ///   the default consumer group which is created implicitly.
-        /// </summary>
-        ///
-        public IReadOnlyList<string> ConsumerGroups { get; }
+        internal IReadOnlyList<string> ConsumerGroups { get; }
 
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="EventHubScope"/> class.
-        /// </summary>
-        ///
-        /// <param name="eventHubHame">The name of the Event Hub that was created.</param>
-        /// <param name="consumerGroups">The set of consumer groups associated with the Event Hub; the default consumer group is not included, as it is implicitly created.</param>
-        ///
         private EventHubScope(string eventHubHame,
                               IReadOnlyList<string> consumerGroups)
         {
@@ -79,11 +49,6 @@ namespace Microsoft.Azure.EventHubs.Tests
             ConsumerGroups = consumerGroups;
         }
 
-        /// <summary>
-        ///   Performs the tasks needed to remove the dynamically created
-        ///   Event Hub.
-        /// </summary>
-        ///
         public async ValueTask DisposeAsync()
         {
             if (_disposed)
@@ -108,40 +73,13 @@ namespace Microsoft.Azure.EventHubs.Tests
             _disposed = true;
         }
 
-        /// <summary>
-        ///   Performs the tasks needed to create a new Event Hub instance with the requested
-        ///   partition count and a dynamically assigned unique name.
-        /// </summary>
-        ///
-        /// <param name="partitionCount">The number of partitions that the Event Hub should be configured with.</param>
-        /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
-        ///
-        public static Task<EventHubScope> CreateAsync(int partitionCount,
+        internal static Task<EventHubScope> CreateAsync(int partitionCount,
                                                       [CallerMemberName] string caller = "") => CreateAsync(partitionCount, Enumerable.Empty<string>(), caller);
 
-        /// <summary>
-        ///   Performs the tasks needed to create a new Event Hub instance with the requested
-        ///   partition count and a dynamically assigned unique name.
-        /// </summary>
-        ///
-        /// <param name="partitionCount">The number of partitions that the Event Hub should be configured with.</param>
-        /// <param name="consumerGroup">The name of a consumer group to create and associate with the Event Hub; the default consumer group should not be specified, as it is implicitly created.</param>
-        /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
-        ///
-        public static Task<EventHubScope> CreateAsync(int partitionCount,
+        internal static Task<EventHubScope> CreateAsync(int partitionCount,
                                                       string consumerGroup,
                                                       [CallerMemberName] string caller = "") => CreateAsync(partitionCount, new[] { consumerGroup }, caller);
-
-        /// <summary>
-        ///   Performs the tasks needed to create a new Event Hub instance with the requested
-        ///   partition count and a dynamically assigned unique name.
-        /// </summary>
-        ///
-        /// <param name="partitionCount">The number of partitions that the Event Hub should be configured with.</param>
-        /// <param name="consumerGroups">The set of consumer groups to create and associate with the Event Hub; the default consumer group should not be included, as it is implicitly created.</param>
-        /// <param name="caller">The name of the calling method; this is intended to be populated by the runtime.</param>
-        ///
-        public static async Task<EventHubScope> CreateAsync(int partitionCount,
+        internal static async Task<EventHubScope> CreateAsync(int partitionCount,
                                                             IEnumerable<string> consumerGroups,
                                                             [CallerMemberName] string caller = "")
         {
@@ -176,47 +114,16 @@ namespace Microsoft.Azure.EventHubs.Tests
             return new EventHubScope(eventHubName, groups);
         }
 
-        /// <summary>
-        ///   Creates the retry policy to apply to a management operation.
-        /// </summary>
-        ///
-        /// <typeparam name="T">The expected type of response from the management operation.</typeparam>
-        ///
-        /// <param name="maxRetryAttempts">The maximum retry attempts to allow.</param>
-        /// <param name="exponentialBackoffSeconds">The number of seconds to use as the basis for backing off on retry attempts.</param>
-        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry backoff calculations.</param>
-        ///
-        /// <returns>The retry policy in which to execute the management operation.</returns>
-        ///
         private static IAsyncPolicy<T> CreateRetryPolicy<T>(int maxRetryAttempts = RetryMaximumAttemps, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
            Policy<T>
                .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
                .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
-        /// <summary>
-        ///   Creates the retry policy to apply to a management operation.
-        /// </summary>
-        ///
-        /// <param name="maxRetryAttempts">The maximum retry attempts to allow.</param>
-        /// <param name="exponentialBackoffSeconds">The number of seconds to use as the basis for backing off on retry attempts.</param>
-        /// <param name="baseJitterSeconds">TThe number of seconds to use as the basis for applying jitter to retry backoff calculations.</param>
-        ///
-        /// <returns>The retry policy in which to execute the management operation.</returns>
-        ///
         private static IAsyncPolicy CreateRetryPolicy(int maxRetryAttempts = RetryMaximumAttemps, double exponentialBackoffSeconds = RetryExponentialBackoffSeconds, double baseJitterSeconds = RetryBaseJitterSeconds) =>
             Policy
                 .Handle<ErrorResponseException>(ex => IsRetriableStatus(ex.Response.StatusCode))
                 .WaitAndRetryAsync(maxRetryAttempts, attempt => CalculateRetryDelay(attempt, exponentialBackoffSeconds, baseJitterSeconds));
 
-        /// <summary>
-        ///   Determines whether the specified HTTP status code is considered eligible to retry
-        ///   the associated operation.
-        /// </summary>
-        ///
-        /// <param name="statusCode">The status code to consider.</param>
-        ///
-        /// <returns><c>true</c> if the status code is eligible for retries; otherwise, <c>false</c>.</returns>
-        ///
         private static bool IsRetriableStatus(HttpStatusCode statusCode) =>
             ((statusCode == HttpStatusCode.Unauthorized)
                 || (statusCode == HttpStatusCode.InternalServerError)
@@ -224,33 +131,12 @@ namespace Microsoft.Azure.EventHubs.Tests
                 || (statusCode == HttpStatusCode.Conflict)
                 || (statusCode == HttpStatusCode.GatewayTimeout));
 
-        /// <summary>
-        ///   Calculates the retry delay to use for management-related operations.
-        /// </summary>
-        ///
-        /// <param name="attempt">The current attempt numner.</param>
-        /// <param name="exponentialBackoffSeconds">The exponential backoff amount,, in seconds.</param>
-        /// <param name="baseJitterSeconds">The amount of base jitter to include, in seconds.</param>
-        ///
-        /// <returns>The interval to wait before retrying the attempted operation.</returns>
-        ///
         private static TimeSpan CalculateRetryDelay(int attempt, double exponentialBackoffSeconds, double baseJitterSeconds) =>
             TimeSpan.FromSeconds((Math.Pow(2, attempt) * exponentialBackoffSeconds) + (RandomNumberGenerator.Value.NextDouble() * baseJitterSeconds));
 
-        /// <summary>
-        ///   Aquires a JWT token for use with the Event Hubs management client.
-        /// </summary>
-        ///
-        /// <returns>The token to use for management operations against the Event Hubs Live test namespace.</returns>
-        ///
         private static async Task<string> AquireManagementTokenAsync()
         {
             var token = s_managementToken;
-
-            // If there was no current token, or it is within the buffer for expiration, request a new token.
-            // There is a benign race condition here, where there may be multiple requests in-flight for a new token.  Since
-            // this is test infrastructure, just allow the aquired token to replace the current one without attempting to
-            // coordinate or ensure that the most recent is kept.
 
             if ((token == null) || (token.ExpiresOn <= DateTimeOffset.UtcNow.Add(CredentialRefreshBuffer)))
             {
@@ -269,27 +155,14 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             return token.Token;
         }
-     
-        /// <summary>
-        ///   An internal type for tracking the management access token and
-        ///   its associated expiration.
-        /// </summary>
-        ///
+
         private class ManagementToken
         {
-            /// <summary>The value bearer token to use for authorization.</summary>
+          
             public readonly string Token;
 
-            /// <summary>The date and time, in UTC, that the token expires.</summary>
             public readonly DateTimeOffset ExpiresOn;
 
-            /// <summary>
-            ///   Initializes a new instance of the <see cref="ManagementToken"/> class.
-            /// </summary>
-            ///
-            /// <param name="token">The value of the bearer token.</param>
-            /// <param name="expiresOn">The date and time, in UTC, that the token expires on.</param>
-            ///
             public ManagementToken(string token, DateTimeOffset expiresOn)
             {
                 Token = token;

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -15,7 +15,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.Rest;
 using Polly;
 
-// Ported from Track Two EventHubScope.cs
+
 namespace Microsoft.Azure.EventHubs.Tests
 {
     // Ported from Track Two EventHubScope.cs

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -10,13 +10,14 @@ namespace Microsoft.Azure.EventHubs.Tests
         // Environment Variables
         internal const string EventHubsConnectionStringEnvironmentVariableName = "EVENT_HUBS_CONNECTION_STRING";
         internal const string StorageConnectionStringEnvironmentVariableName = "EVENT_HUBS_STORAGE_CONNECTION_STRING";
+        //add by Luyun
+        //add six new environment,copy from Track 2 testenvironment.cs
         internal const string EventHubsSubscriptionEnvironmentVariableName = "EVENT_HUBS_SUBSCRIPTION";
         internal const string EventHubsResourceGroupEnvironmentVariableName = "EVENT_HUBS_RESOURCEGROUP";
         internal const string EventHubsNamespaceEnvironmentVariableName = "EVENT_HUBS_NAMESPACE";
         internal const string EventHubsTenantEnvironmentVariableName = "EVENT_HUBS_TENANT";
         internal const string EventHubsClientEnvironmentVariableName = "EVENT_HUBS_CLIENT";
         internal const string EventHubsSecretEnvironmentVariableName = "EVENT_HUBS_SECRET";
-
 
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -9,9 +9,9 @@ namespace Microsoft.Azure.EventHubs.Tests
     {
         // Environment Variables
         internal const string EventHubsConnectionStringEnvironmentVariableName = "EVENT_HUBS_CONNECTION_STRING";
-        internal const string StorageConnectionStringEnvironmentVariableName = "EVENT_HUBS_STORAGE_CONNECTION_STRING";
-        //add by Luyun
-        //add six new environment,copy from Track 2 testenvironment.cs
+        internal const string StorageConnectionStringEnvironmentVariableName = "EVENT_HUBS_STORAGE_CONNECTION_STRING";      
+        
+        //Following 6 const copied from Track two TestEnvironment.cs
         internal const string EventHubsSubscriptionEnvironmentVariableName = "EVENT_HUBS_SUBSCRIPTION";
         internal const string EventHubsResourceGroupEnvironmentVariableName = "EVENT_HUBS_RESOURCEGROUP";
         internal const string EventHubsNamespaceEnvironmentVariableName = "EVENT_HUBS_NAMESPACE";
@@ -19,5 +19,11 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal const string EventHubsClientEnvironmentVariableName = "EVENT_HUBS_CLIENT";
         internal const string EventHubsSecretEnvironmentVariableName = "EVENT_HUBS_SECRET";
 
+
+        //Unused after Track two test infrastructure ported
+        // General
+        //internal const string DefultEventHubName = "eventhubs-sdk-test-hub";
+        //internal const string AlternateConsumerGroupName = "sdk-test-consumer";
+        //internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(30);
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -9,9 +9,7 @@ namespace Microsoft.Azure.EventHubs.Tests
     {
         // Environment Variables
         internal const string EventHubsConnectionStringEnvironmentVariableName = "EVENT_HUBS_CONNECTION_STRING";
-        internal const string StorageConnectionStringEnvironmentVariableName = "EVENT_HUBS_STORAGE_CONNECTION_STRING";      
-        
-        //Following 6 const copied from Track two TestEnvironment.cs
+        internal const string StorageConnectionStringEnvironmentVariableName = "EVENT_HUBS_STORAGE_CONNECTION_STRING";            
         internal const string EventHubsSubscriptionEnvironmentVariableName = "EVENT_HUBS_SUBSCRIPTION";
         internal const string EventHubsResourceGroupEnvironmentVariableName = "EVENT_HUBS_RESOURCEGROUP";
         internal const string EventHubsNamespaceEnvironmentVariableName = "EVENT_HUBS_NAMESPACE";
@@ -20,10 +18,7 @@ namespace Microsoft.Azure.EventHubs.Tests
         internal const string EventHubsSecretEnvironmentVariableName = "EVENT_HUBS_SECRET";
 
 
-        //Unused after Track two test infrastructure ported
         // General
-        //internal const string DefultEventHubName = "eventhubs-sdk-test-hub";
-        //internal const string AlternateConsumerGroupName = "sdk-test-consumer";
           internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(30);
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -24,6 +24,6 @@ namespace Microsoft.Azure.EventHubs.Tests
         // General
         //internal const string DefultEventHubName = "eventhubs-sdk-test-hub";
         //internal const string AlternateConsumerGroupName = "sdk-test-consumer";
-        //internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(30);
+          internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(30);
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -10,10 +10,13 @@ namespace Microsoft.Azure.EventHubs.Tests
         // Environment Variables
         internal const string EventHubsConnectionStringEnvironmentVariableName = "EVENT_HUBS_CONNECTION_STRING";
         internal const string StorageConnectionStringEnvironmentVariableName = "EVENT_HUBS_STORAGE_CONNECTION_STRING";
+        internal const string EventHubsSubscriptionEnvironmentVariableName = "EVENT_HUBS_SUBSCRIPTION";
+        internal const string EventHubsResourceGroupEnvironmentVariableName = "EVENT_HUBS_RESOURCEGROUP";
+        internal const string EventHubsNamespaceEnvironmentVariableName = "EVENT_HUBS_NAMESPACE";
+        internal const string EventHubsTenantEnvironmentVariableName = "EVENT_HUBS_TENANT";
+        internal const string EventHubsClientEnvironmentVariableName = "EVENT_HUBS_CLIENT";
+        internal const string EventHubsSecretEnvironmentVariableName = "EVENT_HUBS_SECRET";
 
-        // General
-        internal const string DefultEventHubName = "eventhubs-sdk-test-hub";
-        internal const string AlternateConsumerGroupName = "sdk-test-consumer";
-        internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(30);
+
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -14,15 +14,91 @@ namespace Microsoft.Azure.EventHubs.Tests
     internal static class TestUtility
     {
         private static readonly Lazy<string> EventHubsConnectionStringInstance =
-            new Lazy<string>( () => BuildEventHubsConnectionString(ReadEnvironmentVariable(TestConstants.EventHubsConnectionStringEnvironmentVariableName)), LazyThreadSafetyMode.PublicationOnly);
+            new Lazy<string>( () => ReadEnvironmentVariable(TestConstants.EventHubsConnectionStringEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
 
         private static readonly Lazy<string> StorageConnectionStringInstance =
             new Lazy<string>( () => ReadEnvironmentVariable(TestConstants.StorageConnectionStringEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
 
+        private static readonly Lazy<string> EventHubsSubscriptionInstance =
+          new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSubscriptionEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        /// <summary>The environment variable value for the Event Hubs resource group name, lazily evaluated.</summary>
+        private static readonly Lazy<string> EventHubsResourceGroupInstance =
+            new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsResourceGroupEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        /// <summary>The environment variable value for the Event Hubs namespace name, lazily evaluated.</summary>
+        private static readonly Lazy<string> EventHubsNamespaceInstance =
+            new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsNamespaceEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        /// <summary>The environment variable value for the Azure Active Directory tenent that holds the service principal, lazily evaluated.</summary>
+        private static readonly Lazy<string> EventHubsTenantInstance =
+            new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsTenantEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        /// <summary>The environment variable value for the Azure Active Directory client identifier of the service principal, lazily evaluated.</summary>
+        private static readonly Lazy<string> EventHubsClientInstance =
+            new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsClientEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
+        /// <summary>The environment variable value for the Azure Active Directory client secret of the service principal, lazily evaluated.</summary>
+        private static readonly Lazy<string> EventHubsSecretInstance =
+            new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSecretEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
         internal static string EventHubsConnectionString => EventHubsConnectionStringInstance.Value;
 
         internal static string StorageConnectionString => StorageConnectionStringInstance.Value;
 
+        internal static string EventHubsSubscription => EventHubsSubscriptionInstance.Value;
+
+        /// <summary>
+        ///   The name of the resource group containing the Event Hubs namespace instance to be used for
+        ///   Live tests.
+        /// </summary>
+        ///
+        /// <value>The name of the namespace is read from the "EVENT_HUBS_RESOURCEGROUP" environment variable.</value>
+        ///
+        internal static string EventHubsResourceGroup => EventHubsResourceGroupInstance.Value;
+
+        /// <summary>
+        ///   The name of the Event Hubs namespace instance to be used for
+        ///   Live tests.
+        /// </summary>
+        ///
+        /// <value>The name of the namespace is read from the "EVENT_HUBS_NAMESPACE" environment variable.</value>
+        ///
+        internal static string EventHubsNamespace => EventHubsNamespaceInstance.Value;
+
+        /// <summary>
+        ///   The name of the Azure Active Directory tenant that holds the service principal to use for management
+        ///   of the Event Hubs namespace during Live tests.
+        /// </summary>
+        ///
+        /// <value>The name of the namespace is read from the "EVENT_HUBS_TENANT" environment variable.</value>
+        ///
+        internal static string EventHubsTenant => EventHubsTenantInstance.Value;
+
+        /// <summary>
+        ///   The name of the Azure Active Directory client identifier of the service principal to use for management
+        ///   of the Event Hubs namespace during Live tests.
+        /// </summary>
+        ///
+        /// <value>The name of the namespace is read from the "EVENT_HUBS_CLIENT" environment variable.</value>
+        ///
+        internal static string EventHubsClient => EventHubsClientInstance.Value;
+
+        /// <summary>
+        ///   The name of the Azure Active Directory client secret of the service principal to use for management
+        ///   of the Event Hubs namespace during Live tests.
+        /// </summary>
+        ///
+        /// <value>The name of the namespace is read from the "EVENT_HUBS_SECRET" environment variable.</value>
+        ///
+        internal static string EventHubsSecret => EventHubsSecretInstance.Value;
+
+        /// <summary>
+        ///   Builds a connection string for a specific Event Hub instance under the Event Hubs namespace used for
+        ///   Live tests.
+        /// </summary>
+        ///
+        /// <value>The namepsace connection string is read from the "EVENT_HUBS_CONNECTION_STRING" environment variable.</value>
+        ///
         internal static string GetEntityConnectionString(string entityName) =>
             new EventHubsConnectionStringBuilder(EventHubsConnectionString) { EntityPath = entityName }.ToString();
 
@@ -75,16 +151,24 @@ namespace Microsoft.Azure.EventHubs.Tests
             Console.WriteLine(formattedMessage);
         }
 
-        private static string BuildEventHubsConnectionString(string sourceConnectionString)
-        {
-            var connectionString = new EventHubsConnectionStringBuilder(sourceConnectionString);
+        //private static string BuildEventHubsConnectionString(string sourceConnectionString)
+        //{
+        //    var connectionString = new EventHubsConnectionStringBuilder(sourceConnectionString);
 
-            connectionString.EntityPath = connectionString.EntityPath ?? TestConstants.DefultEventHubName;
+        //    connectionString.EntityPath = connectionString.EntityPath ?? TestConstants.DefultEventHubName;
+        //    connectionString.OperationTimeout = TestConstants.DefaultOperationTimeout;
+
+        //    return connectionString.ToString();
+        //}
+        public static string BuildEventHubsConnectionString(string eventHubName)
+        {
+            var connectionString = new EventHubsConnectionStringBuilder(EventHubsConnectionString);
+
+            connectionString.EntityPath = connectionString.EntityPath ?? eventHubName;
             connectionString.OperationTimeout = TestConstants.DefaultOperationTimeout;
 
             return connectionString.ToString();
         }
-
         private static string ReadEnvironmentVariable(string variableName)
         {
             var environmentVar = Environment.GetEnvironmentVariable(variableName);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -18,27 +18,26 @@ namespace Microsoft.Azure.EventHubs.Tests
 
         private static readonly Lazy<string> StorageConnectionStringInstance =
             new Lazy<string>( () => ReadEnvironmentVariable(TestConstants.StorageConnectionStringEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-        //add by Luyun
-        //add 6 ReadEnvironment method, copy from Track 2 testenvironment.cs
+        //Copied from Track two TestEnvironment.cs
         private static readonly Lazy<string> EventHubsSubscriptionInstance =
           new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSubscriptionEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-      
+        //Copied from Track two TestEnvironment.cs
         /// <summary>The environment variable value for the Event Hubs resource group name, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsResourceGroupInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsResourceGroupEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-
+        //Copied from Track two TestEnvironment.cs
         /// <summary>The environment variable value for the Event Hubs namespace name, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsNamespaceInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsNamespaceEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-
+        //Copied from Track two TestEnvironment.cs
         /// <summary>The environment variable value for the Azure Active Directory tenent that holds the service principal, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsTenantInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsTenantEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-
+        //Copied from Track two TestEnvironment.cs
         /// <summary>The environment variable value for the Azure Active Directory client identifier of the service principal, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsClientInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsClientEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-
+        //Copied from Track two TestEnvironment.cs
         /// <summary>The environment variable value for the Azure Active Directory client secret of the service principal, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsSecretInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSecretEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
@@ -46,10 +45,10 @@ namespace Microsoft.Azure.EventHubs.Tests
 
         internal static string StorageConnectionString => StorageConnectionStringInstance.Value;
 
-        //add by Luyun
-        //add 6 set and get method, copy from Track 2 testenvironment.cs
+        //Copied from Track two TestEnvironment.cs
         internal static string EventHubsSubscription => EventHubsSubscriptionInstance.Value;
 
+        //Copied from Track two TestEnvironment.cs
         /// <summary>
         ///   The name of the resource group containing the Event Hubs namespace instance to be used for
         ///   Live tests.
@@ -59,6 +58,7 @@ namespace Microsoft.Azure.EventHubs.Tests
         ///
         internal static string EventHubsResourceGroup => EventHubsResourceGroupInstance.Value;
 
+        //Copied from Track two TestEnvironment.cs
         /// <summary>
         ///   The name of the Event Hubs namespace instance to be used for
         ///   Live tests.
@@ -68,6 +68,7 @@ namespace Microsoft.Azure.EventHubs.Tests
         ///
         internal static string EventHubsNamespace => EventHubsNamespaceInstance.Value;
 
+        //Copied from Track two TestEnvironment.cs
         /// <summary>
         ///   The name of the Azure Active Directory tenant that holds the service principal to use for management
         ///   of the Event Hubs namespace during Live tests.
@@ -77,6 +78,7 @@ namespace Microsoft.Azure.EventHubs.Tests
         ///
         internal static string EventHubsTenant => EventHubsTenantInstance.Value;
 
+        //Copied from Track two TestEnvironment.cs
         /// <summary>
         ///   The name of the Azure Active Directory client identifier of the service principal to use for management
         ///   of the Event Hubs namespace during Live tests.
@@ -86,6 +88,7 @@ namespace Microsoft.Azure.EventHubs.Tests
         ///
         internal static string EventHubsClient => EventHubsClientInstance.Value;
 
+        //Copied from Track two TestEnvironment.cs
         /// <summary>
         ///   The name of the Azure Active Directory client secret of the service principal to use for management
         ///   of the Event Hubs namespace during Live tests.
@@ -153,7 +156,8 @@ namespace Microsoft.Azure.EventHubs.Tests
             Debug.WriteLine(formattedMessage);
             Console.WriteLine(formattedMessage);
         }
-
+        
+        //Ported from Track two TestEnvironment.cs 
         public static string BuildEventHubsConnectionString(string eventHubName)
         {
             var connectionString = new EventHubsConnectionStringBuilder(EventHubsConnectionString);
@@ -163,6 +167,19 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             return connectionString.ToString();
         }
+
+        // No need after method BuildEventHubsConnectionString(string eventHubName) ported from Track two
+        //private static string BuildEventHubsConnectionString(string sourceConnectionString)
+        //{
+        //    var connectionString = new EventHubsConnectionStringBuilder(sourceConnectionString);
+
+        //    connectionString.EntityPath = connectionString.EntityPath ?? TestConstants.DefultEventHubName;
+        //    connectionString.OperationTimeout = TestConstants.DefaultOperationTimeout;
+
+        //    return connectionString.ToString();
+        //}
+
+
         private static string ReadEnvironmentVariable(string variableName)
         {
             var environmentVar = Environment.GetEnvironmentVariable(variableName);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -13,99 +13,53 @@ namespace Microsoft.Azure.EventHubs.Tests
 
     internal static class TestUtility
     {
-        //Modified to fit Track two TestEnvironment.cs 
+       
         private static readonly Lazy<string> EventHubsConnectionStringInstance =
             new Lazy<string>( () => ReadEnvironmentVariable(TestConstants.EventHubsConnectionStringEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
 
         private static readonly Lazy<string> StorageConnectionStringInstance =
             new Lazy<string>( () => ReadEnvironmentVariable(TestConstants.StorageConnectionStringEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-        //Copied from Track two TestEnvironment.cs
+       
         private static readonly Lazy<string> EventHubsSubscriptionInstance =
           new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSubscriptionEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>The environment variable value for the Event Hubs resource group name, lazily evaluated.</summary>
+              
         private static readonly Lazy<string> EventHubsResourceGroupInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsResourceGroupEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>The environment variable value for the Event Hubs namespace name, lazily evaluated.</summary>
+       
         private static readonly Lazy<string> EventHubsNamespaceInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsNamespaceEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>The environment variable value for the Azure Active Directory tenent that holds the service principal, lazily evaluated.</summary>
+       
         private static readonly Lazy<string> EventHubsTenantInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsTenantEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>The environment variable value for the Azure Active Directory client identifier of the service principal, lazily evaluated.</summary>
+        
         private static readonly Lazy<string> EventHubsClientInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsClientEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>The environment variable value for the Azure Active Directory client secret of the service principal, lazily evaluated.</summary>
+        
         private static readonly Lazy<string> EventHubsSecretInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSecretEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
+
         internal static string EventHubsConnectionString => EventHubsConnectionStringInstance.Value;
 
         internal static string StorageConnectionString => StorageConnectionStringInstance.Value;
 
-        //Copied from Track two TestEnvironment.cs
         internal static string EventHubsSubscription => EventHubsSubscriptionInstance.Value;
 
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>
-        ///   The name of the resource group containing the Event Hubs namespace instance to be used for
-        ///   Live tests.
-        /// </summary>
-        ///
-        /// <value>The name of the namespace is read from the "EVENT_HUBS_RESOURCEGROUP" environment variable.</value>
-        ///
+       
         internal static string EventHubsResourceGroup => EventHubsResourceGroupInstance.Value;
 
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>
-        ///   The name of the Event Hubs namespace instance to be used for
-        ///   Live tests.
-        /// </summary>
-        ///
-        /// <value>The name of the namespace is read from the "EVENT_HUBS_NAMESPACE" environment variable.</value>
-        ///
+       
         internal static string EventHubsNamespace => EventHubsNamespaceInstance.Value;
 
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>
-        ///   The name of the Azure Active Directory tenant that holds the service principal to use for management
-        ///   of the Event Hubs namespace during Live tests.
-        /// </summary>
-        ///
-        /// <value>The name of the namespace is read from the "EVENT_HUBS_TENANT" environment variable.</value>
-        ///
+       
         internal static string EventHubsTenant => EventHubsTenantInstance.Value;
 
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>
-        ///   The name of the Azure Active Directory client identifier of the service principal to use for management
-        ///   of the Event Hubs namespace during Live tests.
-        /// </summary>
-        ///
-        /// <value>The name of the namespace is read from the "EVENT_HUBS_CLIENT" environment variable.</value>
-        ///
+      
         internal static string EventHubsClient => EventHubsClientInstance.Value;
 
-        //Copied from Track two TestEnvironment.cs
-        /// <summary>
-        ///   The name of the Azure Active Directory client secret of the service principal to use for management
-        ///   of the Event Hubs namespace during Live tests.
-        /// </summary>
-        ///
-        /// <value>The name of the namespace is read from the "EVENT_HUBS_SECRET" environment variable.</value>
-        ///
+       
         internal static string EventHubsSecret => EventHubsSecretInstance.Value;
 
-        /// <summary>
-        ///   Builds a connection string for a specific Event Hub instance under the Event Hubs namespace used for
-        ///   Live tests.
-        /// </summary>
-        ///
-        /// <value>The namepsace connection string is read from the "EVENT_HUBS_CONNECTION_STRING" environment variable.</value>
-        ///
+       
         internal static string GetEntityConnectionString(string entityName) =>
             new EventHubsConnectionStringBuilder(EventHubsConnectionString) { EntityPath = entityName }.ToString();
 
@@ -157,8 +111,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             Debug.WriteLine(formattedMessage);
             Console.WriteLine(formattedMessage);
         }
-        
-        //Ported from Track two TestEnvironment.cs 
+               
         public static string BuildEventHubsConnectionString(string eventHubName)
         {
             var connectionString = new EventHubsConnectionStringBuilder(EventHubsConnectionString);
@@ -168,19 +121,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
             return connectionString.ToString();
         }
-
-        // No need after method BuildEventHubsConnectionString(string eventHubName) ported from Track two
-        //private static string BuildEventHubsConnectionString(string sourceConnectionString)
-        //{
-        //    var connectionString = new EventHubsConnectionStringBuilder(sourceConnectionString);
-
-        //    connectionString.EntityPath = connectionString.EntityPath ?? TestConstants.DefultEventHubName;
-        //    connectionString.OperationTimeout = TestConstants.DefaultOperationTimeout;
-
-        //    return connectionString.ToString();
-        //}
-
-
+      
         private static string ReadEnvironmentVariable(string variableName)
         {
             var environmentVar = Environment.GetEnvironmentVariable(variableName);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
     internal static class TestUtility
     {
+        //Modified to fix Track two TestEnvironment.cs 
         private static readonly Lazy<string> EventHubsConnectionStringInstance =
             new Lazy<string>( () => ReadEnvironmentVariable(TestConstants.EventHubsConnectionStringEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
 
@@ -163,7 +164,7 @@ namespace Microsoft.Azure.EventHubs.Tests
             var connectionString = new EventHubsConnectionStringBuilder(EventHubsConnectionString);
 
             connectionString.EntityPath = connectionString.EntityPath ?? eventHubName;
-            connectionString.OperationTimeout = TimeSpan.FromSeconds(30);
+            connectionString.OperationTimeout = TestConstants.DefaultOperationTimeout;
 
             return connectionString.ToString();
         }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.EventHubs.Tests
 
     internal static class TestUtility
     {
-        //Modified to fix Track two TestEnvironment.cs 
+        //Modified to fit Track two TestEnvironment.cs 
         private static readonly Lazy<string> EventHubsConnectionStringInstance =
             new Lazy<string>( () => ReadEnvironmentVariable(TestConstants.EventHubsConnectionStringEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
 

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestUtility.cs
@@ -18,10 +18,11 @@ namespace Microsoft.Azure.EventHubs.Tests
 
         private static readonly Lazy<string> StorageConnectionStringInstance =
             new Lazy<string>( () => ReadEnvironmentVariable(TestConstants.StorageConnectionStringEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-
+        //add by Luyun
+        //add 6 ReadEnvironment method, copy from Track 2 testenvironment.cs
         private static readonly Lazy<string> EventHubsSubscriptionInstance =
           new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsSubscriptionEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
-
+      
         /// <summary>The environment variable value for the Event Hubs resource group name, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsResourceGroupInstance =
             new Lazy<string>(() => ReadEnvironmentVariable(TestConstants.EventHubsResourceGroupEnvironmentVariableName), LazyThreadSafetyMode.PublicationOnly);
@@ -45,6 +46,8 @@ namespace Microsoft.Azure.EventHubs.Tests
 
         internal static string StorageConnectionString => StorageConnectionStringInstance.Value;
 
+        //add by Luyun
+        //add 6 set and get method, copy from Track 2 testenvironment.cs
         internal static string EventHubsSubscription => EventHubsSubscriptionInstance.Value;
 
         /// <summary>
@@ -151,21 +154,12 @@ namespace Microsoft.Azure.EventHubs.Tests
             Console.WriteLine(formattedMessage);
         }
 
-        //private static string BuildEventHubsConnectionString(string sourceConnectionString)
-        //{
-        //    var connectionString = new EventHubsConnectionStringBuilder(sourceConnectionString);
-
-        //    connectionString.EntityPath = connectionString.EntityPath ?? TestConstants.DefultEventHubName;
-        //    connectionString.OperationTimeout = TestConstants.DefaultOperationTimeout;
-
-        //    return connectionString.ToString();
-        //}
         public static string BuildEventHubsConnectionString(string eventHubName)
         {
             var connectionString = new EventHubsConnectionStringBuilder(EventHubsConnectionString);
 
             connectionString.EntityPath = connectionString.EntityPath ?? eventHubName;
-            connectionString.OperationTimeout = TestConstants.DefaultOperationTimeout;
+            connectionString.OperationTimeout = TimeSpan.FromSeconds(30);
 
             return connectionString.ToString();
         }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
@@ -18,6 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Microsoft.ServiceFabric.Data" />
     <PackageReference Include="System.Net.WebSockets.Client" />

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
@@ -3,6 +3,8 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <VersionPrefix>2.2.0</VersionPrefix>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
+    <LangVersion>preview</LangVersion>
+    <IsClientLibrary>true</IsClientLibrary>
   </PropertyGroup>
 
   <!-- Because Service Fabric is involved, force the platform to x64. -->

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Microsoft.Azure.EventHubs.Tests.csproj
@@ -20,6 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Management.EventHub"  />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="Polly" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorNegativeCases.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorNegativeCases.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task HostReregisterShouldFail()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var eventProcessorHost = new EventProcessorHost(
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task NonexsistentEntity()
         {
-            await using (var scope = await EventHubScope.CreateAsync(2))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Rebuild connection string with a nonexistent entity.

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorNegativeCases.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorNegativeCases.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
 
     public class NegativeCases : ProcessorTestBase
     {
-        //Update Live test to use EventHub managed by EventHubScope
+
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -49,7 +49,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorNegativeCases.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorNegativeCases.cs
@@ -14,60 +14,70 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
 
     public class NegativeCases : ProcessorTestBase
     {
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task HostReregisterShouldFail()
         {
-            var eventProcessorHost = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                this.LeaseContainerName);
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                // Calling register for the first time should succeed.
-                TestUtility.Log("Registering EventProcessorHost for the first time.");
-                await eventProcessorHost.RegisterEventProcessorAsync<TestEventProcessor>();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    scope.EventHubName.ToLower());
 
-                await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                try
                 {
-                    TestUtility.Log("Registering EventProcessorHost for the second time which should fail.");
+                    // Calling register for the first time should succeed.
+                    TestUtility.Log("Registering EventProcessorHost for the first time.");
                     await eventProcessorHost.RegisterEventProcessorAsync<TestEventProcessor>();
-                });
-            }
-            finally
-            {
-                await eventProcessorHost.UnregisterEventProcessorAsync();
+
+                    await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+                    {
+                        TestUtility.Log("Registering EventProcessorHost for the second time which should fail.");
+                        await eventProcessorHost.RegisterEventProcessorAsync<TestEventProcessor>();
+                    });
+                }
+                finally
+                {
+                    await eventProcessorHost.UnregisterEventProcessorAsync();
+                }
             }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task NonexsistentEntity()
         {
-            // Rebuild connection string with a nonexistent entity.
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
-            csb.EntityPath = Guid.NewGuid().ToString();
-
-            var eventProcessorHost = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                csb.ToString(),
-                TestUtility.StorageConnectionString,
-                this.LeaseContainerName);
-
-            TestUtility.Log("Calling RegisterEventProcessorAsync for a nonexistent entity.");
-            var ex = await Assert.ThrowsAsync<EventProcessorConfigurationException>(async () =>
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
-                await eventProcessorHost.RegisterEventProcessorAsync<TestEventProcessor>();
-            });
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Rebuild connection string with a nonexistent entity.
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
+                csb.EntityPath = Guid.NewGuid().ToString();
 
-            Assert.NotNull(ex.InnerException);
-            Assert.IsType<MessagingEntityNotFoundException>(ex.InnerException);
+                var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    csb.ToString(),
+                    TestUtility.StorageConnectionString,
+                    scope.EventHubName.ToLower());
+
+                TestUtility.Log("Calling RegisterEventProcessorAsync for a nonexistent entity.");
+                var ex = await Assert.ThrowsAsync<EventProcessorConfigurationException>(async () =>
+                {
+                    await eventProcessorHost.RegisterEventProcessorAsync<TestEventProcessor>();
+                });
+
+                Assert.NotNull(ex.InnerException);
+                Assert.IsType<MessagingEntityNotFoundException>(ex.InnerException);
+            }
         }
 
         [Fact]

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
@@ -36,7 +36,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         public void ProcessorHostEntityPathSetting()
         {
                 var connectionString = TestUtility.BuildEventHubsConnectionString("dimmyeventhubname");
-
                 var csb = new EventHubsConnectionStringBuilder(connectionString)
                 {
                     EntityPath = "myeh"
@@ -116,8 +115,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task SingleProcessorHost()
         {
-
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var eventProcessorHost = new EventProcessorHost(
@@ -137,7 +135,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task MultipleProcessorHosts()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(3))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);              
                 string[] PartitionIds = GetPartitionIds(connectionString);
@@ -254,13 +252,10 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task WithBlobPrefix()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-
-
                 string leaseContainerName = Guid.NewGuid().ToString();
-
                 var epo = await GetOptionsAsync(connectionString);
 
                 // Consume all messages with first host.
@@ -303,7 +298,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task InvokeAfterReceiveTimeoutTrue()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 string[] PartitionIds = GetPartitionIds(connectionString);
@@ -373,7 +368,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task InvokeAfterReceiveTimeoutFalse()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 const int ReceiveTimeoutInSeconds = 15;
@@ -439,7 +434,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
               {
                 "notdefault"
               };
-            await using (var scope = await EventHubScope.CreateAsync(2, consumerGroups))
+            await using (var scope = await EventHubScope.CreateAsync(1, consumerGroups))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var epo = await GetOptionsAsync(connectionString);
@@ -461,7 +456,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task InitialOffsetProviderWithDateTime()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Send and receive single message so we can find out enqueue date-time of the last message.
@@ -498,7 +493,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task InitialOffsetProviderWithOffset()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Send and receive single message so we can find out offset of the last message.
@@ -536,7 +531,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task InitialOffsetProviderWithEndOfStream()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Use a randomly generated container name so that initial offset provider will be respected.
@@ -566,7 +561,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task InitialOffsetProviderOverrideBehavior()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Generate a new lease container name that will be used through out the test.
@@ -612,7 +607,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task CheckpointEventDataShouldHold()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Generate a new lease container name that will use through out the test.
@@ -649,7 +644,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task CheckpointBatchShouldHold()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Generate a new lease container name that will use through out the test.
@@ -686,14 +681,12 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task HostShouldRecoverAfterReceiverDisconnection()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);              
                 string[] PartitionIds = GetPartitionIds(connectionString);
-
                 // We will target one partition and do validation on it.
                 var targetPartition = PartitionIds.First();
-
                 int targetPartitionOpens = 0;
                 int targetPartitionCloses = 0;
                 int targetPartitionErrors = 0;
@@ -790,7 +783,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task NoCheckpointThenNewHostReadsFromStart()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 // Generate a new lease container name that will be used through out the test.
@@ -833,7 +826,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task CheckpointEveryMessageReceived()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var epo = await GetOptionsAsync(connectionString);
@@ -862,7 +855,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task HostShouldRecoverWhenProcessEventsAsyncThrows()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var client = EventHubClient.CreateFromConnectionString(connectionString);
@@ -1013,7 +1006,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task SingleProcessorHostWithAadTokenProvider()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var appAuthority = "";
@@ -1050,7 +1043,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task ReRegister()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var eventProcessorHost = new EventProcessorHost(
@@ -1080,7 +1073,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task ReRegisterAfterLeaseExpiry()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
                 var hostName = Guid.NewGuid().ToString();

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
@@ -18,36 +18,14 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
 
     public class ProcessorTestBase
     {
-        //Unused after Track two test infrastructure ported
-        //protected string LeaseContainerName;
-        //protected string[] PartitionIds;
-
-        //Unused after Track two test infrastructure ported
-        //public ProcessorTestBase()
-        //{
-        //    // Use entity name as lease container name.
-        //    // Convert to lowercase in case there is capital letter in the entity path.
-        //    // Uppercase is invalid for Azure Storage container names.
-        //    this.LeaseContainerName = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString).EntityPath.ToLower();
-
-        //    // Discover partition ids.
-        //    TestUtility.Log("Discovering partitions on eventhub");
-        //    var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-        //    var eventHubInfo = ehClient.GetRuntimeInformationAsync().WaitAndUnwrapException();
-        //    this.PartitionIds = eventHubInfo.PartitionIds;
-        //    TestUtility.Log($"EventHub has {PartitionIds.Length} partitions");
-        //}
-
-        //update method to use EventHub managed by EventHubScope
-        public String[] ProcessorPartitionIds(string connectionString)
+              
+        public string[] GetPartitionIds(string connectionString)
         {
             var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
             var eventHubInfo = ehClient.GetRuntimeInformationAsync().WaitAndUnwrapException();
-           String[] PartitionIds = eventHubInfo.PartitionIds;
-            return PartitionIds;
+            return eventHubInfo.PartitionIds;
         }
-
-        //Update Live test to use EventHub managed by EventHubScope
+      
         /// <summary>
         /// Validating cases where entity path is provided through eventHubPath and EH connection string parameters
         /// on the EPH constructor.
@@ -55,11 +33,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
-        public async Task ProcessorHostEntityPathSetting()
+        public void ProcessorHostEntityPathSetting()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
-            {
-                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var connectionString = TestUtility.BuildEventHubsConnectionString("dimmyeventhubname");
 
                 var csb = new EventHubsConnectionStringBuilder(connectionString)
                 {
@@ -73,7 +49,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                     PartitionReceiver.DefaultConsumerGroupName,
                     csb.ToString(),
                     TestUtility.StorageConnectionString,
-                    scope.EventHubName.ToLower());
+                    "dimmyeventhubname".ToLower());
                 Assert.Equal("myeh", eventProcessorHost.EventHubPath);
 
                 // Entity path provided in the eventHubPath parameter.
@@ -84,7 +60,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                     PartitionReceiver.DefaultConsumerGroupName,
                     csb.ToString(),
                     TestUtility.StorageConnectionString,
-                     scope.EventHubName.ToLower());
+                    "dimmyeventhubname".ToLower());
                 Assert.Equal("myeh2", eventProcessorHost.EventHubPath);
 
                 // The same entity path provided in both eventHubPath parameter and the connection string.
@@ -95,7 +71,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                     PartitionReceiver.DefaultConsumerGroupName,
                     csb.ToString(),
                     TestUtility.StorageConnectionString,
-                     scope.EventHubName.ToLower());
+                    "dimmyeventhubname".ToLower());
                 Assert.Equal("myeh", eventProcessorHost.EventHubPath);
 
                 // Entity path not provided in both eventHubPath and the connection string.
@@ -108,7 +84,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                         PartitionReceiver.DefaultConsumerGroupName,
                         csb.ToString(),
                         TestUtility.StorageConnectionString,
-                         scope.EventHubName.ToLower());
+                        "dimmyeventhubname".ToLower());
                     throw new Exception("Entity path wasn't provided and this new call was supposed to fail");
                 }
                 catch (ArgumentException)
@@ -126,18 +102,15 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
                         PartitionReceiver.DefaultConsumerGroupName,
                         csb.ToString(),
                         TestUtility.StorageConnectionString,
-                         scope.EventHubName.ToLower());
+                        "dimmyeventhubname".ToLower());
                     throw new Exception("Entity path values conflict and this new call was supposed to fail");
                 }
                 catch (ArgumentException)
                 {
                     TestUtility.Log("Caught ArgumentException as expected.");
                 }
-
-            }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -159,7 +132,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -168,7 +140,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             await using (var scope = await EventHubScope.CreateAsync(4))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);              
-                string[] PartitionIds = ProcessorPartitionIds(connectionString);
+                string[] PartitionIds = GetPartitionIds(connectionString);
                 int hostCount = 3;
 
                 TestUtility.Log($"Testing with {hostCount} EventProcessorHost instances");
@@ -277,7 +249,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -327,7 +298,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -336,7 +306,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             await using (var scope = await EventHubScope.CreateAsync(4))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
-                string[] PartitionIds = ProcessorPartitionIds(connectionString);
+                string[] PartitionIds = GetPartitionIds(connectionString);
                 const int ReceiveTimeoutInSeconds = 15;
 
                 TestUtility.Log("Testing EventProcessorHost with InvokeProcessorAfterReceiveTimeout=true");
@@ -398,7 +368,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -457,7 +426,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// This test requires a eventhub with consumer groups $Default and cgroup1.
         /// </summary>
@@ -488,7 +456,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -526,7 +493,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -565,7 +531,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -596,7 +561,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -643,7 +607,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -681,7 +644,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -719,7 +681,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -728,7 +689,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             await using (var scope = await EventHubScope.CreateAsync(4))
             {
                 var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);              
-                string[] PartitionIds = ProcessorPartitionIds(connectionString);
+                string[] PartitionIds = GetPartitionIds(connectionString);
 
                 // We will target one partition and do validation on it.
                 var targetPartition = PartitionIds.First();
@@ -820,7 +781,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// If a host doesn't checkpoint on the processed events and shuts down, new host should start processing from the beginning.
         /// </summary>
@@ -864,7 +824,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// Checkpointing every message received should be Ok. No failures expected.
         /// </summary>
@@ -894,7 +853,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// While processing events one event causes a failure. Host should be able to recover any error.
         /// </summary>
@@ -1047,7 +1005,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// This test is for manual only purpose. Fill in the tenant-id, app-id and app-secret before running.
         /// </summary>
@@ -1088,7 +1045,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -1119,7 +1075,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
@@ -1154,10 +1109,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             }
         }
 
-        //Update method to use new eventhub created by EventHubScope
         private async Task<Dictionary<string, Tuple<string, DateTime>>> DiscoverEndOfStream(string connectionString)
         {
-            string[] PartitionIds = ProcessorPartitionIds(connectionString);
+            string[] PartitionIds = GetPartitionIds(connectionString);
             var ehClient = EventHubClient.CreateFromConnectionString(connectionString);    
             var partitions = new Dictionary<string, Tuple<string, DateTime>>();
 
@@ -1170,7 +1124,6 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             return partitions.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
-        //Update method to use new eventhub created by EventHubScope
         private async Task<GenericScenarioResult> RunGenericScenario(EventProcessorHost eventProcessorHost,
             EventProcessorOptions epo = null, int totalNumberOfEventsToSend = 1, bool checkpointLastEvent = true,
             bool checkpointBatch = false, bool checkpoingEveryEvent = false)
@@ -1234,7 +1187,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
 
                 // Wait 5 seconds to avoid races in scenarios like EndOfStream.
                 await Task.Delay(5000);
-                string[] PartitionIds = ProcessorPartitionIds(TestUtility.BuildEventHubsConnectionString(eventProcessorHost.EventHubPath));
+                string[] PartitionIds = GetPartitionIds(TestUtility.BuildEventHubsConnectionString(eventProcessorHost.EventHubPath));
                 if (totalNumberOfEventsToSend > 0)
                 {
                     var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.BuildEventHubsConnectionString(eventProcessorHost.EventHubPath));

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
@@ -30,7 +30,8 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         /// Validating cases where entity path is provided through eventHubPath and EH connection string parameters
         /// on the EPH constructor.
         /// </summary>
-        [Fact]       
+        [Fact]
+        [LiveTest]
         [DisplayTestMethodName]
         public void ProcessorHostEntityPathSetting()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
@@ -30,8 +30,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         /// Validating cases where entity path is provided through eventHubPath and EH connection string parameters
         /// on the EPH constructor.
         /// </summary>
-        [Fact]
-        [LiveTest]
+        [Fact]       
         [DisplayTestMethodName]
         public void ProcessorHostEntityPathSetting()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Processor/ProcessorTestBase.cs
@@ -18,24 +18,36 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
 
     public class ProcessorTestBase
     {
-        protected string LeaseContainerName;
-        protected string[] PartitionIds;
+        //Unused after Track two test infrastructure ported
+        //protected string LeaseContainerName;
+        //protected string[] PartitionIds;
 
-        public ProcessorTestBase()
+        //Unused after Track two test infrastructure ported
+        //public ProcessorTestBase()
+        //{
+        //    // Use entity name as lease container name.
+        //    // Convert to lowercase in case there is capital letter in the entity path.
+        //    // Uppercase is invalid for Azure Storage container names.
+        //    this.LeaseContainerName = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString).EntityPath.ToLower();
+
+        //    // Discover partition ids.
+        //    TestUtility.Log("Discovering partitions on eventhub");
+        //    var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+        //    var eventHubInfo = ehClient.GetRuntimeInformationAsync().WaitAndUnwrapException();
+        //    this.PartitionIds = eventHubInfo.PartitionIds;
+        //    TestUtility.Log($"EventHub has {PartitionIds.Length} partitions");
+        //}
+
+        //update method to use EventHub managed by EventHubScope
+        public String[] ProcessorPartitionIds(string connectionString)
         {
-            // Use entity name as lease container name.
-            // Convert to lowercase in case there is capital letter in the entity path.
-            // Uppercase is invalid for Azure Storage container names.
-            this.LeaseContainerName = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString).EntityPath.ToLower();
-
-            // Discover partition ids.
-            TestUtility.Log("Discovering partitions on eventhub");
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
             var eventHubInfo = ehClient.GetRuntimeInformationAsync().WaitAndUnwrapException();
-            this.PartitionIds = eventHubInfo.PartitionIds;
-            TestUtility.Log($"EventHub has {PartitionIds.Length} partitions");
+           String[] PartitionIds = eventHubInfo.PartitionIds;
+            return PartitionIds;
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// Validating cases where entity path is provided through eventHubPath and EH connection string parameters
         /// on the EPH constructor.
@@ -43,373 +55,409 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
-        public void ProcessorHostEntityPathSetting()
+        public async Task ProcessorHostEntityPathSetting()
         {
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString)
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                EntityPath = "myeh"
-            };
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
 
-            // Entity path provided in the connection string.
-            TestUtility.Log("Testing condition: Entity path provided in the connection string only.");
-            var eventProcessorHost = new EventProcessorHost(
-                null,
-                PartitionReceiver.DefaultConsumerGroupName,
-                csb.ToString(),
-                TestUtility.StorageConnectionString,
-                this.LeaseContainerName);
-            Assert.Equal("myeh", eventProcessorHost.EventHubPath);
+                var csb = new EventHubsConnectionStringBuilder(connectionString)
+                {
+                    EntityPath = "myeh"
+                };
 
-            // Entity path provided in the eventHubPath parameter.
-            TestUtility.Log("Testing condition: Entity path provided in the eventHubPath only.");
-            csb.EntityPath = null;
-            eventProcessorHost = new EventProcessorHost(
-                "myeh2",
-                PartitionReceiver.DefaultConsumerGroupName,
-                csb.ToString(),
-                TestUtility.StorageConnectionString,
-                this.LeaseContainerName);
-            Assert.Equal("myeh2", eventProcessorHost.EventHubPath);
-
-            // The same entity path provided in both eventHubPath parameter and the connection string.
-            TestUtility.Log("Testing condition: The same entity path provided in the eventHubPath and connection string.");
-            csb.EntityPath = "mYeH";
-            eventProcessorHost = new EventProcessorHost(
-                "myeh",
-                PartitionReceiver.DefaultConsumerGroupName,
-                csb.ToString(),
-                TestUtility.StorageConnectionString,
-                this.LeaseContainerName);
-            Assert.Equal("myeh", eventProcessorHost.EventHubPath);
-
-            // Entity path not provided in both eventHubPath and the connection string.
-            TestUtility.Log("Testing condition: Entity path not provided in both eventHubPath and connection string.");
-            try
-            {
-                csb.EntityPath = null;
-                new EventProcessorHost(
-                    string.Empty,
+                // Entity path provided in the connection string.
+                TestUtility.Log("Testing condition: Entity path provided in the connection string only.");
+                var eventProcessorHost = new EventProcessorHost(
+                    null,
                     PartitionReceiver.DefaultConsumerGroupName,
                     csb.ToString(),
                     TestUtility.StorageConnectionString,
-                    this.LeaseContainerName);
-                throw new Exception("Entity path wasn't provided and this new call was supposed to fail");
-            }
-            catch (ArgumentException)
-            {
-                TestUtility.Log("Caught ArgumentException as expected.");
-            }
+                    scope.EventHubName.ToLower());
+                Assert.Equal("myeh", eventProcessorHost.EventHubPath);
 
-            // Entity path conflict.
-            TestUtility.Log("Testing condition: Entity path conflict.");
-            try
-            {
-                csb.EntityPath = "myeh";
-                new EventProcessorHost(
+                // Entity path provided in the eventHubPath parameter.
+                TestUtility.Log("Testing condition: Entity path provided in the eventHubPath only.");
+                csb.EntityPath = null;
+                eventProcessorHost = new EventProcessorHost(
                     "myeh2",
                     PartitionReceiver.DefaultConsumerGroupName,
                     csb.ToString(),
                     TestUtility.StorageConnectionString,
-                    this.LeaseContainerName);
-                throw new Exception("Entity path values conflict and this new call was supposed to fail");
-            }
-            catch (ArgumentException)
-            {
-                TestUtility.Log("Caught ArgumentException as expected.");
+                     scope.EventHubName.ToLower());
+                Assert.Equal("myeh2", eventProcessorHost.EventHubPath);
+
+                // The same entity path provided in both eventHubPath parameter and the connection string.
+                TestUtility.Log("Testing condition: The same entity path provided in the eventHubPath and connection string.");
+                csb.EntityPath = "mYeH";
+                eventProcessorHost = new EventProcessorHost(
+                    "myeh",
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    csb.ToString(),
+                    TestUtility.StorageConnectionString,
+                     scope.EventHubName.ToLower());
+                Assert.Equal("myeh", eventProcessorHost.EventHubPath);
+
+                // Entity path not provided in both eventHubPath and the connection string.
+                TestUtility.Log("Testing condition: Entity path not provided in both eventHubPath and connection string.");
+                try
+                {
+                    csb.EntityPath = null;
+                    new EventProcessorHost(
+                        string.Empty,
+                        PartitionReceiver.DefaultConsumerGroupName,
+                        csb.ToString(),
+                        TestUtility.StorageConnectionString,
+                         scope.EventHubName.ToLower());
+                    throw new Exception("Entity path wasn't provided and this new call was supposed to fail");
+                }
+                catch (ArgumentException)
+                {
+                    TestUtility.Log("Caught ArgumentException as expected.");
+                }
+
+                // Entity path conflict.
+                TestUtility.Log("Testing condition: Entity path conflict.");
+                try
+                {
+                    csb.EntityPath = "myeh";
+                    new EventProcessorHost(
+                        "myeh2",
+                        PartitionReceiver.DefaultConsumerGroupName,
+                        csb.ToString(),
+                        TestUtility.StorageConnectionString,
+                         scope.EventHubName.ToLower());
+                    throw new Exception("Entity path values conflict and this new call was supposed to fail");
+                }
+                catch (ArgumentException)
+                {
+                    TestUtility.Log("Caught ArgumentException as expected.");
+                }
+
             }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task SingleProcessorHost()
         {
-            var epo = await GetOptionsAsync();
 
-            var eventProcessorHost = new EventProcessorHost(
-                null, // Entity path will be picked from connection string.
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var eventProcessorHost = new EventProcessorHost(
+                    null, // Entity path will be picked from connection string.
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    Guid.NewGuid().ToString());
 
-            await RunGenericScenario(eventProcessorHost, epo);
+                var epo = await GetOptionsAsync(connectionString);
+                await RunGenericScenario(eventProcessorHost, epo);
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task MultipleProcessorHosts()
         {
-            int hostCount = 3;
-
-            TestUtility.Log($"Testing with {hostCount} EventProcessorHost instances");
-
-            // Prepare partition trackers.
-            var partitionReceiveEvents = new ConcurrentDictionary<string, AsyncAutoResetEvent>();
-            foreach (var partitionId in PartitionIds)
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                partitionReceiveEvents[partitionId] = new AsyncAutoResetEvent(false);
-            }
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);              
+                string[] PartitionIds = ProcessorPartitionIds(connectionString);
+                int hostCount = 3;
 
-            // Prepare host trackers.
-            var hostReceiveEvents = new ConcurrentDictionary<string, AsyncAutoResetEvent>();
+                TestUtility.Log($"Testing with {hostCount} EventProcessorHost instances");
 
-            var containerName = Guid.NewGuid().ToString();
-            var hosts = new List<EventProcessorHost>();
-
-            try
-            {
-                for (int hostId = 0; hostId < hostCount; hostId++)
-                {
-                    var thisHostName = $"host-{hostId}";
-                    hostReceiveEvents[thisHostName] = new AsyncAutoResetEvent(false);
-
-                    TestUtility.Log("Creating EventProcessorHost");
-                    var eventProcessorHost = new EventProcessorHost(
-                        thisHostName,
-                        string.Empty, // Passing empty as entity path here since path is already in EH connection string.
-                        PartitionReceiver.DefaultConsumerGroupName,
-                        TestUtility.EventHubsConnectionString,
-                        TestUtility.StorageConnectionString,
-                        containerName);
-                    hosts.Add(eventProcessorHost);
-                    TestUtility.Log($"Calling RegisterEventProcessorAsync");
-                    var processorOptions = new EventProcessorOptions
-                    {
-                        ReceiveTimeout = TimeSpan.FromSeconds(10),
-                        InvokeProcessorAfterReceiveTimeout = true,
-                        MaxBatchSize = 100,
-                        InitialOffsetProvider = pId => EventPosition.FromEnqueuedTime(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(60)))
-                    };
-
-                    var processorFactory = new TestEventProcessorFactory();
-                    processorFactory.OnCreateProcessor += (f, createArgs) =>
-                    {
-                        var processor = createArgs.Item2;
-                        string partitionId = createArgs.Item1.PartitionId;
-                        string hostName = createArgs.Item1.Owner;
-                        processor.OnOpen += (_, partitionContext) => TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor opened");
-                        processor.OnClose += (_, closeArgs) => TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor closing: {closeArgs.Item2}");
-                        processor.OnProcessError += (_, errorArgs) => TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor process error {errorArgs.Item2.Message}");
-                        processor.OnProcessEvents += (_, eventsArgs) =>
-                        {
-                            int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
-                            if (eventCount > 0)
-                            {
-                                TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
-                                partitionReceiveEvents[partitionId].Set();
-                                hostReceiveEvents[hostName].Set();
-                            }
-                        };
-                    };
-
-                    await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, processorOptions);
-                }
-
-                // Allow some time for each host to own at least 1 partition.
-                // Partition stealing logic balances partition ownership one at a time.
-                TestUtility.Log("Waiting for partition ownership to settle...");
-                await Task.Delay(TimeSpan.FromSeconds(60));
-
-                TestUtility.Log("Sending an event to each partition");
-                var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-                var sendTasks = new List<Task>();
+                // Prepare partition trackers.
+                var partitionReceiveEvents = new ConcurrentDictionary<string, AsyncAutoResetEvent>();
                 foreach (var partitionId in PartitionIds)
                 {
-                    sendTasks.Add(TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event."));
-                }
-                await Task.WhenAll(sendTasks);
-
-                TestUtility.Log("Verifying an event was received by each partition");
-                foreach (var e in partitionReceiveEvents)
-                {
-                    bool ret = await e.Value.WaitAsync(TimeSpan.FromSeconds(30));
-                    Assert.True(ret, $"Partition {e.Key} didn't receive any message!");
+                    partitionReceiveEvents[partitionId] = new AsyncAutoResetEvent(false);
                 }
 
-                TestUtility.Log("Verifying at least an event was received by each host");
-                foreach (var e in hostReceiveEvents)
-                {
-                    bool ret = await e.Value.WaitAsync(TimeSpan.FromSeconds(30));
-                    Assert.True(ret, $"Host {e.Key} didn't receive any message!");
-                }
-            }
-            finally
-            {
-                var shutdownTasks = new List<Task>();
-                foreach (var host in hosts)
-                {
-                    TestUtility.Log($"Host {host} Calling UnregisterEventProcessorAsync.");
-                    shutdownTasks.Add(host.UnregisterEventProcessorAsync());
-                }
+                // Prepare host trackers.
+                var hostReceiveEvents = new ConcurrentDictionary<string, AsyncAutoResetEvent>();
 
-                await Task.WhenAll(shutdownTasks);
+                var containerName = Guid.NewGuid().ToString();
+                var hosts = new List<EventProcessorHost>();
+
+                try
+                {
+                    for (int hostId = 0; hostId < hostCount; hostId++)
+                    {
+                        var thisHostName = $"host-{hostId}";
+                        hostReceiveEvents[thisHostName] = new AsyncAutoResetEvent(false);
+
+                        TestUtility.Log("Creating EventProcessorHost");
+                        var eventProcessorHost = new EventProcessorHost(
+                            thisHostName,
+                            string.Empty, // Passing empty as entity path here since path is already in EH connection string.
+                            PartitionReceiver.DefaultConsumerGroupName,
+                            connectionString,
+                            TestUtility.StorageConnectionString,
+                            containerName);
+                        hosts.Add(eventProcessorHost);
+                        TestUtility.Log($"Calling RegisterEventProcessorAsync");
+                        var processorOptions = new EventProcessorOptions
+                        {
+                            ReceiveTimeout = TimeSpan.FromSeconds(10),
+                            InvokeProcessorAfterReceiveTimeout = true,
+                            MaxBatchSize = 100,
+                            InitialOffsetProvider = pId => EventPosition.FromEnqueuedTime(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(60)))
+                        };
+
+                        var processorFactory = new TestEventProcessorFactory();
+                        processorFactory.OnCreateProcessor += (f, createArgs) =>
+                        {
+                            var processor = createArgs.Item2;
+                            string partitionId = createArgs.Item1.PartitionId;
+                            string hostName = createArgs.Item1.Owner;
+                            processor.OnOpen += (_, partitionContext) => TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor opened");
+                            processor.OnClose += (_, closeArgs) => TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor closing: {closeArgs.Item2}");
+                            processor.OnProcessError += (_, errorArgs) => TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor process error {errorArgs.Item2.Message}");
+                            processor.OnProcessEvents += (_, eventsArgs) =>
+                            {
+                                int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
+                                if (eventCount > 0)
+                                {
+                                    TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
+                                    partitionReceiveEvents[partitionId].Set();
+                                    hostReceiveEvents[hostName].Set();
+                                }
+                            };
+                        };
+
+                        await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, processorOptions);
+                    }
+
+                    // Allow some time for each host to own at least 1 partition.
+                    // Partition stealing logic balances partition ownership one at a time.
+                    TestUtility.Log("Waiting for partition ownership to settle...");
+                    await Task.Delay(TimeSpan.FromSeconds(60));
+
+                    TestUtility.Log("Sending an event to each partition");
+                    var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                    var sendTasks = new List<Task>();
+                    foreach (var partitionId in PartitionIds)
+                    {
+                        sendTasks.Add(TestUtility.SendToPartitionAsync(ehClient, partitionId, $"{partitionId} event."));
+                    }
+                    await Task.WhenAll(sendTasks);
+
+                    TestUtility.Log("Verifying an event was received by each partition");
+                    foreach (var e in partitionReceiveEvents)
+                    {
+                        bool ret = await e.Value.WaitAsync(TimeSpan.FromSeconds(30));
+                        Assert.True(ret, $"Partition {e.Key} didn't receive any message!");
+                    }
+
+                    TestUtility.Log("Verifying at least an event was received by each host");
+                    foreach (var e in hostReceiveEvents)
+                    {
+                        bool ret = await e.Value.WaitAsync(TimeSpan.FromSeconds(30));
+                        Assert.True(ret, $"Host {e.Key} didn't receive any message!");
+                    }
+                }
+                finally
+                {
+                    var shutdownTasks = new List<Task>();
+                    foreach (var host in hosts)
+                    {
+                        TestUtility.Log($"Host {host} Calling UnregisterEventProcessorAsync.");
+                        shutdownTasks.Add(host.UnregisterEventProcessorAsync());
+                    }
+
+                    await Task.WhenAll(shutdownTasks);
+                }
             }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task WithBlobPrefix()
         {
-            string leaseContainerName = Guid.NewGuid().ToString();
-
-            var epo = await GetOptionsAsync();
-
-            // Consume all messages with first host.
-            // Create host with 'firsthost' prefix.
-            var eventProcessorHostFirst = new EventProcessorHost(
-                "host1",
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName,
-                "firsthost");
-            var runResult1 = await RunGenericScenario(eventProcessorHostFirst, epo);
-
-            // Consume all messages with second host.
-            // Create host with 'secondhost' prefix.
-            // Although on the same lease container, this second host should receive exactly the same set of messages
-            // as the first host.
-            var eventProcessorHostSecond = new EventProcessorHost(
-                "host2",
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName,
-                "secondhost");
-            var runResult2 = await RunGenericScenario(eventProcessorHostSecond, epo, totalNumberOfEventsToSend: 0);
-
-            // Confirm that we are looking at 2 identical sets of messages in the end.
-            foreach (var kvp in runResult1.ReceivedEvents)
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                Assert.True(kvp.Value.Count() == runResult2.ReceivedEvents[kvp.Key].Count,
-                    $"The sets of messages returned from first host and the second host are different for partition {kvp.Key}.");
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+
+
+                string leaseContainerName = Guid.NewGuid().ToString();
+
+                var epo = await GetOptionsAsync(connectionString);
+
+                // Consume all messages with first host.
+                // Create host with 'firsthost' prefix.
+                var eventProcessorHostFirst = new EventProcessorHost(
+                    "host1",
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName,
+                    "firsthost");
+                var runResult1 = await RunGenericScenario(eventProcessorHostFirst, epo);
+
+                // Consume all messages with second host.
+                // Create host with 'secondhost' prefix.
+                // Although on the same lease container, this second host should receive exactly the same set of messages
+                // as the first host.
+                var eventProcessorHostSecond = new EventProcessorHost(
+                    "host2",
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName,
+                    "secondhost");
+                var runResult2 = await RunGenericScenario(eventProcessorHostSecond, epo, totalNumberOfEventsToSend: 0);
+
+                // Confirm that we are looking at 2 identical sets of messages in the end.
+                foreach (var kvp in runResult1.ReceivedEvents)
+                {
+                    Assert.True(kvp.Value.Count() == runResult2.ReceivedEvents[kvp.Key].Count,
+                        $"The sets of messages returned from first host and the second host are different for partition {kvp.Key}.");
+                }
             }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task InvokeAfterReceiveTimeoutTrue()
         {
-            const int ReceiveTimeoutInSeconds = 15;
-
-            TestUtility.Log("Testing EventProcessorHost with InvokeProcessorAfterReceiveTimeout=true");
-
-            var emptyBatchReceiveEvents = new ConcurrentDictionary<string, AsyncAutoResetEvent>();
-            foreach (var partitionId in PartitionIds)
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                emptyBatchReceiveEvents[partitionId] = new AsyncAutoResetEvent(false);
-            }
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                string[] PartitionIds = ProcessorPartitionIds(connectionString);
+                const int ReceiveTimeoutInSeconds = 15;
 
-            var eventProcessorHost = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
+                TestUtility.Log("Testing EventProcessorHost with InvokeProcessorAfterReceiveTimeout=true");
 
-            var processorOptions = new EventProcessorOptions
-            {
-                ReceiveTimeout = TimeSpan.FromSeconds(ReceiveTimeoutInSeconds),
-                InvokeProcessorAfterReceiveTimeout = true,
-                InitialOffsetProvider = pId => EventPosition.FromEnd()
-            };
-
-            var processorFactory = new TestEventProcessorFactory();
-            processorFactory.OnCreateProcessor += (f, createArgs) =>
-            {
-                var processor = createArgs.Item2;
-                string partitionId = createArgs.Item1.PartitionId;
-                processor.OnOpen += (_, partitionContext) => TestUtility.Log($"Partition {partitionId} TestEventProcessor opened");
-                processor.OnProcessEvents += (_, eventsArgs) =>
-                {
-                    int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
-                    TestUtility.Log($"Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
-                    if (eventCount == 0)
-                    {
-                        var emptyBatchReceiveEvent = emptyBatchReceiveEvents[partitionId];
-                        emptyBatchReceiveEvent.Set();
-                    }
-                };
-            };
-
-            await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, processorOptions);
-            try
-            {
-                TestUtility.Log("Waiting for each partition to receive an empty batch of events...");
+                var emptyBatchReceiveEvents = new ConcurrentDictionary<string, AsyncAutoResetEvent>();
                 foreach (var partitionId in PartitionIds)
                 {
-                    var emptyBatchReceiveEvent = emptyBatchReceiveEvents[partitionId];
-                    bool emptyBatchReceived = await emptyBatchReceiveEvent.WaitAsync(TimeSpan.FromSeconds(ReceiveTimeoutInSeconds * 2));
-                    Assert.True(emptyBatchReceived, $"Partition {partitionId} didn't receive an empty batch!");
+                    emptyBatchReceiveEvents[partitionId] = new AsyncAutoResetEvent(false);
                 }
-            }
-            finally
-            {
-                TestUtility.Log("Calling UnregisterEventProcessorAsync");
-                await eventProcessorHost.UnregisterEventProcessorAsync();
+
+                var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    Guid.NewGuid().ToString());
+
+                var processorOptions = new EventProcessorOptions
+                {
+                    ReceiveTimeout = TimeSpan.FromSeconds(ReceiveTimeoutInSeconds),
+                    InvokeProcessorAfterReceiveTimeout = true,
+                    InitialOffsetProvider = pId => EventPosition.FromEnd()
+                };
+
+                var processorFactory = new TestEventProcessorFactory();
+                processorFactory.OnCreateProcessor += (f, createArgs) =>
+                {
+                    var processor = createArgs.Item2;
+                    string partitionId = createArgs.Item1.PartitionId;
+                    processor.OnOpen += (_, partitionContext) => TestUtility.Log($"Partition {partitionId} TestEventProcessor opened");
+                    processor.OnProcessEvents += (_, eventsArgs) =>
+                    {
+                        int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
+                        TestUtility.Log($"Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
+                        if (eventCount == 0)
+                        {
+                            var emptyBatchReceiveEvent = emptyBatchReceiveEvents[partitionId];
+                            emptyBatchReceiveEvent.Set();
+                        }
+                    };
+                };
+
+                await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, processorOptions);
+                try
+                {
+                    TestUtility.Log("Waiting for each partition to receive an empty batch of events...");
+                    foreach (var partitionId in PartitionIds)
+                    {
+                        var emptyBatchReceiveEvent = emptyBatchReceiveEvents[partitionId];
+                        bool emptyBatchReceived = await emptyBatchReceiveEvent.WaitAsync(TimeSpan.FromSeconds(ReceiveTimeoutInSeconds * 2));
+                        Assert.True(emptyBatchReceived, $"Partition {partitionId} didn't receive an empty batch!");
+                    }
+                }
+                finally
+                {
+                    TestUtility.Log("Calling UnregisterEventProcessorAsync");
+                    await eventProcessorHost.UnregisterEventProcessorAsync();
+                }
             }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task InvokeAfterReceiveTimeoutFalse()
         {
-            const int ReceiveTimeoutInSeconds = 15;
-
-            TestUtility.Log("Calling RegisterEventProcessorAsync with InvokeProcessorAfterReceiveTimeout=false");
-
-            var eventProcessorHost = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                this.LeaseContainerName);
-
-            var processorOptions = new EventProcessorOptions
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                ReceiveTimeout = TimeSpan.FromSeconds(ReceiveTimeoutInSeconds),
-                InvokeProcessorAfterReceiveTimeout = false,
-                MaxBatchSize = 100
-            };
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                const int ReceiveTimeoutInSeconds = 15;
 
-            var emptyBatchReceiveEvent = new AsyncAutoResetEvent(false);
-            var processorFactory = new TestEventProcessorFactory();
-            processorFactory.OnCreateProcessor += (f, createArgs) =>
-            {
-                var processor = createArgs.Item2;
-                string partitionId = createArgs.Item1.PartitionId;
-                processor.OnProcessEvents += (_, eventsArgs) =>
+                TestUtility.Log("Calling RegisterEventProcessorAsync with InvokeProcessorAfterReceiveTimeout=false");
+
+                var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    scope.EventHubName.ToLower());
+
+                var processorOptions = new EventProcessorOptions
                 {
-                    int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
-                    TestUtility.Log($"Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
-                    if (eventCount == 0)
-                    {
-                        emptyBatchReceiveEvent.Set();
-                    }
+                    ReceiveTimeout = TimeSpan.FromSeconds(ReceiveTimeoutInSeconds),
+                    InvokeProcessorAfterReceiveTimeout = false,
+                    MaxBatchSize = 100
                 };
-            };
 
-            await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, processorOptions);
-            try
-            {
-                TestUtility.Log("Verifying no empty batches arrive...");
-                bool waitSucceeded = await emptyBatchReceiveEvent.WaitAsync(TimeSpan.FromSeconds(ReceiveTimeoutInSeconds * 2));
-                Assert.False(waitSucceeded, "No empty batch should have been received!");
-            }
-            finally
-            {
-                TestUtility.Log("Calling UnregisterEventProcessorAsync");
-                await eventProcessorHost.UnregisterEventProcessorAsync();
+                var emptyBatchReceiveEvent = new AsyncAutoResetEvent(false);
+                var processorFactory = new TestEventProcessorFactory();
+                processorFactory.OnCreateProcessor += (f, createArgs) =>
+                {
+                    var processor = createArgs.Item2;
+                    string partitionId = createArgs.Item1.PartitionId;
+                    processor.OnProcessEvents += (_, eventsArgs) =>
+                    {
+                        int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
+                        TestUtility.Log($"Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
+                        if (eventCount == 0)
+                        {
+                            emptyBatchReceiveEvent.Set();
+                        }
+                    };
+                };
+
+                await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, processorOptions);
+                try
+                {
+                    TestUtility.Log("Verifying no empty batches arrive...");
+                    bool waitSucceeded = await emptyBatchReceiveEvent.WaitAsync(TimeSpan.FromSeconds(ReceiveTimeoutInSeconds * 2));
+                    Assert.False(waitSucceeded, "No empty batch should have been received!");
+                }
+                finally
+                {
+                    TestUtility.Log("Calling UnregisterEventProcessorAsync");
+                    await eventProcessorHost.UnregisterEventProcessorAsync();
+                }
             }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// This test requires a eventhub with consumer groups $Default and cgroup1.
         /// </summary>
@@ -419,314 +467,360 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task NonDefaultConsumerGroup()
         {
-            var epo = await GetOptionsAsync();
+            var consumerGroups = new[]
+              {
+                "notdefault"
+              };
+            await using (var scope = await EventHubScope.CreateAsync(2, consumerGroups))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var epo = await GetOptionsAsync(connectionString);
+                var a = Guid.NewGuid().ToString();
+                // Run on non-default consumer group
+                var eventProcessorHost = new EventProcessorHost(
+                    null, // Entity path will be picked from connection string.
+                    scope.ConsumerGroups[0],
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    a);
 
-            // Run on non-default consumer group
-            var eventProcessorHost = new EventProcessorHost(
-                null, // Entity path will be picked from connection string.
-                TestConstants.AlternateConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
-
-            await RunGenericScenario(eventProcessorHost, epo);
+                await RunGenericScenario(eventProcessorHost, epo);
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task InitialOffsetProviderWithDateTime()
         {
-            // Send and receive single message so we can find out enqueue date-time of the last message.
-            var partitions = await DiscoverEndOfStream();
-
-            // We will use last enqueued message's enqueue date-time so EPH will pick messages only after that point.
-            var lastEnqueueDateTime = partitions.Max(le => le.Value.Item2);
-            TestUtility.Log($"Last message enqueued at {lastEnqueueDateTime}");
-
-            // Use a randomly generated container name so that initial offset provider will be respected.
-            var eventProcessorHost = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
-
-            var processorOptions = new EventProcessorOptions
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                ReceiveTimeout = TimeSpan.FromSeconds(15),
-                InitialOffsetProvider = partitionId => EventPosition.FromEnqueuedTime(lastEnqueueDateTime),
-                MaxBatchSize = 100
-            };
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Send and receive single message so we can find out enqueue date-time of the last message.
+                var partitions = await DiscoverEndOfStream(connectionString);
 
-            var runResult = await this.RunGenericScenario(eventProcessorHost, processorOptions);
+                // We will use last enqueued message's enqueue date-time so EPH will pick messages only after that point.
+                var lastEnqueueDateTime = partitions.Max(le => le.Value.Item2);
+                TestUtility.Log($"Last message enqueued at {lastEnqueueDateTime}");
 
-            // We should have received only 1 event from each partition.
-            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+                // Use a randomly generated container name so that initial offset provider will be respected.
+                var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    Guid.NewGuid().ToString());
+
+                var processorOptions = new EventProcessorOptions
+                {
+                    ReceiveTimeout = TimeSpan.FromSeconds(15),
+                    InitialOffsetProvider = partitionId => EventPosition.FromEnqueuedTime(lastEnqueueDateTime),
+                    MaxBatchSize = 100
+                };
+
+                var runResult = await this.RunGenericScenario(eventProcessorHost, processorOptions);
+
+                // We should have received only 1 event from each partition.
+                Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task InitialOffsetProviderWithOffset()
         {
-            // Send and receive single message so we can find out offset of the last message.
-            var partitions = await DiscoverEndOfStream();
-            TestUtility.Log("Discovered last event offsets on each partition as below:");
-            foreach (var p in partitions)
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                TestUtility.Log($"Partition {p.Key}: {p.Value.Item1}");
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Send and receive single message so we can find out offset of the last message.
+                var partitions = await DiscoverEndOfStream(connectionString);
+                TestUtility.Log("Discovered last event offsets on each partition as below:");
+                foreach (var p in partitions)
+                {
+                    TestUtility.Log($"Partition {p.Key}: {p.Value.Item1}");
+                }
+
+                // Use a randomly generated container name so that initial offset provider will be respected.
+                var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    Guid.NewGuid().ToString());
+
+                var processorOptions = new EventProcessorOptions
+                {
+                    ReceiveTimeout = TimeSpan.FromSeconds(15),
+                    InitialOffsetProvider = partitionId => EventPosition.FromOffset(partitions[partitionId].Item1),
+                    MaxBatchSize = 100
+                };
+
+                var runResult = await this.RunGenericScenario(eventProcessorHost, processorOptions);
+
+                // We should have received only 1 event from each partition.
+                Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
             }
-
-            // Use a randomly generated container name so that initial offset provider will be respected.
-            var eventProcessorHost = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
-
-            var processorOptions = new EventProcessorOptions
-            {
-                ReceiveTimeout = TimeSpan.FromSeconds(15),
-                InitialOffsetProvider = partitionId => EventPosition.FromOffset(partitions[partitionId].Item1),
-                MaxBatchSize = 100
-            };
-
-            var runResult = await this.RunGenericScenario(eventProcessorHost, processorOptions);
-
-            // We should have received only 1 event from each partition.
-            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task InitialOffsetProviderWithEndOfStream()
         {
-            // Use a randomly generated container name so that initial offset provider will be respected.
-            var eventProcessorHost = new EventProcessorHost(
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Use a randomly generated container name so that initial offset provider will be respected.
+                var eventProcessorHost = new EventProcessorHost(
                 string.Empty,
                 PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
+                connectionString,
                 TestUtility.StorageConnectionString,
                 Guid.NewGuid().ToString());
 
-            var processorOptions = new EventProcessorOptions
-            {
-                ReceiveTimeout = TimeSpan.FromSeconds(15),
-                InitialOffsetProvider = partitionId => EventPosition.FromEnd(),
-                MaxBatchSize = 100
-            };
+                var processorOptions = new EventProcessorOptions
+                {
+                    ReceiveTimeout = TimeSpan.FromSeconds(15),
+                    InitialOffsetProvider = partitionId => EventPosition.FromEnd(),
+                    MaxBatchSize = 100
+                };
 
-            var runResult = await this.RunGenericScenario(eventProcessorHost, processorOptions);
+                var runResult = await this.RunGenericScenario(eventProcessorHost, processorOptions);
 
-            // We should have received only 1 event from each partition.
-            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+                // We should have received only 1 event from each partition.
+                Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task InitialOffsetProviderOverrideBehavior()
         {
-            // Generate a new lease container name that will be used through out the test.
-            string leaseContainerName = Guid.NewGuid().ToString();
-            TestUtility.Log($"Using lease container {leaseContainerName}");
-
-            var epo = await GetOptionsAsync();
-
-            // First host will send and receive as usual.
-            var eventProcessorHost = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName);
-            await this.RunGenericScenario(eventProcessorHost, epo);
-
-            // Second host will use an initial offset provider.
-            // Since we are still on the same lease container, initial offset provider shouldn't rule.
-            // We should continue receiving where we left instead if start-of-stream where initial offset provider dictates.
-            eventProcessorHost = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName);
-            var processorOptions = new EventProcessorOptions
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                ReceiveTimeout = TimeSpan.FromSeconds(15),
-                InitialOffsetProvider = partitionId => EventPosition.FromStart(),
-                MaxBatchSize = 100
-            };
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Generate a new lease container name that will be used through out the test.
+                string leaseContainerName = Guid.NewGuid().ToString();
+                TestUtility.Log($"Using lease container {leaseContainerName}");
 
-            var runResult = await this.RunGenericScenario(eventProcessorHost, processorOptions, checkpointLastEvent: false);
+                var epo = await GetOptionsAsync(connectionString);
 
-            // We should have received only 1 event from each partition.
-            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+                // First host will send and receive as usual.
+                var eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName);
+                await this.RunGenericScenario(eventProcessorHost, epo);
+
+                // Second host will use an initial offset provider.
+                // Since we are still on the same lease container, initial offset provider shouldn't rule.
+                // We should continue receiving where we left instead if start-of-stream where initial offset provider dictates.
+                eventProcessorHost = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName);
+                var processorOptions = new EventProcessorOptions
+                {
+                    ReceiveTimeout = TimeSpan.FromSeconds(15),
+                    InitialOffsetProvider = partitionId => EventPosition.FromStart(),
+                    MaxBatchSize = 100
+                };
+
+                var runResult = await this.RunGenericScenario(eventProcessorHost, processorOptions, checkpointLastEvent: false);
+
+                // We should have received only 1 event from each partition.
+                Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task CheckpointEventDataShouldHold()
         {
-            // Generate a new lease container name that will use through out the test.
-            string leaseContainerName = Guid.NewGuid().ToString();
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Generate a new lease container name that will use through out the test.
+                string leaseContainerName = Guid.NewGuid().ToString();
 
-            var epo = await GetOptionsAsync();
+                var epo = await GetOptionsAsync(connectionString);
 
-            // Consume all messages with first host.
-            var eventProcessorHostFirst = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName);
-            await RunGenericScenario(eventProcessorHostFirst, epo);
+                // Consume all messages with first host.
+                var eventProcessorHostFirst = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName);
+                await RunGenericScenario(eventProcessorHostFirst, epo);
 
-            // For the second time we initiate a host and this time it should pick from where the previous host left.
-            // In other words, it shouldn't start receiving from start of the stream.
-            var eventProcessorHostSecond = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName);
-            var runResult = await RunGenericScenario(eventProcessorHostSecond);
+                // For the second time we initiate a host and this time it should pick from where the previous host left.
+                // In other words, it shouldn't start receiving from start of the stream.
+                var eventProcessorHostSecond = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName);
+                var runResult = await RunGenericScenario(eventProcessorHostSecond);
 
-            // We should have received only 1 event from each partition.
-            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+                // We should have received only 1 event from each partition.
+                Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task CheckpointBatchShouldHold()
         {
-            // Generate a new lease container name that will use through out the test.
-            string leaseContainerName = Guid.NewGuid().ToString();
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Generate a new lease container name that will use through out the test.
+                string leaseContainerName = Guid.NewGuid().ToString();
 
-            var epo = await GetOptionsAsync();
+                var epo = await GetOptionsAsync(connectionString);
 
-            // Consume all messages with first host.
-            var eventProcessorHostFirst = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName);
-            await RunGenericScenario(eventProcessorHostFirst, epo, checkpointLastEvent: false, checkpointBatch: true);
+                // Consume all messages with first host.
+                var eventProcessorHostFirst = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName);
+                await RunGenericScenario(eventProcessorHostFirst, epo, checkpointLastEvent: false, checkpointBatch: true);
 
-            // For the second time we initiate a host and this time it should pick from where the previous host left.
-            // In other words, it shouldn't start receiving from start of the stream.
-            var eventProcessorHostSecond = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName);
-            var runResult = await RunGenericScenario(eventProcessorHostSecond, epo);
+                // For the second time we initiate a host and this time it should pick from where the previous host left.
+                // In other words, it shouldn't start receiving from start of the stream.
+                var eventProcessorHostSecond = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName);
+                var runResult = await RunGenericScenario(eventProcessorHostSecond, epo);
 
-            // We should have received only 1 event from each partition.
-            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+                // We should have received only 1 event from each partition.
+                Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "One of the partitions didn't return exactly 1 event");
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task HostShouldRecoverAfterReceiverDisconnection()
         {
-            // We will target one partition and do validation on it.
-            var targetPartition = this.PartitionIds.First();
-
-            int targetPartitionOpens = 0;
-            int targetPartitionCloses = 0;
-            int targetPartitionErrors = 0;
-            PartitionReceiver externalReceiver = null;
-
-            var eventProcessorHost = new EventProcessorHost(
-                "ephhost",
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
-
-            try
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                var processorFactory = new TestEventProcessorFactory();
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);              
+                string[] PartitionIds = ProcessorPartitionIds(connectionString);
 
-                processorFactory.OnCreateProcessor += (f, createArgs) =>
+                // We will target one partition and do validation on it.
+                var targetPartition = PartitionIds.First();
+
+                int targetPartitionOpens = 0;
+                int targetPartitionCloses = 0;
+                int targetPartitionErrors = 0;
+                PartitionReceiver externalReceiver = null;
+
+                var eventProcessorHost = new EventProcessorHost(
+                    "ephhost",
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    Guid.NewGuid().ToString());
+
+                try
                 {
-                    var processor = createArgs.Item2;
-                    string partitionId = createArgs.Item1.PartitionId;
-                    string hostName = createArgs.Item1.Owner;
-                    processor.OnOpen += (_, partitionContext) =>
-                        {
-                            TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor opened");
-                            if (partitionId == targetPartition)
+                    var processorFactory = new TestEventProcessorFactory();
+
+                    processorFactory.OnCreateProcessor += (f, createArgs) =>
+                    {
+                        var processor = createArgs.Item2;
+                        string partitionId = createArgs.Item1.PartitionId;
+                        string hostName = createArgs.Item1.Owner;
+                        processor.OnOpen += (_, partitionContext) =>
                             {
-                                Interlocked.Increment(ref targetPartitionOpens);
-                            }
-                        };
-                    processor.OnClose += (_, closeArgs) =>
-                        {
-                            TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor closing: {closeArgs.Item2}");
-                            if (partitionId == targetPartition && closeArgs.Item2 == CloseReason.Shutdown)
+                                TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor opened");
+                                if (partitionId == targetPartition)
+                                {
+                                    Interlocked.Increment(ref targetPartitionOpens);
+                                }
+                            };
+                        processor.OnClose += (_, closeArgs) =>
                             {
-                                Interlocked.Increment(ref targetPartitionCloses);
-                            }
-                        };
-                    processor.OnProcessError += (_, errorArgs) =>
-                        {
-                            TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor process error {errorArgs.Item2.Message}");
-                            if (partitionId == targetPartition && errorArgs.Item2 is ReceiverDisconnectedException)
+                                TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor closing: {closeArgs.Item2}");
+                                if (partitionId == targetPartition && closeArgs.Item2 == CloseReason.Shutdown)
+                                {
+                                    Interlocked.Increment(ref targetPartitionCloses);
+                                }
+                            };
+                        processor.OnProcessError += (_, errorArgs) =>
                             {
-                                Interlocked.Increment(ref targetPartitionErrors);
-                            }
-                        };
-                };
+                                TestUtility.Log($"{hostName} > Partition {partitionId} TestEventProcessor process error {errorArgs.Item2.Message}");
+                                if (partitionId == targetPartition && errorArgs.Item2 is ReceiverDisconnectedException)
+                                {
+                                    Interlocked.Increment(ref targetPartitionErrors);
+                                }
+                            };
+                    };
 
-                var epo = EventProcessorOptions.DefaultOptions;
-                epo.ReceiveTimeout = TimeSpan.FromSeconds(10);
-                await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, epo);
+                    var epo = EventProcessorOptions.DefaultOptions;
+                    epo.ReceiveTimeout = TimeSpan.FromSeconds(10);
+                    await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, epo);
 
-                // Wait 15 seconds then create a new epoch receiver.
-                // This will trigger ReceiverDisconnectedExcetion in the host.
-                await Task.Delay(15000);
+                    // Wait 15 seconds then create a new epoch receiver.
+                    // This will trigger ReceiverDisconnectedExcetion in the host.
+                    await Task.Delay(15000);
 
-                TestUtility.Log("Creating a new receiver with epoch 2. This will trigger ReceiverDisconnectedException in the host.");
-                var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-                externalReceiver = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName,
-                    targetPartition, EventPosition.FromStart(), 2);
-                await externalReceiver.ReceiveAsync(100, TimeSpan.FromSeconds(5));
+                    TestUtility.Log("Creating a new receiver with epoch 2. This will trigger ReceiverDisconnectedException in the host.");
+                    var ehClient = EventHubClient.CreateFromConnectionString(connectionString);
+                    externalReceiver = ehClient.CreateEpochReceiver(PartitionReceiver.DefaultConsumerGroupName,
+                        targetPartition, EventPosition.FromStart(), 2);
+                    await externalReceiver.ReceiveAsync(100, TimeSpan.FromSeconds(5));
 
-                // Give another 1 minute for host to recover then do the validations.
-                await Task.Delay(60000);
+                    // Give another 1 minute for host to recover then do the validations.
+                    await Task.Delay(60000);
 
-                TestUtility.Log("Verifying that host was able to receive ReceiverDisconnectedException");
-                Assert.True(targetPartitionErrors == 1, $"Host received {targetPartitionErrors} ReceiverDisconnectedExceptions!");
+                    TestUtility.Log("Verifying that host was able to receive ReceiverDisconnectedException");
+                    Assert.True(targetPartitionErrors == 1, $"Host received {targetPartitionErrors} ReceiverDisconnectedExceptions!");
 
-                TestUtility.Log("Verifying that host was able to reopen the partition");
-                Assert.True(targetPartitionOpens == 2, $"Host opened target partition {targetPartitionOpens} times!");
+                    TestUtility.Log("Verifying that host was able to reopen the partition");
+                    Assert.True(targetPartitionOpens == 2, $"Host opened target partition {targetPartitionOpens} times!");
 
-                TestUtility.Log("Verifying that host notified by close");
-                Assert.True(targetPartitionCloses == 1, $"Host closed target partition {targetPartitionCloses} times!");
-            }
-            finally
-            {
-                TestUtility.Log("Calling UnregisterEventProcessorAsync");
-                await eventProcessorHost.UnregisterEventProcessorAsync();
-
-                if (externalReceiver != null)
+                    TestUtility.Log("Verifying that host notified by close");
+                    Assert.True(targetPartitionCloses == 1, $"Host closed target partition {targetPartitionCloses} times!");
+                }
+                finally
                 {
-                    await externalReceiver.CloseAsync();
+                    TestUtility.Log("Calling UnregisterEventProcessorAsync");
+                    await eventProcessorHost.UnregisterEventProcessorAsync();
+
+                    if (externalReceiver != null)
+                    {
+                        await externalReceiver.CloseAsync();
+                    }
                 }
             }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// If a host doesn't checkpoint on the processed events and shuts down, new host should start processing from the beginning.
         /// </summary>
@@ -736,36 +830,41 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task NoCheckpointThenNewHostReadsFromStart()
         {
-            // Generate a new lease container name that will be used through out the test.
-            string leaseContainerName = Guid.NewGuid().ToString();
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                // Generate a new lease container name that will be used through out the test.
+                string leaseContainerName = Guid.NewGuid().ToString();
 
-            var epo = await GetOptionsAsync();
+                var epo = await GetOptionsAsync(connectionString);
 
-            // Consume all messages with first host.
-            var eventProcessorHostFirst = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName);
-            var runResult1 = await RunGenericScenario(eventProcessorHostFirst, epo, checkpointLastEvent: false);
-            var totalEventsFromFirstHost = runResult1.ReceivedEvents.Sum(part => part.Value.Count);
+                // Consume all messages with first host.
+                var eventProcessorHostFirst = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName);
+                var runResult1 = await RunGenericScenario(eventProcessorHostFirst, epo, checkpointLastEvent: false);
+                var totalEventsFromFirstHost = runResult1.ReceivedEvents.Sum(part => part.Value.Count);
 
-            // Second time we initiate a host, it should receive exactly the same number of evets.
-            var eventProcessorHostSecond = new EventProcessorHost(
-                string.Empty,
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                leaseContainerName);
-            var runResult2 = await RunGenericScenario(eventProcessorHostSecond, epo, 0);
-            var totalEventsFromSecondHost = runResult2.ReceivedEvents.Sum(part => part.Value.Count);
+                // Second time we initiate a host, it should receive exactly the same number of evets.
+                var eventProcessorHostSecond = new EventProcessorHost(
+                    string.Empty,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                   connectionString,
+                    TestUtility.StorageConnectionString,
+                    leaseContainerName);
+                var runResult2 = await RunGenericScenario(eventProcessorHostSecond, epo, 0);
+                var totalEventsFromSecondHost = runResult2.ReceivedEvents.Sum(part => part.Value.Count);
 
-            // Second host should have received the same number of events as the first host.
-            Assert.True(totalEventsFromFirstHost == totalEventsFromSecondHost,
-                $"Second host received {totalEventsFromSecondHost} events where as first host receive {totalEventsFromFirstHost} events.");
+                // Second host should have received the same number of events as the first host.
+                Assert.True(totalEventsFromFirstHost == totalEventsFromSecondHost,
+                    $"Second host received {totalEventsFromSecondHost} events where as first host receive {totalEventsFromFirstHost} events.");
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// Checkpointing every message received should be Ok. No failures expected.
         /// </summary>
@@ -775,22 +874,27 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task CheckpointEveryMessageReceived()
         {
-            var epo = await GetOptionsAsync();
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var epo = await GetOptionsAsync(connectionString);
 
-            var eventProcessorHost = new EventProcessorHost(
-                null, // Entity path will be picked from connection string.
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
+                var eventProcessorHost = new EventProcessorHost(
+                    null, // Entity path will be picked from connection string.
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    Guid.NewGuid().ToString());
 
-            var runResult = await RunGenericScenario(eventProcessorHost, epo, totalNumberOfEventsToSend: 10,
-                checkpointLastEvent: false, checkpoingEveryEvent: true);
+                var runResult = await RunGenericScenario(eventProcessorHost, epo, totalNumberOfEventsToSend: 10,
+                    checkpointLastEvent: false, checkpoingEveryEvent: true);
 
-            // Validate there were not failures.
-            Assert.True(runResult.NumberOfFailures == 0, $"RunResult returned with {runResult.NumberOfFailures} failures!");
+                // Validate there were not failures.
+                Assert.True(runResult.NumberOfFailures == 0, $"RunResult returned with {runResult.NumberOfFailures} failures!");
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// While processing events one event causes a failure. Host should be able to recover any error.
         /// </summary>
@@ -800,142 +904,150 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task HostShouldRecoverWhenProcessEventsAsyncThrows()
         {
-            var lastReceivedAt = DateTime.Now;
-            var lastReceivedAtLock = new object();
-            var poisonMessageReceived = false;
-            var poisonMessageProperty = "poison";
-            var processorFactory = new TestEventProcessorFactory();
-            var receivedEventCounts = new ConcurrentDictionary<string, int>();
-
-            var eventProcessorHost = new EventProcessorHost(
-                null, // Entity path will be picked from connection string.
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
-
-            processorFactory.OnCreateProcessor += (f, createArgs) =>
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                var processor = createArgs.Item2;
-                string partitionId = createArgs.Item1.PartitionId;
-                string hostName = createArgs.Item1.Owner;
-                string consumerGroupName = createArgs.Item1.ConsumerGroupName;
-                processor.OnOpen += (_, partitionContext) => TestUtility.Log($"{hostName} > {consumerGroupName} > Partition {partitionId} TestEventProcessor opened");
-                processor.OnClose += (_, closeArgs) => TestUtility.Log($"{hostName} > {consumerGroupName} > Partition {partitionId} TestEventProcessor closing: {closeArgs.Item2}");
-                processor.OnProcessError += (_, errorArgs) =>
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var client = EventHubClient.CreateFromConnectionString(connectionString);
+                var eventHubInfo = client.GetRuntimeInformationAsync().WaitAndUnwrapException();
+                string[] PartitionIds = eventHubInfo.PartitionIds;
+                var lastReceivedAt = DateTime.Now;
+                var lastReceivedAtLock = new object();
+                var poisonMessageReceived = false;
+                var poisonMessageProperty = "poison";
+                var processorFactory = new TestEventProcessorFactory();
+                var receivedEventCounts = new ConcurrentDictionary<string, int>();
+
+                var eventProcessorHost = new EventProcessorHost(
+                    null, // Entity path will be picked from connection string.
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    Guid.NewGuid().ToString());
+
+                processorFactory.OnCreateProcessor += (f, createArgs) =>
                 {
-                    TestUtility.Log($"{hostName} > {consumerGroupName} > Partition {partitionId} TestEventProcessor process error {errorArgs.Item2.Message}");
+                    var processor = createArgs.Item2;
+                    string partitionId = createArgs.Item1.PartitionId;
+                    string hostName = createArgs.Item1.Owner;
+                    string consumerGroupName = createArgs.Item1.ConsumerGroupName;
+                    processor.OnOpen += (_, partitionContext) => TestUtility.Log($"{hostName} > {consumerGroupName} > Partition {partitionId} TestEventProcessor opened");
+                    processor.OnClose += (_, closeArgs) => TestUtility.Log($"{hostName} > {consumerGroupName} > Partition {partitionId} TestEventProcessor closing: {closeArgs.Item2}");
+                    processor.OnProcessError += (_, errorArgs) =>
+                    {
+                        TestUtility.Log($"{hostName} > {consumerGroupName} > Partition {partitionId} TestEventProcessor process error {errorArgs.Item2.Message}");
 
                     // Throw once more here depending on where we are at exception sequence.
                     if (errorArgs.Item2.Message.Contains("ExceptionSequence1"))
-                    {
-                        throw new Exception("ExceptionSequence2");
-                    }
-                };
-                processor.OnProcessEvents += (_, eventsArgs) =>
-                {
-                    int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
-                    TestUtility.Log($"{hostName} > {consumerGroupName} > Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
-                    if (eventCount > 0)
-                    {
-                        lock (lastReceivedAtLock)
                         {
-                            lastReceivedAt = DateTime.Now;
+                            throw new Exception("ExceptionSequence2");
                         }
-
-                        foreach (var e in eventsArgs.Item2.events)
+                    };
+                    processor.OnProcessEvents += (_, eventsArgs) =>
+                    {
+                        int eventCount = eventsArgs.Item2.events != null ? eventsArgs.Item2.events.Count() : 0;
+                        TestUtility.Log($"{hostName} > {consumerGroupName} > Partition {partitionId} TestEventProcessor processing {eventCount} event(s)");
+                        if (eventCount > 0)
                         {
+                            lock (lastReceivedAtLock)
+                            {
+                                lastReceivedAt = DateTime.Now;
+                            }
+
+                            foreach (var e in eventsArgs.Item2.events)
+                            {
                             // If this is poisoned event then throw.
                             if (!poisonMessageReceived && e.Properties.ContainsKey(poisonMessageProperty))
-                            {
-                                poisonMessageReceived = true;
-                                TestUtility.Log($"Received poisoned message from partition {partitionId}");
-                                throw new Exception("ExceptionSequence1");
-                            }
+                                {
+                                    poisonMessageReceived = true;
+                                    TestUtility.Log($"Received poisoned message from partition {partitionId}");
+                                    throw new Exception("ExceptionSequence1");
+                                }
 
                             // Track received events so we can validate at the end.
                             if (!receivedEventCounts.ContainsKey(partitionId))
-                            {
-                                receivedEventCounts[partitionId] = 0;
+                                {
+                                    receivedEventCounts[partitionId] = 0;
+                                }
+
+                                receivedEventCounts[partitionId]++;
                             }
-
-                            receivedEventCounts[partitionId]++;
                         }
-                    }
+                    };
                 };
-            };
 
-            try
-            {
-                TestUtility.Log("Registering processorFactory...");
-                var epo = new EventProcessorOptions()
+                try
                 {
-                    MaxBatchSize = 100,
-                    InitialOffsetProvider = pId => EventPosition.FromEnqueuedTime(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(60)))
-                };
-                await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, epo);
-
-                TestUtility.Log("Waiting for partition ownership to settle...");
-                await Task.Delay(TimeSpan.FromSeconds(5));
-
-                var client = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
-
-                // Send first set of messages.
-                TestUtility.Log("Sending an event to each partition as the first set of messages.");
-                var sendTasks = new List<Task>();
-                foreach (var partitionId in PartitionIds)
-                {
-                    sendTasks.Add(TestUtility.SendToPartitionAsync(client, partitionId, $"{partitionId} event."));
-                }
-                await Task.WhenAll(sendTasks);
-
-                // Now send 1 poisoned message. This will fail one of the partition pumps.
-                TestUtility.Log($"Sending a poison event to partition {PartitionIds.First()}");
-                var pSender = client.CreatePartitionSender(PartitionIds.First());
-                var ed = new EventData(Encoding.UTF8.GetBytes("This is poison message"));
-                ed.Properties[poisonMessageProperty] = true;
-                await pSender.SendAsync(ed);
-
-                // Wait sometime. The host should fail and then recever during this time.
-                await Task.Delay(30000);
-
-                // Send second set of messages.
-                TestUtility.Log("Sending an event to each partition as the second set of messages.");
-                sendTasks.Clear();
-                foreach (var partitionId in PartitionIds)
-                {
-                    sendTasks.Add(TestUtility.SendToPartitionAsync(client, partitionId, $"{partitionId} event."));
-                }
-                await Task.WhenAll(sendTasks);
-
-                TestUtility.Log("Waiting until hosts are idle, i.e. no more messages to receive.");
-                while (lastReceivedAt > DateTime.Now.AddSeconds(-60))
-                {
-                    await Task.Delay(1000);
-                }
-
-                TestUtility.Log("Verifying poison message was received");
-                Assert.True(poisonMessageReceived, "Didn't receive poison message!");
-
-                TestUtility.Log("Verifying received events by each partition");
-                foreach (var partitionId in PartitionIds)
-                {
-                    if (!receivedEventCounts.ContainsKey(partitionId))
+                    TestUtility.Log("Registering processorFactory...");
+                    var epo = new EventProcessorOptions()
                     {
-                        throw new Exception($"Partition {partitionId} didn't receive any messages!");
+                        MaxBatchSize = 100,
+                        InitialOffsetProvider = pId => EventPosition.FromEnqueuedTime(DateTime.UtcNow.Subtract(TimeSpan.FromSeconds(60)))
+                    };
+                    await eventProcessorHost.RegisterEventProcessorFactoryAsync(processorFactory, epo);
+
+                    TestUtility.Log("Waiting for partition ownership to settle...");
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+
+                   
+
+                    // Send first set of messages.
+                    TestUtility.Log("Sending an event to each partition as the first set of messages.");
+                    var sendTasks = new List<Task>();
+                    foreach (var partitionId in PartitionIds)
+                    {
+                        sendTasks.Add(TestUtility.SendToPartitionAsync(client, partitionId, $"{partitionId} event."));
+                    }
+                    await Task.WhenAll(sendTasks);
+
+                    // Now send 1 poisoned message. This will fail one of the partition pumps.
+                    TestUtility.Log($"Sending a poison event to partition {PartitionIds.First()}");
+                    var pSender = client.CreatePartitionSender(PartitionIds.First());
+                    var ed = new EventData(Encoding.UTF8.GetBytes("This is poison message"));
+                    ed.Properties[poisonMessageProperty] = true;
+                    await pSender.SendAsync(ed);
+
+                    // Wait sometime. The host should fail and then recever during this time.
+                    await Task.Delay(30000);
+
+                    // Send second set of messages.
+                    TestUtility.Log("Sending an event to each partition as the second set of messages.");
+                    sendTasks.Clear();
+                    foreach (var partitionId in PartitionIds)
+                    {
+                        sendTasks.Add(TestUtility.SendToPartitionAsync(client, partitionId, $"{partitionId} event."));
+                    }
+                    await Task.WhenAll(sendTasks);
+
+                    TestUtility.Log("Waiting until hosts are idle, i.e. no more messages to receive.");
+                    while (lastReceivedAt > DateTime.Now.AddSeconds(-60))
+                    {
+                        await Task.Delay(1000);
                     }
 
-                    var receivedEventCount = receivedEventCounts[partitionId];
-                    Assert.True(receivedEventCount >= 2, $"Partition {partitionId} received {receivedEventCount} where as at least 2 expected!");
+                    TestUtility.Log("Verifying poison message was received");
+                    Assert.True(poisonMessageReceived, "Didn't receive poison message!");
+
+                    TestUtility.Log("Verifying received events by each partition");
+                    foreach (var partitionId in PartitionIds)
+                    {
+                        if (!receivedEventCounts.ContainsKey(partitionId))
+                        {
+                            throw new Exception($"Partition {partitionId} didn't receive any messages!");
+                        }
+
+                        var receivedEventCount = receivedEventCounts[partitionId];
+                        Assert.True(receivedEventCount >= 2, $"Partition {partitionId} received {receivedEventCount} where as at least 2 expected!");
+                    }
                 }
-            }
-            finally
-            {
-                TestUtility.Log("Calling UnregisterEventProcessorAsync.");
-                await eventProcessorHost.UnregisterEventProcessorAsync();
+                finally
+                {
+                    TestUtility.Log("Calling UnregisterEventProcessorAsync.");
+                    await eventProcessorHost.UnregisterEventProcessorAsync();
+                }
             }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         /// <summary>
         /// This test is for manual only purpose. Fill in the tenant-id, app-id and app-secret before running.
         /// </summary>
@@ -944,96 +1056,112 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
         [DisplayTestMethodName]
         public async Task SingleProcessorHostWithAadTokenProvider()
         {
-            var appAuthority = "";
-            var aadAppId = "";
-            var aadAppSecret = "";
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var appAuthority = "";
+                var aadAppId = "";
+                var aadAppSecret = "";
 
-            AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback =
-                async (audience, authority, state) =>
-                {
-                    var authContext = new AuthenticationContext(authority);
-                    var cc = new ClientCredential(aadAppId, aadAppSecret);
-                    var authResult = await authContext.AcquireTokenAsync(audience, cc);
-                    return authResult.AccessToken;
-                };
+                AzureActiveDirectoryTokenProvider.AuthenticationCallback authCallback =
+                    async (audience, authority, state) =>
+                    {
+                        var authContext = new AuthenticationContext(authority);
+                        var cc = new ClientCredential(aadAppId, aadAppSecret);
+                        var authResult = await authContext.AcquireTokenAsync(audience, cc);
+                        return authResult.AccessToken;
+                    };
 
-            var tokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, appAuthority);
-            var epo = await GetOptionsAsync();
-            var csb = new EventHubsConnectionStringBuilder(TestUtility.EventHubsConnectionString);
+                var tokenProvider = TokenProvider.CreateAzureActiveDirectoryTokenProvider(authCallback, appAuthority);
+                var epo = await GetOptionsAsync(connectionString);
+                var csb = new EventHubsConnectionStringBuilder(connectionString);
 
-            var eventProcessorHost = new EventProcessorHost(
-                csb.Endpoint,
-                csb.EntityPath,
-                PartitionReceiver.DefaultConsumerGroupName,
-                tokenProvider,
-                CloudStorageAccount.Parse(TestUtility.StorageConnectionString),
-                Guid.NewGuid().ToString());
+                var eventProcessorHost = new EventProcessorHost(
+                    csb.Endpoint,
+                    csb.EntityPath,
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    tokenProvider,
+                    CloudStorageAccount.Parse(TestUtility.StorageConnectionString),
+                    Guid.NewGuid().ToString());
 
-            await RunGenericScenario(eventProcessorHost, epo);
+                await RunGenericScenario(eventProcessorHost, epo);
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task ReRegister()
         {
-            var eventProcessorHost = new EventProcessorHost(
+            await using (var scope = await EventHubScope.CreateAsync(4))
+            {
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var eventProcessorHost = new EventProcessorHost(
                 null, // Entity path will be picked from connection string.
                 PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
+                connectionString,
                 TestUtility.StorageConnectionString,
                 Guid.NewGuid().ToString());
 
-            // Calling register for the first time should succeed.
-            TestUtility.Log("Registering EventProcessorHost for the first time.");
-            await eventProcessorHost.RegisterEventProcessorAsync<SecondTestEventProcessor>();
+                // Calling register for the first time should succeed.
+                TestUtility.Log("Registering EventProcessorHost for the first time.");
+                await eventProcessorHost.RegisterEventProcessorAsync<SecondTestEventProcessor>();
 
-            // Unregister event processor should succed
-            TestUtility.Log("Registering EventProcessorHost for the first time.");
-            await eventProcessorHost.UnregisterEventProcessorAsync();
+                // Unregister event processor should succed
+                TestUtility.Log("Registering EventProcessorHost for the first time.");
+                await eventProcessorHost.UnregisterEventProcessorAsync();
 
-            var epo = await GetOptionsAsync();
+                var epo = await GetOptionsAsync(connectionString);
 
-            // Run a generic scenario with TestEventProcessor instead
-            await RunGenericScenario(eventProcessorHost, epo);
+                // Run a generic scenario with TestEventProcessor instead
+                await RunGenericScenario(eventProcessorHost, epo);
+            }
         }
 
+        //Update Live test to use EventHub managed by EventHubScope
         [Fact]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task ReRegisterAfterLeaseExpiry()
         {
-            var hostName = Guid.NewGuid().ToString();
-
-            var processorOptions = new EventProcessorOptions
+            await using (var scope = await EventHubScope.CreateAsync(4))
             {
-                InitialOffsetProvider = pId => EventPosition.FromEnd()
-            };
+                var connectionString = TestUtility.BuildEventHubsConnectionString(scope.EventHubName);
+                var hostName = Guid.NewGuid().ToString();
 
-            var eventProcessorHost = new EventProcessorHost(
-                hostName,
-                null, // Entity path will be picked from connection string.
-                PartitionReceiver.DefaultConsumerGroupName,
-                TestUtility.EventHubsConnectionString,
-                TestUtility.StorageConnectionString,
-                Guid.NewGuid().ToString());
+                var processorOptions = new EventProcessorOptions
+                {
+                    InitialOffsetProvider = pId => EventPosition.FromEnd()
+                };
 
-            var runResult = await RunGenericScenario(eventProcessorHost, processorOptions);
-            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "First host: One of the partitions didn't return exactly 1 event");
+                var eventProcessorHost = new EventProcessorHost(
+                    hostName,
+                    null, // Entity path will be picked from connection string.
+                    PartitionReceiver.DefaultConsumerGroupName,
+                    connectionString,
+                    TestUtility.StorageConnectionString,
+                    Guid.NewGuid().ToString());
 
-            // Allow sometime so that leases can expire.
-            await Task.Delay(60);
+                var runResult = await RunGenericScenario(eventProcessorHost, processorOptions);
+                Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "First host: One of the partitions didn't return exactly 1 event");
 
-            runResult = await RunGenericScenario(eventProcessorHost);
-            Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "Second host: One of the partitions didn't return exactly 1 event");
+                // Allow sometime so that leases can expire.
+                await Task.Delay(60);
+
+                runResult = await RunGenericScenario(eventProcessorHost);
+                Assert.False(runResult.ReceivedEvents.Any(kvp => kvp.Value.Count != 1), "Second host: One of the partitions didn't return exactly 1 event");
+            }
         }
 
-        private async Task<Dictionary<string, Tuple<string, DateTime>>> DiscoverEndOfStream()
+        //Update method to use new eventhub created by EventHubScope
+        private async Task<Dictionary<string, Tuple<string, DateTime>>> DiscoverEndOfStream(string connectionString)
         {
-            var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+            string[] PartitionIds = ProcessorPartitionIds(connectionString);
+            var ehClient = EventHubClient.CreateFromConnectionString(connectionString);    
             var partitions = new Dictionary<string, Tuple<string, DateTime>>();
 
-            foreach (var pid in this.PartitionIds)
+            foreach (var pid in PartitionIds)
             {
                 var pInfo = await ehClient.GetPartitionRuntimeInformationAsync(pid);
                 partitions.Add(pid, Tuple.Create(pInfo.LastEnqueuedOffset, pInfo.LastEnqueuedTimeUtc));
@@ -1042,6 +1170,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             return partitions.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
         }
 
+        //Update method to use new eventhub created by EventHubScope
         private async Task<GenericScenarioResult> RunGenericScenario(EventProcessorHost eventProcessorHost,
             EventProcessorOptions epo = null, int totalNumberOfEventsToSend = 1, bool checkpointLastEvent = true,
             bool checkpointBatch = false, bool checkpoingEveryEvent = false)
@@ -1105,11 +1234,11 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
 
                 // Wait 5 seconds to avoid races in scenarios like EndOfStream.
                 await Task.Delay(5000);
-
+                string[] PartitionIds = ProcessorPartitionIds(TestUtility.BuildEventHubsConnectionString(eventProcessorHost.EventHubPath));
                 if (totalNumberOfEventsToSend > 0)
                 {
-                    TestUtility.Log($"Sending {totalNumberOfEventsToSend} event(s) to each partition");
-                    var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.EventHubsConnectionString);
+                    var ehClient = EventHubClient.CreateFromConnectionString(TestUtility.BuildEventHubsConnectionString(eventProcessorHost.EventHubPath));
+                    TestUtility.Log($"Sending {totalNumberOfEventsToSend} event(s) to each partition");                    
                     var sendTasks = new List<Task>();
                     foreach (var partitionId in PartitionIds)
                     {
@@ -1144,9 +1273,9 @@ namespace Microsoft.Azure.EventHubs.Tests.Processor
             return runResult;
         }
 
-        private async Task<EventProcessorOptions> GetOptionsAsync()
+        private async Task<EventProcessorOptions> GetOptionsAsync(string connectionString)
         {
-            var partitions = await DiscoverEndOfStream();
+            var partitions = await DiscoverEndOfStream( connectionString);
             return new EventProcessorOptions
             {
                 MaxBatchSize = 100,

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Properties/AssemblyInfo.cs
@@ -2,5 +2,3 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using Xunit;
-
-[assembly: CollectionBehavior(DisableTestParallelization = false)]

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Properties/AssemblyInfo.cs
@@ -3,4 +3,4 @@
 
 using Xunit;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+[assembly: CollectionBehavior(DisableTestParallelization = false)]

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/MockReliableDictionary.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/MockReliableDictionary.cs
@@ -119,19 +119,19 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             throw new NotImplementedException();
         }
 
-        public Task<IAsyncEnumerable<KeyValuePair<X, Y>>> CreateEnumerableAsync(ITransaction txn)
+        public Task<ServiceFabric.Data.IAsyncEnumerable<KeyValuePair<X, Y>>> CreateEnumerableAsync(ITransaction txn)
         {
             // Unused
             throw new NotImplementedException();
         }
 
-        public Task<IAsyncEnumerable<KeyValuePair<X, Y>>> CreateEnumerableAsync(ITransaction txn, EnumerationMode enumerationMode)
+        public Task<ServiceFabric.Data.IAsyncEnumerable<KeyValuePair<X, Y>>> CreateEnumerableAsync(ITransaction txn, EnumerationMode enumerationMode)
         {
             // Unused
             throw new NotImplementedException();
         }
 
-        public Task<IAsyncEnumerable<KeyValuePair<X, Y>>> CreateEnumerableAsync(ITransaction txn, Func<X, bool> filter, EnumerationMode enumerationMode)
+        public Task<ServiceFabric.Data.IAsyncEnumerable<KeyValuePair<X, Y>>> CreateEnumerableAsync(ITransaction txn, Func<X, bool> filter, EnumerationMode enumerationMode)
         {
             // Unused
             throw new NotImplementedException();
@@ -224,6 +224,21 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
         public Task<bool> TryUpdateAsync(ITransaction tx, X key, Y newValue, Y comparisonValue, TimeSpan timeout, CancellationToken cancellationToken)
         {
             // Unused
+            throw new NotImplementedException();
+        }
+
+        Task<ServiceFabric.Data.IAsyncEnumerable<KeyValuePair<X, Y>>> IReliableDictionary<X, Y>.CreateEnumerableAsync(ITransaction txn)
+        {
+            throw new NotImplementedException();
+        }
+
+        Task<ServiceFabric.Data.IAsyncEnumerable<KeyValuePair<X, Y>>> IReliableDictionary<X, Y>.CreateEnumerableAsync(ITransaction txn, EnumerationMode enumerationMode)
+        {
+            throw new NotImplementedException();
+        }
+
+        Task<ServiceFabric.Data.IAsyncEnumerable<KeyValuePair<X, Y>>> IReliableDictionary<X, Y>.CreateEnumerableAsync(ITransaction txn, Func<X, bool> filter, EnumerationMode enumerationMode)
+        {
             throw new NotImplementedException();
         }
         #endregion

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/MockReliableStateManager.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/MockReliableStateManager.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
         public event EventHandler<NotifyStateManagerChangedEventArgs> StateManagerChanged;
 #pragma warning restore 67
 
-        public IAsyncEnumerator<IReliableState> GetAsyncEnumerator()
+        public ServiceFabric.Data.IAsyncEnumerator<IReliableState> GetAsyncEnumerator()
         {
             // Unused
             throw new NotImplementedException();
@@ -152,6 +152,11 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
         public Task<ConditionalValue<T>> TryGetAsync<T>(Uri name) where T : IReliableState
         {
             // Unused
+            throw new NotImplementedException();
+        }
+
+        ServiceFabric.Data.IAsyncEnumerator<IReliableState> ServiceFabric.Data.IAsyncEnumerable<IReliableState>.GetAsyncEnumerator()
+        {
             throw new NotImplementedException();
         }
         #endregion


### PR DESCRIPTION
Track One Event Hubs Tests Infrastructure Updates:
Port EventHubScope,
Update TestConstant and TestUtility
Include more references to test project file
resolve namespace conflict introduce by Microsoft.Bcl.AsyncInterfaces
Processor Live Tests
Client Live Tests