### PR TITLE
[Event Hubs Client] Track Two: Second Preview (Test Metadata)  …

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpEventBatchTests.cs
@@ -17,7 +17,6 @@ namespace Azure.Messaging.EventHubs.Tests
     ///   class.
     /// </summary>
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class AmqpEventBatchTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -19,7 +19,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class AmqpMessageConverterTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/TypeExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/TypeExtensionsTests.cs
@@ -15,7 +15,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TypeExtensionsTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubSharedKeyCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubSharedKeyCredentialTests.cs
@@ -14,7 +14,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubSharedKeyCredentialTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
@@ -19,7 +19,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubTokenCredentialTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureCredentialTests.cs
@@ -15,7 +15,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class SharedAccessSignatureCredentialTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/SharedAccessSignatureTests.cs
@@ -15,7 +15,6 @@ namespace Azure.Messaging.EventHubs.Tests.Authorization
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class SharedAccessSignatureTests
     {
         /// <summary>A string that is 300 characters long, breaking invariants for argument maximum lengths.</summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparerTests.cs
@@ -13,7 +13,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneComparerTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubClientTests.cs
@@ -23,7 +23,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneEventHubClientTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubConsumerTests.cs
@@ -21,7 +21,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneEventHubConsumerTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubProducerTests.cs
@@ -25,7 +25,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneEventHubProducerTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneExceptionExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneExceptionExtensionsTests.cs
@@ -16,7 +16,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneExceptionExtensionsTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenProviderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenProviderTests.cs
@@ -20,7 +20,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneGenericTokenProviderTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneGenericTokenTests.cs
@@ -16,7 +16,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneGenericTokenTokenTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneRetryPolicyTests.cs
@@ -14,7 +14,6 @@ namespace Azure.Messaging.EventHubs.Tests
     ///   class.
     /// </summary>
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneRetryPolicyTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneSharedAccessSignatureTokenProviderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneSharedAccessSignatureTokenProviderTests.cs
@@ -16,7 +16,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneSharedAccessSignatureTokenProviderTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneSharedAccessTokenTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneSharedAccessTokenTests.cs
@@ -15,7 +15,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class TrackOneSharedAccessSignatureTokenTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelEnumeratorSubscriptionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelEnumeratorSubscriptionTests.cs
@@ -19,7 +19,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class ChannelEnumeratorSubscriptionTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionStringParserTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionStringParserTests.cs
@@ -14,7 +14,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class ConnectionStringParserTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionTypeExtensionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ConnectionTypeExtensionTests.cs
@@ -13,7 +13,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class ConnectionTypeExtensionTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/GuardTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/GuardTests.cs
@@ -14,7 +14,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class GuardTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Errors/EventHubsExceptionTests.cs
@@ -15,7 +15,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubsExceptionTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientOptionsTests.cs
@@ -10,7 +10,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubClientOptionsTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
@@ -22,7 +22,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubClientTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerOptionsTests.cs
@@ -9,7 +9,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubConsumerOptionsTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubConsumer/EventHubConsumerTests.cs
@@ -24,7 +24,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubConsumerTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/BatchOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/BatchOptionsTests.cs
@@ -9,7 +9,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class BatchOptionsTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventDataBatchTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventDataBatchTests.cs
@@ -11,7 +11,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventDataBatchTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerOptionsTests.cs
@@ -9,7 +9,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubProducerOptionsTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerTests.cs
@@ -19,7 +19,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventHubProducerTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensionTests.cs
@@ -11,7 +11,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class EventDataExtensionsTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/RetryOptionsExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/RetryOptionsExtensionsTests.cs
@@ -12,7 +12,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class RetryOptionsExtensionsTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Properties/AssemblyInfo.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Properties/AssemblyInfo.cs
@@ -4,5 +4,5 @@
 
 using NUnit.Framework;
 
-[assembly: Parallelizable(ParallelScope.Fixtures)]
+[assembly: Parallelizable(ParallelScope.All)]
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/BasicRetryPolicyTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/BasicRetryPolicyTests.cs
@@ -18,7 +18,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class BasicRetryPolicyTests
     {
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/RetryOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/RetryPolicies/RetryOptionsTests.cs
@@ -9,7 +9,6 @@ namespace Azure.Messaging.EventHubs.Tests
     /// </summary>
     ///
     [TestFixture]
-    [Parallelizable(ParallelScope.All)]
     public class RetryOptionsTests
     {
         /// <summary>


### PR DESCRIPTION
# Summary

The intent of these changes is to refactor how metadata is applied to tests to control palatalization.   Moving to a model where parallel is assumed by default and individual tests or fixtures can assert their own preferences to request a different behavior.

# Last Upstream Rebase

Thursday, August 8, 2019  1:12pm (EDT)

# Related and Follow-Up Issues

- [Review Test Parallelism Decorators](https://github.com/Azure/azure-sdk-for-net/issues/7095) (#7095)