### PR TITLE
[Event Hubs Client] Track Two: Third Preview (Test Timing Tweak)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelReaderExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelReaderExtensionsTests.cs
@@ -272,7 +272,7 @@ namespace Azure.Messaging.EventHubs.Tests
             Assert.That(readCancellation.Token.IsCancellationRequested, Is.True, "Cancellation should have been requested.");
             Assert.That(readCount, Is.EqualTo(maxReadItems), "The number of items read should have stopped increasing when cancellation was requested.");
             Assert.That(iterateCount, Is.GreaterThan(readCount), "There should have been default items returned due to the wait time expiring.");
-            Assert.That(stopWatch.Elapsed, Is.EqualTo(cancelTimeout).Within(TimeSpan.FromSeconds(2)), "The elapsed time should be close to the duration set for the cancel timeout.");
+            Assert.That(stopWatch.Elapsed, Is.EqualTo(cancelTimeout).Within(TimeSpan.FromSeconds(5)), "The elapsed time should be close to the duration set for the cancel timeout.");
         }
 
         /// <summary>


### PR DESCRIPTION
# Summary

The intent of these changes is to adjust the timing for a minor test observation to allow for more non-determinism in the CI environment.

# Last Upstream Rebase

Monday, August 19, 2019 12:47pm (EDT)