### PR TITLE
Bump up Package Version after release

### DIFF
--- a/sdk/mgmtcommon/TestFramework/ClientRuntime.Azure.TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj
+++ b/sdk/mgmtcommon/TestFramework/ClientRuntime.Azure.TestFramework/Microsoft.Rest.ClientRuntime.Azure.TestFramework.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <Description>Microsoft.Rest.ClientRuntime.Azure.TestFramework</Description>
     <AssemblyTitle>Test framework for Microsoft AutoRest Generated Clients</AssemblyTitle>
-    <Version>1.7.7</Version>
+    <Version>1.7.8</Version>
     <AssemblyName>Microsoft.Rest.ClientRuntime.Azure.TestFramework</AssemblyName>
     <PackageId>Microsoft.Rest.ClientRuntime.Azure.TestFramework</PackageId>
     <PackageTags>Microsoft AutoRest ClientRuntime REST TestFramework</PackageTags>


### PR DESCRIPTION
Bump up version for Microsoft.Rest.ClientRuntime.Azure.TestFramework to 1.7.8 after release.