### PR TITLE
[CODEOWNERS] - Tweak Event Hubs and Service Bus

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,7 +22,7 @@
 
 /sdk/eventgrid/ @kalyanaj 
 
-/sdk/eventhub/ @serkantkaraca 
+/sdk/eventhub/ @serkantkaraca @jsquire @kinelski
 /sdk/eventhub/azure.messaging.eventhubs/ @jsquire @kinelski
 
 /sdk/identity/azure.identity/ @schaabs
@@ -31,7 +31,7 @@
 /sdk/keyvault/azure.*/ @schaabs @shahabhijeet 
 
 /sdk/search/ @brjohnstmsft
-/sdk/servicebus/ @nemakam 
+/sdk/servicebus/ @nemakam @jsquire
 /sdk/storage/ @kfarmer-msft @seanmcc-msft @tg-msft
 # Management Plane
 /**/*Management*/ @erich-wang


### PR DESCRIPTION
# Summary

The intent of these changes is to add members of the ADP feature team to the Event Hubs root and add jsquire to the list of Service Bus watchers.

# Last Upstream Rebase

Tuesday, August 6, 2019  9:09am (EDT)