### PR TITLE
[Event Hubs Client] Track Two: Second Preview (Test Stability)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubProducer/EventHubProducerLiveTests.cs
@@ -42,7 +42,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(TransportType.AmqpWebSockets)]
         public async Task ProducerWithNoOptionsCanSend(TransportType transportType)
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
@@ -65,7 +65,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCase(TransportType.AmqpWebSockets)]
         public async Task ProducerWithOptionsCanSend(TransportType transportType)
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
                 var producerOptions = new EventHubProducerOptions { RetryOptions = new RetryOptions { MaximumRetries = 5 } };
@@ -87,7 +87,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task ProducerCanSendToASpecificPartition()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var connectionString = TestEnvironment.BuildConnectionStringForEventHub(scope.EventHubName);
 
@@ -113,7 +113,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task ProducerCanSendEventsWithCustomProperties()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(1))
             {
                 var events = new[]
                 {
@@ -147,7 +147,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task ProducerCanSendEventsUsingAPartitionHashKey()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var events = Enumerable
                     .Range(0, 25)
@@ -172,7 +172,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public async Task ProducerCanSendMultipleSetsOfEventsUsingAPartitionHashKey()
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var batchOptions = new SendOptions { PartitionKey = "some123key-!d" };
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Samples/SamplesLiveTests.cs
@@ -46,7 +46,7 @@ namespace Azure.Messaging.EventHubs.Tests
         [TestCaseSource(nameof(SampleTestCases))]
         public async Task SmokeTestASample(IEventHubsSample sample)
         {
-            await using (var scope = await EventHubScope.CreateAsync(4))
+            await using (var scope = await EventHubScope.CreateAsync(2))
             {
                 var connectionString = TestEnvironment.EventHubsConnectionString;
                 Assert.That(async () => await sample.RunAsync(connectionString, scope.EventHubName), Throws.Nothing);


### PR DESCRIPTION
# Summary

The intent of these changes is to improve the stability of tests for the nightly runs.

### Goals

- Refactor tests to add some timing-related backoffs to account for non-determinism in published event availability.

- Tune the number of partions used by Live tests to avoid over-provisioning and improve response time..

- Tweak the method used for dynamic Event Hub generation, allowing a new name to be generated on each retry to account for some newly occurring Conflict response codes, suspected to be the result of increased parallel use.

# Last Upstream Rebase

Friday, August 9, 2019 12:28pm (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 3 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7141) (#7141)
- [Stabilize Live Tests for Nightly Runs](https://github.com/Azure/azure-sdk-for-net/issues/7181) (#7181)