### PR TITLE
[Event Hubs Client] Track Two: Second Preview (EventHubPath Rename)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs
@@ -49,7 +49,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 EventHubProperties properties = await client.GetPropertiesAsync();
 
                 Console.WriteLine("The Event Hub has the following properties:");
-                Console.WriteLine($"\tThe path to the Event Hub from the namespace is: { properties.Path }");
+                Console.WriteLine($"\tThe path to the Event Hub from the namespace is: { properties.Name }");
                 Console.WriteLine($"\tThe Event Hub was created at: { properties.CreatedAt.ToString("yyyy-MM-dd hh:mm:ss tt (zzz)") }, in UTC.");
                 Console.WriteLine();
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample2_ClientWithCustomOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample2_ClientWithCustomOptions.cs
@@ -68,7 +68,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 EventHubProperties properties = await client.GetPropertiesAsync();
 
                 Console.WriteLine("The Event Hub has the following properties:");
-                Console.WriteLine($"\tThe path to the Event Hub from the namespace is: { properties.Path }");
+                Console.WriteLine($"\tThe path to the Event Hub from the namespace is: { properties.Name }");
                 Console.WriteLine($"\tThe Event Hub was created at: { properties.CreatedAt.ToString("yyyy-MM-dd hh:mm:ss tt (zzz)") }, in UTC.");
                 Console.WriteLine("\tThe Event Hub has the following partitions:");
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/AzureClientBuilderExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/AzureClientBuilderExtensions.cs
@@ -15,34 +15,34 @@ namespace Azure.ApplicationModel.Configuration
         /// Registers a <see cref="EventHubClient"/> instance with the provided <paramref name="connectionString"/>
         /// </summary>
         public static IAzureClientBuilder<EventHubClient, EventHubClientOptions> AddEventHubClient<TBuilder>(this TBuilder builder, string connectionString)
-            where TBuilder: IAzureClientFactoryBuilder
+            where TBuilder : IAzureClientFactoryBuilder
         {
             return builder.RegisterClientFactory<EventHubClient, EventHubClientOptions>(options => new EventHubClient(connectionString, options));
         }
 
         /// <summary>
-        /// Registers a <see cref="EventHubClient"/> instance with the provided <paramref name="connectionString"/> and <paramref name="eventHubPath"/>
+        /// Registers a <see cref="EventHubClient"/> instance with the provided <paramref name="connectionString"/> and <paramref name="eventHubName"/>
         /// </summary>
-        public static IAzureClientBuilder<EventHubClient, EventHubClientOptions> AddEventHubClient<TBuilder>(this TBuilder builder, string connectionString, string eventHubPath)
-            where TBuilder: IAzureClientFactoryBuilder
+        public static IAzureClientBuilder<EventHubClient, EventHubClientOptions> AddEventHubClient<TBuilder>(this TBuilder builder, string connectionString, string eventHubName)
+            where TBuilder : IAzureClientFactoryBuilder
         {
-            return builder.RegisterClientFactory<EventHubClient, EventHubClientOptions>(options => new EventHubClient(connectionString, eventHubPath, options));
+            return builder.RegisterClientFactory<EventHubClient, EventHubClientOptions>(options => new EventHubClient(connectionString, eventHubName, options));
         }
 
         /// <summary>
-        /// Registers a <see cref="EventHubClient"/> instance with the provided <paramref name="host"/> and <paramref name="eventHubPath"/>
+        /// Registers a <see cref="EventHubClient"/> instance with the provided <paramref name="host"/> and <paramref name="eventHubName"/>
         /// </summary>
-        public static IAzureClientBuilder<EventHubClient, EventHubClientOptions> AddEventHubClientWithHost<TBuilder>(this TBuilder builder, string host, string eventHubPath)
-            where TBuilder: IAzureClientFactoryBuilderWithCredential
+        public static IAzureClientBuilder<EventHubClient, EventHubClientOptions> AddEventHubClientWithHost<TBuilder>(this TBuilder builder, string host, string eventHubName)
+            where TBuilder : IAzureClientFactoryBuilderWithCredential
         {
-            return builder.RegisterClientFactory<EventHubClient, EventHubClientOptions>((options, token) => new EventHubClient(host, eventHubPath, token, options));
+            return builder.RegisterClientFactory<EventHubClient, EventHubClientOptions>((options, token) => new EventHubClient(host, eventHubName, token, options));
         }
 
         /// <summary>
         /// Registers a <see cref="EventHubClient"/> instance with connection options loaded from the provided <paramref name="configuration"/> instance.
         /// </summary>
         public static IAzureClientBuilder<EventHubClient, EventHubClientOptions> AddEventHubClient<TBuilder, TConfiguration>(this TBuilder builder, TConfiguration configuration)
-            where TBuilder: IAzureClientFactoryBuilderWithConfiguration<TConfiguration>
+            where TBuilder : IAzureClientFactoryBuilderWithConfiguration<TConfiguration>
         {
             return builder.RegisterClientFactory<EventHubClient, EventHubClientOptions>(configuration);
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubClient.cs
@@ -40,7 +40,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         /// </summary>
         ///
         /// <param name="host">The fully qualified host name for the Event Hubs namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
-        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to connect the client to.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requeseted Event Hub, depending on Azure configuration.</param>
         /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
         /// <param name="defaultRetryPolicy">The default retry policy to use if no retry options were specified in the <paramref name="clientOptions" />.</param>
@@ -55,10 +55,10 @@ namespace Azure.Messaging.EventHubs.Compatibility
         /// </remarks>
         ///
         public TrackOneEventHubClient(string host,
-                                      string eventHubPath,
+                                      string eventHubName,
                                       TokenCredential credential,
                                       EventHubClientOptions clientOptions,
-                                      EventHubRetryPolicy defaultRetryPolicy) : this(host, eventHubPath, credential, clientOptions, defaultRetryPolicy, CreateClient)
+                                      EventHubRetryPolicy defaultRetryPolicy) : this(host, eventHubName, credential, clientOptions, defaultRetryPolicy, CreateClient)
         {
         }
 
@@ -67,7 +67,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         /// </summary>
         ///
         /// <param name="host">The fully qualified host name for the Event Hubs namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
-        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to connect the client to.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requeseted Event Hub, depending on Azure configuration.</param>
         /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
         /// <param name="defaultRetryPolicy">The default retry policy to use if no retry options were specified in the <paramref name="clientOptions" />.</param>
@@ -83,20 +83,20 @@ namespace Azure.Messaging.EventHubs.Compatibility
         /// </remarks>
         ///
         public TrackOneEventHubClient(string host,
-                                      string eventHubPath,
+                                      string eventHubName,
                                       TokenCredential credential,
                                       EventHubClientOptions clientOptions,
                                       EventHubRetryPolicy defaultRetryPolicy,
                                       Func<string, string, TokenCredential, EventHubClientOptions, Func<EventHubRetryPolicy>, TrackOne.EventHubClient> eventHubClientFactory)
         {
             Guard.ArgumentNotNullOrEmpty(nameof(host), host);
-            Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
+            Guard.ArgumentNotNullOrEmpty(nameof(eventHubName), eventHubName);
             Guard.ArgumentNotNull(nameof(credential), credential);
             Guard.ArgumentNotNull(nameof(clientOptions), clientOptions);
             Guard.ArgumentNotNull(nameof(defaultRetryPolicy), defaultRetryPolicy);
 
             _retryPolicy = defaultRetryPolicy;
-            _trackOneClient = new Lazy<TrackOne.EventHubClient>(() => eventHubClientFactory(host, eventHubPath, credential, clientOptions, () => _retryPolicy), LazyThreadSafetyMode.PublicationOnly);
+            _trackOneClient = new Lazy<TrackOne.EventHubClient>(() => eventHubClientFactory(host, eventHubName, credential, clientOptions, () => _retryPolicy), LazyThreadSafetyMode.PublicationOnly);
         }
 
         /// <summary>
