### PR TITLE
[Event Hubs Client] Engineering: Update Environment Variables

### DIFF
--- a/sdk/eventhub/tests.yml
+++ b/sdk/eventhub/tests.yml
@@ -6,11 +6,8 @@ jobs:
     MaxParallel: 1
     ServiceDirectory: eventhub
     EnvVars:
-      EVENT_HUBS_CONNECTION_STRING: $(net-eventhubs-internal-namespace-connection-string)
-      EVENT_HUBS_STORAGE_CONNECTION_STRING: $(net-eventhubs-internal-storage-connection-string)
       EVENT_HUBS_CLIENT: $(aad-azure-sdk-test-client-id)
       EVENT_HUBS_SECRET: $(aad-azure-sdk-test-client-secret)
       EVENT_HUBS_TENANT: $(aad-azure-sdk-test-tenant-id)
       EVENT_HUBS_SUBSCRIPTION: $(test-subscription-id)
-      EVENT_HUBS_NAMESPACE: $(net-eventhubs-internal-namespace)
       EVENT_HUBS_RESOURCEGROUP: $(net-eventhubs-internal-group)


### PR DESCRIPTION
# Summary

Removing environment variables no longer used by either track of the Event Hubs client library.   The internal and playground pipeline variable groups have already been updated and the secrets removed from KeyVault.

# Last Upstream Rebase

Friday, August 13, 2019 12:38pm (EDT)

