### PR TITLE
[Event Hubs Client] Track Two: Second Preview (Samples)  …

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md
@@ -42,6 +42,6 @@
 Operation timeouts have been moved from the associated client options and incorporated into the retry options and retry policies.
 
 ## 5.0.0-preview.1 (2019-07-01)
-Version 5.0.0-preview.1 is a preview of our efforts in creating a client library that is developer-friendly, idiomatic to the .NET ecosystem, and as consistent across different languages and platforms as possible.  The principles that guide our efforts can be found in the [Azure SDK Design Guidelines for .NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html).
+Version 5.0.0-preview.1 is a preview of our efforts in creating a client library that is developer-friendly, idiomatic to the .NET ecosystem, and as consistent across different languages and platforms as possible.  The principles that guide our efforts can be found in the [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html).
 
 For more information, please visit: [https://aka.ms/azure-sdk-preview1-net](https://aka.ms/azure-sdk-preview1-net).

--- a/sdk/eventhub/Azure.Messaging.EventHubs/README.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/README.md
@@ -129,7 +129,7 @@ await using (var client = new EventHubClient(connectionString, eventHubName))
 }
 ```
 
-### Consume events from all partitions of an Event Hub
+### Consume events using an Event Processor
 
 To consume events for all partitions of an Event Hub, you'll create an `EventProcessor` for a specific consumer group.  When an Event Hub is created, it provides a default consumer group that can be used to get started.
 
@@ -210,32 +210,43 @@ Each of the samples is self-contained and focused on illustrating one specific s
 
 The available samples are:
 
-- [Hello world](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample1_HelloWorld.cs)  
+- [Hello world](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample01_HelloWorld.cs)  
   An introduction to Event Hubs, illustrating how to connect and query the service.
 
-- [Create an Event Hub client with custom options](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample2_ClientWithCustomOptions.cs)  
+- [Create an Event Hub client with custom options](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs)  
   An introduction to Event Hubs, exploring additional options for creating an Event Hub client.
   
-- [Publish an event to an Event Hub](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample3_PublishAnEvent3.cs)  
+- [Publish an event to an Event Hub](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs)  
   An introduction to publishing events, using a simple Event Hub producer.
   
-- [Publish events using a partition key](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample4_PublishEventsWithPartitionKey.cs)  
+- [Publish events using a partition key](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_PublishEventsWithPartitionKey.cs)  
   An introduction to publishing events, using a partition key to group them together.
   
-- [Publish events to a specific Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample5_PublishEventsToSpecificPartitions.cs)  
+- [Publish a size-limited batch of events](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_PublishAnEventBatch.cs)  
+  An introduction to publishing events, using a size-aware batch to ensure the size does not exceed the transport size limits.
+
+- [Publish events to a specific Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_PublishEventsToSpecificPartitions.cs)  
   An introduction to publishing events, using an Event Hub producer that is associated with a specific partition.
   
-- [Publish events with custom metadata](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample6_PublishEventsWithCustomMetadata.cs)  
+- [Publish events with custom metadata](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample07_PublishEventsWithCustomMetadata.cs)  
   An example of publishing events, extending the event data with custom metadata.
   
-- [Consume events from an Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample7_ConsumeEvents.cs)  
+- [Consume events from an Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample08_ConsumeEvents.cs)  
   An introduction to consuming events, using a simple Event Hub consumer.
   
-- [Consume events from an Event Hub partition in batches](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample8_ConsumeEventsByBatch.cs)   
+- [Consume events from an Event Hub partition, limiting the period of time to wait for an event](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs)  
+  An introduction to consuming events, using an Event Hub consumer with maximum wait time.
+
+- [Consume events from a known position in the Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample10_ConsumeEventsFromAKnownPosition.cs)  
+  An example of consuming events, starting at a well-known position in the Event Hub partition.
+  
+- [Consume events from an Event Hub partition in batches](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsByBatch.cs)
+
   An example of consuming events, using a batch approach to control throughput.
   
-- [Consume events from a known position in the Event Hub partition](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample9_ConsumeEventsFromAKnownPosition.cs)  
-  An example of consuming events, starting at a well-known position in the Event Hub partition.
+- [Consume events from all partitions of an Event Hub with the Event Processor](https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_ConsumeEventsWithEventProcessor.cs)
+
+  An example of consuming events from all Event Hub partitions at once, using the Event Processor.
 
 ## Contributing  
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Program.cs
@@ -76,13 +76,10 @@ namespace Azure.Messaging.EventHubs.Samples
             }
 
             Console.WriteLine();
-            Console.Write("Please enter the number of a sample to run or press \"X\" to exit: ");
+            var choice = ReadSelection(samples.Count);
 
-            var key = ReadSelection(samples.Count);
-
-            if ((key == 'x') || (key == 'X'))
+            if (choice == null)
             {
-                Console.Write(key);
                 Console.WriteLine();
                 Console.WriteLine();
                 Console.WriteLine("Quitting...");
@@ -91,18 +88,15 @@ namespace Azure.Messaging.EventHubs.Samples
             }
             else
             {
-                var choice = ((int)key);
-
-                Console.Write(key);
                 Console.WriteLine();
                 Console.WriteLine();
                 Console.WriteLine();
                 Console.WriteLine("-------------------------------------------------------------------------");
-                Console.WriteLine($"Running: { samples[choice].Name }");
+                Console.WriteLine($"Running: { samples[choice.Value].Name }");
                 Console.WriteLine("-------------------------------------------------------------------------");
                 Console.WriteLine();
 
-                await samples[choice].RunAsync(parsedArgs.ConnectionString, parsedArgs.EventHub);
+                await samples[choice.Value].RunAsync(parsedArgs.ConnectionString, parsedArgs.EventHub);
                 return;
             }
         }
@@ -150,24 +144,26 @@ namespace Azure.Messaging.EventHubs.Samples
         ///
         /// <returns>The validated selection that was made.</returns>
         ///
-        private static char ReadSelection(int sampleCount)
+        private static int? ReadSelection(int sampleCount)
         {
             while(true)
             {
-                var key = Console.ReadKey(true);
+                Console.Write("Please enter the number of a sample to run or press \"X\" to exit: ");
 
-                if ((key.KeyChar == 'x') || (key.KeyChar == 'X'))
+                var value = Console.ReadLine();
+
+                if (String.Equals(value, "X", StringComparison.OrdinalIgnoreCase))
                 {
-                    return key.KeyChar;
+                    return null;
                 }
 
-                if (Char.IsDigit(key.KeyChar))
+                if (Int32.TryParse(value, out var choice))
                 {
-                    var choice = ((int)Char.GetNumericValue(key.KeyChar) - 1);
+                    --choice;
 
                     if ((choice >= 0) && (choice < sampleCount))
                     {
-                        return (char)choice;
+                        return choice;
                     }
                 }
             }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample01_HelloWorld.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample01_HelloWorld.cs
@@ -12,13 +12,13 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to Event Hubs, illustrating how to connect and query the service.
     /// </summary>
     ///
-    public class Sample1_HelloWorld : IEventHubsSample
+    public class Sample01_HelloWorld : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample1_HelloWorld);
+        public string Name { get; } = nameof(Sample01_HelloWorld);
 
         /// <summary>
         ///   A short description of the sample.
@@ -38,7 +38,7 @@ namespace Azure.Messaging.EventHubs.Samples
         {
             // To interact with Event Hubs, a client is needed.  The client manages resources and should be
             // explicitly closed or disposed, but it is not necessary to do both.  In our case, we will take
-            // advantage of the new asynchonous dispose to ensure that we clean up our client when we are
+            // advantage of the new asynchronous dispose to ensure that we clean up our client when we are
             // done or when an exception is encountered.
 
             await using (var client = new EventHubClient(connectionString, eventHubName))
@@ -60,7 +60,7 @@ namespace Azure.Messaging.EventHubs.Samples
                 {
                     PartitionProperties partitionProperties = await client.GetPartitionPropertiesAsync(partitionId);
 
-                    Console.WriteLine($"\tPartiton: { partitionProperties.Id }");
+                    Console.WriteLine($"\tPartition: { partitionProperties.Id }");
                     Console.WriteLine($"\t\tThe partition contains no events: { partitionProperties.IsEmpty }");
                     Console.WriteLine($"\t\tThe first sequence number of an event in the partition is: { partitionProperties.BeginningSequenceNumber }");
                     Console.WriteLine($"\t\tThe last sequence number of an event in the partition is: { partitionProperties.LastEnqueuedSequenceNumber }");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample02_ClientWithCustomOptions.cs
@@ -13,13 +13,13 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to Event Hubs, exploring additional options for creating an <see cref="EventHubClient" />.
     /// </summary>
     ///
-    public class Sample2_ClientWithCustomOptions : IEventHubsSample
+    public class Sample02_ClientWithCustomOptions : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample2_ClientWithCustomOptions);
+        public string Name { get; } = nameof(Sample02_ClientWithCustomOptions);
 
         /// <summary>
         ///   A short description of the sample.
@@ -48,7 +48,7 @@ namespace Azure.Messaging.EventHubs.Samples
             // The Event Hub client also allows you to customize how it connects to the service by specifying the specific transport that it
             // should communicate over and whether it should make use of a proxy for network communication.
             //
-            // Please note that the proxy is only supported when using Websockets as a transport; it isn't compatibile with raw TCP or other
+            // Please note that the proxy is only supported when using WebSockets as a transport; it isn't compatible with raw TCP or other
             // transport channels.
 
             var clientOptions = new EventHubClientOptions

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample03_PublishAnEvent.cs
@@ -12,13 +12,13 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to publishing events, using a simple <see cref="EventHubProducer" />.
     /// </summary>
     ///
-    public class Sample3_PublishAnEvent : IEventHubsSample
+    public class Sample03_PublishAnEvent : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample3_PublishAnEvent);
+        public string Name { get; } = nameof(Sample03_PublishAnEvent);
 
         /// <summary>
         ///   A short description of the sample.
@@ -41,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Samples
             //
             // Using our client, we will then create a producer.  Like the client, our Event Hub producer also manages resources
             // and should be explicitly closed or disposed, but it is not necessary to do both.  In our case, we will take
-            // advantage of the new asynchonous dispose to ensure that we clean up our client and producer when we are
+            // advantage of the new asynchronous dispose to ensure that we clean up our client and producer when we are
             // done or when an exception is encountered.
 
             await using (var client = new EventHubClient(connectionString, eventHubName))
@@ -63,7 +63,7 @@ namespace Azure.Messaging.EventHubs.Samples
 
                 var eventData = new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!"));
 
-                // When the producer sends the event, it will receive an acknowedgement from the Event Hubs service; so
+                // When the producer sends the event, it will receive an acknowledgment from the Event Hubs service; so
                 // long as there is no exception thrown by this call, the service is now responsible for delivery.  Your
                 // event data will be published to one of the Event Hub partitions, though there may be a (very) slight
                 // delay until it is available to be consumed.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_PublishEventsWithPartitionKey.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample04_PublishEventsWithPartitionKey.cs
@@ -12,13 +12,13 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to publishing events, using a partition key to group them together.
     /// </summary>
     ///
-    public class Sample4_PublishEventsWithPartitionKey : IEventHubsSample
+    public class Sample04_PublishEventsWithPartitionKey : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample4_PublishEventsWithPartitionKey);
+        public string Name { get; } = nameof(Sample04_PublishEventsWithPartitionKey);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_PublishAnEventBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample05_PublishAnEventBatch.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An introduction to publishing events, using a size-aware batch to ensure the size
+    ///   does not exceed the transport size limits.
+    /// </summary>
+    ///
+    public class Sample05_PublishAnEventBatch : IEventHubsSample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample05_PublishAnEventBatch);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An introduction to publishing events, using a size-aware batch to ensure the size does not exceed the transport size limits.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // We will start by creating a client and a producer, each using their default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            await using (EventHubProducer producer = client.CreateProducer())
+            {
+                // There is a limit to the size of an event or batch of events that can be published at once.  This limit varies, and depends
+                // on the underlying transport and protocol that the Event Hub producer is using.  Because the size limit is based on the
+                // size of an event or batch as it would be sent over the network, it is not simple to understand the size of an event as
+                // it is being created.  For this reason, producers creating events with a large body or batching a large number of events
+                // may experience errors when they attempt to send.
+                //
+                // In order to avoid errors, support creation of known-good batches, and allow for producers with the need to predictably
+                // control bandwidth use, the Event Hub producer allows creation of an Event Data Batch, which acts as a container for
+                // a batch of events.  Events can be added to the batch using a "TryAdd" pattern, allowing insight into when an event
+                // or batch would be too large without triggering an exception.
+                //
+                // An Event Data Batch can be created using a partition key or without one, following the same rules as the Event Hub
+                // producer with respect to partition routing.  (see, Sample04_PublishEventsWithPartitionKey for more information.)
+
+                // We will publish a batch of events based on simple sentences.
+
+                var events = new EventData[]
+                {
+                    new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")),
+                    new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!")),
+                    new EventData(Encoding.UTF8.GetBytes("A third event, the plot thickens!")),
+                    new EventData(Encoding.UTF8.GetBytes("...and a fourth too."))
+                };
+
+                // When creating the batch, you may specify a custom set of options or allow the defaults to take precedence.
+                // If a size limit is not specified, the maximum size allowed by the transport is used.  In this example, we
+                // will set a custom partition key and otherwise use the default options.
+
+                BatchOptions options = new BatchOptions { PartitionKey = "This is a custom key!" };
+                EventDataBatch batch = await producer.CreateBatchAsync(options);
+
+                foreach (EventData eventData in events)
+                {
+                    if (!batch.TryAdd(eventData))
+                    {
+                        throw new ApplicationException("The events will not fit in the same batch.");
+                    }
+                }
+
+                // When publishing a batch, no SendOptions may be specified.  Those options are
+                // all expressed upfront during batch creation and apply to all events in the batch.
+
+                await producer.SendAsync(batch);
+
+                Console.WriteLine("The event batch has been published.");
+            }
+
+            // At this point, our client and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_PublishEventsToSpecificPartitions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample06_PublishEventsToSpecificPartitions.cs
@@ -12,13 +12,13 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An introduction to publishing events, using an <see cref="EventHubProducer" /> that is associated with a specific partition.
     /// </summary>
     ///
-    public class Sample5_PublishEventsToSpecificPartitions : IEventHubsSample
+    public class Sample06_PublishEventsToSpecificPartitions : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample5_PublishEventsToSpecificPartitions);
+        public string Name { get; } = nameof(Sample06_PublishEventsToSpecificPartitions);
 
         /// <summary>
         ///   A short description of the sample.
@@ -41,7 +41,7 @@ namespace Azure.Messaging.EventHubs.Samples
             await using (var client = new EventHubClient(connectionString, eventHubName))
             {
                 // Because partitions are owned by the Event Hubs service, it is not advised to assume that they have a stable
-                // and predictable set of identifiers.  We'll inspect the Event Hub and select the first parition to use for
+                // and predictable set of identifiers.  We'll inspect the Event Hub and select the first partition to use for
                 // publishing our event batch.
 
                 string[] partitionIds = await client.GetPartitionIdsAsync();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample07_PublishEventsWithCustomMetadata.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample07_PublishEventsWithCustomMetadata.cs
@@ -12,13 +12,13 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An example of publishing events, extending the event data with custom metadata.
     /// </summary>
     ///
-    public class Sample6_PublishEventsWithCustomMetadata : IEventHubsSample
+    public class Sample07_PublishEventsWithCustomMetadata : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample6_PublishEventsWithCustomMetadata);
+        public string Name { get; } = nameof(Sample07_PublishEventsWithCustomMetadata);
 
         /// <summary>
         ///   A short description of the sample.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample09_ConsumeEventsWithMaximumWaitTime.cs
@@ -1,0 +1,155 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An introduction to consuming events, using a simple <see cref="EventHubConsumer" />.
+    /// </summary>
+    ///
+    public class Sample09_ConsumeEventsWithMaximumWaitTime : IEventHubsSample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample09_ConsumeEventsWithMaximumWaitTime);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An introduction to consuming events, using an Event Hub consumer with maximum wait time.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // An Event Hub consumer is associated with a specific Event Hub partition and a consumer group.  The consumer group is
+            // a label that identifies one or more consumers as a set.  Often, consumer groups are named after the responsibility
+            // of the consumer in an application, such as "Telemetry" or "OrderProcessing".  When an Event Hub is created, a default
+            // consumer group is created with it, called "$Default."
+            //
+            // Each consumer has a unique view of the events in the partition, meaning that events are available to all consumers
+            // and are not removed from the partition when a consumer reads them.  This allows for different consumers to read and
+            // process events from the partition at different speeds and beginning with different events without interfering with
+            // one another.
+            //
+            // When events are published, they will continue to exist in the partition and be available for consuming until they
+            // reach an age where they are older than the retention period.
+            // (see: https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-faq#what-is-the-maximum-retention-period-for-events)
+            //
+            // Because events are not removed from the partition when consuming, a consumer must specify where in the partition it
+            // would like to begin reading events.  For example, this may be starting from the very beginning of the stream, at an
+            // offset from the beginning, the next event available after a specific point in time, or at a specific event.
+
+            // We will start by creating a client using its default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            {
+                // With our client, we can now inspect the partitions and find the identifier
+                // of the first.
+
+                string firstPartition = (await client.GetPartitionIdsAsync()).First();
+
+                // In this example, we will create our consumer for the first partition in the Event Hub, using the default consumer group
+                // that is created with an Event Hub.  Our consumer will begin watching the partition at the very end, reading only new events
+                // that we will publish for it.
+
+                await using (EventHubConsumer consumer = client.CreateConsumer(EventHubConsumer.DefaultConsumerGroupName, firstPartition, EventPosition.Latest))
+                await using (EventHubProducer producer = client.CreateProducer(new EventHubProducerOptions { PartitionId = firstPartition }))
+                {
+                    // Because our consumer is reading from the latest position, it won't see events that have previously
+                    // been published.  Before we can publish the events, we will need to ask the consumer to perform an operation,
+                    // because it opens its connection only when it needs to.  The first receive that we ask of it will not see
+                    // any events, but will allow the consumer to start watching the partition.
+                    //
+                    // Because the maximum wait time is specified as zero, this call will return immediately and will not
+                    // have consumed any events.
+
+                    await consumer.ReceiveAsync(1, TimeSpan.Zero);
+
+                    // Now that the consumer is watching the partition, let's publish the events that we would like to
+                    // receive.
+
+                    EventData[] eventsToPublish = new EventData[]
+                    {
+                        new EventData(Encoding.UTF8.GetBytes("Hello, Event Hubs!")),
+                        new EventData(Encoding.UTF8.GetBytes("Goodbye, Event Hubs!"))
+                    };
+
+                    await producer.SendAsync(eventsToPublish);
+                    Console.WriteLine("The event batch has been published.");
+
+                    // Because publishing and receiving events is asynchronous, the events that we published may not be immediately
+                    // available for our consumer to see.  We will iterate over the available events in the partition, which should be
+                    // just the events that we published.
+                    //
+                    // When a maximum wait time is specified, the iteration will ensure that it returns control after that time has elapsed,
+                    // whether or not an event is available in the partition.  If no event was available a null value will be emitted instead.
+                    // This is intended to return control to the loop and avoid blocking for an indeterminate period of time to allow event
+                    // processors to verify that the iterator is still consuming the partition and to make decisions on whether or not to continue
+                    // if events are not arriving.
+                    //
+                    // For this example, we will specify a maximum wait time, and won't exit the loop until we've received at least one more
+                    // event than we published, which is expected to be a null value triggered by exceeding the wait time.
+                    //
+                    // To be sure that we do not end up in an infinite loop, we will specify a fairly long time to allow processing to complete
+                    // then cancel.
+
+                    CancellationTokenSource cancellationSource = new CancellationTokenSource();
+                    cancellationSource.CancelAfter(TimeSpan.FromSeconds(30));
+
+                    TimeSpan maximumWaitTime = TimeSpan.FromMilliseconds(250);
+                    List<EventData> receivedEvents = new List<EventData>();
+                    Stopwatch watch = Stopwatch.StartNew();
+
+                    await foreach(EventData currentEvent in consumer.SubscribeToEvents(maximumWaitTime, cancellationSource.Token))
+                    {
+                        receivedEvents.Add(currentEvent);
+
+                        if (receivedEvents.Count > eventsToPublish.Length)
+                        {
+                            watch.Stop();
+                            break;
+                        }
+                    }
+
+                    // Print out the events that we received.
+
+                    Console.WriteLine();
+                    Console.WriteLine($"The following events were consumed in { watch.ElapsedMilliseconds } milliseconds:");
+
+                    foreach (EventData eventData in receivedEvents)
+                    {
+                        // The body of our event was an encoded string; we'll recover the
+                        // message by reversing the encoding process.
+
+                        string message = (eventData == null) ? "<< This was a null event >>" : Encoding.UTF8.GetString(eventData.Body.ToArray());
+                        Console.WriteLine($"\tMessage: \"{ message }\"");
+                    }
+                }
+            }
+
+            // At this point, our client, consumer, and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsByBatch.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample11_ConsumeEventsByBatch.cs
@@ -14,19 +14,19 @@ namespace Azure.Messaging.EventHubs.Samples
     ///   An example of consuming events, using a batch approach to control throughput.
     /// </summary>
     ///
-    public class Sample8_ConsumeEventsByBatch : IEventHubsSample
+    public class Sample11_ConsumeEventsByBatch : IEventHubsSample
     {
         /// <summary>
         ///   The name of the sample.
         /// </summary>
         ///
-        public string Name { get; } = nameof(Sample8_ConsumeEventsByBatch);
+        public string Name { get; } = nameof(Sample11_ConsumeEventsByBatch);
 
         /// <summary>
         ///   A short description of the sample.
         /// </summary>
         ///
-        public string Description { get; } = "An example of consuming events, using a batch approach tocontrol throughput.";
+        public string Description { get; } = "An example of consuming events, using a batch approach to control throughput.";
 
         /// <summary>
         ///   Runs the sample using the specified Event Hubs connection information.
@@ -59,7 +59,7 @@ namespace Azure.Messaging.EventHubs.Samples
                     // because it opens its connection only when it needs to.  The first receive that we ask of it will not see
                     // any events, but will allow the consumer to start watching the partition.
                     //
-                    // Because the maximum wait time is specivied as zero, this call will return immediately and will not
+                    // Because the maximum wait time is specified as zero, this call will return immediately and will not
                     // have consumed any events.
 
                     await consumer.ReceiveAsync(1, TimeSpan.Zero);
@@ -88,9 +88,9 @@ namespace Azure.Messaging.EventHubs.Samples
                     // where some experimentation in the application context may prove helpful.
                     //
                     // Our example will attempt to read about 1/5 of the batch at a time, which should result in the need for 5 batches to
-                    // be consumed.  Because publishing and receving events is asynchronous, the events that we published may not be
+                    // be consumed.  Because publishing and receiving events is asynchronous, the events that we published may not be
                     // immediately available for our consumer to see. To compensate, we will allow for a small number of extra attempts beyond
-                    // the expected 5 to to be sure that we don't stop reading before we receive all of our events.
+                    // the expected 5 to be sure that we don't stop reading before we receive all of our events.
 
                     var receivedEvents = new List<EventData>();
                     int consumeBatchSize = (int)Math.Floor(eventBatchSize / 5.0f);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_ConsumeEventsWithEventProcessor.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/samples/Sample12_ConsumeEventsWithEventProcessor.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Samples.Infrastructure;
+
+namespace Azure.Messaging.EventHubs.Samples
+{
+    /// <summary>
+    ///   An example of consuming events from all Event Hub partitions at once, using the Event Processor.
+    /// </summary>
+    ///
+    public class Sample12_ConsumeEventsWithEventProcessor : IEventHubsSample
+    {
+        /// <summary>
+        ///   The name of the sample.
+        /// </summary>
+        ///
+        public string Name { get; } = nameof(Sample12_ConsumeEventsWithEventProcessor);
+
+        /// <summary>
+        ///   A short description of the sample.
+        /// </summary>
+        ///
+        public string Description { get; } = "An example of consuming events from all Event Hub partitions at once, using the Event Processor.";
+
+        /// <summary>
+        ///   Runs the sample using the specified Event Hubs connection information.
+        /// </summary>
+        ///
+        /// <param name="connectionString">The connection string for the Event Hubs namespace that the sample should target.</param>
+        /// <param name="eventHubName">The name of the Event Hub, sometimes known as its path, that she sample should run against.</param>
+        ///
+        public async Task RunAsync(string connectionString,
+                                   string eventHubName)
+        {
+            // We will start by creating a client using its default set of options.
+
+            await using (var client = new EventHubClient(connectionString, eventHubName))
+            {
+                //TODO (caio, pri1): Populate the sample
+            }
+
+            // At this point, our client, all consumers, and producer have passed their "using" scope and have safely been disposed of.  We
+            // have no further obligations.
+
+            Console.WriteLine();
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The intent of these changes is enhance the samples to cover the new scenarios added for preview two and improve upon the existing set of samples.

# Last Upstream Rebase

Tuesday, August 6, 2019  9:090am (EDT)

# Resources

- [Azure Messaging Exception Documentation](https://docs.microsoft.com/en-us/azure/event-hubs/event-hubs-messaging-exceptions)
- [.NET Event Hubs Client: Second Preview Design Proposal](https://github.com/jsquire/azure-sdk-for-net/blob/master/sdk/eventhub/Azure.Messaging.EventHubs/design/proposal-event-hubs-second-preview.md)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 2](https://github.com/Azure/azure-sdk-for-net/issues/6752) (#6752)
- [Create samples](https://github.com/Azure/azure-sdk-for-net/issues/6797) (#6797)   