@@ -105,7 +105,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         /// </summary>
         ///
         /// <param name="host">The fully qualified host name for the Event Hubs namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
-        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to connect the client to.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requeseted Event Hub, depending on Azure configuration.</param>
         /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
         /// <param name="defaultRetryPolicyFactory">A function that retrieves a default retry policy to use if no retry options were specified in the <paramref name="clientOptions" />.</param>
@@ -113,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         /// <returns>The <see cref="TrackOne.EventHubClient" /> to use.</returns>
         ///
         public static TrackOne.EventHubClient CreateClient(string host,
-                                                           string eventHubPath,
+                                                           string eventHubName,
                                                            TokenCredential credential,
                                                            EventHubClientOptions clientOptions,
                                                            Func<EventHubRetryPolicy> defaultRetryPolicyFactory)
@@ -160,7 +160,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
             {
                 Scheme = clientOptions.TransportType.GetUriScheme(),
                 Host = host,
-                Path = eventHubPath,
+                Path = eventHubName,
                 Port = -1,
             };
 
@@ -171,7 +171,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
                 : defaultRetryPolicyFactory();
 
             var operationTimeout = retryPolicy.CalculateTryTimeout(0);
-            var client = TrackOne.EventHubClient.Create(endpointBuilder.Uri, eventHubPath, tokenProvider, operationTimeout, transportType);
+            var client = TrackOne.EventHubClient.Create(endpointBuilder.Uri, eventHubName, tokenProvider, operationTimeout, transportType);
 
             client.WebProxy = clientOptions.Proxy;
             client.RetryPolicy = new TrackOneRetryPolicy(retryPolicy);
@@ -226,7 +226,7 @@ namespace Azure.Messaging.EventHubs.Compatibility
         }
 
         /// <summary>
-        ///   Retrieves information about a specific partiton for an Event Hub, including elements that describe the available
+        ///   Retrieves information about a specific partition for an Event Hub, including elements that describe the available
         ///   events in the partition event stream.
         /// </summary>
         ///

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ConnectionStringParser.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ConnectionStringParser.cs
@@ -24,8 +24,8 @@ namespace Azure.Messaging.EventHubs.Core
         /// <summary>The token that identifies the endpoint address for the Event Hubs namespace.</summary>
         private const string EndpointToken = "Endpoint";
 
-        /// <summary>The token that identifies the path to a specific Event Hub under the namespace.</summary>
-        private const string EventHubPathToken = "EntityPath";
+        /// <summary>The token that identifies the name of a specific Event Hub under the namespace.</summary>
+        private const string EventHubNameToken = "EntityPath";
 
         /// <summary>The token that identifies the name of a shared access key.</summary>
         private const string SharedAccessKeyNameToken = "SharedAccessKeyName";
@@ -59,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Core
             var parsedValues =
             (
                 EndpointToken: default(UriBuilder),
-                EventHubPathToken: default(string),
+                EventHubNameToken: default(string),
                 SharedAccessKeyNameToken: default(string),
                 SharedAccessKeyValueToken: default(string)
             );
@@ -116,9 +116,9 @@ namespace Azure.Messaging.EventHubs.Core
                         parsedValues.EndpointToken = new UriBuilder(value);
                         parsedValues.EndpointToken.Scheme = EventHubsEndpointScheme;
                     }
