### PR TITLE
Update EventProcessorHost.cs

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/EventProcessorHost.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/EventProcessorHost.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.EventHubs.Processor
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.EventHubs.Primitives;
-    using Microsoft.WindowsAzure.Storage;
+    using Microsoft.Azure.Storage;
 
     /// <summary>
     /// Represents a host for processing Event Hubs event data.


### PR DESCRIPTION
Wrong Namespace was used.
Correct is using Microsoft.Azure.Storage;
Related to https://github.com/Azure/azure-sdk-for-net/issues/7305#issuecomment-522127901