### PR TITLE
[Event Hubs Client] Track Two: Second Preview (Streaming Reciever)

### DIFF
--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -105,6 +105,7 @@
     <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />
     <PackageReference Update="Microsoft.Extensions.Options" Version="2.1.0" />
+    <PackageReference Update="System.Threading.Channels" Version="4.6.0-preview7.19362.9" />
     <PackageReference Update="System.Text.Json" Version="4.6.0-preview7.19362.9" />
     <PackageReference Update="System.Diagnostics.DiagnosticSource" Version="4.6.0-preview7.19362.9" />
     <PackageReference Update="System.Runtime.CompilerServices.Unsafe" Version="4.6.0-preview7.19362.9" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/AmqpError.cs
@@ -49,7 +49,7 @@ namespace Azure.Messaging.EventHubs
         /// <summary>Indicates that the producer requesting an operation is not allowed to publish events to the requested resource.</summary>
         public static readonly AmqpSymbol PublisherRevokedError = AmqpConstants.Vendor + ":publisher-revoked";
 
-        /// <summary>Indicates that an operation was cancelled by the Event Hubs service.</summary>
+        /// <summary>Indicates that an operation was canceled by the Event Hubs service.</summary>
         public static readonly AmqpSymbol OperationCancelledError = AmqpConstants.Vendor + ":operation-cancelled";
 
         /// <summary>Indicates that the requested resource cannot be created because it already exists.</summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Azure.Messaging.EventHubs.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="System.Reflection.TypeExtensions" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
+    <PackageReference Include="System.Threading.Channels" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
   </ItemGroup>
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/BasicRetryPolicy.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/BasicRetryPolicy.cs
@@ -50,7 +50,7 @@ namespace Azure.Messaging.EventHubs.Core
         }
 
         /// <summary>
-        ///   Calculates the amount of time to allow the curent attempt for an operation to
+        ///   Calculates the amount of time to allow the current attempt for an operation to
         ///   complete before considering it to be timed out.
         /// </summary>
         ///
@@ -137,7 +137,6 @@ namespace Azure.Messaging.EventHubs.Core
                     return ex.IsTransient;
 
                 case TimeoutException _:
-                case OperationCanceledException _:
                 case SocketException _:
                     return true;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ChannelEnumerableSubscription.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ChannelEnumerableSubscription.cs