-                    else if (String.Compare(EventHubPathToken, token, StringComparison.OrdinalIgnoreCase) == 0)
+                    else if (String.Compare(EventHubNameToken, token, StringComparison.OrdinalIgnoreCase) == 0)
                     {
-                        parsedValues.EventHubPathToken = value;
+                        parsedValues.EventHubNameToken = value;
                     }
                     else if (String.Compare(SharedAccessKeyNameToken, token, StringComparison.OrdinalIgnoreCase) == 0)
                     {
@@ -131,7 +131,7 @@ namespace Azure.Messaging.EventHubs.Core
                 }
                 else if ((slice.Length != 1) || (slice[0] != TokenValuePairDelimiter))
                 {
-                    // This wasn't a legal pair and it is not simply a trailing delmieter; consider
+                    // This wasn't a legal pair and it is not simply a trailing delimiter; consider
                     // the connection string to be malformed.
 
                     throw new FormatException(Resources.InvalidConnectionString);
@@ -144,7 +144,7 @@ namespace Azure.Messaging.EventHubs.Core
             return new ConnectionStringProperties
             (
                 parsedValues.EndpointToken?.Uri,
-                parsedValues.EventHubPathToken,
+                parsedValues.EventHubNameToken,
                 parsedValues.SharedAccessKeyNameToken,
                 parsedValues.SharedAccessKeyValueToken
             );

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubClient.cs
@@ -28,11 +28,11 @@ namespace Azure.Messaging.EventHubs
         private EventHubRetryPolicy _retryPolicy;
 
         /// <summary>
-        ///   The path of the specific Event Hub that the client is connected to, relative
-        ///   to the Event Hubs namespace that contains it.
+        ///   The name of the Event Hub that the client is connected to, specific to the
+        ///   Event Hubs namespace that contains it.
         /// </summary>
         ///
-        public string EventHubPath { get; }
+        public string EventHubName { get; }
 
         /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
@@ -71,15 +71,15 @@ namespace Azure.Messaging.EventHubs
         ///   Initializes a new instance of the <see cref="EventHubClient"/> class.
         /// </summary>
         ///
-        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub path and the shared key properties are contained in this connection string.</param>
+        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and the shared key properties are contained in this connection string.</param>
         ///
         /// <remarks>
-        ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the path to the desired Event Hub,
-        ///   which is needed.  In this case, the path can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the
+        ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
+        ///   which is needed.  In this case, the name can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the
         ///   connection string.  For example, ";EntityPath=telemetry-hub".
         ///
         ///   If you have defined a shared access policy directly on the Event Hub itself, then copying the connection string from that
-        ///   Event Hub will result in a connection string that contains the path.
+        ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
         public EventHubClient(string connectionString) : this(connectionString, null, null)
@@ -90,16 +90,16 @@ namespace Azure.Messaging.EventHubs
         ///   Initializes a new instance of the <see cref="EventHubClient"/> class.
         /// </summary>
         ///
-        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub path and SAS token are contained in this connection string.</param>
+        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and SAS token are contained in this connection string.</param>
         /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
         ///
         /// <remarks>
-        ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the path to the desired Event Hub,
-        ///   which is needed.  In this case, the path can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the
+        ///   If the connection string is copied from the Event Hubs namespace, it will likely not contain the name of the desired Event Hub,
+        ///   which is needed.  In this case, the name can be added manually by adding ";EntityPath=[[ EVENT HUB NAME ]]" to the end of the
         ///   connection string.  For example, ";EntityPath=telemetry-hub".
         ///
         ///   If you have defined a shared access policy directly on the Event Hub itself, then copying the connection string from that
-        ///   Event Hub will result in a connection string that contains the path.
+        ///   Event Hub will result in a connection string that contains the name.
         /// </remarks>
         ///
         public EventHubClient(string connectionString,
@@ -111,17 +111,17 @@ namespace Azure.Messaging.EventHubs
         ///   Initializes a new instance of the <see cref="EventHubClient"/> class.
         /// </summary>
         ///
-        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the shared key properties are contained in this connection string, but not the Event Hub path.</param>
-        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the shared key properties are contained in this connection string, but not the Event Hub name.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to connect the client to.</param>
         ///
         /// <remarks>
-        ///   If the connection string is copied from the Event Hub itself, it will contain the path to the desired Event Hub,
-        ///   and can be used directly without passing the <paramref name="eventHubPath" />.  The path to the Event Hub should be
+        ///   If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
+        ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
         ///   passed only once, either as part of the connection string or separately.
         /// </remarks>
         ///
         public EventHubClient(string connectionString,
-                              string eventHubPath) : this(connectionString, eventHubPath, null)
+                              string eventHubName) : this(connectionString, eventHubName, null)
         {
         }
 
@@ -129,18 +129,18 @@ namespace Azure.Messaging.EventHubs
         ///   Initializes a new instance of the <see cref="EventHubClient"/> class.
         /// </summary>
         ///
-        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub path and SAS token are contained in this connection string.</param>
-        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="connectionString">The connection string to use for connecting to the Event Hubs namespace; it is expected that the Event Hub name and SAS token are contained in this connection string.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to connect the client to.</param>
         /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
         ///
         /// <remarks>
-        ///   If the connection string is copied from the Event Hub itself, it will contain the path to the desired Event Hub,
-        ///   and can be used directly without passing the <paramref name="eventHubPath" />.  The path to the Event Hub should be
+        ///   If the connection string is copied from the Event Hub itself, it will contain the name of the desired Event Hub,
+        ///   and can be used directly without passing the <paramref name="eventHubName" />.  The name of the Event Hub should be
         ///   passed only once, either as part of the connection string or separately.
         /// </remarks>
         ///
         public EventHubClient(string connectionString,
-                              string eventHubPath,
+                              string eventHubName,
                               EventHubClientOptions clientOptions)
         {
             clientOptions = clientOptions?.Clone() ?? new EventHubClientOptions();
@@ -149,26 +149,26 @@ namespace Azure.Messaging.EventHubs
             ValidateClientOptions(clientOptions);
 
             var connectionStringProperties = ParseConnectionString(connectionString);
-            ValidateConnectionProperties(connectionStringProperties, eventHubPath, nameof(connectionString));
+            ValidateConnectionProperties(connectionStringProperties, eventHubName, nameof(connectionString));
 
             var eventHubsHostName = connectionStringProperties.Endpoint.Host;
 
-            if (String.IsNullOrEmpty(eventHubPath))
+            if (String.IsNullOrEmpty(eventHubName))
             {
-                eventHubPath = connectionStringProperties.EventHubPath;
+                eventHubName = connectionStringProperties.EventHubName;
             }
 
             var sharedAccessSignature = new SharedAccessSignature
             (
-                 BuildResource(clientOptions.TransportType, eventHubsHostName, eventHubPath),
+                 BuildResource(clientOptions.TransportType, eventHubsHostName, eventHubName),
                  connectionStringProperties.SharedAccessKeyName,
                  connectionStringProperties.SharedAccessKey
             );
 
             _retryPolicy = new BasicRetryPolicy(clientOptions.RetryOptions);
             ClientOptions = clientOptions;
-            EventHubPath = eventHubPath;
-            InnerClient = BuildTransportClient(eventHubsHostName, eventHubPath, new SharedAccessSignatureCredential(sharedAccessSignature), clientOptions, _retryPolicy);
+            EventHubName = eventHubName;
+            InnerClient = BuildTransportClient(eventHubsHostName, eventHubName, new SharedAccessSignatureCredential(sharedAccessSignature), clientOptions, _retryPolicy);
         }
 
         /// <summary>
@@ -176,19 +176,19 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="host">The fully qualified host name for the Event Hubs namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
-        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
-        /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requeseted Event Hub, depending on Azure configuration.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to connect the client to.</param>
+        /// <param name="credential">The Azure managed identity credential to use for authorization.  Access controls may be specified by the Event Hubs namespace or the requested Event Hub, depending on Azure configuration.</param>
         /// <param name="clientOptions">A set of options to apply when configuring the client.</param>
         ///
         public EventHubClient(string host,
-                              string eventHubPath,
+                              string eventHubName,
                               TokenCredential credential,
                               EventHubClientOptions clientOptions = default)
         {
             clientOptions = clientOptions?.Clone() ?? new EventHubClientOptions();
 
             Guard.ArgumentNotNullOrEmpty(nameof(host), host);
-            Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
+            Guard.ArgumentNotNullOrEmpty(nameof(eventHubName), eventHubName);
             Guard.ArgumentNotNull(nameof(credential), credential);
             ValidateClientOptions(clientOptions);
 
@@ -198,18 +198,18 @@ namespace Azure.Messaging.EventHubs
                     break;
 
                 case EventHubSharedKeyCredential sharedKeyCredential:
-                    credential = sharedKeyCredential.ConvertToSharedAccessSignatureCredential(BuildResource(clientOptions.TransportType, host, eventHubPath));
+                    credential = sharedKeyCredential.ConvertToSharedAccessSignatureCredential(BuildResource(clientOptions.TransportType, host, eventHubName));
                     break;
 
                 default:
-                    credential = new EventHubTokenCredential(credential, BuildResource(clientOptions.TransportType, host, eventHubPath));
+                    credential = new EventHubTokenCredential(credential, BuildResource(clientOptions.TransportType, host, eventHubName));
                     break;
             }
 
             _retryPolicy = new BasicRetryPolicy(clientOptions.RetryOptions);
-            EventHubPath = eventHubPath;
+            EventHubName = eventHubName;
             ClientOptions = clientOptions;
-            InnerClient = BuildTransportClient(host, eventHubPath, credential, clientOptions, _retryPolicy);
+            InnerClient = BuildTransportClient(host, eventHubName, credential, clientOptions, _retryPolicy);
         }
 
         /// <summary>
@@ -407,12 +407,12 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="host">The fully qualified host name for the Event Hubs namespace.</param>
-        /// <param name="eventHubPath">The path to a specific Event Hub.</param>
+        /// <param name="eventHubName">The name of a specific Event Hub.</param>
         /// <param name="credential">The Azure managed identity credential to use for authorization.</param>
         /// <param name="options">The set of options to use for the client.</param>
         /// <param name="defaultRetryPolicy">The default retry policy to use if no retry options were specified in the <paramref name="options" />.</param>
         ///
-        /// <returns>A client generalization spcecific to the specified protocol/transport to which operations may be delegated.</returns>
+        /// <returns>A client generalization specific to the specified protocol/transport to which operations may be delegated.</returns>
         ///
         /// <remarks>
         ///   As an internal method, only basic sanity checks are performed against arguments.  It is
@@ -423,7 +423,7 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         internal virtual TransportEventHubClient BuildTransportClient(string host,
-                                                                      string eventHubPath,
+                                                                      string eventHubName,
                                                                       TokenCredential credential,
                                                                       EventHubClientOptions options,
                                                                       EventHubRetryPolicy defaultRetryPolicy)
@@ -432,7 +432,7 @@ namespace Azure.Messaging.EventHubs
             {
                 case TransportType.AmqpTcp:
                 case TransportType.AmqpWebSockets:
-                    return new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetryPolicy);
+                    return new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetryPolicy);
 
                 default:
                     throw new ArgumentException(String.Format(CultureInfo.CurrentCulture, Resources.InvalidTransportType, options.TransportType.ToString()), nameof(options.TransportType));
