### PR TITLE
Annotate Azure.Core with non-null reference types

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@
 
 - Install VS 2019 (Community or higher) and make sure you have the latest updates (https://www.visualstudio.com/).
 - Install the **.NET Core cross-platform development** workloads in VisualStudio
-- Install **.NET Core 3 preview 5** or higher for your specific platform. (https://dotnet.microsoft.com/download/dotnet-core/3.0)
+- Install **.NET Core 3 preview 7** or higher for your specific platform. (https://dotnet.microsoft.com/download/dotnet-core/3.0)
 
 > **Client Libraries** are sdks used to interact with azure resources at application run time while **Management Libraries** are those used to manage (create/modify/delete) Azure resources.
 <br/>

--- a/eng/Directory.Build.Data.props
+++ b/eng/Directory.Build.Data.props
@@ -108,7 +108,7 @@
     <DelaySign>false</DelaySign>
     <PublicSign>false</PublicSign>
     <ImportDefaultReferences>false</ImportDefaultReferences>
-    <UseProjectReferenceToAzureCore>false</UseProjectReferenceToAzureCore>
+    <UseProjectReferenceToAzureCore>true</UseProjectReferenceToAzureCore>
     <LangVersion>preview</LangVersion>
     <DocumentationFile>$(IntermediateOutputPath)$(TargetFramework)\$(MSBuildProjectName).xml</DocumentationFile>
   </PropertyGroup>

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
-  DotNetCoreSDKVersion: '3.0.100-preview5-011568'
+  DotNetCoreSDKVersion: '3.0.100-preview7-012821'
   DotNetCoreRuntimeVersion: '2.1.10'
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true

--- a/sdk/core/Azure.Core/src/AsyncCollection.cs
+++ b/sdk/core/Azure.Core/src/AsyncCollection.cs
@@ -13,7 +13,7 @@ namespace Azure
     /// iterate over.
     /// </summary>
     /// <typeparam name="T">The type of the values.</typeparam>
-    public abstract class AsyncCollection<T> : IAsyncEnumerable<Response<T>>
+    public abstract class AsyncCollection<T> : IAsyncEnumerable<Response<T>> where T : notnull
     {
         /// <summary>
         /// Gets a <see cref="CancellationToken"/> used for requests made while
@@ -55,7 +55,7 @@ namespace Azure
         /// An async sequence of <see cref="Page{T}"/>s.
         /// </returns>
         public abstract IAsyncEnumerable<Page<T>> ByPage(
-            string continuationToken = default,
+            string? continuationToken = default,
             int? pageSizeHint = default);
 
         /// <summary>

--- a/sdk/core/Azure.Core/src/Azure.Core.csproj
+++ b/sdk/core/Azure.Core/src/Azure.Core.csproj
@@ -13,7 +13,7 @@
       Bug fixes.
       ]]>
     </PackageReleaseNotes>
-
+    <Nullable>enable</Nullable>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EnableClientSdkAnalyzers>false</EnableClientSdkAnalyzers>

--- a/sdk/core/Azure.Core/src/AzureExtentions.cs
+++ b/sdk/core/Azure.Core/src/AzureExtentions.cs
@@ -8,7 +8,7 @@ namespace Azure
 {
     public static class AzureExtensions
     {
-        public static async ValueTask<Response<T>> WaitCompletionAsync<T>(this Task<Operation<T>> operation, CancellationToken cancellationToken = default)
+        public static async ValueTask<Response<T>> WaitCompletionAsync<T>(this Task<Operation<T>> operation, CancellationToken cancellationToken = default) where T : notnull
         {
             Operation<T> o = await operation.ConfigureAwait(false);
             return await o.WaitCompletionAsync(cancellationToken).ConfigureAwait(false);

--- a/sdk/core/Azure.Core/src/Buffers/StreamMemoryExtensions.cs
+++ b/sdk/core/Azure.Core/src/Buffers/StreamMemoryExtensions.cs
@@ -17,7 +17,7 @@ namespace Azure.Core.Buffers
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
             if (buffer.Length == 0) return;
-            byte[] array = null;
+            byte[]? array = null;
             try
             {
                 if (MemoryMarshal.TryGetArray(buffer, out var arraySegment))
@@ -47,7 +47,7 @@ namespace Azure.Core.Buffers
             if (stream == null) throw new ArgumentNullException(nameof(stream));
 
             if (buffer.Length == 0) return;
-            byte[] array = null;
+            byte[]? array = null;
             try
             {
                 foreach (var segment in buffer)

--- a/sdk/core/Azure.Core/src/Diagnostics/HttpPipelineEventSource.cs
+++ b/sdk/core/Azure.Core/src/Diagnostics/HttpPipelineEventSource.cs
@@ -58,7 +58,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public async Task RequestContentAsync(Request request, CancellationToken cancellationToken)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            if (request.Content != null && IsEnabled(EventLevel.Verbose, EventKeywords.None))
             {
                 RequestContent(request.ClientRequestId, await FormatContentAsync(request.Content, cancellationToken).ConfigureAwait(false));
             }
@@ -67,7 +67,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public void RequestContent(Request request, CancellationToken cancellationToken)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            if (request.Content != null && IsEnabled(EventLevel.Verbose, EventKeywords.None))
             {
                 RequestContent(request.ClientRequestId, FormatContent(request.Content, cancellationToken));
             }
@@ -76,7 +76,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public async Task RequestContentTextAsync(Request request, Encoding encoding, CancellationToken cancellationToken)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            if (request.Content != null && IsEnabled(EventLevel.Verbose, EventKeywords.None))
             {
                 RequestContentText(request.ClientRequestId, await FormatContentStringAsync(request.Content, encoding, cancellationToken).ConfigureAwait(false));
             }
@@ -85,7 +85,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public void RequestContentText(Request request, Encoding encoding, CancellationToken cancellationToken)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            if (request.Content != null && IsEnabled(EventLevel.Verbose, EventKeywords.None))
             {
                 RequestContentText(request.ClientRequestId, FormatContentString(request.Content, encoding, cancellationToken));
             }
@@ -103,7 +103,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public async Task ResponseContentAsync(Response response, CancellationToken cancellationToken)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            if (response.ContentStream != null && IsEnabled(EventLevel.Verbose, EventKeywords.None))
             {
                 ResponseContent(response.ClientRequestId, await FormatContentAsync(response.ContentStream, cancellationToken).ConfigureAwait(false));
             }
@@ -112,7 +112,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public void ResponseContent(Response response)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            if (response.ContentStream != null && IsEnabled(EventLevel.Verbose, EventKeywords.None))
             {
                 ResponseContent(response.ClientRequestId, FormatContent(response.ContentStream));
             }
@@ -130,7 +130,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public async Task ResponseContentTextAsync(Response response, Encoding encoding, CancellationToken cancellationToken)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            if (response.ContentStream != null && IsEnabled(EventLevel.Verbose, EventKeywords.None))
             {
                 ResponseContentText(response.ClientRequestId, await FormatContentStringAsync(response.ContentStream, encoding, cancellationToken).ConfigureAwait(false));
             }
@@ -139,7 +139,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public void ResponseContentText(Response response, Encoding encoding)
         {
-            if (IsEnabled(EventLevel.Verbose, EventKeywords.None))
+            if (response.ContentStream != null && IsEnabled(EventLevel.Verbose, EventKeywords.None))
             {
                 ResponseContentText(response.ClientRequestId, FormatContentString(response.ContentStream, encoding));
             }
@@ -157,7 +157,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public async Task ErrorResponseContentAsync(Response response, CancellationToken cancellationToken)
         {
-            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
+            if (response.ContentStream != null && IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 ErrorResponseContent(response.ClientRequestId, await FormatContentAsync(response.ContentStream, cancellationToken).ConfigureAwait(false));
             }
@@ -166,7 +166,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public void ErrorResponseContent(Response response)
         {
-            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
+            if (response.ContentStream != null && IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 ErrorResponseContent(response.ClientRequestId, FormatContent(response.ContentStream));
             }
@@ -175,7 +175,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public async Task ErrorResponseContentTextAsync(Response response, Encoding encoding, CancellationToken cancellationToken)
         {
-            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
+            if (response.ContentStream != null && IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 ErrorResponseContentText(response.ClientRequestId, await FormatContentStringAsync(response.ContentStream, encoding, cancellationToken).ConfigureAwait(false));
             }
@@ -184,7 +184,7 @@ namespace Azure.Core.Diagnostics
         [NonEvent]
         public void ErrorResponseContentText(Response response, Encoding encoding)
         {
-            if (IsEnabled(EventLevel.Informational, EventKeywords.None))
+            if (response.ContentStream != null && IsEnabled(EventLevel.Informational, EventKeywords.None))
             {
                 ErrorResponseContentText(response.ClientRequestId, FormatContentString(response.ContentStream, encoding));
             }

--- a/sdk/core/Azure.Core/src/FailedResponseException.cs
+++ b/sdk/core/Azure.Core/src/FailedResponseException.cs
@@ -13,7 +13,7 @@ namespace Azure
             : this(status, message, null)
         {}
 
-        public RequestFailedException(int status, string message, Exception innerException)
+        public RequestFailedException(int status, string message, Exception? innerException)
             : base(message, innerException)
         {
             Status = status;

--- a/sdk/core/Azure.Core/src/Http/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Http/HttpClientTransport.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Net;
 using System.Net.Http;
@@ -73,7 +74,7 @@ namespace Azure.Core.Pipeline
             return pipelineRequest.BuildRequestMessage(message.CancellationToken);
         }
 
-        internal static bool TryGetHeader(HttpHeaders headers, HttpContent content, string name, out string value)
+        internal static bool TryGetHeader(HttpHeaders headers, HttpContent? content, string name, [NotNullWhen(true)] out string? value)
         {
             if (TryGetHeader(headers, content, name, out IEnumerable<string> values))
             {
@@ -85,12 +86,12 @@ namespace Azure.Core.Pipeline
             return false;
         }
 
-        internal static bool TryGetHeader(HttpHeaders headers, HttpContent content, string name, out IEnumerable<string> values)
+        internal static bool TryGetHeader(HttpHeaders headers, HttpContent? content, string name, out IEnumerable<string> values)
         {
             return headers.TryGetValues(name, out values) || content?.Headers.TryGetValues(name, out values) == true;
         }
 
-        internal static IEnumerable<HttpHeader> GetHeaders(HttpHeaders headers, HttpContent content)
+        internal static IEnumerable<HttpHeader> GetHeaders(HttpHeaders headers, HttpContent? content)
         {
             foreach (var header in headers)
             {
@@ -106,7 +107,7 @@ namespace Azure.Core.Pipeline
             }
         }
 
-        internal static bool RemoveHeader(HttpHeaders headers, HttpContent content, string name)
+        internal static bool RemoveHeader(HttpHeaders headers, HttpContent? content, string name)
         {
             // .Remove throws on invalid header name so use TryGet here to check
             if (headers.TryGetValues(name, out _ ) && headers.Remove(name))
@@ -117,7 +118,7 @@ namespace Azure.Core.Pipeline
             return content?.Headers.TryGetValues(name, out _ ) == true && content.Headers.Remove(name);
         }
 
-        internal static bool ContainsHeader(HttpHeaders headers, HttpContent content, string name)
+        internal static bool ContainsHeader(HttpHeaders headers, HttpContent? content, string name)
         {
             // .Contains throws on invalid header name so use TryGet here
             if (headers.TryGetValues(name, out _))
@@ -149,7 +150,7 @@ namespace Azure.Core.Pipeline
             private bool _wasSent = false;
             private readonly HttpRequestMessage _requestMessage;
 
-            private PipelineContentAdapter _requestContent;
+            private PipelineContentAdapter? _requestContent;
 
             public PipelineRequest()
             {
@@ -163,7 +164,7 @@ namespace Azure.Core.Pipeline
                 set => _requestMessage.Method = ToHttpClientMethod(value);
             }
 
-            public override HttpPipelineRequestContent Content { get; set; }
+            public override HttpPipelineRequestContent? Content { get; set; }
 
             public override string ClientRequestId { get; set; }
 
@@ -174,14 +175,14 @@ namespace Azure.Core.Pipeline
                     return;
                 }
 
-                EnsureContentInitialized();
-                if (!_requestContent.Headers.TryAddWithoutValidation(name, value))
+                var requestContent = EnsureContentInitialized();
+                if (!requestContent.Headers.TryAddWithoutValidation(name, value))
                 {
                     throw new InvalidOperationException("Unable to add header to request or content");
                 }
             }
 
-            protected internal override bool TryGetHeader(string name, out string value) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out value);
+            protected internal override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out value);
 
             protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_requestMessage.Headers, _requestContent, name, out values);
 
@@ -209,7 +210,7 @@ namespace Azure.Core.Pipeline
                 currentRequest.RequestUri = UriBuilder.Uri;
 
 
-                if (Content != null)
+                if (Content != null && _requestContent != null)
                 {
                     PipelineContentAdapter currentContent;
                     if (_wasSent)
@@ -284,31 +285,33 @@ namespace Azure.Core.Pipeline
                 return new HttpMethod(method);
             }
 
-            private void EnsureContentInitialized()
+            private PipelineContentAdapter EnsureContentInitialized()
             {
                 if (_requestContent == null)
                 {
                     _requestContent = new PipelineContentAdapter();
                 }
+
+                return _requestContent;
             }
 
             sealed class PipelineContentAdapter : HttpContent
             {
-                public HttpPipelineRequestContent PipelineContent { get; set; }
+                public HttpPipelineRequestContent? PipelineContent { get; set; }
 
                 public CancellationToken CancellationToken { get; set; }
 
                 protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
                 {
                     Debug.Assert(PipelineContent != null);
-                    await PipelineContent.WriteToAsync(stream, CancellationToken).ConfigureAwait(false);
+                    await PipelineContent!.WriteToAsync(stream, CancellationToken).ConfigureAwait(false);
                 }
 
                 protected override bool TryComputeLength(out long length)
                 {
                     Debug.Assert(PipelineContent != null);
 
-                    return PipelineContent.TryComputeLength(out length);
+                    return PipelineContent!.TryComputeLength(out length);
                 }
             }
         }
@@ -317,7 +320,7 @@ namespace Azure.Core.Pipeline
         {
             private readonly HttpResponseMessage _responseMessage;
 
-            private Stream _contentStream;
+            private Stream? _contentStream;
 
             public PipelineResponse(string requestId, HttpResponseMessage responseMessage)
             {
@@ -329,7 +332,7 @@ namespace Azure.Core.Pipeline
 
             public override string ReasonPhrase => _responseMessage.ReasonPhrase;
 
-            public override Stream ContentStream
+            public override Stream? ContentStream
             {
                 get
                 {
@@ -364,7 +367,7 @@ namespace Azure.Core.Pipeline
 
             public override string ClientRequestId { get; set; }
 
-            protected internal override bool TryGetHeader(string name, out string value) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseMessage.Content, name, out value);
+            protected internal override bool TryGetHeader(string name, [NotNullWhen(true)] out string? value) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseMessage.Content, name, out value);
 
             protected internal override bool TryGetHeaderValues(string name, out IEnumerable<string> values) => HttpClientTransport.TryGetHeader(_responseMessage.Headers, _responseMessage.Content, name, out values);
 
@@ -383,36 +386,34 @@ namespace Azure.Core.Pipeline
         private class ContentStream : ReadOnlyStream
         {
             private readonly Task<Stream> _contentTask;
-            private Stream _contentStream;
+            private Stream? _contentStream;
 
             public ContentStream(Task<Stream> contentTask)
             {
                 _contentTask = contentTask;
             }
+
             public override long Seek(long offset, SeekOrigin origin)
             {
-                EnsureStream();
-                return _contentStream.Seek(offset, origin);
+                return Stream.Seek(offset, origin);
             }
 
             public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
             {
                 await EnsureStreamAsync().ConfigureAwait(false);
-                return await _contentStream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
+                return await Stream.ReadAsync(buffer, offset, count, cancellationToken).ConfigureAwait(false);
             }
 
             public override int Read(byte[] buffer, int offset, int count)
             {
-                EnsureStream();
-                return _contentStream.Read(buffer, offset, count);
+                return Stream.Read(buffer, offset, count);
             }
 
             public override bool CanRead
             {
                 get
                 {
-                    EnsureStream();
-                    return _contentStream.CanRead;
+                    return Stream.CanRead;
                 }
             }
 
@@ -420,8 +421,7 @@ namespace Azure.Core.Pipeline
             {
                 get
                 {
-                    EnsureStream();
-                    return _contentStream.CanSeek;
+                    return Stream.CanSeek;
                 }
             }
 
@@ -429,8 +429,7 @@ namespace Azure.Core.Pipeline
             {
                 get
                 {
-                    EnsureStream();
-                    return _contentStream.Length;
+                    return Stream.Length;
                 }
             }
 
@@ -438,32 +437,35 @@ namespace Azure.Core.Pipeline
             {
                 get
                 {
-                    EnsureStream();
-                    return _contentStream.Position;
+                    return Stream.Position;
                 }
                 set
                 {
-                    EnsureStream();
-                    _contentStream.Position = value;
+                    Stream.Position = value;
                 }
             }
 
-            private void EnsureStream()
+            private Stream Stream
             {
-                if (_contentStream != null)
+                get
                 {
-                    EnsureStreamAsync().GetAwaiter().GetResult();
+                    if (_contentStream == null)
+                    {
+                        return EnsureStreamAsync().GetAwaiter().GetResult();
+                    }
+
+                    return _contentStream;
                 }
             }
 
-            private Task EnsureStreamAsync()
+            private ValueTask<Stream> EnsureStreamAsync()
             {
-                async Task EnsureStreamAsyncImpl()
+                async ValueTask<Stream> EnsureStreamAsyncImpl()
                 {
-                    _contentStream = await _contentTask.ConfigureAwait(false);
+                    return (_contentStream = await _contentTask.ConfigureAwait(false));
                 }
 
-                return _contentStream == null ? EnsureStreamAsyncImpl() : Task.CompletedTask;
+                return _contentStream == null ? EnsureStreamAsyncImpl() : new ValueTask<Stream>(_contentStream);
             }
         }
     }

--- a/sdk/core/Azure.Core/src/Http/HttpClientTransport.cs
+++ b/sdk/core/Azure.Core/src/Http/HttpClientTransport.cs
@@ -210,18 +210,17 @@ namespace Azure.Core.Pipeline
                 currentRequest.RequestUri = UriBuilder.Uri;
 
 
-                if (Content != null && _requestContent != null)
+                if (Content != null)
                 {
                     PipelineContentAdapter currentContent;
                     if (_wasSent)
                     {
                         currentContent = new PipelineContentAdapter();
-                        CopyHeaders(_requestContent.Headers, currentContent.Headers);
+                        CopyHeaders(_requestContent!.Headers, currentContent.Headers);
                     }
                     else
                     {
-                        EnsureContentInitialized();
-                        currentContent = _requestContent;
+                        currentContent = EnsureContentInitialized();
                     }
 
                     currentContent.CancellationToken = cancellation;

--- a/sdk/core/Azure.Core/src/Http/HttpPipelineUriBuilder.cs
+++ b/sdk/core/Azure.Core/src/Http/HttpPipelineUriBuilder.cs
@@ -16,15 +16,15 @@ namespace Azure.Core.Http
 
         private int _queryIndex = -1;
 
-        private Uri _uri;
+        private Uri? _uri;
 
         private int _port;
 
-        private string _host;
+        private string? _host;
 
-        private string _scheme;
+        private string? _scheme;
 
-        public string Scheme
+        public string? Scheme
         {
             get => _scheme;
             set
@@ -34,7 +34,7 @@ namespace Azure.Core.Http
             }
         }
 
-        public string Host
+        public string? Host
         {
             get => _host;
             set
@@ -200,8 +200,8 @@ namespace Azure.Core.Http
         }
 
         private bool HasDefaultPortForScheme =>
-            (Port == 80 && Scheme.Equals("http", StringComparison.InvariantCultureIgnoreCase)) ||
-            (Port == 443 && Scheme.Equals("https", StringComparison.InvariantCultureIgnoreCase));
+            (Port == 80 && string.Equals(Scheme, "http", StringComparison.InvariantCultureIgnoreCase)) ||
+            (Port == 443 && string.Equals(Scheme, "https", StringComparison.InvariantCultureIgnoreCase));
 
         private void ResetUri()
         {

--- a/sdk/core/Azure.Core/src/Http/RequestHeaders.cs
+++ b/sdk/core/Azure.Core/src/Http/RequestHeaders.cs
@@ -3,6 +3,7 @@
 
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Azure.Core.Http
 {
@@ -35,7 +36,7 @@ namespace Azure.Core.Http
             _request.AddHeader(name, value);
         }
 
-        public bool TryGetValue(string name, out string value)
+        public bool TryGetValue(string name, [NotNullWhen(true)] out string? value)
         {
             return _request.TryGetHeader(name, out value);
         }

--- a/sdk/core/Azure.Core/src/Http/ResponseHeaders.cs
+++ b/sdk/core/Azure.Core/src/Http/ResponseHeaders.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 
 namespace Azure.Core.Http
@@ -23,9 +24,9 @@ namespace Azure.Core.Http
                 (DateTimeOffset?)DateTimeOffset.Parse(value, CultureInfo.InvariantCulture) :
                 null;
 
-        public string ContentType => TryGetValue(HttpHeader.Names.ContentType, out var value) ? value : null;
+        public string? ContentType => TryGetValue(HttpHeader.Names.ContentType, out var value) ? value : null;
 
-        public string RequestId => TryGetValue(HttpHeader.Names.XMsRequestId, out var value) ? value : null;
+        public string? RequestId => TryGetValue(HttpHeader.Names.XMsRequestId, out var value) ? value : null;
 
         public IEnumerator<HttpHeader> GetEnumerator()
         {
@@ -37,7 +38,7 @@ namespace Azure.Core.Http
             return _response.EnumerateHeaders().GetEnumerator();
         }
 
-        public bool TryGetValue(string name, out string value)
+        public bool TryGetValue(string name, [NotNullWhen(true)] out string? value)
         {
             return _response.TryGetHeader(name, out value);
         }

--- a/sdk/core/Azure.Core/src/OperationOfT.cs
+++ b/sdk/core/Azure.Core/src/OperationOfT.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable disable
+
 using System;
 using System.ComponentModel;
 using System.Threading;
@@ -12,7 +14,7 @@ namespace Azure
     /// Represents a long running operation (LRO).
     /// </summary>
     /// <typeparam name="T">The final result of the LRO.</typeparam>
-    public abstract class Operation<T>
+    public abstract class Operation<T> where T : notnull
     {
         T _value;
         Response _response;
@@ -42,7 +44,9 @@ namespace Azure
         public T Value
         {
             get {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
                 if (!HasValue) throw new InvalidOperationException("operation has not completed");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
                 return _value;
             }
             protected set

--- a/sdk/core/Azure.Core/src/Page.cs
+++ b/sdk/core/Azure.Core/src/Page.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable enable
-
 using System.Collections.Generic;
 using System.ComponentModel;
 

--- a/sdk/core/Azure.Core/src/Page.cs
+++ b/sdk/core/Azure.Core/src/Page.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -23,7 +25,7 @@ namespace Azure
         /// <see cref="Page{T}"/>.  The continuation token may be null or
         /// empty when there are no more pages.
         /// </summary>
-        public string ContinuationToken { get; }
+        public string? ContinuationToken { get; }
 
         /// <summary>
         /// The <see cref="Response"/> that provided this <see cref="Page{T}"/>.
@@ -48,7 +50,7 @@ namespace Azure
         /// <param name="response">
         /// The <see cref="Response"/> that provided this <see cref="Page{T}"/>.
         /// </param>
-        public Page(IReadOnlyList<T> values, string continuationToken, Response response)
+        public Page(IReadOnlyList<T> values, string? continuationToken, Response response)
         {
             this.Values = values;
             this.ContinuationToken = continuationToken;

--- a/sdk/core/Azure.Core/src/Pipeline/AzureOperationScope.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/AzureOperationScope.cs
@@ -8,7 +8,7 @@ namespace Azure.Core.Pipeline
 {
     public struct DiagnosticScope: IDisposable
     {
-        private Activity _activity;
+        private Activity? _activity;
 
         private readonly string _name;
 
@@ -30,7 +30,7 @@ namespace Azure.Core.Pipeline
 
         public void AddAttribute<T>(string name, T value)
         {
-            if (_activity != null)
+            if (_activity != null && value != null)
             {
                 AddAttribute(name, value.ToString());
             }

--- a/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/BearerTokenAuthenticationPolicy.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Pipeline
 
         private readonly string[] _scopes;
 
-        private string _headerValue;
+        private string? _headerValue;
 
         private DateTimeOffset _refreshOn;
 
@@ -61,7 +61,10 @@ namespace Azure.Core.Pipeline
                 _refreshOn = token.ExpiresOn - TimeSpan.FromMinutes(2);
             }
 
-            message.Request.SetHeader(HttpHeader.Names.Authorization, _headerValue);
+            if (_headerValue != null)
+            {
+                message.Request.SetHeader(HttpHeader.Names.Authorization, _headerValue);
+            }
 
             if (async)
             {

--- a/sdk/core/Azure.Core/src/Pipeline/DiagnosticsOptions.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/DiagnosticsOptions.cs
@@ -17,9 +17,9 @@ namespace Azure.Core.Pipeline
 
         public bool IsTelemetryEnabled { get; set; }
 
-        public string ApplicationId { get; set; }
+        public string? ApplicationId { get; set; }
 
-        public static string DefaultApplicationId { get; set; }
+        public static string? DefaultApplicationId { get; set; }
 
         private static bool? EnvironmentVariableToBool(string value)
         {

--- a/sdk/core/Azure.Core/src/Pipeline/HttpEnvironmentProxy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpEnvironmentProxy.cs
@@ -4,6 +4,8 @@
 
 // Copied from https://raw.githubusercontent.com/dotnet/corefx/master/src/System.Net.Http/src/System/Net/Http/SocketsHttpHandler/HttpEnvironmentProxy.cs
 
+#nullable disable
+
 using System;
 using System.Net;
 using System.Collections.Generic;
@@ -103,7 +105,7 @@ namespace Azure.Core.Pipeline
 
         private Uri _httpProxyUri;      // String URI for HTTP requests
         private Uri _httpsProxyUri;     // String URI for HTTPS requests
-        private string[] _bypass = null;// list of domains not to proxy
+        private string[] _bypass;// list of domains not to proxy
         private ICredentials _credentials;
 
         public static bool TryCreate(out IWebProxy proxy)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs
@@ -15,7 +15,7 @@ namespace Azure.Core.Pipeline
         private readonly ResponseClassifier _responseClassifier;
         private readonly ReadOnlyMemory<HttpPipelinePolicy> _pipeline;
 
-        public HttpPipeline(HttpPipelineTransport transport, HttpPipelinePolicy[] policies = null, ResponseClassifier responseClassifier = null, ClientDiagnostics clientDiagnostics = null)
+        public HttpPipeline(HttpPipelineTransport transport, HttpPipelinePolicy[]? policies = null, ResponseClassifier? responseClassifier = null, ClientDiagnostics? clientDiagnostics = null)
         {
             _transport = transport ?? throw new ArgumentNullException(nameof(transport));
             _responseClassifier = responseClassifier ?? new ResponseClassifier();
@@ -39,7 +39,7 @@ namespace Azure.Core.Pipeline
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public async Task<Response> SendRequestAsync(Request request, CancellationToken cancellationToken)
         {
-            var message = new HttpPipelineMessage(cancellationToken);
+            var message = new HttpPipelineMessage(request, _responseClassifier, cancellationToken);
             message.Request = request;
             message.ResponseClassifier = _responseClassifier;
             await _pipeline.Span[0].ProcessAsync(message, _pipeline.Slice(1)).ConfigureAwait(false);
@@ -49,7 +49,7 @@ namespace Azure.Core.Pipeline
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Response SendRequest(Request request, CancellationToken cancellationToken)
         {
-            var message = new HttpPipelineMessage(cancellationToken);
+            var message = new HttpPipelineMessage(request, _responseClassifier, cancellationToken);
             message.Request = request;
             message.ResponseClassifier = _responseClassifier;
             _pipeline.Span[0].Process(message, _pipeline.Slice(1));

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
@@ -42,6 +42,8 @@ namespace Azure.Core.Pipeline
             set => _response = value;
         }
 
+        public bool HasResponse => _response != null;
+
         public ResponseClassifier ResponseClassifier { get; set; }
 
         public bool TryGetProperty(string name, out object? value)

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineMessage.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using Azure.Core.Http;
@@ -9,22 +12,39 @@ namespace Azure.Core.Pipeline
 {
     public class HttpPipelineMessage
     {
-        private Dictionary<string, object> _properties;
+        private Dictionary<string, object>? _properties;
+
+        private Response? _response;
 
         public CancellationToken CancellationToken { get; }
 
-        public HttpPipelineMessage(CancellationToken cancellationToken)
+        public HttpPipelineMessage(Request request, ResponseClassifier responseClassifier, CancellationToken cancellationToken)
         {
+            Request = request;
+            ResponseClassifier = responseClassifier;
             CancellationToken = cancellationToken;
         }
 
         public Request Request { get; set; }
 
-        public Response Response { get; set; }
+        public Response Response
+        {
+            get
+            {
+                if (_response == null)
+                {
+#pragma warning disable CA1065 // Do not raise exceptions in unexpected locations
+                    throw new InvalidOperationException("Response was not set, make sure SendAsync was called");
+#pragma warning restore CA1065 // Do not raise exceptions in unexpected locations
+                }
+                return _response;
+            }
+            set => _response = value;
+        }
 
         public ResponseClassifier ResponseClassifier { get; set; }
 
-        public bool TryGetProperty(string name, out object value)
+        public bool TryGetProperty(string name, out object? value)
         {
             value = null;
             return _properties?.TryGetValue(name, out value) == true;

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;

--- a/sdk/core/Azure.Core/src/Pipeline/HttpPipelineRequestContent.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/HttpPipelineRequestContent.cs
@@ -87,8 +87,7 @@ namespace Azure.Core.Pipeline
 
             public override void Dispose()
             {
-                _stream?.Dispose();
-                _stream = null;
+                _stream.Dispose();
             }
         }
 

--- a/sdk/core/Azure.Core/src/Pipeline/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RequestActivityPolicy.cs
@@ -40,7 +40,7 @@ namespace Azure.Core.Pipeline
             var activity = new Activity("Azure.Core.Http.Request");
             activity.AddTag("http.method", message.Request.Method.Method);
             activity.AddTag("http.url", message.Request.UriBuilder.ToString());
-            if (message.Request.Headers.TryGetValue("User-Agent", out string userAgent))
+            if (message.Request.Headers.TryGetValue("User-Agent", out string? userAgent))
             {
                 activity.AddTag("http.user_agent", userAgent);
             }

--- a/sdk/core/Azure.Core/src/Pipeline/RetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RetryPolicy.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Runtime.ExceptionServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -44,10 +45,10 @@ namespace Azure.Core.Pipeline
         private async Task ProcessAsync(HttpPipelineMessage message, ReadOnlyMemory<HttpPipelinePolicy> pipeline, bool async)
         {
             int attempt = 0;
-            List<Exception> exceptions = null;
+            List<Exception>? exceptions = null;
             while (true)
             {
-                Exception lastException = null;
+                Exception? lastException = null;
 
                 try
                 {
@@ -87,7 +88,7 @@ namespace Azure.Core.Pipeline
                     else
                     {
                         // Rethrow a singular exception
-                        if (exceptions.Count == 1)
+                        if (exceptions?.Count == 1)
                         {
                             ExceptionDispatchInfo.Capture(lastException).Throw();
                         }
@@ -139,6 +140,11 @@ namespace Azure.Core.Pipeline
 
         protected virtual TimeSpan GetServerDelay(HttpPipelineMessage message)
         {
+            if (message.Response == null)
+            {
+                return TimeSpan.Zero;
+            }
+
             if (message.Response.TryGetHeader(RetryAfterMsHeaderName, out var retryAfterValue) ||
                 message.Response.TryGetHeader(XRetryAfterMsHeaderName, out retryAfterValue))
             {

--- a/sdk/core/Azure.Core/src/Pipeline/TelemetryPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/TelemetryPolicy.cs
@@ -10,7 +10,7 @@ namespace Azure.Core.Pipeline
     {
         private readonly string _header;
 
-        public TelemetryPolicy(string componentName, string componentVersion, string applicationId)
+        public TelemetryPolicy(string componentName, string componentVersion, string? applicationId)
         {
             var platformInformation = $"({RuntimeInformation.FrameworkDescription}; {RuntimeInformation.OSDescription})";
             if (applicationId != null)

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Azure.Core.Pipeline;
 
-#nullable enable
-
 namespace Azure.Core.Http
 {
     public abstract class Request : IDisposable

--- a/sdk/core/Azure.Core/src/Request.cs
+++ b/sdk/core/Azure.Core/src/Request.cs
@@ -3,7 +3,10 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using Azure.Core.Pipeline;
+
+#nullable enable
 
 namespace Azure.Core.Http
 {
@@ -19,11 +22,11 @@ namespace Azure.Core.Http
             UriBuilder.Uri = uri;
         }
 
-        public virtual HttpPipelineRequestContent Content { get; set; }
+        public virtual HttpPipelineRequestContent? Content { get; set; }
 
         protected internal abstract void AddHeader(string name, string value);
 
-        protected internal abstract bool TryGetHeader(string name, out string value);
+        protected internal abstract bool TryGetHeader(string name, [NotNullWhen(true)] out string? value);
 
         protected internal abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
 

--- a/sdk/core/Azure.Core/src/Response.cs
+++ b/sdk/core/Azure.Core/src/Response.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Azure.Core.Http;
-using Azure.Core.Pipeline;
 
 namespace Azure
 {
@@ -15,7 +17,7 @@ namespace Azure
 
         public abstract string ReasonPhrase { get; }
 
-        public abstract Stream ContentStream { get; set; }
+        public abstract Stream? ContentStream { get; set; }
 
         public abstract string ClientRequestId { get; set; }
 
@@ -23,7 +25,7 @@ namespace Azure
 
         public abstract void Dispose();
 
-        protected internal abstract bool TryGetHeader(string name, out string value);
+        protected internal abstract bool TryGetHeader(string name, [NotNullWhen(true)] out string? value);
 
         protected internal abstract bool TryGetHeaderValues(string name, out IEnumerable<string> values);
 

--- a/sdk/core/Azure.Core/src/Response.cs
+++ b/sdk/core/Azure.Core/src/Response.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable enable
-
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;

--- a/sdk/core/Azure.Core/src/ResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/ResponseOfT.cs
@@ -1,12 +1,14 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.ComponentModel;
 
 namespace Azure
 {
-    public readonly struct Response<T> : IDisposable
+    public readonly struct Response<T> : IDisposable where T : notnull
     {
         private readonly Response _rawResponse;
 

--- a/sdk/core/Azure.Core/src/ResponseOfT.cs
+++ b/sdk/core/Azure.Core/src/ResponseOfT.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-#nullable enable
-
 using System;
 using System.ComponentModel;
 

--- a/sdk/core/Azure.Core/src/Shared/ContentTypeUtilities.cs
+++ b/sdk/core/Azure.Core/src/Shared/ContentTypeUtilities.cs
@@ -1,14 +1,17 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text;
 
 namespace Azure.Core.Pipeline
 {
     internal static class ContentTypeUtilities
     {
-        public static bool TryGetTextEncoding(string contentType, out Encoding encoding)
+        public static bool TryGetTextEncoding(string? contentType, [NotNullWhen(true)] out Encoding? encoding)
         {
             const string charsetMarker = "; charset=";
             const string utf8Charset = "utf-8";

--- a/sdk/core/Azure.Core/src/Shared/NullableAttributes.cs
+++ b/sdk/core/Azure.Core/src/Shared/NullableAttributes.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#define INTERNAL_NULLABLE_ATTRIBUTES
+
+namespace System.Diagnostics.CodeAnalysis
+{
+    /// <summary>Specifies that null is allowed as an input even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class AllowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that null is disallowed as an input even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class DisallowNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class MaybeNullAttribute : Attribute { }
+
+    /// <summary>Specifies that an output will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class NotNullAttribute : Attribute { }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter may be null even if the corresponding type disallows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class MaybeNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter may be null.
+        /// </param>
+        public MaybeNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that when a method returns <see cref="ReturnValue"/>, the parameter will not be null even if the corresponding type allows it.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class NotNullWhenAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified return value condition.</summary>
+        /// <param name="returnValue">
+        /// The return value condition. If the method returns this value, the associated parameter will not be null.
+        /// </param>
+        public NotNullWhenAttribute(bool returnValue) => ReturnValue = returnValue;
+
+        /// <summary>Gets the return value condition.</summary>
+        public bool ReturnValue { get; }
+    }
+
+    /// <summary>Specifies that the output will be non-null if the named parameter is non-null.</summary>
+    [AttributeUsage(AttributeTargets.Parameter | AttributeTargets.Property | AttributeTargets.ReturnValue, AllowMultiple = true, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class NotNullIfNotNullAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the associated parameter name.</summary>
+        /// <param name="parameterName">
+        /// The associated parameter name.  The output will be non-null if the argument to the parameter specified is non-null.
+        /// </param>
+        public NotNullIfNotNullAttribute(string parameterName) => ParameterName = parameterName;
+
+        /// <summary>Gets the associated parameter name.</summary>
+        public string ParameterName { get; }
+    }
+
+    /// <summary>Applied to a method that will never return under any circumstance.</summary>
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class DoesNotReturnAttribute : Attribute { }
+
+    /// <summary>Specifies that the method will not return if the associated Boolean parameter is passed the specified value.</summary>
+    [AttributeUsage(AttributeTargets.Parameter, Inherited = false)]
+#if INTERNAL_NULLABLE_ATTRIBUTES
+    internal
+#else
+    public
+#endif
+        sealed class DoesNotReturnIfAttribute : Attribute
+    {
+        /// <summary>Initializes the attribute with the specified parameter value.</summary>
+        /// <param name="parameterValue">
+        /// The condition parameter value. Code after the method will be considered unreachable by diagnostics if the argument to
+        /// the associated parameter matches this value.
+        /// </param>
+        public DoesNotReturnIfAttribute(bool parameterValue) => ParameterValue = parameterValue;
+
+        /// <summary>Gets the condition parameter value.</summary>
+        public bool ParameterValue { get; }
+    }
+}

--- a/sdk/core/Azure.Core/src/Shared/PageResponseEnumerator.cs
+++ b/sdk/core/Azure.Core/src/Shared/PageResponseEnumerator.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#nullable enable
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/sdk/core/Azure.Core/src/Shared/PageResponseEnumerator.cs
+++ b/sdk/core/Azure.Core/src/Shared/PageResponseEnumerator.cs
@@ -2,18 +2,16 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Core
 {
     internal static class PageResponseEnumerator
     {
-        public static IEnumerable<Response<T>> CreateEnumerable<T>(Func<string, Page<T>> pageFunc)
+        public static IEnumerable<Response<T>> CreateEnumerable<T>(Func<string?, Page<T>> pageFunc) where T : notnull
         {
-            string nextLink = null;
+            string? nextLink = null;
             do
             {
                 Page<T> pageResponse = pageFunc(nextLink);
@@ -25,26 +23,26 @@ namespace Azure.Core
             } while (nextLink != null);
         }
 
-        public static AsyncCollection<T> CreateAsyncEnumerable<T>(Func<string, Task<Page<T>>> pageFunc)
+        public static AsyncCollection<T> CreateAsyncEnumerable<T>(Func<string?, Task<Page<T>>> pageFunc) where T : notnull
         {
             return new FuncAsyncCollection<T>((continuationToken, pageSizeHint) => pageFunc(continuationToken));
         }
 
-        public static AsyncCollection<T> CreateAsyncEnumerable<T>(Func<string, int?, Task<Page<T>>> pageFunc)
+        public static AsyncCollection<T> CreateAsyncEnumerable<T>(Func<string?, int?, Task<Page<T>>> pageFunc) where T : notnull
         {
             return new FuncAsyncCollection<T>(pageFunc);
         }
 
-        internal class FuncAsyncCollection<T>: AsyncCollection<T>
+        internal class FuncAsyncCollection<T>: AsyncCollection<T> where T : notnull
         {
-            private readonly Func<string, int?, Task<Page<T>>> _pageFunc;
+            private readonly Func<string?, int?, Task<Page<T>>> _pageFunc;
 
-            public FuncAsyncCollection(Func<string, int?, Task<Page<T>>> pageFunc)
+            public FuncAsyncCollection(Func<string?, int?, Task<Page<T>>> pageFunc)
             {
                 _pageFunc = pageFunc;
             }
 
-            public override async IAsyncEnumerable<Page<T>> ByPage(string continuationToken = default, int? pageSizeHint = default)
+            public override async IAsyncEnumerable<Page<T>> ByPage(string? continuationToken = default, int? pageSizeHint = default)
             {
                 do
                 {

--- a/sdk/core/Azure.Core/tests/PipelineTestBase.cs
+++ b/sdk/core/Azure.Core/tests/PipelineTestBase.cs
@@ -12,7 +12,7 @@ namespace Azure.Core.Tests
     {
         protected static async Task<Response> ExecuteRequest(Request request, HttpClientTransport transport)
         {
-            var message = new HttpPipelineMessage(CancellationToken.None) { Request = request };
+            var message = new HttpPipelineMessage(request, new ResponseClassifier(), CancellationToken.None) { Request = request };
             await transport.ProcessAsync(message);
             return message.Response;
         }

--- a/sdk/core/Azure.Core/tests/PipelineTests.cs
+++ b/sdk/core/Azure.Core/tests/PipelineTests.cs
@@ -33,7 +33,7 @@ namespace Azure.Core.Tests
         [Test]
         public void TryGetPropertyReturnsFalseIfNotExist()
         {
-            HttpPipelineMessage message = new HttpPipelineMessage(CancellationToken.None);
+            HttpPipelineMessage message = new HttpPipelineMessage(new MockRequest(), new ResponseClassifier(), CancellationToken.None);
 
             Assert.False(message.TryGetProperty("someName", out _));
         }
@@ -41,7 +41,7 @@ namespace Azure.Core.Tests
         [Test]
         public void TryGetPropertyReturnsValueIfSet()
         {
-            HttpPipelineMessage message = new HttpPipelineMessage(CancellationToken.None);
+            HttpPipelineMessage message = new HttpPipelineMessage(new MockRequest(), new ResponseClassifier(), CancellationToken.None);
             message.SetProperty("someName", "value");
 
             Assert.True(message.TryGetProperty("someName", out object value));
@@ -51,7 +51,7 @@ namespace Azure.Core.Tests
         [Test]
         public void TryGetPropertyIsCaseSensitive()
         {
-            HttpPipelineMessage message = new HttpPipelineMessage(CancellationToken.None);
+            HttpPipelineMessage message = new HttpPipelineMessage(new MockRequest(), new ResponseClassifier(), CancellationToken.None);
             message.SetProperty("someName", "value");
 
             Assert.False(message.TryGetProperty("SomeName", out object value));

--- a/sdk/core/Azure.Core/tests/TestFramework.props
+++ b/sdk/core/Azure.Core/tests/TestFramework.props
@@ -6,6 +6,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)\TestFramework\*.cs" Link="TestFramework\%(RecursiveDir)\%(Filename)%(Extension)" />
     <Compile Include="$(MSBuildThisFileDirectory)\..\src\Shared\ContentTypeUtilities.cs" Link="TestFramework\ContentTypeUtilities.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\..\src\Shared\NullableAttributes.cs" Link="TestFramework\NullableAttributes.cs" />
     <None Update="SessionRecords\**\*.json" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 

--- a/sdk/keyvault/Shared/ChallengeBasedAuthenticationPolicy.cs
+++ b/sdk/keyvault/Shared/ChallengeBasedAuthenticationPolicy.cs
@@ -153,7 +153,7 @@ namespace Azure.Security.KeyVault
             {
                 AuthenticationChallenge challenge = null;
 
-                if (message.Response != null)
+                if (message.HasResponse)
                 {
                     challenge = GetChallengeFromResponse(message.Response);
 


### PR DESCRIPTION
Exploring what non-nullable reference types feature mean for us.

Fixes: https://github.com/Azure/azure-sdk-for-net/issues/7215

I've added annotations to all public and internal types except Options<T> as it requires a little bit more refactoring.

Caught couple bugs. Nullable annotations are way better in preview7

### Breaking change

`HttpPipelineMessage.Response` now throws when not initialized, check `HasResponse` property to verify that it has value. I know it's slightly against property design guidelines but 99.9% of consumers expect the value to be there.

Minor breaking changes in HTTP pipeline related types that are not used by clients directly.

