### PR TITLE
[Event Hubs Client] Track Two: Second Preview (.NET Core 3 Fix)  …

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ChannelEnumerableSubscription.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ChannelEnumerableSubscription.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;
@@ -112,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Core
         ///
         private static async IAsyncEnumerable<T> EnumerateChannel(ChannelReader<T> reader,
                                                                   TimeSpan? maximumWaitTime,
-                                                                  CancellationToken cancellationToken)
+                                                                  [EnumeratorCancellation]CancellationToken cancellationToken)
         {
             T result;
             int delayMilliseconds;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/InMemoryPartitionManager.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Processor/InMemoryPartitionManager.cs
@@ -56,7 +56,7 @@ namespace Azure.Messaging.EventHubs.Processor
         {
             List<PartitionOwnership> ownershipList;
 
-            lock(OwnershipClaimLock)
+            lock (OwnershipClaimLock)
             {
                 ownershipList = Ownership.Values
                     .Where(ownership => ownership.EventHubName == eventHubName &&


### PR DESCRIPTION
# Summary

The intent of these changes is to correct a build error under .NET Core 3 preview (3.0.100-preview7-012821) regarding a decorator needed for cancellation of async enumerables.

# Last Upstream Rebase

Thursday, August 8, 2019  11:18am (EDT)

# Related and Follow-Up Issues

- [EventHubs fails to build with 3.0 preview7 SDK](https://github.com/Azure/azure-sdk-for-net/issues/7151) (#7151)