@@ -445,18 +445,18 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="transportType">The type of protocol and transport that will be used for communicating with the Event Hubs service.</param>
         /// <param name="host">The fully qualified host name for the Event Hubs namespace.  This is likely to be similar to <c>{yournamespace}.servicebus.windows.net</c>.</param>
-        /// <param name="eventHubPath">The path of the specific Event Hub to connect the client to.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub to connect the client to.</param>
         ///
         /// <returns>The value to use as the audience of the signature.</returns>
         ///
         private static string BuildResource(TransportType transportType,
                                             string host,
-                                            string eventHubPath)
+                                            string eventHubName)
         {
             var builder = new UriBuilder(host)
             {
                 Scheme = transportType.GetUriScheme(),
-                Path = eventHubPath,
+                Path = eventHubName,
                 Port = -1,
                 Fragment = String.Empty,
                 Password = String.Empty,
@@ -477,29 +477,29 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="properties">The set of properties parsed from the connection string associated this client.</param>
-        /// <param name="eventHubPath">The path of the Event Hub passed independent of the connection string, allowing easier use of a namespace-level connection string.</param>
+        /// <param name="eventHubName">The name of the Event Hub passed independent of the connection string, allowing easier use of a namespace-level connection string.</param>
         /// <param name="connectionStringArgumentName">The name of the argument associated with the connection string; to be used when raising <see cref="ArgumentException" /> variants.</param>
         ///
         /// <remarks>
-        ///   In the case that the prioperties violate an invariant or otherwise represent a combination that
+        ///   In the case that the properties violate an invariant or otherwise represent a combination that
         ///   is not permissible, an appropriate exception will be thrown.
         /// </remarks>
         ///
         private static void ValidateConnectionProperties(ConnectionStringProperties properties,
-                                                         string eventHubPath,
+                                                         string eventHubName,
                                                          string connectionStringArgumentName)
         {
-            // The Event Hub path may only be specified in one of the possible forms, either as part of the
+            // The Event Hub name may only be specified in one of the possible forms, either as part of the
             // connection string or as a stand-alone parameter, but not both.
 
-            if ((!String.IsNullOrEmpty(eventHubPath)) && (!String.IsNullOrEmpty(properties.EventHubPath)))
+            if ((!String.IsNullOrEmpty(eventHubName)) && (!String.IsNullOrEmpty(properties.EventHubName)))
             {
                 throw new ArgumentException(Resources.OnlyOneEventHubNameMayBeSpecified, connectionStringArgumentName);
             }
 
             // Ensure that each of the needed components are present for connecting.
 
-            if ((String.IsNullOrEmpty(eventHubPath)) && (String.IsNullOrEmpty(properties.EventHubPath))
+            if ((String.IsNullOrEmpty(eventHubName)) && (String.IsNullOrEmpty(properties.EventHubName))
                 || (String.IsNullOrEmpty(properties.Endpoint?.Host))
                 || (String.IsNullOrEmpty(properties.SharedAccessKeyName))
                 || (String.IsNullOrEmpty(properties.SharedAccessKey)))

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventHubProducer.cs
@@ -52,11 +52,11 @@ namespace Azure.Messaging.EventHubs
         public string PartitionId { get; }
 
         /// <summary>
-        ///   The path of the specific Event Hub that the producer is connected to, relative
-        ///   to the Event Hubs namespace that contains it.
+        ///   The name of the Event Hub that the producer is connected to, specific to the
+        ///   Event Hubs namespace that contains it.
         /// </summary>
         ///
-        public string EventHubPath { get; }
+        public string EventHubName { get; }
 
         /// <summary>
         ///   The policy to use for determining retry behavior for when an operation fails.
@@ -96,7 +96,7 @@ namespace Azure.Messaging.EventHubs
         /// </summary>
         ///
         /// <param name="transportProducer">An abstracted Event Hub producer specific to the active protocol and transport intended to perform delegated operations.</param>
-        /// <param name="eventHubPath">The path of the Event Hub to which events will be sent.</param>
+        /// <param name="eventHubName">The name of the Event Hub to which events will be sent.</param>
         /// <param name="producerOptions">The set of options to use for this consumer.</param>
         /// <param name="retryPolicy">The policy to apply when making retry decisions for failed operations.</param>
         ///
@@ -107,17 +107,17 @@ namespace Azure.Messaging.EventHubs
         /// </remarks>
         ///
         internal EventHubProducer(TransportEventHubProducer transportProducer,
-                                  string eventHubPath,
+                                  string eventHubName,
                                   EventHubProducerOptions producerOptions,
                                   EventHubRetryPolicy retryPolicy)
         {
             Guard.ArgumentNotNull(nameof(transportProducer), transportProducer);
-            Guard.ArgumentNotNullOrEmpty(nameof(eventHubPath), eventHubPath);
+            Guard.ArgumentNotNullOrEmpty(nameof(eventHubName), eventHubName);
             Guard.ArgumentNotNull(nameof(producerOptions), producerOptions);
             Guard.ArgumentNotNull(nameof(retryPolicy), retryPolicy);
 
             PartitionId = producerOptions.PartitionId;
-            EventHubPath = eventHubPath;
+            EventHubName = eventHubName;
             Options = producerOptions;
             InnerProducer = transportProducer;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/ConnectionStringProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/ConnectionStringProperties.cs
@@ -21,10 +21,10 @@ namespace Azure.Messaging.EventHubs.Metadata
         public Uri Endpoint { get; }
 
         /// <summary>
-        ///   The path to the specific Event Hub under the namespace.
+        ///   The name of the specific Event Hub instance under the associated Event Hubs namespace.
         /// </summary>
         ///
-        public string EventHubPath { get; }
+        public string EventHubName { get; }
 
         /// <summary>
         ///   The name of the shared access key, either for the Event Hubs namespace
@@ -41,21 +41,21 @@ namespace Azure.Messaging.EventHubs.Metadata
         public string SharedAccessKey { get; }
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="ConnectionStringProperties"/> struct.
+        ///   Initializes a new instance of the <see cref="ConnectionStringProperties"/> structure.
         /// </summary>
         ///
         /// <param name="endpoint">The endpoint of the Event Hubs namespace.</param>
-        /// <param name="eventHubPath">The path to the specific Event Hub under the namespace.</param>
+        /// <param name="eventHubName">The name of the specific Event Hub under the namespace.</param>
         /// <param name="sharedAccessKeyName">The name of the shared access key, to use authorization.</param>
         /// <param name="sharedAccessKey">The shared access key to use for authorization.</param>
         ///
         public ConnectionStringProperties(Uri endpoint,
-                                          string eventHubPath,
+                                          string eventHubName,
                                           string sharedAccessKeyName,
                                           string sharedAccessKey)
         {
             Endpoint = endpoint;
-            EventHubPath = eventHubPath;
+            EventHubName = eventHubName;
             SharedAccessKeyName = sharedAccessKeyName;
             SharedAccessKey = sharedAccessKey;
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/EventHubProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/EventHubProperties.cs
@@ -12,11 +12,11 @@ namespace Azure.Messaging.EventHubs.Metadata
     public sealed class EventHubProperties
     {
         /// <summary>
-        ///   The path of the Event Hub, relative to the namespace
+        ///   The name of the Event Hub, specific to the namespace
         ///   that contains it.
         /// </summary>
         ///
-        public string Path { get; }
+        public string Name { get; }
 
         /// <summary>
         ///   The date and time, in UTC, at which the Event Hub was created.
@@ -34,15 +34,15 @@ namespace Azure.Messaging.EventHubs.Metadata
         ///   Initializes a new instance of the <see cref="EventHubProperties"/> class.
         /// </summary>
         ///
-        /// <param name="path">The path of the Event Hub.</param>
+        /// <param name="name">The name of the Event Hub.</param>
         /// <param name="createdAt">The date and time at which the Event Hub was created.</param>
         /// <param name="partitionIds">The set of unique identifiers for each partition.</param>
         ///
-        internal EventHubProperties(string path,
+        internal EventHubProperties(string name,
                                     DateTimeOffset createdAt,
                                     string[] partitionIds)
         {
-            Path = path;
+            Name = name;
             CreatedAt = createdAt;
             PartitionIds = partitionIds;
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/PartitionProperties.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Metadata/PartitionProperties.cs
@@ -12,11 +12,11 @@ namespace Azure.Messaging.EventHubs.Metadata
     public sealed class PartitionProperties
     {
         /// <summary>
-        ///   The path of the Event Hub that contains the partitions, relative to the namespace
-        ///   that contains it.
+        ///   The name of the Event Hub where the partitions reside, specific to the
+        ///   Event Hubs namespace that contains it.
         /// </summary>
         ///
-        public string EventHubPath { get; }
+        public string EventHubName { get; }
 
         /// <summary>
         ///   The identifier of the partition, unique to the Event Hub which contains it.
@@ -68,7 +68,7 @@ namespace Azure.Messaging.EventHubs.Metadata
         ///   Initializes a new instance of the <see cref="PartitionProperties"/> class.
         /// </summary>
         ///
-        /// <param name="path">The path of the Event Hub that contains the partitions.</param>
+        /// <param name="name">The name of the Event Hub that contains the partitions.</param>
         /// <param name="partitionId">The identifier of the partition.</param>
         /// <param name="beginningSequenceNumber">The first sequence number available for events in the partition.</param>
         /// <param name="lastSequenceNumber">The sequence number observed the last event to be enqueued in the partition.</param>
@@ -76,7 +76,7 @@ namespace Azure.Messaging.EventHubs.Metadata
         /// <param name="lastEnqueuedTime">The date and time, in UTC, that the last event was enqueued in the partition.</param>
         /// <param name="isEmpty">Indicates whether or not the partition is currently empty.</param>
         ///
-        internal PartitionProperties(string path,
+        internal PartitionProperties(string name,
                                      string partitionId,
                                      long beginningSequenceNumber,
                                      long lastSequenceNumber,
@@ -84,7 +84,7 @@ namespace Azure.Messaging.EventHubs.Metadata
                                      DateTimeOffset lastEnqueuedTime,
                                      bool isEmpty)
         {
-            EventHubPath = path;
+            EventHubName = name;
             Id = partitionId;
             BeginningSequenceNumber = beginningSequenceNumber;
             LastEnqueuedSequenceNumber = lastSequenceNumber;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/Checkpoint.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/Checkpoint.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Messaging.EventHubs.Core;
 using System;
+using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs.Processor
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/EventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/EventProcessor.cs
@@ -1,12 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Messaging.EventHubs.Core;
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs.Processor
 {
@@ -132,7 +132,7 @@ namespace Azure.Messaging.EventHubs.Processor
                         await Task.WhenAll(partitionIds
                             .Select(partitionId =>
                             {
-                                var partitionContext = new PartitionContext(InnerClient.EventHubPath, ConsumerGroup, partitionId);
+                                var partitionContext = new PartitionContext(InnerClient.EventHubName, ConsumerGroup, partitionId);
                                 var checkpointManager = new CheckpointManager(partitionContext, Manager, Identifier);
 
                                 var partitionProcessor = PartitionProcessorFactory(partitionContext, checkpointManager);
@@ -217,7 +217,7 @@ namespace Azure.Messaging.EventHubs.Processor
                         {
                             await kvp.Value.StopAsync();
                         }
-                        catch(Exception)
+                        catch (Exception)
                         {
                             // We're catching every possible unhandled exception that may have happened during Partition Pump execution.
                             // TODO: delegate the exception handling to an Exception Callback.
@@ -225,7 +225,7 @@ namespace Azure.Messaging.EventHubs.Processor
 
                         var partitionId = kvp.Key;
 
-                        var partitionContext = new PartitionContext(InnerClient.EventHubPath, ConsumerGroup, partitionId);
+                        var partitionContext = new PartitionContext(InnerClient.EventHubName, ConsumerGroup, partitionId);
                         var checkpointManager = new CheckpointManager(partitionContext, Manager, Identifier);
 
                         var partitionProcessor = PartitionProcessorFactory(partitionContext, checkpointManager);
@@ -242,7 +242,7 @@ namespace Azure.Messaging.EventHubs.Processor
 
                     await Task.Delay(1000, cancellationToken).ConfigureAwait(false);
                 }
-                catch(TaskCanceledException) { }
+                catch (TaskCanceledException) { }
             }
         }
     }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/EventProcessorOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/EventProcessorOptions.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Messaging.EventHubs.Core;
 using System;
+using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs.Processor
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionOwnership.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionOwnership.cs
@@ -1,8 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Messaging.EventHubs.Core;
 using System;
+using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs.Processor
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionPump.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/PartitionPump.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Azure.Messaging.EventHubs.Core;
 using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Core;
 
 namespace Azure.Messaging.EventHubs.Processor
 {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
@@ -45,7 +45,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(null)]
         [TestCase("")]
-        public void ConstructorRequiresTheEventHubPath(string path)
+        public void ConstructorRequiresTheEventHubName(string path)
         {
             Assert.That(() => new TrackOneEventHubClient("my.eventhub.com", path, Mock.Of<TokenCredential>(), new EventHubClientOptions(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
@@ -94,13 +94,13 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
 
-            Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetry), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetry), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -113,10 +113,10 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
+            var eventHubName = "some-path";
             var credential = Mock.Of<TokenCredential>();
 
-            Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -129,12 +129,12 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var client = TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetry);
+            var client = TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetry);
 
             try
             {
@@ -163,12 +163,12 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetry);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetry);
 
             try
             {
@@ -198,12 +198,12 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetry);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetry);
 
             try
             {
@@ -227,11 +227,11 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var credential = new EventHubTokenCredential(Mock.Of<TokenCredential>(), resource);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetry);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetry);
 
             try
             {
@@ -255,19 +255,19 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetry);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetry);
 
             try
             {
                 var endpoint = client.ConnectionStringBuilder.Endpoint;
                 Assert.That(endpoint.Scheme.ToLowerInvariant(), Contains.Substring(options.TransportType.GetUriScheme().ToLowerInvariant()), "The scheme should be part of the endpoint.");
                 Assert.That(endpoint.Host.ToLowerInvariant(), Contains.Substring(host.ToLowerInvariant()), "The host should be part of the endpoint.");
-                Assert.That(endpoint.AbsolutePath.ToLowerInvariant(), Contains.Substring(eventHubPath.ToLowerInvariant()), "The host should be part of the endpoint.");
+                Assert.That(endpoint.AbsolutePath.ToLowerInvariant(), Contains.Substring(eventHubName.ToLowerInvariant()), "The host should be part of the endpoint.");
             }
             finally
             {
@@ -281,20 +281,20 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public async Task CreateClientPopulatesTheEventHubPath()
+        public async Task CreateClientPopulatesTheEventHubName()
         {
             var options = new EventHubClientOptions();
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetry);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetry);
 
             try
             {
-                Assert.That(client.EventHubName, Is.EqualTo(eventHubPath), "The client should recognize the Event Hub path.");
+                Assert.That(client.EventHubName, Is.EqualTo(eventHubName), "The client should recognize the Event Hub path.");
             }
             finally
             {
@@ -317,12 +317,12 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetry);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetry);
 
             try
             {
@@ -356,11 +356,11 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
-            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => Mock.Of<EventHubRetryPolicy>());
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => Mock.Of<EventHubRetryPolicy>());
 
             try
             {
@@ -400,12 +400,12 @@ namespace Azure.Messaging.EventHubs.Tests
             options.ClearRetryOptions();
 
             var host = "my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetryPolicy = new BasicRetryPolicy(retryOptions);
-            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubPath, credential, options, () => defaultRetryPolicy);
+            var client = (AmqpEventHubClient)TrackOneEventHubClient.CreateClient(host, eventHubName, credential, options, () => defaultRetryPolicy);
 
             try
             {
@@ -435,14 +435,14 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var options = new EventHubClientOptions { RetryOptions = retryOptions };
             var defaultRetryPolicy = new BasicRetryPolicy(retryOptions);
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetryPolicy, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetryPolicy, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -467,13 +467,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             await client.CloseAsync(default);
             Assert.That(mock.WasCloseAsyncInvoked, Is.False);
@@ -489,13 +489,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             // Invoke an operation to force the client to be lazily instantiated.  Otherwise,
             // Close does not delegate the call.
@@ -515,13 +515,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -544,13 +544,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -575,13 +575,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -609,13 +609,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -658,13 +658,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -693,13 +693,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -736,13 +736,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -789,13 +789,13 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var options = new EventHubClientOptions();
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var defaultRetry = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetry, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -833,15 +833,15 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var options = new EventHubClientOptions();
             var defaultRetryPolicy = new BasicRetryPolicy(retryOptions);
             var newRetryPolicy = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetryPolicy, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetryPolicy, (host, path, credential, options, retry) => mock);
 
             client.UpdateRetryPolicy(newRetryPolicy);
 
@@ -865,15 +865,15 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var options = new EventHubClientOptions();
             var defaultRetryPolicy = new BasicRetryPolicy(retryOptions);
             var newRetryPolicy = Mock.Of<EventHubRetryPolicy>();
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetryPolicy, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetryPolicy, (host, path, credential, options, retry) => mock);
 
             try
             {
@@ -909,15 +909,15 @@ namespace Azure.Messaging.EventHubs.Tests
             };
 
             var host = "http://my.eventhub.com";
-            var eventHubPath = "some-path";
-            var resource = $"amqps://{ host }/{ eventHubPath }";
+            var eventHubName = "some-path";
+            var resource = $"amqps://{ host }/{ eventHubName }";
             var signature = new SharedAccessSignature(resource, "keyName", "KEY", TimeSpan.FromHours(1));
             var credential = new SharedAccessSignatureCredential(signature);
             var options = new EventHubClientOptions();
             var defaultRetryPolicy = new BasicRetryPolicy(new RetryOptions());
             var newRetryPolicy = new BasicRetryPolicy(retryOptions);
-            var mock = new ObservableClientMock(host, eventHubPath, credential, options);
-            var client = new TrackOneEventHubClient(host, eventHubPath, credential, options, defaultRetryPolicy, (host, path, credential, options, retry) => mock);
+            var mock = new ObservableClientMock(host, eventHubName, credential, options);
+            var client = new TrackOneEventHubClient(host, eventHubName, credential, options, defaultRetryPolicy, (host, path, credential, options, retry) => mock);
 
             try
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelEnumeratorSubscriptionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelEnumeratorSubscriptionTests.cs
@@ -202,7 +202,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var subscription = new ChannelEnumerableSubscription<int>(mockReader.Object, null, disposeCallback, CancellationToken.None);
 
-            await foreach(var item in subscription)
+            await foreach (var item in subscription)
             {
                 readItems.Add(item);
                 ++readIndex;
@@ -254,7 +254,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var subscription = new ChannelEnumerableSubscription<int>(mockReader.Object, null, disposeCallback, readCancellation.Token);
 
-            await foreach(var item in subscription)
+            await foreach (var item in subscription)
             {
                 ++readIndex;
 
@@ -331,7 +331,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var subscription = new ChannelEnumerableSubscription<int>(mockReader.Object, maxWaitTime, disposeCallback, readCancellation.Token);
             var stopWatch = Stopwatch.StartNew();
 
-            await foreach(var item in subscription)
+            await foreach (var item in subscription)
             {
                 ++iterateCount;
 
@@ -342,8 +342,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 if (stopWatch.Elapsed > abortTimeout)
                 {
-                   forcedAbort = true;
-                   break;
+                    forcedAbort = true;
+                    break;
                 }
             }
 
@@ -414,7 +414,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var subscription = new ChannelEnumerableSubscription<int>(mockReader.Object, null, disposeCallback, readCancellation.Token);
             var stopWatch = Stopwatch.StartNew();
 
-            await foreach(var item in subscription)
+            await foreach (var item in subscription)
             {
                 ++iterateCount;
 
@@ -425,8 +425,8 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 if (stopWatch.Elapsed > abortTimeout)
                 {
-                   forcedAbort = true;
-                   break;
+                    forcedAbort = true;
+                    break;
                 }
             }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionStringParserTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionStringParserTests.cs
@@ -83,7 +83,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.Null, "The Event Hub path was not included in the connection string");
+            Assert.That(parsed.EventHubName, Is.Null, "The Event Hub path was not included in the connection string");
         }
 
         /// <summary>
@@ -104,7 +104,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+            Assert.That(parsed.EventHubName, Is.EqualTo(eventHub), "The Event Hub path should match.");
         }
 
         /// <summary>
@@ -125,7 +125,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+            Assert.That(parsed.EventHubName, Is.EqualTo(eventHub), "The Event Hub path should match.");
         }
 
         /// <summary>
@@ -146,7 +146,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+            Assert.That(parsed.EventHubName, Is.EqualTo(eventHub), "The Event Hub path should match.");
         }
 
         /// <summary>
@@ -167,7 +167,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+            Assert.That(parsed.EventHubName, Is.EqualTo(eventHub), "The Event Hub path should match.");
         }
 
         /// <summary>
@@ -188,7 +188,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+            Assert.That(parsed.EventHubName, Is.EqualTo(eventHub), "The Event Hub path should match.");
         }
 
         /// <summary>
@@ -209,7 +209,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+            Assert.That(parsed.EventHubName, Is.EqualTo(eventHub), "The Event Hub path should match.");
         }
 
         /// <summary>
