### PR TITLE
Clean-up nuget.config

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,20 +3,7 @@
   <packageSources>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="Local" value="tools/LocalNugetFeed" />
-    <add key="roslyn" value="https://dotnet.myget.org/F/roslyn-tools/api/v3/index.json" />
     <add key="azure-sdk-tools" value="https://azuresdkartifacts.blob.core.windows.net/azure-sdk-tools/index.json" />
     <add key="azure-sdk-for-net" value="https://azuresdkartifacts.blob.core.windows.net/azure-sdk-for-net/index.json" />
   </packageSources>
-  <config>
-		<add key="globalPackagesFolder" value="restoredPackages" />
-    <add key="RestorePackagesPath" value="restoredPackages" />
-	</config>
-  
-	<packageRestore>
-		<!-- Allow NuGet to download missing packages -->
-		<add key="enabled" value="True" />
-
-		<!-- Automatically check for missing packages during build in Visual Studio -->
-		<add key="automatic" value="True" />
-  </packageRestore>
 </configuration>

--- a/eng/Packages.Data.props
+++ b/eng/Packages.Data.props
@@ -46,7 +46,7 @@
     <PackageReference Update="Microsoft.Identity.Client" Version="4.1.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Update="Microsoft.NETCore.Platforms" Version="2.2.1" />
-    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-alpha-004" />
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" />
     <PackageReference Update="Microsoft.Rest.ClientRuntime.Azure.TestFramework" Version="[1.7.5, 2.0.0)" />
     <PackageReference Update="Microsoft.Rest.ClientRuntime.Azure" Version="[3.3.18, 4.0.0)" />
     <PackageReference Update="Microsoft.Rest.ClientRuntime" Version="[2.3.20, 3.0.0)" />


### PR DESCRIPTION
- Stop putting the restored packages into the source tree.
- remove roslyn feed as the .NET targeting packs are on nuget.org now.

cc @shahabhijeet @erich-wang @chidozieononiwu 