### PR TITLE
Add request-id and client-request-id to HTTP call span

### DIFF
--- a/sdk/core/Azure.Core/src/Pipeline/RequestActivityPolicy.cs
+++ b/sdk/core/Azure.Core/src/Pipeline/RequestActivityPolicy.cs
@@ -40,6 +40,7 @@ namespace Azure.Core.Pipeline
             var activity = new Activity("Azure.Core.Http.Request");
             activity.AddTag("http.method", message.Request.Method.Method);
             activity.AddTag("http.url", message.Request.UriBuilder.ToString());
+            activity.AddTag("requestId", message.Request.ClientRequestId);
             if (message.Request.Headers.TryGetValue("User-Agent", out string? userAgent))
             {
                 activity.AddTag("http.user_agent", userAgent);
@@ -67,6 +68,7 @@ namespace Azure.Core.Pipeline
             }
 
             activity.AddTag("http.status_code", message.Response.Status.ToString(CultureInfo.InvariantCulture));
+            activity.AddTag("serviceRequestId", message.Response.Headers.RequestId);
 
             if (diagnosticSourceActivityEnabled)
             {

--- a/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
+++ b/sdk/core/Azure.Core/tests/RequestActivityPolicyTests.cs
@@ -30,7 +30,9 @@ namespace Azure.Core.Tests
             {
                 activity = Activity.Current;
                 startEvent = testListener.Events.Dequeue();
-                return new MockResponse(201);
+                MockResponse mockResponse = new MockResponse(201);
+                mockResponse.AddHeader(new HttpHeader("x-ms-request-id", "server request id"));
+                return mockResponse;
             });
 
             using Request request = mockTransport.CreateRequest();
@@ -53,6 +55,8 @@ namespace Azure.Core.Tests
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("http.url", "http://example.com/"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("http.method", "GET"));
             CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("http.user_agent", "agent"));
+            CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("requestId", request.ClientRequestId));
+            CollectionAssert.Contains(activity.Tags, new KeyValuePair<string, string>("serviceRequestId", "server request id"));
         }
 
 

--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/TokenProviderTests.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/tests/TokenProviderTests.cs
@@ -38,6 +38,8 @@ namespace Microsoft.Azure.ServiceBus.UnitTests
         }
 
         [Fact]
+        [LiveTest]
+        [DisplayTestMethodName]
         public async Task AzureActiveDirectoryTokenProviderAuthCallbackTest()
         {
             string TestToken = @"eyJhbGciOiJIUzI1NiJ9.e30.ZRrHA1JJJW8opsbCGfG_HACGpVUMN_a9IV7pAx_Zmeo";


### PR DESCRIPTION
According to the spec: https://gist.github.com/johanste/319960a2c60f1f3bc7e0596af2c61324#iwe-dont-create-links-or-a-parentchild-relationship-between-spans-for-polling-requests-in-a-long-running-operation