@@ -230,7 +230,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+            Assert.That(parsed.EventHubName, Is.EqualTo(eventHub), "The Event Hub path should match.");
         }
 
         /// <summary>
@@ -251,7 +251,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(parsed.Endpoint?.Host, Is.EqualTo(endpoint).Using((IComparer<string>)StringComparer.OrdinalIgnoreCase), "The endpoint host should match.");
             Assert.That(parsed.SharedAccessKeyName, Is.EqualTo(sasKeyName), "The SAS key name should match.");
             Assert.That(parsed.SharedAccessKey, Is.EqualTo(sasKey), "The SAS key value should match.");
-            Assert.That(parsed.EventHubPath, Is.EqualTo(eventHub), "The Event Hub path should match.");
+            Assert.That(parsed.EventHubName, Is.EqualTo(eventHub), "The Event Hub path should match.");
         }
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsLiveTests.cs
@@ -455,7 +455,7 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             AssertTagMatches(activity, "peer.hostname", connectionStringProperties.Endpoint.Host);
-            AssertTagMatches(activity, "eh.event_hub_name", connectionStringProperties.EventHubPath);
+            AssertTagMatches(activity, "eh.event_hub_name", connectionStringProperties.EventHubName);
             AssertTagMatches(activity, "eh.active_partition_routing", activePartitionRouting);
             AssertTagMatches(activity, "eh.event_count", eventCount.ToString());
             AssertTagExists(activity, "eh.client_id");
