### PR TITLE
[Event Hubs Client] Track Two: Second Preview (Ephemeral Test Namespaces)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-﻿# Contributing 
+# Contributing 
 
 Thank you for your interest in contributing to the Event Hubs client library.  As an open source effort, we're excited to welcome feedback and contributions from the community.  A great first step in sharing your thoughts and understanding where help is needed would be to take a look at the [open issues](https://github.com/Azure/azure-sdk-for-net/issues?q=is%3Aopen+is%3Aissue+label%3AClient+label%3A%22Event+Hubs%22).
 
@@ -13,8 +13,9 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 Before working on a contribution, it would be beneficial to familiarize yourself with the process and guidelines used for the Azure SDKs so that your submission is consistent with the project standards and is ready to be accepted with fewer changes requested.  In particular, it is recommended to review:
 
   - [Azure SDK README](https://github.com/Azure/azure-sdk), to learn more about the overall project and processes used.
-  - [Azure SDK Design Guidelines](https://azuresdkspecs.z5.web.core.windows.net/DesignGuidelines.html#general-documentation), to understand the general guidelines for the Azure SDK across all languages and platforms.
-  - [Azure SDK Design Guidelines for .NET](https://azuresdkspecs.z5.web.core.windows.net/DotNetSpec.html), to understand the guidelines specific to the Azure SDK for .NET.
+  - [Azure SDK Contributing Guide](https://github.com/Azure/azure-sdk-for-net/blob/master/CONTRIBUTING.md), for information about how to onboard and contribute to the overall Azure SDK ecosystem.
+  - [Azure SDK Design Guidelines](https://azure.github.io/azure-sdk/general_introduction.html), to understand the general guidelines for the Azure SDK across all languages and platforms.
+  - [Azure SDK Design Guidelines for .NET](https://azure.github.io/azure-sdk/dotnet_introduction.html), to understand the guidelines specific to the Azure SDK for .NET.
 
 ## Development environment setup
 
@@ -26,14 +27,10 @@ Tests in the Event Hubs client library are split into two categories:
 
 - **Unit tests** have no special considerations; these are self-contained and execute locally without any reliance on external resources.  Unit tests are considered the default test type in the Event Hubs client library and, thus, have no explicit category trait attached to them.
 
-- **Integration tests** have dependencies on live Azure resources and require setting up your development environment prior to running.  Known in the Azure SDK project commonly as "Live" tests, these tests are decorated with a category trait of "Live".  Specifically, an Azure resource group, Event Hubs namespace, and Azure Service Principal with "contributor" rights to the Event Hub namespace is required.  The Live tests read information from the following environment variables:
+- **Integration tests** have dependencies on live Azure resources and require setting up your development environment prior to running.  Known in the Azure SDK project commonly as "Live" tests, these tests are decorated with a category trait of "Live".  Specifically, an Azure resource group and Azure Service Principal with "contributor" rights to that resource group is required.  For each test run, the Live tests will use the service principal to dynamically create an Event Hubs namespace within the resource group and remove it once the test run is complete.
 
-`EVENT_HUBS_CONNECTION_STRING`  
-  The full connection string to the Event Hubs namespace, using the default shared access policy.
-    
-`EVENT_HUBS_NAMESPACE`  
- The host name of the Event Hubs namespace, without the protocol or domain found in the connection string.
-    
+The Live tests read information from the following environment variables:
+
 `EVENT_HUBS_RESOURCEGROUP`  
  The name of the Azure resource group that contains the Event Hubs namespace
    

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Azure.Messaging.EventHubs.Tests.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" />
     <PackageReference Include="System.Threading.Tasks.Extensions" />
+    <PackageReference Include="Microsoft.Azure.Management.ResourceManager" />
     <PackageReference Include="Microsoft.Azure.Management.EventHub" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" />
   </ItemGroup>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestEnvironment.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestEnvironment.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Threading;
+using Azure.Messaging.EventHubs.Tests.Infrastructure;
 
 namespace Azure.Messaging.EventHubs.Tests
 {
@@ -14,10 +15,6 @@ namespace Azure.Messaging.EventHubs.Tests
     ///
     public static class TestEnvironment
     {
-        /// <summary>The environment variable value for the Event Hubs connection string, lazily evaluated.</summary>
-        private static readonly Lazy<string> EventHubsConnectionStringInstance =
-            new Lazy<string>(() => ReadAndVerifyEnvironmentVariable("EVENT_HUBS_CONNECTION_STRING"), LazyThreadSafetyMode.PublicationOnly);
-
         /// <summary>The environment variable value for the Event Hubs subscription name, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsSubscriptionInstance =
             new Lazy<string>(() => ReadAndVerifyEnvironmentVariable("EVENT_HUBS_SUBSCRIPTION"), LazyThreadSafetyMode.PublicationOnly);
@@ -25,10 +22,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <summary>The environment variable value for the Event Hubs resource group name, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsResourceGroupInstance =
             new Lazy<string>(() => ReadAndVerifyEnvironmentVariable("EVENT_HUBS_RESOURCEGROUP"), LazyThreadSafetyMode.PublicationOnly);
-
-        /// <summary>The environment variable value for the Event Hubs namespace name, lazily evaluated.</summary>
-        private static readonly Lazy<string> EventHubsNamespaceInstance =
-            new Lazy<string>(() => ReadAndVerifyEnvironmentVariable("EVENT_HUBS_NAMESPACE"), LazyThreadSafetyMode.PublicationOnly);
 
         /// <summary>The environment variable value for the Azure Active Directory tenant that holds the service principal, lazily evaluated.</summary>
         private static readonly Lazy<string> EventHubsTenantInstance =
@@ -42,14 +35,37 @@ namespace Azure.Messaging.EventHubs.Tests
         private static readonly Lazy<string> EventHubsSecretInstance =
             new Lazy<string>(() => ReadAndVerifyEnvironmentVariable("EVENT_HUBS_SECRET"), LazyThreadSafetyMode.PublicationOnly);
 
+        /// <summary>The active Event Hubs namespace for this test run, lazily created.</summary>
+        private static readonly Lazy<EventHubScope.NamespaceProperties> ActiveEventHubsNamespace =
+            new Lazy<EventHubScope.NamespaceProperties>(() => EventHubScope.CreateNamespaceAsync().GetAwaiter().GetResult(), LazyThreadSafetyMode.ExecutionAndPublication);
+
+        /// <summary>The name of the shared access key to be used for accessing an Event Hubs namespace.</summary>
+        public const string EventHubsDefaultSharedAccessKey = "RootManageSharedAccessKey";
+
+        /// <summary>
+        ///   Indicates whether or not an ephemeral namespace was created for the current test execution.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if an Event Hubs namespace was created; otherwise, <c>false</c>.</value>
+        ///
+        public static bool WasEventHubsNamespaceCreated => ActiveEventHubsNamespace.IsValueCreated;
+
         /// <summary>
         ///   The connection string for the Event Hubs namespace instance to be used for
         ///   Live tests.
         /// </summary>
         ///
-        /// <value>The connection string is read from the "EVENT_HUBS_CONNECTION_STRING" environment variable.</value>
+        /// <value>The connection string will be determined by creating an ephemeral Event Hubs namespace for the test execution.</value>
         ///
-        public static string EventHubsConnectionString => EventHubsConnectionStringInstance.Value;
+        public static string EventHubsConnectionString => ActiveEventHubsNamespace.Value.ConnectionString;
+
+        /// <summary>
+        ///   The name of the Event Hubs namespace to be used for Live tests.
+        /// </summary>
+        ///
+        /// <value>The name will be determined by creating an ephemeral Event Hubs namespace for the test execution.</value>
+        ///
+        public static string EventHubsNamespace => ActiveEventHubsNamespace.Value.Name;
 
         /// <summary>
         ///   The name of the Azure subscription containing the Event Hubs namespace instance to be used for
@@ -68,15 +84,6 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <value>The name of the namespace is read from the "EVENT_HUBS_RESOURCEGROUP" environment variable.</value>
         ///
         public static string EventHubsResourceGroup => EventHubsResourceGroupInstance.Value;
-
-        /// <summary>
-        ///   The name of the Event Hubs namespace instance to be used for
-        ///   Live tests.
-        /// </summary>
-        ///
-        /// <value>The name of the namespace is read from the "EVENT_HUBS_NAMESPACE" environment variable.</value>
-        ///
-        public static string EventHubsNamespace => EventHubsNamespaceInstance.Value;
 
         /// <summary>
         ///   The name of the Azure Active Directory tenant that holds the service principal to use for management

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestRunFixture.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/TestRunFixture.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Messaging.EventHubs.Tests.Infrastructure;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests
+{
+    /// <summary>
+    ///   Serves as a fixture for operations that are scoped to the entire
+    ///   test run pass, rather than specific to a given test or test fixture.
+    /// </summary>
+    ///
+    [SetUpFixture]
+    public class TestRunFixture
+    {
+        /// <summary>
+        ///  Performs the tasks needed to clean up after a test run
+        ///  has completed.
+        /// </summary>
+        [OneTimeTearDown]
+        public void Teardown()
+        {
+            if (TestEnvironment.WasEventHubsNamespaceCreated)
+            {
+                EventHubScope.DeleteNamespaceAsync(TestEnvironment.EventHubsNamespace).GetAwaiter().GetResult();
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary

The intent of these changes is to revise the approach used for dynamic resource management by the test suite, shifting to an approach where an ephemeral Event Hubs namespace is created upon request by a Live test and remains only for the duration of a given test run.

### Goals

- Reduce contention on a single Event Hubs namespace when tests are run; full parallelization of the track one and track two tests suites for each of their associated platforms  has begun to overwhelm the management plane with requests against a single namespace.  

- Reduce Azure spend for the cost center by limiting the time that charges are accrued by having an active resource only when being used.   This also allows for a greater number of throughput units to be allocated without increasing spend.

- Revise the associated assets and documentation to align with the changes.

# Last Upstream Rebase

Monday, August 2, 2019  4:25pm (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 3 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7141) (#7141)
- [Stabilize Live Tests for Nightly Runs](https://github.com/Azure/azure-sdk-for-net/issues/7181) (#7181)
- [Investigate: Is it feasible to create a dynamic Event Hubs namespace for a single test run](https://github.com/Azure/azure-sdk-for-net/issues/7220) (#7220)