### PR TITLE
Flow trace header when listener is attached

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RequestActivityPolicy.cs
@@ -59,11 +59,11 @@ namespace Azure.Core.Pipeline
 
             if (isAsync)
             {
-                await ProcessNextAsync(message, pipeline).ConfigureAwait(false);
+                await ProcessNextAsync(message, pipeline, true).ConfigureAwait(false);
             }
             else
             {
-                ProcessNext(message, pipeline);
+                ProcessNextAsync(message, pipeline, false).EnsureCompleted();
             }
 
             activity.AddTag("http.status_code", message.Response.Status.ToString(CultureInfo.InvariantCulture));

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -53,12 +53,6 @@ namespace Azure.Core.Tests
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("http.url", "http://example.com/"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("http.method", "GET"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("http.user_agent", "agent"));
-
-            Assert.True(mockTransport.SingleRequest.TryGetHeader("traceparent", out string requestId));
-            Assert.AreEqual(activity.Id, requestId);
-
-            Assert.True(mockTransport.SingleRequest.TryGetHeader("tracestate", out string traceState));
-            Assert.AreEqual("trace", traceState);
         }
 
 


### PR DESCRIPTION
I was calling into the wrong ProcessNextAsync overload.