@@ -569,7 +569,7 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             AssertTagMatches(activity, "peer.hostname", connectionStringProperties.Endpoint.Host);
-            AssertTagMatches(activity, "eh.event_hub_name", connectionStringProperties.EventHubPath);
+            AssertTagMatches(activity, "eh.event_hub_name", connectionStringProperties.EventHubName);
             AssertTagMatches(activity, "eh.active_partition_routing", activePartitionRouting);
             AssertTagMatches(activity, "eh.consumer_group", consumerGroup);
             AssertTagMatches(activity, "eh.start_offset", position.Offset);
@@ -673,7 +673,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var expectedEndpointStart = "amqps://" + connectionStringProperties.Endpoint.Host;
 
             Assert.That(endpoint.AbsoluteUri.StartsWith(expectedEndpointStart), Is.True);
-            Assert.That(entityPath, Is.EqualTo(connectionStringProperties.EventHubPath));
+            Assert.That(entityPath, Is.EqualTo(connectionStringProperties.EventHubName));
             Assert.That(partitionRouting, Is.EqualTo(activePartitionRouting));
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientLiveTests.cs
@@ -107,14 +107,14 @@ namespace Azure.Messaging.EventHubs.Tests
                 (
                     new SharedAccessSignature
                     (
-                        $"{ clientOptions.TransportType.GetUriScheme() }://{ connectionProperties.Endpoint.Host }/{ connectionProperties.EventHubPath }".ToLowerInvariant(),
+                        $"{ clientOptions.TransportType.GetUriScheme() }://{ connectionProperties.Endpoint.Host }/{ connectionProperties.EventHubName }".ToLowerInvariant(),
                         connectionProperties.SharedAccessKeyName,
                         connectionProperties.SharedAccessKey,
                         TimeSpan.FromHours(4)
                     )
                 );
 
