### PR TITLE
[Event Hubs Client] Track Two: Third Preview (Iterator Read Tweak)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ChannelReaderExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Core/ChannelReaderExtensions.cs
@@ -17,9 +17,6 @@ namespace Azure.Messaging.EventHubs.Core
     ///
     internal static class ChannelReaderExtensions
     {
-        /// <summary>The maximum delay allowed when interacting with cancellation tokens.</summary>
-        private static readonly TimeSpan maximumCancellationDelay = TimeSpan.FromDays(10);
-
         /// <summary>
         ///   Enumerates the events as they become available in the associated channel.
         /// </summary>
@@ -54,7 +51,7 @@ namespace Azure.Messaging.EventHubs.Core
                 {
                     if (reader.TryRead(out result))
                     {
-                        waitSource?.CancelAfter(maximumCancellationDelay);
+                        waitSource?.CancelAfter(Timeout.Infinite);
                         yield return result;
                     }
                     else if (reader.Completion.IsCompleted)
@@ -85,7 +82,7 @@ namespace Azure.Messaging.EventHubs.Core
 
                             if (await reader.WaitToReadAsync(waitToken).ConfigureAwait(false))
                             {
-                                waitSource?.CancelAfter(maximumCancellationDelay);
+                                waitSource?.CancelAfter(Timeout.Infinite);
                                 continue;
                             }
                         }


### PR DESCRIPTION
# Summary

The intent of these changes is to replace the custom maximum value to the built-in `Timeout.Infinite` to signal that the "wait time" cancellation token should not expire.

# Last Upstream Rebase

Monday, August 19, 2019 9:28am (EDT)

# Related and Follow-Up Issues

- [Revisit Async Iterator Loop](https://github.com/Azure/azure-sdk-for-net/issues/7094) (#7094)
- [[Event Hubs Client] Track Two: Third Preview (Iterator Read Improvements)](https://github.com/Azure/azure-sdk-for-net/issues/7289) (#7289)

Changing 