### PR TITLE
Add overload for mockcontext

### DIFF
--- a/sdk/mgmtcommon/TestFramework/ClientRuntime.Azure.TestFramework/MockContext.cs
+++ b/sdk/mgmtcommon/TestFramework/ClientRuntime.Azure.TestFramework/MockContext.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
         
         
         /// <summary>
-        /// Return a new UndoContext
+        /// Return a new MockContext
         /// </summary>
         /// <returns></returns>
         public static MockContext Start(
@@ -71,6 +71,18 @@ namespace Microsoft.Rest.ClientRuntime.Azure.TestFramework
             }
 
             return context;
+        }
+
+        /// <summary>
+        /// Return a new MockContext
+        /// </summary>
+        /// <returns></returns>
+        public static MockContext Start(
+            Type type,
+            [System.Runtime.CompilerServices.CallerMemberName]
+            string methodName= "testframework_failed")
+        {
+            return MockContext.Start(type.Name, methodName);
         }
 
         /// <summary>


### PR DESCRIPTION
Add MockContext.Start() Overload that takes a Type and passes the TypeName to the overloaded Start method. Need to create a new release to Nuget to be able to use this in the repo
Update Microsoft.IdentityModel.Tokens Version to [5.1.2, 6.0.0) to fix version conflict for @estebanreyl 