-                await using (var client = new EventHubClient(connectionProperties.Endpoint.Host, connectionProperties.EventHubPath, credential))
+                await using (var client = new EventHubClient(connectionProperties.Endpoint.Host, connectionProperties.EventHubName, credential))
                 {
                     Assert.That(() => client.GetPropertiesAsync(), Throws.Nothing);
                 }
@@ -142,7 +142,7 @@ namespace Azure.Messaging.EventHubs.Tests
                     var properties = await client.GetPropertiesAsync();
 
                     Assert.That(properties, Is.Not.Null, "A set of properties should have been returned.");
-                    Assert.That(properties.Path, Is.EqualTo(scope.EventHubName), "The property Event Hub name should match the scope.");
+                    Assert.That(properties.Name, Is.EqualTo(scope.EventHubName), "The property Event Hub name should match the scope.");
                     Assert.That(properties.PartitionIds.Length, Is.EqualTo(partitionCount), "The properties should have the requested number of partitions.");
                     Assert.That(properties.CreatedAt, Is.EqualTo(DateTimeOffset.UtcNow).Within(TimeSpan.FromSeconds(10)), "The Event Hub should have been created just about now.");
                 }
@@ -171,14 +171,14 @@ namespace Azure.Messaging.EventHubs.Tests
                 (
                     new SharedAccessSignature
                     (
-                        $"{ clientOptions.TransportType.GetUriScheme() }://{ connectionProperties.Endpoint.Host }/{ connectionProperties.EventHubPath }".ToLowerInvariant(),
+                        $"{ clientOptions.TransportType.GetUriScheme() }://{ connectionProperties.Endpoint.Host }/{ connectionProperties.EventHubName }".ToLowerInvariant(),
                         connectionProperties.SharedAccessKeyName,
                         connectionProperties.SharedAccessKey,
                         TimeSpan.FromHours(4)
                     )
                 );
 
-                await using (var client = new EventHubClient(connectionProperties.Endpoint.Host, connectionProperties.EventHubPath, credential, new EventHubClientOptions { TransportType = transportType }))
+                await using (var client = new EventHubClient(connectionProperties.Endpoint.Host, connectionProperties.EventHubName, credential, new EventHubClientOptions { TransportType = transportType }))
                 {
                     var cancellation = new CancellationTokenSource(TimeSpan.FromSeconds(20));
                     var properties = await client.GetPropertiesAsync();
@@ -187,7 +187,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                     Assert.That(partitionProperties, Is.Not.Null, "A set of partition properties should have been returned.");
                     Assert.That(partitionProperties.Id, Is.EqualTo(partition), "The partition identifier should match.");
-                    Assert.That(partitionProperties.EventHubPath, Is.EqualTo(connectionProperties.EventHubPath).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
+                    Assert.That(partitionProperties.EventHubName, Is.EqualTo(connectionProperties.EventHubName).Using((IEqualityComparer<string>)StringComparer.InvariantCultureIgnoreCase), "The Event Hub path should match.");
                     Assert.That(partitionProperties.BeginningSequenceNumber, Is.Not.EqualTo(default(Int64)), "The beginning sequence number should have been populated.");
                     Assert.That(partitionProperties.LastEnqueuedSequenceNumber, Is.Not.EqualTo(default(Int64)), "The last sequence number should have been populated.");
                     Assert.That(partitionProperties.LastEnqueuedOffset, Is.Not.EqualTo(default(Int64)), "The last offset should have been populated.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
@@ -160,10 +160,10 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCaseSource(nameof(ConstructorExpandedArgumentInvalidCases))]
         public void ConstructorValidatesExpandedArguments(string host,
-                                                          string eventHubPath,
+                                                          string eventHubName,
                                                           TokenCredential credential)
         {
-            Assert.That(() => new EventHubClient(host, eventHubPath, credential), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubClient(host, eventHubName, credential), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -218,7 +218,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var fakeConnection = $"Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath={ entityPath }";
             var client = new EventHubClient(fakeConnection);
 
-            Assert.That(client.EventHubPath, Is.EqualTo(entityPath));
+            Assert.That(client.EventHubName, Is.EqualTo(entityPath));
         }
 
         /// <summary>
@@ -233,7 +233,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var fakeConnection = $"Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real]";
             var client = new EventHubClient(fakeConnection, entityPath);
 
-            Assert.That(client.EventHubPath, Is.EqualTo(entityPath));
+            Assert.That(client.EventHubName, Is.EqualTo(entityPath));
         }
 
         /// <summary>
@@ -249,7 +249,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var credential = Mock.Of<TokenCredential>();
             var client = new EventHubClient(host, entityPath, credential);
 
-            Assert.That(client.EventHubPath, Is.EqualTo(entityPath));
+            Assert.That(client.EventHubName, Is.EqualTo(entityPath));
         }
 
         /// <summary>
@@ -886,10 +886,10 @@ namespace Azure.Messaging.EventHubs.Tests
         private string BuildResource(EventHubClient client,
                                      TransportType transportType,
                                      string host,
-                                     string eventHubPath) =>
+                                     string eventHubName) =>
              typeof(EventHubClient)
                  .GetMethod("BuildResource", BindingFlags.Static | BindingFlags.NonPublic)