@@ -1,0 +1,248 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Azure.Messaging.EventHubs.Core
+{
+    /// <summary>
+    ///   A read-only subscription to a channel, exposed as an
+    ///   asynchronous enumerator.
+    /// </summary>
+    ///
+    /// <typeparam name="T">The type of data contained in the channel.</typeparam>
+    ///
+    /// <seealso cref="IAsyncEnumerable{T}" />
+    ///
+    internal class ChannelEnumerableSubscription<T> : IAsyncEnumerable<T>, IAsyncDisposable
+    {
+        /// <summary>The reader for the channel associated with the subscription.</summary>
+        private readonly ChannelReader<T> ChannelReader;
+
+        /// <summary>The callback function to invoke to unsubscribe.</summary>
+        private readonly Func<Task> UnsubscribeCallbackAsync;
+
+        /// <summary>The maximum amount of time to wait to for an event to be available before emitting an empty item; if <c>null</c>, empty items will not be published.</summary>
+        private readonly TimeSpan? MaximumWaitTime;
+
+        /// <summary>The <see cref="System.Threading.CancellationToken"/> instance to signal the request to cancel reading from the channel for enumeration.</summary>
+        private readonly CancellationToken CancellationToken;
+
+        /// <summary>A flag that indicates whether or not the instance has been disposed.</summary>
+        private bool _disposed = false;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="ChannelEnumerableSubscription{T}"/> class.
+        /// </summary>
+        ///
+        /// <param name="reader">The reader for the channel associated with the subscription.</param>
+        /// <param name="maximumWaitTime">The maximum amount of time to wait to for an event to be available before emitting an empty item; if <c>null</c>, empty items will not be emitted.</param>
+        /// <param name="unsubscribeCallbackAsync">The callback function to invoke to unsubscribe.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> instance to signal the request to cancel reading from the channel for enumeration.</param>
+        ///
+        public ChannelEnumerableSubscription(ChannelReader<T> reader,
+                                             TimeSpan? maximumWaitTime,
+                                             Func<Task> unsubscribeCallbackAsync,
+                                             CancellationToken cancellationToken)
+        {
+            Guard.ArgumentNotNull(nameof(reader), reader);
+            Guard.ArgumentNotNull(nameof(unsubscribeCallbackAsync), unsubscribeCallbackAsync);
+
+            if (maximumWaitTime.HasValue)
+            {
+                Guard.ArgumentNotNegative(nameof(maximumWaitTime), maximumWaitTime.Value);
+            }
+
+            ChannelReader = reader;
+            MaximumWaitTime = maximumWaitTime;
+            UnsubscribeCallbackAsync = unsubscribeCallbackAsync;
+            CancellationToken = cancellationToken;
+        }
+
+        /// <summary>
+        ///   Builds an asynchronous enumerator based on the event channel.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The cancellation token.</param>
+        ///
+        /// <returns>The asynchronous enumerator to use for iterating over events.</returns>
+        ///
+        public IAsyncEnumerator<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(nameof(ChannelEnumerableSubscription<T>));
+            }
+
+            return new ChannelEnumerator(EnumerateChannel(ChannelReader, MaximumWaitTime, CancellationToken)
+                .GetAsyncEnumerator(cancellationToken), DisposeAsync);
+        }
+
+        /// <summary>
+        ///   Performs the tasks needed to clean up the enumerable, including
+        ///   attempting to unsubscribe from the associated subscription.
+        /// </summary>
+        ///
+        ///
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            await UnsubscribeCallbackAsync().ConfigureAwait(false);
+            _disposed = true;
+        }
+
+        /// <summary>
+        ///   Enumerates the events as they become available in the associated channel.
+        /// </summary>
+        ///
+        /// <param name="reader">The reader for the channel from which events are to be sourced.</param>
+        /// <param name="maximumWaitTime">The maximum amount of time to wait to for an event to be available before emitting an empty item; if <c>null</c>, empty items will not be emitted.</param>
+        /// <param name="cancellationToken">The <see cref="System.Threading.CancellationToken"/> instance to signal the request to cancel enumeration.</param>
+        ///
+        /// <returns>An asynchronous enumerator that can be used to iterate over events as they are available.</returns>
+        ///
+        private static async IAsyncEnumerable<T> EnumerateChannel(ChannelReader<T> reader,
+                                                                  TimeSpan? maximumWaitTime,
+                                                                  CancellationToken cancellationToken)
+        {
+            T result;
+            int delayMilliseconds;
+
+            var waitTime = maximumWaitTime?.TotalMilliseconds;
+            var timer = (waitTime.HasValue) ? Stopwatch.StartNew() : default;
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // Attempt to read events from the channel.
+
+                if (reader.TryRead(out result))
+                {
+                    yield return result;
+                    timer?.Restart();
+                }
+                else if ((waitTime.HasValue) && (timer.ElapsedMilliseconds > waitTime.Value))
+                {
+                    // If there was no event and the wait time has expired, emit an empty event to return control to
+                    // the calling iterator.
+
+                    yield return default;
+                    timer.Restart();
+                }
+                else if (reader.Completion.IsCompleted)
+                {
+                    // If the channel was marked as final, then await the completion task to surface any exceptions.
+
+                    try
+                    {
+                        await reader.Completion.ConfigureAwait(false);
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        // This is an expected case when the cancellation token was
+                        // triggered during an operation; no action is needed.
+                    }
+
+                    break;
+                }
+                else
+                {
+                    // TODO (P1//squire): Determine a better approach to prevent a tight loop that consumes resources or
+                    // has excessive allocations.  (see: https://github.com/Azure/azure-sdk-for-net/issues/7094)
+
+                    try
+                    {
+                        delayMilliseconds = 50;
+
+                        if (waitTime.HasValue)
+                        {
+                            delayMilliseconds = (int)Math.Min(delayMilliseconds, (waitTime.Value - timer.ElapsedMilliseconds));
+                        }
+
+                        if (delayMilliseconds > 0)
+                        {
+                            await Task.Delay(delayMilliseconds, cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                    catch (TaskCanceledException)
+                    {
+                        // This is an expected case when the cancellation token was
+                        // triggered during an operation; no action is needed.
+                    }
+                }
+            }
+
+            yield break;
+        }
+
+        /// <summary>
+        ///   An asynchronous enumerator associated with a channel-reading source enumerable that will
+        ///   attempt to unsubscribe when disposed.
+        /// </summary>
+        ///
+        /// <seealso cref="IAsyncEnumerator{T}" />
+        ///
+        private class ChannelEnumerator : IAsyncEnumerator<T>
+        {
+            /// <summary>The callback function to invoke on disposal.</summary>
+            private readonly Func<ValueTask> DisposeCallbackAsync;
+
+            /// <summary>The enumerator instance to use as the source of events.</summary>
+            private readonly IAsyncEnumerator<T> Source;
+
+            /// <summary>
+            ///   The current event in the set being enumerated.
+            /// </summary>
+            ///
+            public T Current => Source.Current;
+
+            /// <summary>
+            ///   Initializes a new instance of the <see cref="ChannelEnumerator"/> class.
+            /// </summary>
+            ///
+            /// <param name="source">The enumerator instance to use as the source of events.</param>
+            /// <param name="disposeCallbackAsync">The callback function to invoke on disposal.</param>
+            ///
+            public ChannelEnumerator(IAsyncEnumerator<T> source,
+                                     Func<ValueTask> disposeCallbackAsync)
+            {
+                Source = source;
+                DisposeCallbackAsync = disposeCallbackAsync;
+            }
+
+            /// <summary>
+            ///   Moves to the next event in the set being enumerated.
+            /// </summary>
+            ///
+            /// <returns><c>true</c> if there was an event to move to; otherwise, <c>false</c>.</returns>
+            ///
+            public ValueTask<bool> MoveNextAsync() => Source.MoveNextAsync();
+
+            /// <summary>
+            ///   Performs the tasks needed to clean up the enumerator, including
+            ///   attempting to unsubscribe from the associated subscription.
+            /// </summary>
+            ///
+            ///
+            public async ValueTask DisposeAsync()
+            {
+                try
+                {
+                    await Source.DisposeAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    await DisposeCallbackAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/TransportEventHubConsumer.cs
@@ -26,7 +26,7 @@ namespace Azure.Messaging.EventHubs.Core
         public abstract void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy);
 
         /// <summary>
-        ///   Receives a bach of <see cref="EventData" /> from the the Event Hub partition.
+        ///   Receives a batch of <see cref="EventData" /> from the Event Hub partition.
         /// </summary>
         ///
         /// <param name="maximumMessageCount">The maximum number of messages to receive in this batch.</param>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Diagnostics/EventHubsEventSource.cs
@@ -135,7 +135,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         /// <param name="eventHubName">The name of the Event Hub being received from.</param>
         /// <param name="partitionId">The identifier of the partition events are being received from.</param>
         ///
-        [Event(6, Level = EventLevel.Informational, Message = "Receiveing events for Event Hub: {0} (Partition Id: '{1}').")]
+        [Event(6, Level = EventLevel.Informational, Message = "Receiving events for Event Hub: {0} (Partition Id: '{1}').")]
         public void EventReceiveStart(string eventHubName,
                                       string partitionId)
         {
@@ -353,7 +353,7 @@ namespace Azure.Messaging.EventHubs.Diagnostics
         ///
         [Event(18, Level = EventLevel.Informational, Message = "Subscribing to Event Hub: {0} (Partition Id: '{1}').")]
         public void SubscribeToPartitionStart(string eventHubName,
-                                                string partitionId)
+                                              string partitionId)
         {
             if (IsEnabled())
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumer.cs
@@ -2,11 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Errors;
 
 namespace Azure.Messaging.EventHubs
 {
@@ -28,28 +33,56 @@ namespace Azure.Messaging.EventHubs
         /// <summary>The name of the default consumer group in the Event Hubs service.</summary>
         public const string DefaultConsumerGroupName = "$Default";
 
+        /// <summary>The size of event batch requested by the background publishing operation used for subscriptions.</summary>
+        private const int BackgroundPublishReceiveBatchSize = 50;
+
+        /// <summary>The maximum wait time for receiving an event batch for the background publishing operation used for subscriptions.</summary>
+        private readonly TimeSpan BackgroundPublishingWaitTime = TimeSpan.FromMilliseconds(250);
+
+        /// <summary>The set of channels for publishing events to local subscribers.</summary>
+        private readonly ConcurrentDictionary<Guid, Channel<EventData>> ActiveChannels = new ConcurrentDictionary<Guid, Channel<EventData>>();
+
+        /// <summary>The primitive for synchronizing access during subscribe and unsubscribe operations.</summary>
+        private readonly SemaphoreSlim ChannelSyncRoot = new SemaphoreSlim(1, 1);
+
+        /// <summary>Indicates whether events are actively being published to subscribed channels.</summary>
+        private bool _isPublishingActive = false;
+
+        /// <summary>The cancellation token to use for requesting to cancel publishing events to the subscribed channels.</summary>
+        private CancellationTokenSource _channelPublishingTokenSource;
+
+        /// <summary>The <see cref="Task"/> associated with publishing events to subscribed channels.</summary>
+        private Task _channelPublishingTask;
+
         /// <summary>The policy to use for determining retry behavior for when an operation fails.</summary>
         private EventHubRetryPolicy _retryPolicy;
+
+        /// <summary>
+        ///   The path of the specific Event Hub that the consumer is connected to, relative
+        ///   to the Event Hubs namespace that contains it.
+        /// </summary>
+        ///
+        public string EventHubPath { get; }
 
         /// <summary>
         ///   The identifier of the Event Hub partition that this consumer is associated with.  Events will be read
         ///   only from this partition.
         /// </summary>
         ///
-        public string PartitionId { get; protected set; }
+        public string PartitionId { get; }
 
         /// <summary>
         ///   The name of the consumer group that this consumer is associated with.  Events will be read
         ///   only in the context of this group.
         /// </summary>
         ///
-        public string ConsumerGroup { get; protected set; }
+        public string ConsumerGroup { get; }
 
         /// <summary>
         ///   When populated, the priority indicates that a consumer is intended to be the only reader of events for the
         ///   requested partition and an associated consumer group.  To do so, this consumer will attempt to assert ownership
         ///   over the partition; in the case where more than one exclusive consumer attempts to assert ownership for the same
-        ///   partition/consumer group pair, the one having a larger onwership level value will "win."
+        ///   partition/consumer group pair, the one having a larger ownership level value will "win."
         ///
         ///   When an exclusive consumer is used, those consumers which are not exclusive or which have a lower owner level will either
         ///   not be allowed to be created, if they already exist, will encounter an exception during the next attempted operation.
@@ -57,13 +90,13 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <value>The priority to associated with an exclusive consumer; for a non-exclusive consumer, this value will be <c>null</c>.</value>
         ///
-        public long? OwnerLevel { get; protected set; }
+        public long? OwnerLevel { get; }
 
         /// <summary>
         ///   The position of the event in the partition where the consumer should begin reading.
         /// </summary>
         ///
-        public EventPosition StartingPosition { get; protected set; }
+        public EventPosition StartingPosition { get; }
 
         /// <summary>
         ///   The text-based identifier label that has optionally been assigned to the consumer.
@@ -142,6 +175,7 @@ namespace Azure.Messaging.EventHubs
             Guard.ArgumentNotNull(nameof(consumerOptions), consumerOptions);
             Guard.ArgumentNotNull(nameof(retryPolicy), retryPolicy);
 
+            EventHubPath = eventHubPath;
             PartitionId = partitionId;
             StartingPosition = eventPosition;
             OwnerLevel = consumerOptions.OwnerLevel;
@@ -161,7 +195,7 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   Receives a bach of <see cref="EventData" /> from the Event Hub partition.
+        ///   Receives a batch of <see cref="EventData" /> from the Event Hub partition.
         /// </summary>
         ///
         /// <param name="maximumMessageCount">The maximum number of messages to receive in this batch.</param>
@@ -180,6 +214,83 @@ namespace Azure.Messaging.EventHubs
             Guard.ArgumentNotNegative(nameof(maximumWaitTime), maximumWaitTime.Value);
 
             return InnerConsumer.ReceiveAsync(maximumMessageCount, maximumWaitTime.Value, cancellationToken);
+        }
+
+        /// <summary>
+        ///   Subscribes to events for the associated partition in the form of an asynchronous enumerable that sends events as they
+        ///   become available on the partition, waiting as necessary should there be no events available.
+        ///
+        ///   This version of the enumerator may block for an indeterminate amount of time for an <c>await</c> if events are not available
+        ///   on the partition, requiring cancellation via the <paramref name="cancellationToken"/> to be requested in order to return control.
+        ///   It is recommended to call the overload which accepts a maximum wait time for scenarios where a more deterministic wait period is
+        ///   desired.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>An <see cref="IAsyncEnumerable{T}"/> to be used for iterating over events in the partition.</returns>
+        ///
+        /// <remarks>
+        ///   Unlike calls to <see cref="ReceiveAsync"/>, each subscriber to events is presented with an independent iterator; if there are multiple
+        ///   subscribers, they will each receive their own copy of an event to process, rather than competing for them.
+        ///
+        ///   Subscriptions will still compete with <see cref="ReceiveAsync" /> calls, however.  It is recommended that consumers either subscribe to
+        ///   events or explicitly receive batches, but do not use both approaches concurrently.
+        /// </remarks>
+        ///
+        /// <seealso cref="SubscribeToEvents(TimeSpan?, CancellationToken)"/>
+        ///
+        public virtual IAsyncEnumerable<EventData> SubscribeToEvents(CancellationToken cancellationToken = default) => SubscribeToEvents(null, cancellationToken);
+
+        /// <summary>
+        ///   Subscribes to events for the associated partition in the form of an asynchronous enumerable that sends events as they
+        ///   become available on the partition, waiting as necessary should there be no events available.
+        ///
+        ///   If the <paramref name="maximumWaitTime" /> is passed, if no events were available before the wait time elapsed, an empty
+        ///   item will be sent in the enumerable in order to return control and ensure that <c>await</c> calls do not block for an
+        ///   indeterminate length of time.
+        /// </summary>
+        ///
+        /// <param name="maximumWaitTime">The maximum amount of time to wait to for an event to be available before emitting an empty item; if <c>null</c>, empty items will not be published.</param>
+        /// <param name="cancellationToken">An optional <see cref="CancellationToken"/> instance to signal the request to cancel the operation.</param>
+        ///
+        /// <returns>An <see cref="IAsyncEnumerable{T}"/> to be used for iterating over events in the partition.</returns>
+        ///
+        /// <remarks>
+        ///   Unlike calls to <see cref="ReceiveAsync"/>, each subscriber to events is presented with an independent iterator; if there are multiple
+        ///   subscribers, they will each receive their own copy of an event to process, rather than competing for them.
+        ///
+        ///   Subscriptions will still compete with <see cref="ReceiveAsync" /> calls, however.  It is recommended that consumers either subscribe to
+        ///   events or explicitly receive batches, but do not use both approaches concurrently.
+        /// </remarks>
+        ///
+        /// <seealso cref="SubscribeToEvents(CancellationToken)"/>
+        ///
+        public virtual IAsyncEnumerable<EventData> SubscribeToEvents(TimeSpan? maximumWaitTime,
+                                                                     CancellationToken cancellationToken = default)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                return CreateEmptyAsyncEnumerable<EventData>();
+            }
+
+            try
+            {
+                var maximumQueuedEvents = Math.Min((Options.PrefetchCount / 4), (BackgroundPublishReceiveBatchSize * 2));
+                var subscription = SubscribeToChannel(EventHubPath, PartitionId, ConsumerGroup, maximumQueuedEvents, cancellationToken);
+
+                return new ChannelEnumerableSubscription<EventData>(subscription.ChannelReader, maximumWaitTime, () => UnsubscribeFromChannelAsync(subscription.Identifier), cancellationToken);
+            }
+            catch (Exception ex) when
+                (ex is TaskCanceledException
+                || ex is OperationCanceledException)
+            {
+
+                // This is unlikely, but possible if cancellation is triggered after the conditional, and
+                // indicates that the synchronization primitive for subscriptions referenced the canceled token.
+
+                return CreateEmptyAsyncEnumerable<EventData>();
+            }
         }
 
         /// <summary>
@@ -237,5 +348,281 @@ namespace Azure.Messaging.EventHubs
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
+
+        /// <summary>
+        ///   Creates a subscription to events being published to the partition associated with
+        ///   the consumer.
+        /// </summary>
+        ///
+        /// <param name="eventHubName">The name of the event hub with the subscription; used for informational purposes only.</param>
+        /// <param name="partitionId">The identifier for the partition to associate with the subscription; used for informational purposes only.</param>
+        /// <param name="consumerGroup">The name of the consumer group to associate with the subscription; used for informational purposes only.</param>
+        /// <param name="maximumQueuedEvents">The maximum number of events to queue while waiting for them to be read.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to signal the request to cancel the event enumeration.</param>
+        ///
+        /// <returns>The elements of a channel subscription, including its identifier and a reader for the subscribed channel.</returns>
+        ///
+        private (Guid Identifier, ChannelReader<EventData> ChannelReader) SubscribeToChannel(string eventHubName,
+                                                                                             string partitionId,
+                                                                                             string consumerGroup,
+                                                                                             int maximumQueuedEvents,
+                                                                                             CancellationToken cancellationToken)
+        {
+            var channel = CreateEventChannel(maximumQueuedEvents);
+            var identifier = Guid.NewGuid();
+
+            if (!ActiveChannels.TryAdd(identifier, channel))
+            {
+                throw new EventHubsException(true, eventHubName, String.Format(CultureInfo.CurrentCulture, Resources.FailedToCreateEventSubscription, eventHubName, partitionId, consumerGroup));
+            }
+
+            // Ensure that publishing is taking place.  To avoid race conditions, always acquire the semaphore and then perform the check.
+
+            ChannelSyncRoot.Wait(cancellationToken);
+
+            try
+            {
+                if (!_isPublishingActive)
+                {
+                    _channelPublishingTokenSource?.Cancel();
+                    _channelPublishingTask?.GetAwaiter().GetResult();
+                    _channelPublishingTokenSource?.Dispose();
+
+                    _channelPublishingTokenSource = new CancellationTokenSource();
+                    _channelPublishingTask = StartBackgroundChannelPublishingAsync(_channelPublishingTokenSource.Token);
+                    _isPublishingActive = true;
+                }
+            }
+            finally
+            {
+                ChannelSyncRoot.Release();
+            }
+
+            return (identifier, channel.Reader);
+        }
+
+        /// <summary>
+        ///   Unsubscribe from a channel subscription.
+        /// </summary>
+        ///
+        /// <param name="identifier">The identifier of the subscription to unsubscribe.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        private async Task UnsubscribeFromChannelAsync(Guid identifier)
+        {
+            if ((ActiveChannels.TryRemove(identifier, out var unsubscribeChannel)) && (ActiveChannels.Count == 0))
+            {
+                await ChannelSyncRoot.WaitAsync().ConfigureAwait(false);
+
+                try
+                {
+                    // If the channel was the last active channel and publishing is still marked as active, take
+                    // the necessary steps to stop publishing.
+
+                    if ((_isPublishingActive) && (ActiveChannels.Count == 0))
+                    {
+                        _channelPublishingTokenSource?.Cancel();
+
+                        if (_channelPublishingTask != null)
+                        {
+                            try
+                            {
+                                await _channelPublishingTask.ConfigureAwait(false);
+                            }
+                            catch (TaskCanceledException)
+                            {
+                               // This is an expected scenario; no action is needed.
+                            }
+                        }
+
+                        _channelPublishingTokenSource?.Dispose();
+                        _isPublishingActive = false;
+                    }
+                }
+                finally
+                {
+                    ChannelSyncRoot.Release();
+                }
+            }
+
+            // Attempt to finalize the channel, signaling that no more writes should be
+            // expected to occur.
+
+            unsubscribeChannel?.Writer.TryComplete();
+        }
+
+        /// <summary>
+        ///   Begins the background process responsible for receiving from the partition
+        ///   and publishing to all subscribed channels.
+        /// </summary>
+        ///
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> to signal the request to cancel the background publishing.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        private Task StartBackgroundChannelPublishingAsync(CancellationToken cancellationToken) =>
+            Task.Run(async () =>
+            {
+                var failedAttemptCount = 0;
+                var publishTasks = new List<Task>();
+                var publishChannels = default(ICollection<Channel<EventData>>);
+                var receivedItems = default(IEnumerable<EventData>);
+                var retryDelay = default(TimeSpan?);
+                var activeException = default(Exception);
+
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    try
+                    {
+                        // Receive items in batches and then write them to the subscribed channels.  The channels will naturally
+                        // block if they reach their maximum queue size, so there is no need to throttle publishing.
+
+                        receivedItems = await InnerConsumer.ReceiveAsync(BackgroundPublishReceiveBatchSize, BackgroundPublishingWaitTime, cancellationToken).ConfigureAwait(false);
+                        publishChannels = ActiveChannels.Values;
+
+                        foreach (var item in receivedItems)
+                        {
+                            foreach (var channel in publishChannels)
+                            {
+                                publishTasks.Add(channel.Writer.WriteAsync(item, cancellationToken).AsTask());
+                            }
+                        }
+
+                        await Task.WhenAll(publishTasks).ConfigureAwait(false);
+
+                        publishTasks.Clear();
+                        failedAttemptCount = 0;
+                    }
+                    catch (TaskCanceledException ex)
+                    {
+                        // In the case that a task was canceled, if cancellation was requested, then publishing should
+                        // is already terminating.  Otherwise, something unexpected canceled the operation and it should
+                        // be treated as an exception to ensure that the channels are marked final and consumers are made
+                        // aware.
+
+                        activeException = (cancellationToken.IsCancellationRequested) ? null : ex;
+                        break;
+                    }
+                    catch (ConsumerDisconnectedException ex)
+                    {
+                        // If the consumer was disconnected, it is known to be unrecoverable; do not offer the chance to retry.
+
+                        activeException = ex;
+                        break;
+                    }
+                    catch (Exception ex) when
+                        (ex is OutOfMemoryException
+                        || ex is StackOverflowException
+                        || ex is ThreadAbortException)
+                    {
+                        // These exceptions are known to be unrecoverable and there should be no attempts at further processing.
+                        // The environment is in a bad state and is likely to fail.
+                        //
+                        // Attempt to clean up, which may or may not fail due to resource constraints,
+                        // then let the exception bubble.
+
+                        _isPublishingActive = false;
+
+                        foreach (var channel in ActiveChannels.Values)
+                        {
+                            channel.Writer.TryComplete(ex);
+                        }
+
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        // Determine if there should be a retry for the next attempt; if so enforce the delay but do not quit the loop.
+                        // Otherwise, mark the exception as active and break out of the loop.
+
+                        ++failedAttemptCount;
+                        retryDelay = _retryPolicy.CalculateRetryDelay(ex, failedAttemptCount);
+
+                        if (retryDelay.HasValue)
+                        {
+                            await Task.Delay(retryDelay.Value).ConfigureAwait(false);
+                            activeException = null;
+                        }
+                        else
+                        {
+                            activeException = ex;
+                            break;
+                        }
+                    }
+                }
+
+                // Publishing has terminated; if there was an active exception, then take the necessary steps to mark publishing as aborted rather
+                // than completed normally.
+
+                if (activeException != null)
+                {
+                    await AbortBackgroundChannelPublishingAsync(activeException).ConfigureAwait(false);
+                }
+
+            }, cancellationToken);
+
+        /// <summary>
+        ///   Creates a channel for publishing events to local subscribers.
+        /// </summary>
+        ///
+        /// <param name="capacity">The maximum amount of events that can be queued in the channel.</param>
+        ///
+        /// <returns>A bounded channel, configured for 1:1 read/write usage.</returns>
+        ///
+        private Channel<EventData> CreateEventChannel(int capacity) =>
+            Channel.CreateBounded<EventData>(new BoundedChannelOptions(capacity)
+            {
+                FullMode = BoundedChannelFullMode.Wait,
+                SingleWriter = true,
+                SingleReader = true
+            });
+
+        /// <summary>
+        ///   Aborts the background channel publishing in the case of an exception that it was
+        ///   unable to recover from.
+        /// </summary>
+        ///
+        /// <param name="exception">The exception that triggered publishing to terminate.</param>
+        ///
+        /// <returns>A task to be resolved on when the operation has completed.</returns>
+        ///
+        private async Task AbortBackgroundChannelPublishingAsync(Exception exception)
+        {
+            // Though state is normally managed through subscribe and unsubscribe, in the case of aborting,
+            // forcefully clear the subscription and reset publishing state.
+
+            await ChannelSyncRoot.WaitAsync().ConfigureAwait(false);
+
+            try
+            {
+                foreach (var channel in ActiveChannels.Values)
+                {
+                    channel.Writer.TryComplete(exception);
+                }
+
+                ActiveChannels.Clear();
+                _channelPublishingTokenSource.Dispose();
+                _isPublishingActive = false;
+            }
+            finally
+            {
+                ChannelSyncRoot.Release();
+            }
+        }
+
+        /// <summary>
+        ///   Creates an empty <see cref="IAsyncEnumerable{T}" />.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The type of data represented by the empty enumerable.</typeparam>
+        ///
+        /// <returns>An empty asynchronous enumerable.</returns>
+        ///
+        private async IAsyncEnumerable<T> CreateEmptyAsyncEnumerable<T>()
+        {
+            await Task.Delay(0).ConfigureAwait(false);
+            yield break;
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubConsumerOptions.cs
@@ -47,7 +47,7 @@ namespace Azure.Messaging.EventHubs
         /// <summary>
         ///   The set of options to use for determining whether a failed operation should be retried and,
         ///   if so, the amount of time to wait between retry attempts.  If not specified, the retry policy from
-        ///   the associcated <see cref="EventHubClient" /> will be used.
+        ///   the associated <see cref="EventHubClient" /> will be used.
         /// </summary>
         ///
         public RetryOptions RetryOptions { get; set; }
@@ -82,7 +82,7 @@ namespace Azure.Messaging.EventHubs
         ///     An optional text-based identifier label to assign to a consumer.
         /// </summary>
         ///
-        /// <value>The identifier is used for informational purposes only.  If not specified, the reaciever will have no assigned identifier label.</value>
+        /// <value>The identifier is used for informational purposes only.  If not specified, the receiver will have no assigned identifier label.</value>
         ///
         public string Identifier
         {
@@ -96,7 +96,7 @@ namespace Azure.Messaging.EventHubs
         }
 
         /// <summary>
-        ///   The prefetch count used by the consumer to control the number of events this consumer will actively receive
+        ///   The count used by the consumer to control the number of events this consumer will actively receive
         ///   and queue locally without regard to whether a receive operation is currently active.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducer.cs
@@ -52,7 +52,7 @@ namespace Azure.Messaging.EventHubs
         public string PartitionId { get; }
 
         /// <summary>
-        ///   The path of the specific Event Hub that the client is connected to, relative
+        ///   The path of the specific Event Hub that the producer is connected to, relative
         ///   to the Event Hubs namespace that contains it.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventPosition.cs
@@ -30,14 +30,14 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   Corresponds to the end of the partition, where no more events are currently enqueued.  Use this
-        ///   position to begin receiving from the next event to be enqueued in the partion after an <see cref="EventHubConsumer"/>
+        ///   position to begin receiving from the next event to be enqueued in the partition after an <see cref="EventHubConsumer"/>
         ///   is created with this position.
         /// </summary>
         ///
         public static EventPosition Latest => FromOffset(EndOfStreamOffset, false);
 
         /// <summary>
-        ///   The offset of the eventidentified by this position.
+        ///   The offset of the event identified by this position.
         /// </summary>
         ///
         /// <value>Expected to be <c>null</c> if the event position represents a sequence number or enqueue time.</value>
@@ -52,7 +52,7 @@ namespace Azure.Messaging.EventHubs
 
         /// <summary>
         ///   Indicates if the specified offset is inclusive of the event which it identifies.  This
-        ///   information is only relevent if the event position was identified by an offset or sequence number.
+        ///   information is only relevant if the event position was identified by an offset or sequence number.
         /// </summary>
         ///
         /// <value><c>true</c> if the offset is inclusive; otherwise, <c>false</c>.</value>
@@ -68,10 +68,10 @@ namespace Azure.Messaging.EventHubs
         internal DateTimeOffset? EnqueuedTime { get; set; }
 
         /// <summary>
-        ///   The sequence number of the event identified by this poistion;
+        ///   The sequence number of the event identified by this position;
         /// </summary>
         ///
-        /// <value>Excpected to be <c>null</c> if the event position represents an offset or enqueue time.</value>
+        /// <value>Expected to be <c>null</c> if the event position represents an offset or enqueue time.</value>
         ///
         internal long? SequenceNumber { get; set; }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.Designer.cs
@@ -395,5 +395,27 @@ namespace Azure.Messaging.EventHubs
                 return ResourceManager.GetString("UnsupportedTransportEventType", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Could not create a subscription for events for Event Hub: '{0}', partition: '{1}'..
+        /// </summary>
+        internal static string FailedToCreateEventSubscription
+        {
+            get
+            {
+                return ResourceManager.GetString("FailedToCreateEventSubscription", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to An unrecoverable exception was encountered that left the environment in a bad state..
+        /// </summary>
+        internal static string UnrecoverableException
+        {
+            get
+            {
+                return ResourceManager.GetString("UnrecoverableException", resourceCulture);
+            }
+        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Resources.resx
@@ -207,4 +207,10 @@
   <data name="UnsupportedTransportEventType" xml:space="preserve">
     <value>The requested transport event type, '{0}', is not supported by the active transport client.</value>
   </data>
+  <data name="FailedToCreateEventSubscription" xml:space="preserve">
+    <value>Could not create a subscription for events for Event Hub: '{0}', partition: '{1}', consumer group: '{2}'.</value>
+  </data>
+  <data name="UnrecoverableException" xml:space="preserve">
+    <value>An unrecoverable exception was encountered that left the environment in a bad state.</value>
+  </data>
 </root>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/Amqp/AmqpEventDataSender.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/Amqp/AmqpEventDataSender.cs
@@ -108,8 +108,8 @@ namespace TrackOne.Amqp
                 return;
             }
 
-            await this.SendLinkManager.GetOrCreateAsync(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
-            await Task.Delay(TimeSpan.FromMilliseconds(5)).ConfigureAwait(false);
+            await this.SendLinkManager.GetOrCreateAsync(TimeSpan.FromSeconds(AmqpClientConstants.AmqpSessionTimeoutInSeconds)).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromMilliseconds(15)).ConfigureAwait(false);
 
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -535,7 +535,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(null)]
         [TestCase("")]
         [TestCase("a-key-that-is-for-partitions")]
-        public void CCreateBatchFromMessagesWithOneMessagePopulatesEnvelopeProperties(string partitionKey)
+        public void CreateBatchFromMessagesWithOneMessagePopulatesEnvelopeProperties(string partitionKey)
         {
             var eventData = new EventData(new byte[] { 0x11, 0x22, 0x33 });
             var converter = new AmqpMessageConverter();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelEnumeratorSubscriptionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelEnumeratorSubscriptionTests.cs
@@ -1,0 +1,443 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="ChannelEnumerableSubscription{T}" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    [Parallelizable(ParallelScope.All)]
+    public class ChannelEnumeratorSubscriptionTests
+    {
+        /// <summary>
+        ///   A delegate signature for use as a callback when mocking methods, such as
+        ///   <see cref="ChannelReader{T}.TryRead(out T)"/>.
+        /// </summary>
+        ///
+        /// <typeparam name="T">The type of parameter being used for the out parameter.</typeparam>
+        ///
+        /// <param name="item">The item to modify.</param>
+        ///
+        private delegate void ReturnOutParam<T>(out T item);
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheReader()
+        {
+            Assert.That(() => new ChannelEnumerableSubscription<int>(null, TimeSpan.FromSeconds(1), () => Task.CompletedTask, CancellationToken.None), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheWaitTime()
+        {
+            Assert.That(() => new ChannelEnumerableSubscription<int>(Mock.Of<ChannelReader<int>>(), TimeSpan.FromSeconds(-1), () => Task.CompletedTask, CancellationToken.None), Throws.InstanceOf<ArgumentException>());
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesTheUnsubscribeCallback()
+        {
+            Assert.That(() => new ChannelEnumerableSubscription<int>(Mock.Of<ChannelReader<int>>(), TimeSpan.FromSeconds(1), null, CancellationToken.None), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorAllowsNullWaitTime()
+        {
+            Assert.That(() => new ChannelEnumerableSubscription<int>(Mock.Of<ChannelReader<int>>(), null, () => Task.CompletedTask, CancellationToken.None), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorAllowsZeroWaitTime()
+        {
+            Assert.That(() => new ChannelEnumerableSubscription<int>(Mock.Of<ChannelReader<int>>(), TimeSpan.Zero, () => Task.CompletedTask, CancellationToken.None), Throws.Nothing);
+        }
+
+        /// <summary>
+        ///     Verifies functionality of the subscription's
+        ///     enumerator.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EnumeratorInvokesUnsubscribeOnDispose()
+        {
+            var unsubscribeCalled = false;
+            var mockReader = Mock.Of<ChannelReader<int>>();
+
+            Func<Task> unsubscribeAsync = () =>
+            {
+                unsubscribeCalled = true;
+                return Task.CompletedTask;
+            };
+
+            var subscription = new ChannelEnumerableSubscription<int>(mockReader, null, unsubscribeAsync, CancellationToken.None);
+            await subscription.DisposeAsync();
+
+            Assert.That(unsubscribeCalled, Is.True);
+        }
+
+        /// <summary>
+        ///     Verifies functionality of the subscription's
+        ///     enumerator.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EnumeratorDoesNotCreateEnumerableIfDisposed()
+        {
+            var mockReader = Mock.Of<ChannelReader<int>>();
+            var subscription = new ChannelEnumerableSubscription<int>(mockReader, null, () => Task.CompletedTask, CancellationToken.None);
+
+            await subscription.DisposeAsync();
+            Assert.That(() => subscription.GetAsyncEnumerator(), Throws.InstanceOf<ObjectDisposedException>());
+        }
+
+        /// <summary>
+        ///     Verifies functionality of the subscription's
+        ///     enumerator.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EnumeratorCreatesEnumerable()
+        {
+            var mockReader = Mock.Of<ChannelReader<int>>();
+
+            await using (var subscription = new ChannelEnumerableSubscription<int>(mockReader, null, () => Task.CompletedTask, CancellationToken.None))
+            await using (var enumerator = subscription.GetAsyncEnumerator())
+            {
+
+                Assert.That(enumerator, Is.Not.Null);
+            }
+        }
+
+        /// <summary>
+        ///     Verifies functionality of the subscription's
+        ///     enumerator.
+        /// </summary>
+        ///
+        [Test]
+        public async Task DisposingEnumeratorDisposesEnumerable()
+        {
+            var unsubscribeCalled = false;
+            var mockReader = Mock.Of<ChannelReader<int>>();
+
+            Func<Task> unsubscribeAsync = () =>
+            {
+                unsubscribeCalled = true;
+                return Task.CompletedTask;
+            };
+
+            await using (var subscription = new ChannelEnumerableSubscription<int>(mockReader, null, unsubscribeAsync, CancellationToken.None))
+            {
+                var enumerator = subscription.GetAsyncEnumerator();
+                await enumerator.DisposeAsync();
+
+                Assert.That(unsubscribeCalled, Is.True, "The unsubscribe callback should have been invoked.");
+                Assert.That(() => subscription.GetAsyncEnumerator(), Throws.InstanceOf<ObjectDisposedException>(), "The enumerable should have been disposed.");
+            }
+        }
+
+        /// <summary>
+        ///     Verifies functionality of the subscription's
+        ///     enumerator.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EnumeratorReadsChannel()
+        {
+            var disposed = false;
+            var channelIndex = -1;
+            var readIndex = 0;
+            var currentItem = 0;
+            var channelItems = new[] { 1, 4, 7, 9 };
+            var readItems = new List<int>();
+            var mockReader = new Mock<ChannelReader<int>>();
+
+            Func<Task> disposeCallback = () =>
+            {
+                disposed = true;
+                return Task.CompletedTask;
+            };
+
+            mockReader
+              .SetupGet(reader => reader.Completion)
+              .Returns(new Task(() => Thread.Sleep(5)));
+
+            mockReader
+                .Setup(reader => reader.TryRead(out currentItem))
+                .Callback((ReturnOutParam<int>)((out int current) => current = channelItems[++channelIndex]))
+                .Returns(() => channelIndex < channelItems.Length);
+
+            // Create the subscription and deliberately do not dispose; the common usage will be in immediate foreach call,
+            // which should trigger disposal after iterating.
+
+            var subscription = new ChannelEnumerableSubscription<int>(mockReader.Object, null, disposeCallback, CancellationToken.None);
+
+            await foreach(var item in subscription)
+            {
+                readItems.Add(item);
+                ++readIndex;
+
+                if (readIndex >= channelItems.Length)
+                {
+                    break;
+                }
+            }
+
+            Assert.That(readItems, Is.EquivalentTo(channelItems), "The items read should match the channel items.");
+            Assert.That(disposed, Is.True, "The subscription should have been disposed.");
+        }
+
+        /// <summary>
+        ///     Verifies functionality of the subscription's
+        ///     enumerator.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EnumeratorRespectsTheCancellationToken()
+        {
+            var disposed = false;
+            var channelIndex = -1;
+            var readIndex = 0;
+            var maxReadItems = 1;
+            var currentItem = 0;
+            var channelItems = new[] { 1, 4, 7, 9 };
+            var readCancellation = new CancellationTokenSource();
+            var mockReader = new Mock<ChannelReader<int>>();
+
+            Func<Task> disposeCallback = () =>
+            {
+                disposed = true;
+                return Task.CompletedTask;
+            };
+
+            mockReader
+              .SetupGet(reader => reader.Completion)
+              .Returns(new Task(() => Thread.Sleep(5)));
+
+            mockReader
+                .Setup(reader => reader.TryRead(out currentItem))
+                .Callback((ReturnOutParam<int>)((out int current) => current = channelItems[++channelIndex]))
+                .Returns(() => (channelIndex < channelItems.Length));
+
+            // Create the subscription and deliberately do not dispose; the common usage will be in immediate foreach call,
+            // which should trigger disposal after iterating.
+
+            var subscription = new ChannelEnumerableSubscription<int>(mockReader.Object, null, disposeCallback, readCancellation.Token);
+
+            await foreach(var item in subscription)
+            {
+                ++readIndex;
+
+                if (readIndex >= maxReadItems)
+                {
+                    readCancellation.Cancel();
+                }
+
+                if (readIndex >= channelItems.Length)
+                {
+                    break;
+                }
+            }
+
+            Assert.That(readCancellation.Token.IsCancellationRequested, Is.True, "Cancellation should have been requested.");
+            Assert.That(readIndex, Is.EqualTo(maxReadItems), "The number of items read should have stopped increasing when cancellation was requested.");
+            Assert.That(disposed, Is.True, "The subscription should have been disposed.");
+        }
+
+        /// <summary>
+        ///     Verifies functionality of the subscription's
+        ///     enumerator.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EnumeratorRespectsTheMaximumWaitTime()
+        {
+            var disposed = false;
+            var forcedAbort = false;
+            var channelIndex = -1;
+            var readCount = 0;
+            var iterateCount = 0;
+            var maxReadItems = 2;
+            var currentItem = 0;
+            var maxWaitTime = TimeSpan.FromMilliseconds(25);
+            var cancelTimeout = TimeSpan.FromMilliseconds(280);
+            var abortTimeout = cancelTimeout.Add(TimeSpan.FromSeconds(1));
+            var channelItems = new[] { 1, 4, 7, 9 };
+            var mockReader = new Mock<ChannelReader<int>>();
+
+            Func<Task> disposeCallback = () =>
+            {
+                disposed = true;
+                return Task.CompletedTask;
+            };
+
+            var channelReadCallback = (ReturnOutParam<int>)((out int current) =>
+            {
+                if (channelIndex < channelItems.Length - 1)
+                {
+                    ++channelIndex;
+                }
+
+                current = channelItems[channelIndex];
+            });
+
+            mockReader
+              .SetupGet(reader => reader.Completion)
+              .Returns(new Task(async () => await Task.Delay(5)));
+
+            mockReader
+                .Setup(reader => reader.TryRead(out currentItem))
+                .Callback(channelReadCallback)
+                .Returns(() =>
+                {
+                    Thread.Sleep(maxWaitTime);
+                    return channelIndex < maxReadItems;
+                });
+
+            // Create the subscription and deliberately do not dispose; the common usage will be in immediate foreach call,
+            // which should trigger disposal after iterating.
+
+            var readCancellation = new CancellationTokenSource(cancelTimeout);
+            var subscription = new ChannelEnumerableSubscription<int>(mockReader.Object, maxWaitTime, disposeCallback, readCancellation.Token);
+            var stopWatch = Stopwatch.StartNew();
+
+            await foreach(var item in subscription)
+            {
+                ++iterateCount;
+
+                if (item != default)
+                {
+                    ++readCount;
+                }
+
+                if (stopWatch.Elapsed > abortTimeout)
+                {
+                   forcedAbort = true;
+                   break;
+                }
+            }
+
+            stopWatch.Stop();
+
+            // Due to the random delay applied while waiting for items without the maximum wait time, the
+            // actual iteration count is non-deterministic.  It is known, however, that it will be greater than the
+            // channel read count, as the wait time accounts for the maximum random period; at least one default item
+            // will be emitted.
+
+            Assert.That(forcedAbort, Is.False, "The timeout should have occurred due to the cancellation token, not have been forced.");
+            Assert.That(readCancellation.Token.IsCancellationRequested, Is.True, "Cancellation should have been requested.");
+            Assert.That(readCount, Is.EqualTo(maxReadItems), "The number of items read should have stopped increasing when cancellation was requested.");
+            Assert.That(iterateCount, Is.GreaterThan(readCount), "There should have been default items returned due to the wait time expiring.");
+            Assert.That(stopWatch.Elapsed, Is.EqualTo(cancelTimeout).Within(TimeSpan.FromSeconds(2)), "The elapsed time should be close to the duration set for the cancel timeout.");
+            Assert.That(disposed, Is.True, "The subscription should have been disposed.");
+        }
+
+        /// <summary>
+        ///     Verifies functionality of the subscription's
+        ///     enumerator.
+        /// </summary>
+        ///
+        [Test]
+        public async Task EnumeratorRespectsWhenThereIsNoMaximumWaitTime()
+        {
+            var disposed = false;
+            var forcedAbort = false;
+            var channelIndex = -1;
+            var readCount = 0;
+            var iterateCount = 0;
+            var maxReadItems = 2;
+            var currentItem = 0;
+            var cancelTimeout = TimeSpan.FromMilliseconds(280);
+            var abortTimeout = cancelTimeout.Add(TimeSpan.FromSeconds(1));
+            var channelItems = new[] { 1, 4, 7, 9 };
+            var mockReader = new Mock<ChannelReader<int>>();
+
+            Func<Task> disposeCallback = () =>
+            {
+                disposed = true;
+                return Task.CompletedTask;
+            };
+
+            var channelReadCallback = (ReturnOutParam<int>)((out int current) =>
+            {
+                if (channelIndex < channelItems.Length - 1)
+                {
+                    ++channelIndex;
+                }
+
+                current = channelItems[channelIndex];
+            });
+
+            mockReader
+              .SetupGet(reader => reader.Completion)
+              .Returns(new Task(() => Thread.Sleep(5)));
+
+            mockReader
+                .Setup(reader => reader.TryRead(out currentItem))
+                .Callback(channelReadCallback)
+                .Returns(() => channelIndex < maxReadItems);
+
+            // Create the subscription and deliberately do not dispose; the common usage will be in immediate foreach call,
+            // which should trigger disposal after iterating.
+
+            var readCancellation = new CancellationTokenSource(cancelTimeout);
+            var subscription = new ChannelEnumerableSubscription<int>(mockReader.Object, null, disposeCallback, readCancellation.Token);
+            var stopWatch = Stopwatch.StartNew();
+
+            await foreach(var item in subscription)
+            {
+                ++iterateCount;
+
+                if (item != default)
+                {
+                    ++readCount;
+                }
+
+                if (stopWatch.Elapsed > abortTimeout)
+                {
+                   forcedAbort = true;
+                   break;
+                }
+            }
+
+            stopWatch.Stop();
+
+            Assert.That(forcedAbort, Is.False, "The timeout should have occurred due to the cancellation token, not have been forced.");
+            Assert.That(readCancellation.Token.IsCancellationRequested, Is.True, "Cancellation should have been requested.");
+            Assert.That(readCount, Is.EqualTo(maxReadItems), "The number of items read should have stopped increasing when cancellation was requested.");
+            Assert.That(iterateCount, Is.EqualTo(readCount), "There should have been no items returned; all iterations should have been reading actual values.");
+            Assert.That(stopWatch.Elapsed, Is.EqualTo(cancelTimeout).Within(TimeSpan.FromSeconds(2)), "The elapsed time should be close to the duration set for the cancel timeout.");
+            Assert.That(disposed, Is.True, "The subscription should have been disposed.");
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerLiveTests.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Net;
 using System.Net.WebSockets;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Errors;
 using Azure.Messaging.EventHubs.Tests.Infrastructure;
@@ -120,7 +121,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await producer.SendAsync(eventSet);
 
-                        // Receive and validate the events; because there is some non-determinism in the messaging flow, the
+                        // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
                         // to account for availability delays.
 
@@ -131,6 +132,9 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             receivedEvents.AddRange(await consumer.ReceiveAsync(eventSet.Length + 10, TimeSpan.FromMilliseconds(25)));
                         }
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
 
                         index = 0;
 
@@ -192,7 +196,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await producer.SendAsync(eventBatch);
 
-                        // Receive and validate the events; because there is some non-determinism in the messaging flow, the
+                        // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
                         // to account for availability delays.
 
@@ -203,6 +207,9 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             receivedEvents.AddRange(await consumer.ReceiveAsync(eventBatch.Count + 10, TimeSpan.FromMilliseconds(25)));
                         }
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
 
                         index = 0;
 
@@ -264,7 +271,10 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         foreach (var eventData in eventSet)
                         {
-                            eventBatch.TryAdd(eventData);
+                            if (!eventBatch.TryAdd(eventData))
+                            {
+                                Assert.Fail("All of the events could not be added to the batch.");
+                            }
                         }
 
                         // Initiate an operation to force the consumer to connect and set its position at the
@@ -274,9 +284,9 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         // Send the batch of events, receive and validate them.
 
-                        await producer.SendAsync(eventSet);
+                        await producer.SendAsync(eventBatch);
 
-                        // Receive and validate the events; because there is some non-determinism in the messaging flow, the
+                        // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
                         // to account for availability delays.
 
@@ -294,6 +304,9 @@ namespace Azure.Messaging.EventHubs.Tests
 
                             ++batchNumber;
                         }
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
 
                         index = 0;
 
@@ -342,7 +355,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await producer.SendAsync(eventBatch);
 
-                        // Receive and validate the events; because there is some non-determinism in the messaging flow, the
+                        // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
                         // to account for availability delays.
 
@@ -353,6 +366,9 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             receivedEvents.AddRange(await consumer.ReceiveAsync(eventBatch.Length + 10, TimeSpan.FromMilliseconds(25)));
                         }
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
 
                         index = 0;
 
@@ -401,7 +417,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await producer.SendAsync(eventBatch);
 
-                        // Receive and validate the events; because there is some non-determinism in the messaging flow, the
+                        // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
                         // to account for availability delays.
 
@@ -412,6 +428,9 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             receivedEvents.AddRange(await consumer.ReceiveAsync(eventBatch.Length + 10, TimeSpan.FromMilliseconds(25)));
                         }
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
 
                         index = 0;
 
@@ -462,7 +481,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await producer.SendAsync(eventSet);
 
-                        // Receive and validate the events; because there is some non-determinism in the messaging flow, the
+                        // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
                         // to account for availability delays.
 
@@ -473,6 +492,9 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             receivedEvents.AddRange(await consumer.ReceiveAsync(eventSet.Length + 10, TimeSpan.FromMilliseconds(25)));
                         }
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
 
                         index = 0;
 
@@ -502,9 +524,10 @@ namespace Azure.Messaging.EventHubs.Tests
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
+                // The actual limit is 1046520 for a single event
+
                 var eventBatch = new[]
                 {
-                    // Actual limit is 1046520 for a single event
                     new EventData(new byte[100000])
                 };
 
@@ -528,7 +551,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await Task.Delay(TimeSpan.FromSeconds(5));
 
-                        // Receive and validate the events; because there is some non-determinism in the messaging flow, the
+                        // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
                         // to account for availability delays.
 
@@ -537,8 +560,11 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         while ((receivedEvents.Count < eventBatch.Length) && (++index < ReceiveRetryLimit))
                         {
-                            receivedEvents.AddRange(await consumer.ReceiveAsync(eventBatch.Length + 10, TimeSpan.FromMilliseconds(25)));
+                            receivedEvents.AddRange(await consumer.ReceiveAsync(eventBatch.Length + 10, TimeSpan.FromMilliseconds(500)));
                         }
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
 
                         index = 0;
 
@@ -596,7 +622,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                         await producer.SendAsync(eventBatch);
 
-                        // Receive and validate the events; because there is some non-determinism in the messaging flow, the
+                        // Receive the events; because there is some non-determinism in the messaging flow, the
                         // sent events may not be immediately available.  Allow for a small number of attempts to receive, in order
                         // to account for availability delays.
 
@@ -607,6 +633,9 @@ namespace Azure.Messaging.EventHubs.Tests
                         {
                             receivedEvents.AddRange(await consumer.ReceiveAsync(eventBatch.Length + 10, TimeSpan.FromMilliseconds(25)));
                         }
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
 
                         index = 0;
 
@@ -929,6 +958,225 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
+        public async Task SubscribeCanReceiveEventsFromTheEnumerable()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(1))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                var eventSet = new[]
+                {
+                    new EventData(Encoding.UTF8.GetBytes("One")),
+                    new EventData(Encoding.UTF8.GetBytes("Two")),
+                    new EventData(Encoding.UTF8.GetBytes("Three")),
+                    new EventData(Encoding.UTF8.GetBytes("Four")),
+                    new EventData(Encoding.UTF8.GetBytes("Five")),
+                    new EventData(Encoding.UTF8.GetBytes("Six")),
+                    new EventData(Encoding.UTF8.GetBytes("Seven")),
+                    new EventData(Encoding.UTF8.GetBytes("Eight")),
+                    new EventData(Encoding.UTF8.GetBytes("Nine")),
+                    new EventData(Encoding.UTF8.GetBytes("Ten")),
+                    new EventData(Encoding.UTF8.GetBytes("Eleven")),
+                    new EventData(Encoding.UTF8.GetBytes("Twelve")),
+                    new EventData(Encoding.UTF8.GetBytes("Thirteen")),
+                    new EventData(Encoding.UTF8.GetBytes("Fourteen")),
+                    new EventData(Encoding.UTF8.GetBytes("Fifteen"))
+                };
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var partition = (await client.GetPartitionIdsAsync()).First();
+
+                    await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Earliest))
+                    {
+                        // Create the batch of events to publish.
+
+                        using var eventBatch = await producer.CreateBatchAsync();
+
+                        foreach (var eventData in eventSet)
+                        {
+                            if (!eventBatch.TryAdd(eventData))
+                            {
+                                Assert.Fail("All of the events could not be added to the batch.");
+                            }
+                        }
+
+                        // Send the batch of events, receive and validate them.
+
+                        await producer.SendAsync(eventBatch);
+
+                        // Receive the events; when there have been multiple consecutive empty events emitted due to
+                        // exceeding the maximum wait time, assume the batch is complete and terminate.
+
+                        var consecutiveEmpties = 0;
+                        var maximumWaitTime = TimeSpan.FromMilliseconds(50);
+                        var receivedEvents = new List<EventData>();
+
+                        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+
+                        await foreach (var receivedEvent in consumer.SubscribeToEvents(maximumWaitTime, cancellation.Token))
+                        {
+                            receivedEvents.Add(receivedEvent);
+                            consecutiveEmpties = (receivedEvent == null) ? consecutiveEmpties + 1 : 0;
+
+                            if (consecutiveEmpties > 1)
+                            {
+                                break;
+                            }
+                        }
+
+                        Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+                        Assert.That(receivedEvents.Count, Is.AtLeast(eventSet.Length), "The number of received events should be at least the number of events sent.");
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
+
+                        var index = 0;
+                        receivedEvents = receivedEvents.Where(item => item != null).ToList();
+
+                        foreach (var receivedEvent in receivedEvents)
+                        {
+                            Assert.That(receivedEvent.IsEquivalentTo(eventSet[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
+                            ++index;
+                        }
+
+                        Assert.That(index, Is.EqualTo(eventSet.Length), "The number of received events did not match the batch size.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumer" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribeCanReceiveBatchedEventsFromTheEnumerable()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(1))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                var firstEvents = new[]
+                {
+                    new EventData(Encoding.UTF8.GetBytes("One")),
+                    new EventData(Encoding.UTF8.GetBytes("Two")),
+                    new EventData(Encoding.UTF8.GetBytes("Three")),
+                    new EventData(Encoding.UTF8.GetBytes("Four")),
+                    new EventData(Encoding.UTF8.GetBytes("Five")),
+                    new EventData(Encoding.UTF8.GetBytes("Six")),
+                    new EventData(Encoding.UTF8.GetBytes("Seven")),
+                    new EventData(Encoding.UTF8.GetBytes("Eight"))
+                };
+
+                var secondEvents = new[]
+                {
+                    new EventData(Encoding.UTF8.GetBytes("Nine")),
+                    new EventData(Encoding.UTF8.GetBytes("Ten")),
+                    new EventData(Encoding.UTF8.GetBytes("Eleven")),
+                    new EventData(Encoding.UTF8.GetBytes("Twelve")),
+                    new EventData(Encoding.UTF8.GetBytes("Thirteen")),
+                    new EventData(Encoding.UTF8.GetBytes("Fourteen")),
+                    new EventData(Encoding.UTF8.GetBytes("Fifteen"))
+                };
+
+                var eventSet = firstEvents.Concat(secondEvents).ToArray();
+
+                await using (var client = new EventHubClient(connectionString))
+                {
+                    var partition = (await client.GetPartitionIdsAsync()).First();
+
+                    await using (var producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = partition }))
+                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, partition, EventPosition.Earliest))
+                    {
+                        // Create the batch of events to publish.
+
+                        using var firstBatch = await producer.CreateBatchAsync();
+                        using var secondBatch = await producer.CreateBatchAsync();
+
+                        foreach (var eventData in firstEvents)
+                        {
+                            if (!firstBatch.TryAdd(eventData))
+                            {
+                                Assert.Fail("All of the events could not be added to the batch.");
+                            }
+                        }
+
+                        foreach (var eventData in secondEvents)
+                        {
+                            if (!secondBatch.TryAdd(eventData))
+                            {
+                                Assert.Fail("All of the events could not be added to the batch.");
+                            }
+                        }
+
+                        // Send the batches of events, receive and validate them.
+
+                        await producer.SendAsync(firstBatch);
+
+                        Task secondSend = new Task(async () =>
+                        {
+                            await Task.Delay(15).ConfigureAwait(false);
+                            await producer.SendAsync(secondBatch).ConfigureAwait(false);
+                        });
+
+                        // Receive the events; when there have been multiple consecutive empty events emitted due to
+                        // exceeding the maximum wait time, assume the batch is complete and terminate.
+
+                        var consecutiveEmpties = 0;
+                        var maximumWaitTime = TimeSpan.FromMilliseconds(25);
+                        var receivedEvents = new List<EventData>();
+
+                        using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(90));
+
+                        await foreach (var receivedEvent in consumer.SubscribeToEvents(maximumWaitTime, cancellation.Token))
+                        {
+                            secondSend?.Start();
+
+                            receivedEvents.Add(receivedEvent);
+                            consecutiveEmpties = (receivedEvent == null) ? consecutiveEmpties + 1 : 0;
+
+                            if (consecutiveEmpties > 5)
+                            {
+                                break;
+                            }
+
+                            if (secondSend != null)
+                            {
+                                await secondSend.ConfigureAwait(false);
+                                secondSend = null;
+                            }
+                        }
+
+                        Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+                        Assert.That(receivedEvents.Count, Is.AtLeast(eventSet.Length), "The number of received events should be at least the number of events sent.");
+
+                        // Validate the events; once nulls have been removed, they should have been received in the order they were added to the batch.
+                        // Because there's a custom equality check, the built-in collection comparison is not adequate.
+
+                        var index = 0;
+                        receivedEvents = receivedEvents.Where(item => item != null).ToList();
+
+                        foreach (var receivedEvent in receivedEvents)
+                        {
+                            Assert.That(receivedEvent.IsEquivalentTo(eventSet[index]), Is.True, $"The received event at index: { index } did not match the sent batch.");
+                            ++index;
+                        }
+
+                        Assert.That(index, Is.EqualTo(eventSet.Length), "The number of received events did not match the batch size.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubConsumer" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
         [TestCase(true)]
         [TestCase(false)]
         public async Task ConsumerCannotReceiveWhenClosed(bool sync)
@@ -979,11 +1227,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
                 await using (var client = new EventHubClient(connectionString))
+                await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, invalidPartition, EventPosition.Latest))
                 {
-                    await using (var consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, invalidPartition, EventPosition.Latest))
-                    {
-                        Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ArgumentOutOfRangeException>());
-                    }
+                    Assert.That(async () => await consumer.ReceiveAsync(1, TimeSpan.Zero), Throws.InstanceOf<ArgumentOutOfRangeException>());
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerOptionsTests.cs
@@ -31,7 +31,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var clone = options.Clone();
             Assert.That(clone, Is.Not.Null, "The clone should not be null.");
 
-            Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The ownerlevel of the clone should match.");
+            Assert.That(clone.OwnerLevel, Is.EqualTo(options.OwnerLevel), "The owner level of the clone should match.");
             Assert.That(clone.DefaultMaximumReceiveWaitTime, Is.EqualTo(options.DefaultMaximumReceiveWaitTime), "The default maximum wait time of the clone should match.");
             Assert.That(clone.Identifier, Is.EqualTo(options.Identifier), "The identifier of the clone should match.");
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -2,11 +2,17 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
+using System.Text;
 using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Core;
+using Azure.Messaging.EventHubs.Errors;
 using Moq;
 using NUnit.Framework;
 
@@ -21,6 +27,34 @@ namespace Azure.Messaging.EventHubs.Tests
     [Parallelizable(ParallelScope.All)]
     public class EventHubConsumerTests
     {
+        /// <summary>
+        ///   Provides the test cases for non-fatal exceptions that are not retriable
+        ///   when encountered in a subscription.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> NonFatalNotRetriableExceptionTestCases()
+        {
+            yield return new object[] { new ConsumerDisconnectedException("Test", "Test") };
+            yield return new object[] { new EventHubsResourceNotFoundException("Test", "Test") };
+            yield return new object[] { new InvalidOperationException() };
+            yield return new object[] { new NotSupportedException() };
+            yield return new object[] { new NullReferenceException() };
+            yield return new object[] { new ObjectDisposedException("dummy") };
+        }
+
+        /// <summary>
+        ///   Provides the test cases for non-fatal exceptions that are retriable
+        ///   when encountered in a subscription.
+        /// </summary>
+        ///
+        public static IEnumerable<object[]> NonFatalRetriableExceptionTestCases()
+        {
+            yield return new object[] { new EventHubsException(true, "Test") };
+            yield return new object[] { new EventHubsCommunicationException("Test", "Test") };
+            yield return new object[] { new ServiceBusyException("Test", "Test") };
+            yield return new object[] { new TimeoutException() };
+        }
+
         /// <summary>
         ///   Verifies functionality of the constructor.
         /// </summary>
@@ -319,6 +353,752 @@ namespace Azure.Messaging.EventHubs.Tests
         }
 
         /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribeWithNoWaitTimeReturnsAnEnumerable()
+        {
+            var transportConsumer = new ObservableTransportConsumerMock();
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var enumerable = consumer.SubscribeToEvents();
+
+            Assert.That(enumerable, Is.Not.Null, "An enumerable should have been returned.");
+            Assert.That(enumerable, Is.InstanceOf<IAsyncEnumerable<EventData>>(), "The enumerable should be of the correct type.");
+
+            await using (var enumerator = enumerable.GetAsyncEnumerator())
+            {
+                Assert.That(enumerator, Is.Not.Null, "The enumerable should be able to produce an enumerator.");
+                Assert.That(enumerator, Is.InstanceOf<IAsyncEnumerator<EventData>>(), "The enumerator should be of the correct type.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribeWithWaitTimeReturnsAnEnumerable()
+        {
+            var transportConsumer = new ObservableTransportConsumerMock();
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var enumerable = consumer.SubscribeToEvents(TimeSpan.FromSeconds(15));
+
+            Assert.That(enumerable, Is.Not.Null, "An enumerable should have been returned.");
+            Assert.That(enumerable, Is.InstanceOf<IAsyncEnumerable<EventData>>(), "The enumerable should be of the correct type.");
+
+            await using (var enumerator = enumerable.GetAsyncEnumerator())
+            {
+                Assert.That(enumerator, Is.Not.Null, "The enumerable should be able to produce an enumerator.");
+                Assert.That(enumerator, Is.InstanceOf<IAsyncEnumerator<EventData>>(), "The enumerator should be of the correct type.");
+            }
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribeManagesActiveChannels()
+        {
+            var transportConsumer = new ObservableTransportConsumerMock();
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var channels = GetActiveChannels(consumer);
+
+            // Create the subscriptions in the background, wrapping each request in its own task.  The
+            // goal is to ensure that channel creation can handle concurrent requests.
+
+            var subscriptions = (await Task.WhenAll(
+                Enumerable.Range(0, 10)
+                .Select(index => Task.Run(() => consumer.SubscribeToEvents()))
+            ).ConfigureAwait(false))
+                .Select(enumerable => (ChannelEnumerableSubscription<EventData>)enumerable)
+                .ToList();
+
+            try
+            {
+                Assert.That(channels, Is.Not.Null, "The consumer should have a set of active channels.");
+                Assert.That(channels.Count, Is.EqualTo(subscriptions.Count), "Each subscription should have an associated channel.");
+            }
+            finally
+            {
+                await Task.WhenAll(subscriptions.Select(subscription => Task.Run(async () => await subscription.DisposeAsync()))).ConfigureAwait(false);
+            }
+
+            Assert.That(channels, Is.Not.Null, "The consumer should have a set of active channels.");
+            Assert.That(channels.Count, Is.EqualTo(0), "Channels should have been removed when subscriptions were removed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribeManagesBackgroundPublishingWithOneSubscriber()
+        {
+            var transportConsumer = new ObservableTransportConsumerMock();
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var publishing = GetIsPublishingActiveFlag(consumer);
+
+            Assert.That(publishing, Is.False, "Background publishing should not start without a subscription.");
+
+            await using (var subscription = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents())
+            {
+                publishing = GetIsPublishingActiveFlag(consumer);
+                Assert.That(publishing, Is.True, "Background publishing should be taking place when there is a subscriber.");
+            }
+
+            publishing = GetIsPublishingActiveFlag(consumer);
+            Assert.That(publishing, Is.False, "Background publishing should stop when at the last unsubscribe.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribeManagesBackgroundPublishingWithMultipleSubscribers()
+        {
+            var transportConsumer = new PublishingTransportConsumerMock();
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var publishing = GetIsPublishingActiveFlag(consumer);
+
+            Assert.That(publishing, Is.False, "Background publishing should not start without a subscription.");
+
+            await using (var subscription = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents())
+            {
+                transportConsumer.StartPublishing();
+
+                await using (var secondSubscription = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents())
+                await using (var thirdSubscription = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents())
+                {
+                    publishing = GetIsPublishingActiveFlag(consumer);
+                    Assert.That(publishing, Is.True, "Background publishing should be taking place when there are multiple subscribers.");
+                }
+
+                publishing = GetIsPublishingActiveFlag(consumer);
+                Assert.That(publishing, Is.True, "Background publishing should be taking place when there is a single subscriber left.");
+            }
+
+            publishing = GetIsPublishingActiveFlag(consumer);
+            Assert.That(publishing, Is.False, "Background publishing should stop when at the last unsubscribe.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribePublishesEmptyEnumerableIfCancelledBeforeSubscribe()
+        {
+            var events = new List<EventData>
+            {
+               new EventData(Encoding.UTF8.GetBytes("One")),
+               new EventData(Encoding.UTF8.GetBytes("Two")),
+               new EventData(Encoding.UTF8.GetBytes("Three")),
+               new EventData(Encoding.UTF8.GetBytes("Four")),
+               new EventData(Encoding.UTF8.GetBytes("Five"))
+            };
+
+            var transportConsumer = new PublishingTransportConsumerMock(events, true);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var receivedEvents = 0;
+
+            using var cancellation = new CancellationTokenSource();
+            cancellation.Cancel();
+
+            await foreach (var eventData in consumer.SubscribeToEvents(cancellation.Token))
+            {
+                if (eventData == null)
+                {
+                    break;
+                }
+
+                ++receivedEvents;
+            }
+
+            Assert.That(cancellation.IsCancellationRequested, Is.True, "The cancellation should have been requested.");
+            Assert.That(receivedEvents, Is.EqualTo(0), "There should have been no events received.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribePublishesEventsWithOneSubscriberAndSingleBatch()
+        {
+            var events = new List<EventData>
+            {
+                new EventData(Encoding.UTF8.GetBytes("One")),
+                new EventData(Encoding.UTF8.GetBytes("Two")),
+                new EventData(Encoding.UTF8.GetBytes("Three")),
+                new EventData(Encoding.UTF8.GetBytes("Four")),
+                new EventData(Encoding.UTF8.GetBytes("Five"))
+            };
+
+            var transportConsumer = new PublishingTransportConsumerMock(events, true);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var receivedEvents = new List<EventData>();
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            await foreach (var eventData in consumer.SubscribeToEvents(cancellation.Token))
+            {
+                receivedEvents.Add(eventData);
+
+                if (receivedEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            Assert.That(receivedEvents, Is.EquivalentTo(events), "The received events should match the published events.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribePublishesEventsWithMultipleSubscribersAndSingleBatch()
+        {
+            var events = new List<EventData>
+            {
+                new EventData(Encoding.UTF8.GetBytes("One")),
+                new EventData(Encoding.UTF8.GetBytes("Two")),
+                new EventData(Encoding.UTF8.GetBytes("Three")),
+                new EventData(Encoding.UTF8.GetBytes("Four")),
+                new EventData(Encoding.UTF8.GetBytes("Five"))
+            };
+
+            var transportConsumer = new PublishingTransportConsumerMock(events);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var firstSubscriberEvents = new List<EventData>();
+            var secondSubscriberEvents = new List<EventData>();
+            var firstCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            // Create the subscriptions explicitly for better determinism; they should subscribe at the same time
+            // to ensure they receive the same set of events.
+
+            await using (var firstSubscriber = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents(cancellation.Token))
+            await using (var secondSubscriber = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents(cancellation.Token))
+            {
+                transportConsumer.StartPublishing();
+
+                var firstSubscriberTask = Task.Run(async () =>
+                {
+                    await foreach (var eventData in firstSubscriber)
+                    {
+                        firstSubscriberEvents.Add(eventData);
+
+                        if (firstSubscriberEvents.Count >= events.Count)
+                        {
+                            break;
+                        }
+                    }
+
+                    await Task.Delay(250).ConfigureAwait(false);
+                    firstCompletionSource.TrySetResult(0);
+
+                }, cancellation.Token);
+
+                var secondSubscriberTask = Task.Run(async () =>
+                {
+                    await foreach (var eventData in secondSubscriber)
+                    {
+                        secondSubscriberEvents.Add(eventData);
+
+                        if (secondSubscriberEvents.Count >= events.Count)
+                        {
+                            break;
+                        }
+                    }
+
+                    await Task.Delay(250).ConfigureAwait(false);
+                    secondCompletionSource.TrySetResult(0);
+
+                }, cancellation.Token);
+
+                await Task.WhenAll(firstSubscriberTask, secondSubscriberTask, firstCompletionSource.Task, secondCompletionSource.Task).ConfigureAwait(false);
+                Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            }
+
+            Assert.That(firstSubscriberEvents, Is.EquivalentTo(events), "The received events for the first subscriber should match the published events.");
+            Assert.That(secondSubscriberEvents, Is.EquivalentTo(events), "The received events for the second subscriber should match the published events.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribePublishesEventsWithOneSubscriberAndMultipleBatches()
+        {
+            var events = new List<EventData>();
+            var transportConsumer = new PublishingTransportConsumerMock(events, true);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var receivedEvents = new List<EventData>();
+
+            events.AddRange(
+                Enumerable.Range(0, (GetBackgroundPublishReceiveBatchSize(consumer) * 3))
+                    .Select(index => new EventData(Encoding.UTF8.GetBytes($"Event Number { index }")))
+            );
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            await foreach (var eventData in consumer.SubscribeToEvents(cancellation.Token))
+            {
+                receivedEvents.Add(eventData);
+
+                if (receivedEvents.Count >= events.Count)
+                {
+                    break;
+                }
+            }
+
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            Assert.That(receivedEvents, Is.EquivalentTo(events), "The received events should match the published events.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribePublishesEventsWithMultipleSubscribersAndMultipleBatches()
+        {
+            var events = new List<EventData>();
+            var transportConsumer = new PublishingTransportConsumerMock(events);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var firstSubscriberEvents = new List<EventData>();
+            var secondSubscriberEvents = new List<EventData>();
+            var firstCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            events.AddRange(
+                Enumerable.Range(0, (GetBackgroundPublishReceiveBatchSize(consumer) * 3))
+                    .Select(index => new EventData(Encoding.UTF8.GetBytes($"Event Number { index }")))
+            );
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            // Create the subscriptions explicitly for better determinism; they should subscribe at the same time
+            // to ensure they receive the same set of events.
+
+            await using (var firstSubscriber = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents(cancellation.Token))
+            await using (var secondSubscriber = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents(cancellation.Token))
+            {
+                transportConsumer.StartPublishing();
+
+                var firstSubscriberTask = Task.Run(async () =>
+                {
+                    await foreach (var eventData in firstSubscriber)
+                    {
+                        firstSubscriberEvents.Add(eventData);
+
+                        if (firstSubscriberEvents.Count >= events.Count)
+                        {
+                            break;
+                        }
+                    }
+
+                    await Task.Delay(250).ConfigureAwait(false);
+                    firstCompletionSource.TrySetResult(0);
+
+                }, cancellation.Token);
+
+                var secondSubscriberTask = Task.Run(async () =>
+                {
+                    await foreach (var eventData in secondSubscriber)
+                    {
+                        secondSubscriberEvents.Add(eventData);
+
+                        if (secondSubscriberEvents.Count >= events.Count)
+                        {
+                            break;
+                        }
+                    }
+
+                    await Task.Delay(250).ConfigureAwait(false);
+                    secondCompletionSource.TrySetResult(0);
+
+                }, cancellation.Token);
+
+                await Task.WhenAll(firstSubscriberTask, secondSubscriberTask, firstCompletionSource.Task, secondCompletionSource.Task).ConfigureAwait(false);
+                Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            }
+
+            Assert.That(firstSubscriberEvents, Is.EquivalentTo(events), "The received events for the first subscriber should match the published events.");
+            Assert.That(secondSubscriberEvents, Is.EquivalentTo(events), "The received events for the second subscriber should match the published events.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task UnsubscribeHappensAfterIterationWithSingleSubcriber()
+        {
+            var events = new List<EventData>
+            {
+                new EventData(Encoding.UTF8.GetBytes("One")),
+                new EventData(Encoding.UTF8.GetBytes("Two")),
+                new EventData(Encoding.UTF8.GetBytes("Three")),
+                new EventData(Encoding.UTF8.GetBytes("Four")),
+                new EventData(Encoding.UTF8.GetBytes("Five"))
+            };
+
+            var transportConsumer = new PublishingTransportConsumerMock(events, true);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var activeChannels = GetActiveChannels(consumer);
+            var receivedEvents = 0;
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            await foreach (var eventData in consumer.SubscribeToEvents(cancellation.Token))
+            {
+                ++receivedEvents;
+
+                if (receivedEvents >= events.Count)
+                {
+                    Assert.That(activeChannels.Count, Is.EqualTo(1), "There should be a single active channel for the subscriber.");
+                    break;
+                }
+            }
+
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            Assert.That(activeChannels.Count, Is.EqualTo(0), "The iterator should unsubscribe when complete.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task UnsubscribeHappensAfterIterationWithMultipleSubcribers()
+        {
+            var events = new List<EventData>
+            {
+                new EventData(Encoding.UTF8.GetBytes("One")),
+                new EventData(Encoding.UTF8.GetBytes("Two")),
+                new EventData(Encoding.UTF8.GetBytes("Three")),
+                new EventData(Encoding.UTF8.GetBytes("Four")),
+                new EventData(Encoding.UTF8.GetBytes("Five"))
+            };
+
+            var waitTime = TimeSpan.FromMilliseconds(5);
+            var transportConsumer = new PublishingTransportConsumerMock(events);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var activeChannels = GetActiveChannels(consumer);
+            var firstCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var secondCompletionSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var firstSubscriberEvents = new List<EventData>();
+            var secondSubscriberEvents = new List<EventData>();
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+
+            // Create the subscriptions explicitly for better determinism; they should subscribe at the same time
+            // to ensure they receive the same set of events.
+
+            await using (var firstSubscriber = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents(waitTime, cancellation.Token))
+            await using (var secondSubscriber = (ChannelEnumerableSubscription<EventData>)consumer.SubscribeToEvents(waitTime, cancellation.Token))
+            {
+                var firstSubscriberTask = Task.Run(async () =>
+                {
+                    transportConsumer.StartPublishing();
+
+                    await foreach (var eventData in firstSubscriber)
+                    {
+                        firstSubscriberEvents.Add(eventData);
+
+                        if (firstSubscriberEvents.Count >= events.Count)
+                        {
+                            Assert.That(activeChannels.Count, Is.AtLeast(1).And.AtMost(2), "There should be a one active channel for each subscriber.");
+                            break;
+                        }
+                    }
+
+                    await Task.Delay(250).ConfigureAwait(false);
+                    firstCompletionSource.TrySetResult(0);
+
+                }, cancellation.Token);
+
+                var secondSubscriberTask = Task.Run(async () =>
+                {
+                    await foreach (var eventData in secondSubscriber)
+                    {
+                        secondSubscriberEvents.Add(eventData);
+
+                        if (secondSubscriberEvents.Count >= events.Count)
+                        {
+                            Assert.That(activeChannels.Count, Is.AtLeast(1).And.AtMost(2), "There should be a one active channel for each subscriber.");
+                            break;
+                        }
+                    }
+
+                    await Task.Delay(250).ConfigureAwait(false);
+                    secondCompletionSource.TrySetResult(0);
+
+                }, cancellation.Token);
+
+                await Task.WhenAll(firstSubscriberTask, secondSubscriberTask, firstCompletionSource.Task, secondCompletionSource.Task).ConfigureAwait(false);
+                Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            }
+
+            Assert.That(activeChannels.Count, Is.EqualTo(0), "The iterator should unsubscribe when complete.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribeRespectsWaitTimeWhenPublishingEvents()
+        {
+            var events = new List<EventData>
+            {
+                new EventData(Encoding.UTF8.GetBytes("One")),
+                new EventData(Encoding.UTF8.GetBytes("Two")),
+                new EventData(Encoding.UTF8.GetBytes("Three")),
+                new EventData(Encoding.UTF8.GetBytes("Four")),
+                new EventData(Encoding.UTF8.GetBytes("Five"))
+            };
+
+            var maxWaitTime = TimeSpan.FromMilliseconds(50);
+            var publishDelay = maxWaitTime.Add(TimeSpan.FromMilliseconds(15));
+            var transportConsumer = new PublishingTransportConsumerMock(events, true, () => publishDelay);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var receivedEvents = new List<EventData>();
+            var consecutiveEmptyCount = 0;
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            await foreach (var eventData in consumer.SubscribeToEvents(maxWaitTime, cancellation.Token))
+            {
+                receivedEvents.Add(eventData);
+                consecutiveEmptyCount = (eventData == null) ? consecutiveEmptyCount + 1 : 0;
+
+                if (consecutiveEmptyCount > 1)
+                {
+                    break;
+                }
+            }
+
+            // Because there is a random delay in the receive loop, the exact count of empty events cannot be predicted.  There
+            // should be at least one total, but no more than one for each published event.
+
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            Assert.That(receivedEvents.Count, Is.AtLeast(events.Count + 1).And.LessThanOrEqualTo(events.Count * 2), "There should be empty events present due to the wait time.");
+            Assert.That(receivedEvents.Where(item => item != null), Is.EquivalentTo(events), "The received events should match the published events when empty events are removed.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task SubscribeExpectsTaskCanceledException()
+        {
+            var transportConsumer = new ReceiveCallbackTransportConsumerMock((_max, _time) => throw new TaskCanceledException());
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var receivedEvents = 0;
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            await foreach (var eventData in consumer.SubscribeToEvents(cancellation.Token))
+            {
+                ++receivedEvents;
+                break;
+            }
+
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            Assert.That(receivedEvents, Is.EqualTo(0), "No events should have been received.");
+            Assert.That(GetIsPublishingActiveFlag(consumer), Is.False, "The consumer should no longer be publishing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(NonFatalNotRetriableExceptionTestCases))]
+        public void SubscribeSurfacesNonRetriableExceptions(Exception exception)
+        {
+            var transportConsumer = new ReceiveCallbackTransportConsumerMock((_max, _time) => throw exception);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), Mock.Of<EventHubRetryPolicy>());
+            var receivedEvents = 0;
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            Func<Task> invoke = async () =>
+            {
+                await foreach (var eventData in consumer.SubscribeToEvents(cancellation.Token))
+                {
+                    ++receivedEvents;
+                    break;
+                }
+            };
+
+            Assert.That(async () => await invoke(), Throws.TypeOf(exception.GetType()), "The enumerator should surface the exception.");
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            Assert.That(receivedEvents, Is.EqualTo(0), "No events should have been received.");
+            Assert.That(GetIsPublishingActiveFlag(consumer), Is.False, "The consumer should no longer be publishing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(NonFatalRetriableExceptionTestCases))]
+        public void SubscribeRetriesAndSurfacesRetriableExceptions(Exception exception)
+        {
+            const int maximumRetries = 2;
+
+            var expectedReceiveCalls = (maximumRetries + 1);
+            var receiveCalls = 0;
+
+            Func<int, TimeSpan?, IEnumerable<EventData>> receiveCallback = (_max, _time) =>
+            {
+                ++receiveCalls;
+                throw exception;
+            };
+
+            var mockRetryPolicy = new Mock<EventHubRetryPolicy>();
+            var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), mockRetryPolicy.Object);
+            var receivedEvents = 0;
+
+            mockRetryPolicy
+                .Setup(policy => policy.CalculateRetryDelay(It.Is<Exception>(value => value == exception), It.Is<int>(value => value <= maximumRetries)))
+                .Returns(TimeSpan.FromMilliseconds(5));
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            Func<Task> invoke = async () =>
+            {
+                await foreach (var eventData in consumer.SubscribeToEvents(cancellation.Token))
+                {
+                    ++receivedEvents;
+                    break;
+                }
+            };
+
+            Assert.That(async () => await invoke(), Throws.TypeOf(exception.GetType()), "The enumerator should surface the exception.");
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            Assert.That(receiveCalls, Is.EqualTo(expectedReceiveCalls), "The retry policy should have been applied.");
+            Assert.That(receivedEvents, Is.EqualTo(0), "No events should have been received.");
+            Assert.That(GetIsPublishingActiveFlag(consumer), Is.False, "The consumer should no longer be publishing.");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubConsumer.SubscribeToEvents" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(NonFatalRetriableExceptionTestCases))]
+        public void SubscribeHonorsRetryPolicyForRetriableExceptions(Exception exception)
+        {
+            var receiveCalls = 0;
+
+            Func<int, TimeSpan?, IEnumerable<EventData>> receiveCallback = (_max, _time) =>
+            {
+                ++receiveCalls;
+                throw exception;
+            };
+
+            var mockRetryPolicy = new Mock<EventHubRetryPolicy>();
+            var transportConsumer = new ReceiveCallbackTransportConsumerMock(receiveCallback);
+            var consumer = new EventHubConsumer(transportConsumer, "dummy", EventHubConsumer.DefaultConsumerGroupName, "0", EventPosition.Latest, new EventHubConsumerOptions(), mockRetryPolicy.Object);
+            var receivedEvents = 0;
+
+            mockRetryPolicy
+                .Setup(policy => policy.CalculateRetryDelay(It.IsAny<Exception>(), It.IsAny<int>()))
+                .Returns(default(TimeSpan?));
+
+            using var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+            Func<Task> invoke = async () =>
+            {
+                await foreach (var eventData in consumer.SubscribeToEvents(cancellation.Token))
+                {
+                    ++receivedEvents;
+                    break;
+                }
+            };
+
+            Assert.That(async () => await invoke(), Throws.TypeOf(exception.GetType()), "The enumerator should surface the exception.");
+            Assert.That(cancellation.IsCancellationRequested, Is.False, "The iteration should have completed normally.");
+            Assert.That(receiveCalls, Is.EqualTo(1), "The retry policy should have been respected.");
+            Assert.That(receivedEvents, Is.EqualTo(0), "No events should have been received.");
+            Assert.That(GetIsPublishingActiveFlag(consumer), Is.False, "The consumer should no longer be publishing.");
+        }
+
+        /// <summary>
+        ///   Retrieves the active channels for a consumer, using its private field.
+        /// </summary>
+        ///
+        /// <param name="consumer">The consumer to retrieve the channels for.</param>
+        ///
+        /// <returns>The set of active channels for the consumer.</returns>
+        ///
+        private ConcurrentDictionary<Guid, Channel<EventData>> GetActiveChannels(EventHubConsumer consumer) =>
+            (ConcurrentDictionary<Guid, Channel<EventData>>)
+                typeof(EventHubConsumer)
+                    .GetField("ActiveChannels", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(consumer);
+
+        /// <summary>
+        ///   Retrieves the "is publishing" flag for a consumer, using its private field.
+        /// </summary>
+        ///
+        /// <param name="consumer">The consumer to retrieve the channels for.</param>
+        ///
+        /// <returns>The flag that indicates whether or not a consumer is publishing events in the background.</returns>
+        ///
+        private bool GetIsPublishingActiveFlag(EventHubConsumer consumer) =>
+            (bool)
+                typeof(EventHubConsumer)
+                    .GetField("_isPublishingActive", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .GetValue(consumer);
+
+        /// <summary>
+        ///   Retrieves the number of background publish event batch size for a consumer, using its private field.
+        /// </summary>
+        ///
+        /// <param name="consumer">The consumer to retrieve the channels for.</param>
+        ///
+        /// <returns>The size of the batch that is received when publishing events in the background.</returns>
+        ///
+        private int GetBackgroundPublishReceiveBatchSize(EventHubConsumer consumer) =>
+            (int)
+                typeof(EventHubConsumer)
+                    .GetField("BackgroundPublishReceiveBatchSize", BindingFlags.Static | BindingFlags.NonPublic)
+                    .GetValue(consumer);
+
+        /// <summary>
         ///   Allows for observation of operations performed by the consumer for testing purposes.
         /// </summary>
         ///
@@ -333,7 +1113,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                       CancellationToken cancellationToken)
             {
                 ReceiveCalledWith = (maximumMessageCount, maximumWaitTime);
-                return Task.FromResult(default(IEnumerable<EventData>));
+                return Task.FromResult(Enumerable.Empty<EventData>());
             }
 
             public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy)
@@ -346,6 +1126,99 @@ namespace Azure.Messaging.EventHubs.Tests
                 WasCloseCalled = true;
                 return Task.CompletedTask;
             }
+        }
+
+        /// <summary>
+        ///   Allows for publishing a known set of events in response to receive calls
+        ///   by the consumer for testing purposes.
+        /// </summary>
+        ///
+        private class PublishingTransportConsumerMock : TransportEventHubConsumer
+        {
+            public bool IsPublishingStarted = false;
+            public IList<EventData> EventsToPublish = new List<EventData>(0);
+            public Func<TimeSpan?> PublishDelayCallback = () => null;
+            public int PublishIndex = 0;
+
+            public PublishingTransportConsumerMock(IList<EventData> eventsToPublish = null,
+                                                   bool startPublishing = false,
+                                                   Func<TimeSpan?> publishDelayCallback = null) : base()
+            {
+                if (eventsToPublish != null)
+                {
+                    EventsToPublish = eventsToPublish;
+                }
+
+                if (publishDelayCallback != null)
+                {
+                    PublishDelayCallback = publishDelayCallback;
+                }
+
+                IsPublishingStarted = startPublishing;
+            }
+
+            public void StartPublishing() => IsPublishingStarted = true;
+
+            public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken)
+            {
+                if (!IsPublishingStarted)
+                {
+                    return Task.FromResult(Enumerable.Empty<EventData>());
+                }
+
+                var stopWatch = Stopwatch.StartNew();
+                PublishDelayCallback?.Invoke();
+                stopWatch.Stop();
+
+                if (((maximumWaitTime.HasValue) && (stopWatch.Elapsed >= maximumWaitTime))  || (PublishIndex >= EventsToPublish.Count))
+                {
+                    return Task.FromResult(Enumerable.Empty<EventData>());
+                }
+
+                var index = PublishIndex;
+
+                if (index + maximumMessageCount > EventsToPublish.Count)
+                {
+                   maximumMessageCount = (EventsToPublish.Count - index);
+                }
+
+                PublishIndex = (index + maximumMessageCount);
+                var source = EventsToPublish.Skip(index).Take(maximumMessageCount).ToList();
+
+                return Task.FromResult((IEnumerable<EventData>)source);
+            }
+
+            public override Task CloseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy){}
+        }
+
+        /// <summary>
+        ///   Allows for invoking a callback in response to receive calls
+        ///   by the consumer for testing purposes.
+        /// </summary>
+        ///
+        private class ReceiveCallbackTransportConsumerMock : TransportEventHubConsumer
+        {
+            public Func<int, TimeSpan?, IEnumerable<EventData>> ReceiveCallback = (_max, _wait) => Enumerable.Empty<EventData>();
+
+            public ReceiveCallbackTransportConsumerMock(Func<int, TimeSpan?, IEnumerable<EventData>> receiveCallback = null) : base()
+            {
+                if (receiveCallback != null)
+                {
+                    ReceiveCallback = receiveCallback;
+                }
+            }
+
+            public override Task<IEnumerable<EventData>> ReceiveAsync(int maximumMessageCount, TimeSpan? maximumWaitTime, CancellationToken cancellationToken)
+            {
+                var results = ReceiveCallback(maximumMessageCount, maximumWaitTime);
+                return Task.FromResult(results);
+            }
+
+            public override Task CloseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+            public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy){}
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -266,10 +266,31 @@ namespace Azure.Messaging.EventHubs.Tests
                 {
                     // Actual limit is 1046520 for a single event.
                     var singleEvent = new EventData(new byte[100000]);
-                    var eventBatch = new[] { new EventData(new byte[100000]) };
 
                     Assert.That(async () => await producer.SendAsync(singleEvent), Throws.Nothing);
-                    Assert.That(async () => await producer.SendAsync(eventBatch), Throws.Nothing);
+                }
+            }
+        }
+
+        /// <summary>
+        ///   Verifies that the <see cref="EventHubProducer" /> is able to
+        ///   connect to the Event Hubs service and perform operations.
+        /// </summary>
+        ///
+        [Test]
+        public async Task ProducerCanSendSingleLargeEventInASet()
+        {
+            await using (var scope = await EventHubScope.CreateAsync(1))
+            {
+                var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
+
+                await using (var client = new EventHubClient(connectionString, new EventHubClientOptions { RetryOptions = new RetryOptions { TryTimeout = TimeSpan.FromMinutes(5) } }))
+                await using (var producer = client.CreateProducer())
+                {
+                    // Actual limit is 1046520 for a single event.
+                    var eventSet = new[] { new EventData(new byte[100000]) };
+
+                    Assert.That(async () => await producer.SendAsync(eventSet), Throws.Nothing);
                 }
             }
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/BasicRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/BasicRetryPolicyTests.cs
@@ -28,7 +28,6 @@ namespace Azure.Messaging.EventHubs.Tests
         public static IEnumerable<object[]> RetriableExceptionTestCases()
         {
             yield return new object[] { new TimeoutException() };
-            yield return new object[] { new OperationCanceledException() };
             yield return new object[] { new SocketException(500) };
 
             // Task Canceled should use the inner exception as the decision point.


### PR DESCRIPTION
# Summary

The intent of these changes is to implement a means to receive events with a streaming approach via an asynchronous iterator.

### Goals

- Introduction of `System.Threading.Channels` package for internal publish/subscribe usage.

- Implementation of a background publishing loop based on a `ChannelWriter`, intended to make events available to subscribed iterators.

- Creation of an asynchronous enumerator abstraction aimed at consuming  a `ChannelReader`.

- Tweaks around test timing to help stablize nightly test runs due to environmental differences around timing.

# Last Upstream Rebase

Friday, August 2, 2019  2:39pm (EDT)

# Resources

- [Azure Messaging Exception Documentation](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions)
- [.NET Event Hubs Client: Second Preview Design Proposal](https://github.com/jsquire/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-second-preview.md)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 2](https://github.com/Azure/azure-sdk-for-net/issues/6752) (#6752)
- [Implement streaming receive feature in Event Hub consumer](https://github.com/Azure/azure-sdk-for-net/issues/6788) (#6788)