-                 .Invoke(client, new object[] { transportType, host, eventHubPath }) as string;
+                 .Invoke(client, new object[] { transportType, host, eventHubName }) as string;
 
         /// <summary>
         ///   Provides a test shim for retrieving the transport client contained by an
@@ -930,13 +930,13 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             public ReadableOptionsMock(string host,
-                                       string eventHubPath,
+                                       string eventHubName,
                                        TokenCredential credential,
-                                       EventHubClientOptions clientOptions = default) : base(host, eventHubPath, credential, clientOptions)
+                                       EventHubClientOptions clientOptions = default) : base(host, eventHubName, credential, clientOptions)
             {
             }
 
-            internal override TransportEventHubClient BuildTransportClient(string host, string eventHubPath, TokenCredential credential, EventHubClientOptions options, EventHubRetryPolicy defaultRetry)
+            internal override TransportEventHubClient BuildTransportClient(string host, string eventHubName, TokenCredential credential, EventHubClientOptions options, EventHubRetryPolicy defaultRetry)
             {
                 TransportClientOptions = options;
                 _transportClient = new ObservableTransportClientMock();
@@ -958,9 +958,9 @@ namespace Azure.Messaging.EventHubs.Tests
             }
 
             public ObservableOperationsMock(string host,
-                                       string eventHubPath,
+                                       string eventHubName,
                                        TokenCredential credential,
-                                       EventHubClientOptions clientOptions = default) : base(host, eventHubPath, credential, clientOptions)
+                                       EventHubClientOptions clientOptions = default) : base(host, eventHubName, credential, clientOptions)
             {
             }
 
@@ -991,16 +991,16 @@ namespace Azure.Messaging.EventHubs.Tests
 
             public InjectableTransportClientMock(TransportEventHubClient transportClient,
                                                  string host,
-                                                 string eventHubPath,
+                                                 string eventHubName,
                                                  TokenCredential credential,
-                                                 EventHubClientOptions clientOptions = default) : base(host, eventHubPath, credential, clientOptions)
+                                                 EventHubClientOptions clientOptions = default) : base(host, eventHubName, credential, clientOptions)
             {
                 TransportClient = transportClient;
                 SetTransportClient(transportClient);
             }
 
             internal override TransportEventHubClient BuildTransportClient(string host,
-                                                                           string eventHubPath,
+                                                                           string eventHubName,
                                                                            TokenCredential credential,
                                                                            EventHubClientOptions options,
                                                                            EventHubRetryPolicy defaultRetry) => TransportClient;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -1170,7 +1170,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 PublishDelayCallback?.Invoke();
                 stopWatch.Stop();
 
-                if (((maximumWaitTime.HasValue) && (stopWatch.Elapsed >= maximumWaitTime))  || (PublishIndex >= EventsToPublish.Count))
+                if (((maximumWaitTime.HasValue) && (stopWatch.Elapsed >= maximumWaitTime)) || (PublishIndex >= EventsToPublish.Count))
                 {
                     return Task.FromResult(Enumerable.Empty<EventData>());
                 }
@@ -1179,7 +1179,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
                 if (index + maximumMessageCount > EventsToPublish.Count)
                 {
-                   maximumMessageCount = (EventsToPublish.Count - index);
+                    maximumMessageCount = (EventsToPublish.Count - index);
                 }
 
                 PublishIndex = (index + maximumMessageCount);
@@ -1190,7 +1190,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             public override Task CloseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-            public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy){}
+            public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy) { }
         }
 
         /// <summary>
@@ -1218,7 +1218,7 @@ namespace Azure.Messaging.EventHubs.Tests
 
             public override Task CloseAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-            public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy){}
+            public override void UpdateRetryPolicy(EventHubRetryPolicy newRetryPolicy) { }
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -664,7 +664,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         // The following properties should not have been altered.
 
                         Assert.That(newPartitionProperties.Id, Is.EqualTo(oldPartitionProperties.Id));
-                        Assert.That(newPartitionProperties.EventHubPath, Is.EqualTo(oldPartitionProperties.EventHubPath));
+                        Assert.That(newPartitionProperties.EventHubName, Is.EqualTo(oldPartitionProperties.EventHubName));
                         Assert.That(newPartitionProperties.BeginningSequenceNumber, Is.EqualTo(oldPartitionProperties.BeginningSequenceNumber));
 
                         // The following properties should have been updated.
@@ -713,7 +713,7 @@ namespace Azure.Messaging.EventHubs.Tests
                         // All properties should remain the same.
 
                         Assert.That(newPartitionProperties.Id, Is.EqualTo(oldPartitionProperties.Id));
-                        Assert.That(newPartitionProperties.EventHubPath, Is.EqualTo(oldPartitionProperties.EventHubPath));
+                        Assert.That(newPartitionProperties.EventHubName, Is.EqualTo(oldPartitionProperties.EventHubName));
                         Assert.That(newPartitionProperties.BeginningSequenceNumber, Is.EqualTo(oldPartitionProperties.BeginningSequenceNumber));
                         Assert.That(newPartitionProperties.LastEnqueuedSequenceNumber, Is.EqualTo(oldPartitionProperties.LastEnqueuedSequenceNumber));
                         Assert.That(newPartitionProperties.LastEnqueuedOffset, Is.EqualTo(oldPartitionProperties.LastEnqueuedOffset));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerTests.cs
@@ -39,9 +39,9 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         [TestCase(null)]
         [TestCase("")]
-        public void ConstructorValidatesTheEventHubPath(string eventHubPath)
+        public void ConstructorValidatesTheEventHubName(string eventHubName)
         {
-            Assert.That(() => new EventHubProducer(new ObservableTransportProducerMock(), eventHubPath, new EventHubProducerOptions(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
+            Assert.That(() => new EventHubProducer(new ObservableTransportProducerMock(), eventHubName, new EventHubProducerOptions(), Mock.Of<EventHubRetryPolicy>()), Throws.InstanceOf<ArgumentException>());
         }
 
         /// <summary>
@@ -72,10 +72,10 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase("123")]
         [TestCase(" ")]
         [TestCase("someValue")]
-        public void ConstructorSetsTheEventHubPath(string eventHubPath)
+        public void ConstructorSetsTheEventHubName(string eventHubName)
         {
-            var producer = new EventHubProducer(new ObservableTransportProducerMock(), eventHubPath, new EventHubProducerOptions(), Mock.Of<EventHubRetryPolicy>());
-            Assert.That(producer.EventHubPath, Is.EqualTo(eventHubPath));
+            var producer = new EventHubProducer(new ObservableTransportProducerMock(), eventHubName, new EventHubProducerOptions(), Mock.Of<EventHubRetryPolicy>());
+            Assert.That(producer.EventHubName, Is.EqualTo(eventHubName));
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The intent of these changes is to update members, variables, and comments referencing an Event Hub as a conceptual path and change to referencing as a name.

# Last Upstream Rebase

Friday, August 2, 2019  5:08pm (EDT)

# Resources

- [Azure Messaging Exception Documentation](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions)
- [.NET Event Hubs Client: Second Preview Design Proposal](https://github.com/jsquire/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-second-preview.md)

# Related and Follow-Up Issues

- [Rename `EventHubPath` to `EventHubName`](https://github.com/Azure/azure-sdk-for-net/issues/7096) (#7096)  