### PR TITLE
Work around AutoRest schema validation by changing to x-az- prefix

### DIFF
--- a/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Blobs/swagger/readme.md
@@ -28,9 +28,9 @@ directive:
     $["client-name"] = "BlobRestClient";
     $["client-extensions-name"] = "BlobsExtensions";
     $["client-model-factory-name"] = "BlobsModelFactory";
-    $["x-ms-skip-path-components"] = true;
-    $["x-ms-include-sync-methods"] = true;
-    $["x-ms-public"] = false;
+    $["x-az-skip-path-components"] = true;
+    $["x-az-include-sync-methods"] = true;
+    $["x-az-public"] = false;
 ```
 
 ### Move directory operations last
@@ -76,7 +76,7 @@ directive:
   transform: >
     $["x-ms-client-name"] = "resourceUri";
     $.format = "url";
-    $["x-ms-trace"] = true;
+    $["x-az-trace"] = true;
 ```
 
 ### Ignore common headers
@@ -85,19 +85,19 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["x-ms-request-id"]
   transform: >
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["x-ms-version"]
   transform: >
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["Date"]
   transform: >
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["x-ms-client-request-id"]
   transform: >
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 ```
 
 ### Clean up Failure response
@@ -107,9 +107,9 @@ directive:
   where: $["x-ms-paths"]..responses.default
   transform: >
     delete $.headers;
-    $["x-ms-client-name"] = "StorageErrorResult";
-    $["x-ms-create-exception"] = true;
-    $["x-ms-public"] = false;
+    $["x-az-response-name"] = "StorageErrorResult";
+    $["x-az-create-exception"] = true;
+    $["x-az-public"] = false;
 ```
 
 ### /?restype=service&comp=properties
@@ -178,7 +178,7 @@ directive:
     if (!$.ContainersSegment) {
         $.ContainersSegment = $.ListContainersSegmentResponse;
         delete $.ListContainersSegmentResponse;
-        $.ContainersSegment["x-ms-public"] = false;
+        $.ContainersSegment["x-az-public"] = false;
         $.ContainersSegment.required.push("NextMarker");
     }
 - from: swagger-document
@@ -200,9 +200,9 @@ directive:
     $.get.responses["200"].headers["x-ms-lease-state"]["x-ms-enum"].name = "LeaseState";
     $.get.responses["200"].headers["x-ms-lease-status"]["x-ms-enum"].name = "LeaseStatus";
     $.get.responses["200"].headers["x-ms-blob-public-access"]["x-ms-enum"].modelAsString = false;
-    $.get.responses["200"]["x-ms-client-name"] = "FlattenedContainerItem";
-    $.get.responses["200"]["x-ms-public"] = false;
-    $.put.responses["201"]["x-ms-client-name"] = "ContainerInfo";
+    $.get.responses["200"]["x-az-response-name"] = "FlattenedContainerItem";
+    $.get.responses["200"]["x-az-public"] = false;
+    $.put.responses["201"]["x-az-response-name"] = "ContainerInfo";
 ```
 
 ### BlobPublicAccess
@@ -221,7 +221,7 @@ directive:
   where: $["x-ms-paths"]["/?restype=account&comp=properties"]
   transform: >
     $.get.description = "Returns the sku name and account kind";
-    $.get.responses["200"]["x-ms-client-name"] = "AccountInfo";
+    $.get.responses["200"]["x-az-response-name"] = "AccountInfo";
 - from: swagger-document
   where: $["x-ms-paths"]
   transform: >
@@ -239,7 +239,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}?restype=container&comp=metadata"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "ContainerInfo";
+    $.put.responses["200"]["x-az-response-name"] = "ContainerInfo";
 ```
 
 ### /{containerName}?restype=container&comp=acl
@@ -249,10 +249,10 @@ directive:
   where: $["x-ms-paths"]["/{containerName}?restype=container&comp=acl"]
   transform: >
     $.get.responses["200"].headers["x-ms-blob-public-access"]["x-ms-enum"].modelAsString = false;
-    $.get.responses["200"]["x-ms-client-name"] = "ContainerAccessPolicy";
-    $.get.responses["200"]["x-ms-schema-client-name"] = "SignedIdentifiers";
+    $.get.responses["200"]["x-az-response-name"] = "ContainerAccessPolicy";
+    $.get.responses["200"]["x-az-response-schema-name"] = "SignedIdentifiers";
     $.put.responses["200"].description = "Success";
-    $.put.responses["200"]["x-ms-client-name"] = "ContainerInfo";
+    $.put.responses["200"]["x-az-response-name"] = "ContainerInfo";
 - from: swagger-document
   where: $.parameters.ContainerAcl
   transform: $["x-ms-client-name"] = "permissions"
@@ -270,7 +270,7 @@ directive:
   transform: >
     $.put.responses["201"].description = "The lease operation completed successfully.";
     $.put.responses["201"].headers["x-ms-lease-id"].description = "Uniquely identifies a container's or blob's lease";
-    $.put.responses["201"]["x-ms-client-name"] = "Lease";
+    $.put.responses["201"]["x-az-response-name"] = "Lease";
 ```
 
 ### /{containerName}?comp=lease&restype=container&release
@@ -280,7 +280,7 @@ directive:
   where: $["x-ms-paths"]["/{containerName}?comp=lease&restype=container&release"]
   transform: >
     $.put.responses["200"].description = "Success";
-    $.put.responses["200"]["x-ms-client-name"] = "ContainerInfo";
+    $.put.responses["200"]["x-az-response-name"] = "ContainerInfo";
 ```
 
 ### /{containerName}?comp=lease&restype=container&renew
@@ -291,7 +291,7 @@ directive:
   transform: >
     $.put.responses["200"].description = "The lease operation completed successfully.";
     $.put.responses["200"].headers["x-ms-lease-id"].description = "Uniquely identifies a container's or blob's lease";
-    $.put.responses["200"]["x-ms-client-name"] = "Lease";
+    $.put.responses["200"]["x-az-response-name"] = "Lease";
 ```
 
 ### /{containerName}?comp=lease&restype=container&break
@@ -300,8 +300,8 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}?comp=lease&restype=container&break"]
   transform: >
-    $.put.responses["202"]["x-ms-client-name"] = "BrokenLease";
-    $.put.responses["202"]["x-ms-public"] = false;
+    $.put.responses["202"]["x-az-response-name"] = "BrokenLease";
+    $.put.responses["202"]["x-az-public"] = false;
 ```
 
 ### /{containerName}?comp=lease&restype=container&change
@@ -312,7 +312,7 @@ directive:
   transform: >
     $.put.responses["200"].description = "The lease operation completed successfully.";
     $.put.responses["200"].headers["x-ms-lease-id"].description = "Uniquely identifies a container's or blob's lease";
-    $.put.responses["200"]["x-ms-client-name"] = "Lease";
+    $.put.responses["200"]["x-az-response-name"] = "Lease";
 ```
 
 ### /{containerName}?restype=container&comp=list&flat
@@ -325,7 +325,7 @@ directive:
         $.BlobsFlatSegment = $.ListBlobsFlatSegmentResponse;
         delete $.ListBlobsFlatSegmentResponse;
         $.BlobsFlatSegment["x-ms-client-name"] = "BlobsFlatSegment";
-        $.BlobsFlatSegment["x-ms-public"] = false;
+        $.BlobsFlatSegment["x-az-public"] = false;
         $.BlobsFlatSegment.required.push("NextMarker");
         const path = $.BlobsFlatSegment.properties.Segment.$ref.replace(/[#].*$/, "#/definitions/");
         $.BlobsFlatSegment.properties.BlobItems = {
@@ -341,7 +341,7 @@ directive:
   where: $["x-ms-paths"]["/{containerName}?restype=container&comp=list&flat"]
   transform: >
     $.get.operationId = "Container_ListBlobsFlatSegment";
-    $.get.responses["200"].headers["Content-Type"]["x-ms-ignore"] = true;
+    $.get.responses["200"].headers["Content-Type"]["x-az-demote-header"] = true;
     const def = $.get.responses["200"].schema;
     if (def && def["$ref"] && !def["$ref"].endsWith("BlobsFlatSegment")) {
         const path = def["$ref"].replace(/[#].*$/, "#/definitions/BlobsFlatSegment");
@@ -359,7 +359,7 @@ directive:
         $.BlobsHierarchySegment = $.ListBlobsHierarchySegmentResponse;
         delete $.ListBlobsHierarchySegmentResponse;
         $.BlobsHierarchySegment["x-ms-client-name"] = "BlobsHierarchySegment";
-        $.BlobsHierarchySegment["x-ms-public"] = false;
+        $.BlobsHierarchySegment["x-az-public"] = false;
         $.BlobsHierarchySegment.required.push("NextMarker");
         const path = $.BlobsHierarchySegment.properties.Segment.$ref.replace(/[#].*$/, "#/definitions/");
         $.BlobsHierarchySegment.properties.BlobItems = {
@@ -375,7 +375,7 @@ directive:
         delete $.BlobsHierarchySegment.properties.Segment;
         delete $.BlobHierarchyListSegment;
     }
-    $.BlobPrefix["x-ms-public"] = false;
+    $.BlobPrefix["x-az-public"] = false;
 - from: swagger-document
   where: $.parameters.Delimiter
   transform: >
@@ -384,7 +384,7 @@ directive:
   where: $["x-ms-paths"]["/{containerName}?restype=container&comp=list&hierarchy"]
   transform: >
     $.get.operationId = "Container_ListBlobsHierarchySegment";
-    $.get.responses["200"].headers["Content-Type"]["x-ms-ignore"] = true;
+    $.get.responses["200"].headers["Content-Type"]["x-az-demote-header"] = true;
     const def = $.get.responses["200"].schema;
     if (def && def["$ref"] && !def["$ref"].endsWith("BlobsHierarchySegment")) {
         const path = def["$ref"].replace(/[#].*$/, "#/definitions/BlobsHierarchySegment");
@@ -429,7 +429,7 @@ directive:
         $.BlobItemProperties.properties.ETag = $.BlobItemProperties.properties.Etag;
         $.BlobItemProperties.properties.ETag.xml = { "name":  "Etag" };
         delete $.BlobItemProperties.properties.Etag;
-        $.BlobItemProperties.required = [];
+        delete $.BlobItemProperties.required;
         $.BlobItemProperties.properties["Content-MD5"]["x-ms-client-name"] = "ContentHash";
         $.BlobItemProperties.properties.CopySource.format = "url";
         const path = $.BlobItem.properties.Properties.$ref.replace(/[#].*$/, "#/definitions/BlobItemProperties");
@@ -438,52 +438,52 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}"]
   transform: >
-    $.get.responses["200"]["x-ms-client-name"] = "FlattenedDownloadProperties";
-    $.get.responses["200"]["x-ms-public"] = false;
+    $.get.responses["200"]["x-az-response-name"] = "FlattenedDownloadProperties";
+    $.get.responses["200"]["x-az-public"] = false;
     $.get.responses["200"].headers["x-ms-copy-source"].format = "url";
     $.get.responses["200"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
     $.get.responses["200"].headers["x-ms-lease-state"]["x-ms-enum"].name = "LeaseState";
     $.get.responses["200"].headers["x-ms-lease-status"]["x-ms-enum"].name = "LeaseStatus";
     $.get.responses["200"].headers["x-ms-blob-content-md5"]["x-ms-client-name"] = "BlobContentHash";
-    $.get.responses["200"]["x-ms-schema-client-name"] = "Content";
-    $.get.responses["206"]["x-ms-client-name"] = "FlattenedDownloadProperties";
-    $.get.responses["206"]["x-ms-public"] = false;
+    $.get.responses["200"]["x-az-response-schema-name"] = "Content";
+    $.get.responses["206"]["x-az-response-name"] = "FlattenedDownloadProperties";
+    $.get.responses["206"]["x-az-public"] = false;
     $.get.responses["206"].headers["x-ms-copy-source"].format = "url";
     $.get.responses["206"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
     $.get.responses["206"].headers["x-ms-lease-state"]["x-ms-enum"].name = "LeaseState";
     $.get.responses["206"].headers["x-ms-lease-status"]["x-ms-enum"].name = "LeaseStatus";
     $.get.responses["206"].headers["x-ms-blob-content-md5"]["x-ms-client-name"] = "BlobContentHash";
-    $.get.responses["206"]["x-ms-schema-client-name"] = "Content";
+    $.get.responses["206"]["x-az-response-schema-name"] = "Content";
     $.get.responses["304"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
-        "x-ms-client-name": "ConditionNotMetError",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "ConditionNotMetError",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } } };
-    $.head.responses["200"]["x-ms-client-name"] = "BlobProperties";
+    $.head.responses["200"]["x-az-response-name"] = "BlobProperties";
     $.head.responses["200"].headers["x-ms-copy-source"].format = "url";
     $.head.responses["200"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
     $.head.responses["200"].headers["x-ms-lease-state"]["x-ms-enum"].name = "LeaseState";
     $.head.responses["200"].headers["x-ms-lease-status"]["x-ms-enum"].name = "LeaseStatus";
     $.head.responses["200"].headers["Content-MD5"]["x-ms-client-name"] = "ContentHash";
     $.head.responses["200"].headers["Content-Encoding"].type = "array";
-    $.head.responses["200"].headers["Content-Encoding"].collectionFormat = "multi";
+    $.head.responses["200"].headers["Content-Encoding"].collectionFormat = "csv";
     $.head.responses["200"].headers["Content-Encoding"].items = { "type": "string" };
     $.head.responses["200"].headers["Content-Language"].type = "array";
-    $.head.responses["200"].headers["Content-Language"].collectionFormat = "multi";
+    $.head.responses["200"].headers["Content-Language"].collectionFormat = "csv";
     $.head.responses["200"].headers["Content-Language"].items = { "type": "string" };
     $.head.responses["304"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
-        "x-ms-client-name": "ConditionNotMetError",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "ConditionNotMetError",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } }
     };
     $.head.responses["default"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
-        "x-ms-client-name": "ConditionNotMetError",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "ConditionNotMetError",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } }
     };
 ```
@@ -525,19 +525,19 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=properties&SetHTTPHeaders"]
   transform: >
     $.put.operationId = "Blob_SetHttpHeaders";
-    $.put.responses["200"]["x-ms-client-name"] = "SetHttpHeadersOperation";
-    $.put.responses["200"]["x-ms-public"] = false;
+    $.put.responses["200"]["x-az-response-name"] = "SetHttpHeadersOperation";
+    $.put.responses["200"]["x-az-public"] = false;
 - from: swagger-document
   where: $.parameters.BlobContentEncoding
   transform: >
     $.type = "array";
-    $.collectionFormat = "multi";
+    $.collectionFormat = "csv";
     $.items = { "type": "string" };
 - from: swagger-document
   where: $.parameters.BlobContentLanguage
   transform: >
     $.type = "array";
-    $.collectionFormat = "multi";
+    $.collectionFormat = "csv";
     $.items = { "type": "string" };
 ```
 
@@ -547,8 +547,8 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=metadata"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "SetMetadataOperation";
-    $.put.responses["200"]["x-ms-public"] = false;
+    $.put.responses["200"]["x-az-response-name"] = "SetMetadataOperation";
+    $.put.responses["200"]["x-az-public"] = false;
 ```
 
 ### /{containerName}/{blob}?comp=lease&acquire
@@ -557,7 +557,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=lease&acquire"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "Lease";
+    $.put.responses["201"]["x-az-response-name"] = "Lease";
     $.put.responses["201"].description = "The lease operation completed successfully.";
     $.put.responses["201"].headers["x-ms-lease-id"].description = "Uniquely identifies a container's or blob's lease";
 ```
@@ -569,7 +569,7 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=lease&release"]
   transform: >
     $.put.responses["200"].description = "The operation completed successfully.";
-    $.put.responses["200"]["x-ms-client-name"] = "BlobInfo";
+    $.put.responses["200"]["x-az-response-name"] = "BlobInfo";
 ```
 
 ### /{containerName}/{blob}?comp=lease&renew
@@ -578,7 +578,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=lease&renew"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "Lease";
+    $.put.responses["200"]["x-az-response-name"] = "Lease";
     $.put.responses["200"].description = "The lease operation completed successfully.";
     $.put.responses["200"].headers["x-ms-lease-id"].description = "Uniquely identifies a container's or blob's lease";
 ```
@@ -589,7 +589,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=lease&change"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "Lease";
+    $.put.responses["200"]["x-az-response-name"] = "Lease";
     $.put.responses["200"].description = "The lease operation completed successfully.";
     $.put.responses["200"].headers["x-ms-lease-id"].description = "Uniquely identifies a container's or blob's lease";
 ```
@@ -600,8 +600,8 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=lease&break"]
   transform: >
-    $.put.responses["202"]["x-ms-client-name"] = "BrokenLease";
-    $.put.responses["202"]["x-ms-public"] = false;
+    $.put.responses["202"]["x-az-response-name"] = "BrokenLease";
+    $.put.responses["202"]["x-az-public"] = false;
 ```
 
 ### /{containerName}/{blob}?comp=snapshot
@@ -610,7 +610,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=snapshot"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "BlobSnapshotInfo";
+    $.put.responses["201"]["x-az-response-name"] = "BlobSnapshotInfo";
 ```
 
 ### /{containerName}/{blob}?comp=copy
@@ -620,7 +620,7 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=copy"]
   transform: >
     $.put.operationId = "Blob_StartCopyFromUri";
-    $.put.responses["202"]["x-ms-client-name"] = "BlobCopyInfo";
+    $.put.responses["202"]["x-az-response-name"] = "BlobCopyInfo";
     $.put.responses["202"].description = "The operation completed successfully.";
     $.put.responses["202"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
 ```
@@ -632,7 +632,7 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=copy&sync"]
   transform: >
     $.put.operationId = "Blob_CopyFromUri";
-    $.put.responses["202"]["x-ms-client-name"] = "BlobCopyInfo";
+    $.put.responses["202"]["x-az-response-name"] = "BlobCopyInfo";
     $.put.responses["202"].description = "The operation completed successfully.";
     $.put.responses["202"].headers["x-ms-copy-status"].enum = ["pending", "success", "aborted", "failed"];
     $.put.responses["202"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
@@ -662,9 +662,9 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?PageBlob"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "BlobContentInfo";
+    $.put.responses["201"]["x-az-response-name"] = "BlobContentInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
     $.put.responses["201"].headers["x-ms-blob-sequence-number"] = {
         "x-ms-client-name": "BlobSequenceNumber",
         "type": "integer",
@@ -679,10 +679,10 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=page&update"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "PageInfo";
+    $.put.responses["201"]["x-az-response-name"] = "PageInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
     $.put.responses["201"].headers["x-ms-blob-sequence-number"].description = "The current sequence number for the page blob.  This is only returned for page blobs.";
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
 ```
 
 ### /{containerName}/{blob}?comp=page&clear
@@ -691,13 +691,13 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=page&clear"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "PageInfo";
+    $.put.responses["201"]["x-az-response-name"] = "PageInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
     $.put.responses["201"].headers["x-ms-blob-sequence-number"].description = "The current sequence number for the page blob.  This is only returned for page blobs.";
     $.put.responses["201"].headers["x-ms-request-server-encrypted"] = {
         "x-ms-client-name": "IsServerEncrypted",
         "type": "boolean",
-        "x-ms-ignore": true,
+        "x-az-demote-header": true,
         "description": "The value of this header is set to true if the contents of the request are successfully encrypted using the specified algorithm, and false otherwise."
     };
 ```
@@ -709,15 +709,15 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=page&update&fromUrl"]
   transform: >
     $.put.operationId = "PageBlob_UploadPagesFromUri";
-    $.put.responses["201"]["x-ms-client-name"] = "PageInfo";
+    $.put.responses["201"]["x-az-response-name"] = "PageInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
     $.put.responses["201"].headers["x-ms-blob-sequence-number"].description = "The current sequence number for the page blob.  This is only returned for page blobs.";
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
     $.put.responses["304"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
-        "x-ms-client-name": "ConditionNotMetError",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "ConditionNotMetError",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } }
     };
 ```
@@ -728,12 +728,12 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=pagelist"]
   transform: >
-    $.get.responses["200"]["x-ms-client-name"] = "PageRangesInfo";
+    $.get.responses["200"]["x-az-response-name"] = "PageRangesInfo";
     $.get.responses["304"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
-        "x-ms-client-name": "ConditionNotMetError",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "ConditionNotMetError",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } }
     };
 ```
@@ -744,12 +744,12 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=pagelist&diff"]
   transform: >
-    $.get.responses["200"]["x-ms-client-name"] = "PageRangesInfo";
+    $.get.responses["200"]["x-az-response-name"] = "PageRangesInfo";
     $.get.responses["304"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
-        "x-ms-client-name": "ConditionNotMetError",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "ConditionNotMetError",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } }
     };
 ```
@@ -760,7 +760,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=properties&Resize"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "PageBlobInfo";
+    $.put.responses["200"]["x-az-response-name"] = "PageBlobInfo";
     $.put.responses["200"].description = "The operation completed successfully.";
     $.put.responses["200"].headers["Last-Modified"].description = "Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob's metadata or properties, changes the last-modified time of the blob.";
     $.put.responses["200"].headers["x-ms-blob-sequence-number"].description = "The current sequence number for the page blob.  This is only returned for page blobs.";
@@ -772,7 +772,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=properties&UpdateSequenceNumber"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "PageBlobInfo";
+    $.put.responses["200"]["x-az-response-name"] = "PageBlobInfo";
     $.put.responses["200"].description = "The operation completed successfully.";
     $.put.responses["200"].headers["Last-Modified"].description = "Returns the date and time the blob was last modified. Any operation that modifies the blob, including an update of the blob's metadata or properties, changes the last-modified time of the blob.";
     $.put.responses["200"].headers["x-ms-blob-sequence-number"].description = "The current sequence number for the page blob.  This is only returned for page blobs.";
@@ -784,7 +784,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=incrementalcopy"]
   transform: >
-    $.put.responses["202"]["x-ms-client-name"] = "BlobCopyInfo";
+    $.put.responses["202"]["x-az-response-name"] = "BlobCopyInfo";
     $.put.responses["202"].description = "The operation completed successfully.";
     $.put.responses["202"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
 ```
@@ -795,9 +795,9 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?AppendBlob"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "BlobContentInfo";
+    $.put.responses["201"]["x-az-response-name"] = "BlobContentInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
     $.put.responses["201"].headers["x-ms-blob-sequence-number"] = {
         "x-ms-client-name": "BlobSequenceNumber",
         "type": "integer",
@@ -812,7 +812,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=appendblock"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "BlobAppendInfo";
+    $.put.responses["201"]["x-az-response-name"] = "BlobAppendInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
 ```
 
@@ -823,7 +823,7 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=appendblock&fromUrl"]
   transform: >
     $.put.operationId = "AppendBlob_AppendBlockFromUri";
-    $.put.responses["201"]["x-ms-client-name"] = "BlobAppendInfo";
+    $.put.responses["201"]["x-az-response-name"] = "BlobAppendInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
     $.put.responses["201"].headers["x-ms-request-server-encrypted"] = {
         "x-ms-client-name": "IsServerEncrypted",
@@ -832,9 +832,9 @@ directive:
     };
     $.put.responses["304"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
-        "x-ms-client-name": "ConditionNotMetError",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "ConditionNotMetError",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } }
     };
 ```
@@ -845,9 +845,9 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?BlockBlob"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "BlobContentInfo";
+    $.put.responses["201"]["x-az-response-name"] = "BlobContentInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
     $.put.responses["201"].headers["x-ms-blob-sequence-number"] = {
         "x-ms-client-name": "BlobSequenceNumber",
         "type": "integer",
@@ -862,9 +862,9 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=block"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "BlockInfo";
+    $.put.responses["201"]["x-az-response-name"] = "BlockInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
 ```
 
 ### /{containerName}/{blob}?comp=block&fromURL
@@ -874,14 +874,14 @@ directive:
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=block&fromURL"]
   transform: >
     $.put.operationId = "BlockBlob_StageBlockFromUri";
-    $.put.responses["201"]["x-ms-client-name"] = "BlockInfo";
+    $.put.responses["201"]["x-az-response-name"] = "BlockInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
     $.put.responses["304"] = {
         "description": "The condition specified using HTTP conditional header(s) is not met.",
-        "x-ms-client-name": "ConditionNotMetError",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "ConditionNotMetError",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } }
     };
 ```
@@ -892,18 +892,18 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{containerName}/{blob}?comp=blocklist"]
   transform: >
-    $.get.responses["200"]["x-ms-client-name"] = "GetBlockListOperation";
-    $.get.responses["200"]["x-ms-public"] = false;
-    $.put.responses["201"]["x-ms-client-name"] = "BlobContentInfo";
+    $.get.responses["200"]["x-az-response-name"] = "GetBlockListOperation";
+    $.get.responses["200"]["x-az-public"] = false;
+    $.put.responses["201"]["x-az-response-name"] = "BlobContentInfo";
     $.put.responses["201"].description = "The operation completed successfully.";
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
     $.put.responses["201"].headers["x-ms-blob-sequence-number"] = {
         "x-ms-client-name": "BlobSequenceNumber",
         "type": "integer",
         "format": "int64",
         "description": "The current sequence number for the page blob.  This is only returned for page blobs."
     };
-    $.put.responses["201"].headers["x-ms-content-crc64"]["x-ms-ignore"] = true;
+    $.put.responses["201"].headers["x-ms-content-crc64"]["x-az-demote-header"] = true;
 ```
 
 ### BlockLookupList
@@ -912,7 +912,7 @@ directive:
 - from: swagger-document
   where: $.definitions.BlockLookupList
   transform: >
-    $["x-ms-public"] = false;
+    $["x-az-public"] = false;
     $.description = "A list of block IDs split between the committed block list, in the uncommitted block list, or in the uncommitted block list first and then in the committed block list.";
 ```
 
@@ -946,13 +946,21 @@ directive:
     $["x-ms-enum"].modelAsString = false;
 ```
 
-### Metrics
+### Make sure everything has a type
 ``` yaml
 directive:
 - from: swagger-document
   where: $.definitions.Metrics
   transform: >
     $.type = "object";
+- from: swagger-document
+  where: $.definitions.BlobTags
+  transform: >
+    $.type = "object";
+- from: swagger-document
+  where: $.definitions.DataLakeStorageError
+  transform: >
+    $.properties.error.type = "object";
 ```
 
 ### KeyInfo
@@ -962,8 +970,8 @@ directive:
   where: $.definitions.KeyInfo
   transform: >
     $.required = ["Expiry"];
-    $.properties.Start.type = $.properties.Expiry.type = "date-time-8601";
-    $["x-ms-public"] = false;
+    $.properties.Start.format = $.properties.Expiry.format = "date-time-8601";
+    $["x-az-public"] = false;
 ```
 
 ### Hide various Include types
@@ -972,11 +980,11 @@ directive:
 - from: swagger-document
   where: $.parameters.ListBlobsInclude
   transform: >
-    $.items["x-ms-public"] = false;
+    $.items["x-az-public"] = false;
 - from: swagger-document
   where: $.parameters.ListContainersInclude
   transform: >
-    $["x-ms-public"] = false;
+    $["x-az-public"] = false;
 ```
 
 ### Logging
@@ -985,7 +993,7 @@ directive:
 - from: swagger-document
   where: $.definitions.Logging
   transform: >
-    $["x-ms-disable-warnings"] = "CA1724";
+    $["x-az-disable-warnings"] = "CA1724";
 ```
 
 ### Hide StorageError
@@ -994,12 +1002,12 @@ directive:
 - from: swagger-document
   where: $.definitions.StorageError
   transform: >
-    $["x-ms-public"] = false;
+    $["x-az-public"] = false;
     $.properties.Code = { "type": "string" };
 - from: swagger-document
   where: $.definitions.DataLakeStorageError
   transform: >
-    $["x-ms-public"] = false;
+    $["x-az-public"] = false;
 ```
 
 ### Make AccessTier Unique

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/readme.md
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/readme.md
@@ -1,6 +1,17 @@
 # azure-track2-csharp
 An early code generator for Track 2 C# client libraries on top of Azure.Core.
 
+We support a number of extensions including using the vendor prefix `x-az-`:
+
+- `x-az-public`: Expose APIs as `public` when `true` or `internal` when `false`.  The default value is `true`.
+- `x-az-response-name`: Provide a name for response types other than `GroupOperationResponse`.  Any responses using the same name will be merged together.
+- `x-az-response-schema-name`: If we combine headers and a schema into a response type, this allows you to provide the name of the scehma property.  The default value is `Body`.
+- `x-az-create-exception`: `true` denotes that this partial type will provide an implementation of the method `Exception CreateException()` to turn an error object into something that can be thrown.  The default value is `false`.
+- `x-az-trace`: Indicates whether a parameter will be logged as part of our distributed tracing.  The default value is `false`.
+- `x-az-disable-warnings`: Wraps a declaration in a `#pragma disable` when specified.
+- `x-az-skip-path-components`: Whether to skip any path components and always assume a fully formed URL to the resource (this currently must be set to `true`).
+- `x-az-include-sync-methods`: Whether to generate support for sync methods.  The default value is `false` (this flag should go away soon and always be `true`).
+
 ### Autorest plugin configuration
 The AutoRest example at https://github.com/Azure/autorest-extension-helloworld
 walks through the following section and the docs at

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/generator.ts
@@ -269,10 +269,7 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                         use("_pair");
                     });
                 });
-            } else if (isPrimitiveType(param.model) && param.model.collectionFormat === `multi`) {
-                if (!param.model.itemType || param.model.itemType.type !== `string`) {
-                    throw `collectionFormat multi is only supported for strings, at the moment`;
-                }
+            } else if (param.location === `header` && isPrimitiveType(param.model) && param.model.collectionFormat === `csv`) {
                 w.scope(() => {
                     w.line(`foreach (string _item in ${naming.parameter(param.clientName)})`);
                     w.scope('{', '}', () => {
@@ -557,9 +554,9 @@ function generateOperation(w: IndentWriter, serviceModel: IServiceModel, group: 
                     w.line(`if (${responseName}.Headers.TryGetValue("${header.name}", out ${headerName}))`);
                     w.scope('{', '}', () => {
                         w.write(`${valueName}.${naming.pascalCase(header.clientName)} = `);
-                        if (isPrimitiveType(header.model) && header.model.collectionFormat === `multi`) {
+                        if (isPrimitiveType(header.model) && header.model.collectionFormat === `csv`) {
                             if (!header.model.itemType || header.model.itemType.type !== `string`) {
-                                throw `collectionFormat multi is only supported for strings, at the moment`;
+                                throw `collectionFormat csv is only supported for strings, at the moment`;
                             }
                             w.write(`(${headerName} ?? "").Split(',')`);
                         } else {

--- a/sdk/storage/Azure.Storage.Common/swagger/Generator/src/serviceModel.ts
+++ b/sdk/storage/Azure.Storage.Common/swagger/Generator/src/serviceModel.ts
@@ -195,13 +195,13 @@ function createServiceInfo(project: IProject): IServiceInfo {
     const swaggerVersion = required(() => project.swagger.swagger);
     if (swaggerVersion !== `2.0`) { throw `Can only process swagger 2.0, not ${swaggerVersion}`; }
 
-    // x-ms-skip-path-components is designed to let you pass in the base URI
+    // x-az-skip-path-components is designed to let you pass in the base URI
     // and path components together as a formed URI rather than constructing it
     // via components.  
     const collapseResourceUris = optional(
-        () => project.swagger.info[`x-ms-code-generation-settings`][`x-ms-skip-path-components`]);
+        () => project.swagger.info[`x-ms-code-generation-settings`][`x-az-skip-path-components`]);
     if (!collapseResourceUris) {
-        throw `x-ms-skip-path-components is required (in project.swagger.info['x-ms-code-generation-settings'])`;
+        throw `x-az-skip-path-components is required (in project.swagger.info['x-ms-code-generation-settings'])`;
     }
 
     // Process info
@@ -259,7 +259,7 @@ function createServiceInfo(project: IProject): IServiceInfo {
         project.context.verbose(`project.swagger.securityDefinitions is being ignored`);
     }
 
-    let isPublic: boolean|undefined = project.swagger.info[`x-ms-code-generation-settings`][`x-ms-public`];
+    let isPublic: boolean|undefined = project.swagger.info[`x-ms-code-generation-settings`][`x-az-public`];
     if (isPublic === undefined) {
         isPublic = true;
     }
@@ -278,7 +278,7 @@ function createServiceInfo(project: IProject): IServiceInfo {
             title + ' ModelFactory'),
         versions: [ <string>required(() => project.swagger.info.version) ],
         public: isPublic,
-        sync: <boolean>optional(() => project.swagger.info[`x-ms-code-generation-settings`][`x-ms-include-sync-methods`], false),
+        sync: <boolean>optional(() => project.swagger.info[`x-ms-code-generation-settings`][`x-az-include-sync-methods`], false),
         consumes: [`application/xml`],
         produces: [`application/xml`],
         host: serviceHost,
@@ -320,7 +320,7 @@ function createParameter(project: IProject, swagger: any, location: string): IPa
         unsupported(() => grouping.postfix, `${location}['x-ms-parameter-grouping'].postfix`);
     }
 
-    const trace = optional(() => swagger[`x-ms-trace`], false);
+    const trace = optional(() => swagger[`x-az-trace`], false);
 
     unsupported(() => swagger[`x-ms-client-flatten`], location);
     unsupported(() => swagger[`x-ms-client-request-id`], location);
@@ -424,7 +424,7 @@ function createObjectType(project: IProject, name: string, swagger: any, locatio
     unsupported(() => swagger.readOnly, location);
     unsupported(() => swagger[`x-ms-azure-resource`], location);
     
-    let isPublic: boolean|undefined = swagger[`x-ms-public`];
+    let isPublic: boolean|undefined = swagger[`x-az-public`];
     if (isPublic === undefined) {
         isPublic = true;
     }
@@ -440,7 +440,7 @@ function createObjectType(project: IProject, name: string, swagger: any, locatio
         xml: swagger.xml || { },
         serialize: false,
         deserialize: false,
-        disableWarnings: swagger[`x-ms-disable-warnings`],
+        disableWarnings: swagger[`x-az-disable-warnings`],
         public: isPublic,
         extendedHeaders: []
     };
@@ -466,7 +466,7 @@ function createEnumType(project: IProject, name: string, swagger: any, location:
     // Check if we need a custom serializer
     const customSerialization = values.some(v => (v.value !== naming.enumField(v.name || v.value)));
 
-    let isPublic: boolean|undefined = swagger[`x-ms-public`];
+    let isPublic: boolean|undefined = swagger[`x-az-public`];
     if (isPublic === undefined) {
         isPublic = true;
     }
@@ -597,7 +597,7 @@ function createResponse(project: IProject, code: string, name: string, swagger: 
 
     unsupported(() => swagger.examples, `${location}['${code}']`);
 
-    let isPublic: boolean|undefined = swagger[`x-ms-public`];
+    let isPublic: boolean|undefined = swagger[`x-az-public`];
     if (isPublic === undefined) {
         isPublic = true;
     }
@@ -605,11 +605,11 @@ function createResponse(project: IProject, code: string, name: string, swagger: 
     return {
         code,
         description: swagger.description,
-        clientName: <string>optional(() => swagger[`x-ms-client-name`]),
+        clientName: <string>optional(() => swagger[`x-az-response-name`]),
         body: model,
-        bodyClientName: <string>optional(() => swagger[`x-ms-schema-client-name`], `Body`), // TODO: switch from 'Body' to body.name?
+        bodyClientName: <string>optional(() => swagger[`x-az-response-schema-name`], `Body`), // TODO: switch from 'Body' to body.name?
         headers,
-        exception: <boolean>optional(() => swagger[`x-ms-create-exception`]),
+        exception: <boolean>optional(() => swagger[`x-az-create-exception`]),
         public: isPublic
     };
 }
@@ -617,7 +617,7 @@ function createResponse(project: IProject, code: string, name: string, swagger: 
 function createHeaders(project: IProject, swagger: any, location: string): IHeaders {
     const headers: IHeaders = { };
     for (const [name, def] of <[string, any]>Object.entries(swagger || {})) {
-        let ignore = def[`x-ms-ignore`];
+        let ignore = def[`x-az-demote-header`];
         if (ignore === undefined) {
             ignore = false;
         }

--- a/sdk/storage/Azure.Storage.Files/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Files/swagger/readme.md
@@ -28,9 +28,9 @@ directive:
     $["client-name"] = "FileRestClient";
     $["client-extensions-name"] = "FilesExtensions";
     $["client-model-factory-name"] = "FilesModelFactory";
-    $["x-ms-skip-path-components"] = true;
-    $["x-ms-include-sync-methods"] = true;
-    $["x-ms-public"] = false;
+    $["x-az-skip-path-components"] = true;
+    $["x-az-include-sync-methods"] = true;
+    $["x-az-public"] = false;
 ```
 
 ### Url
@@ -41,7 +41,7 @@ directive:
   transform: >
     $["x-ms-client-name"] = "resourceUri";
     $.format = "url";
-    $["x-ms-trace"] = true;
+    $["x-az-trace"] = true;
 ```
 
 ### Ignore common headers
@@ -50,15 +50,15 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["x-ms-request-id"]
   transform: >
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["x-ms-version"]
   transform: >
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["Date"]
   transform: >
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 ```
 
 ### Clean up Failure response
@@ -67,10 +67,10 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]..responses.default
   transform: >
-    $["x-ms-client-name"] = "StorageErrorResult";
-    $["x-ms-create-exception"] = true;
-    $["x-ms-public"] = false;
-    $.headers["x-ms-error-code"]["x-ms-ignore"] = true;
+    $["x-az-response-name"] = "StorageErrorResult";
+    $["x-az-create-exception"] = true;
+    $["x-az-public"] = false;
+    $.headers["x-ms-error-code"]["x-az-demote-header"] = true;
 ```
 
 ### ApiVersionParameter
@@ -126,7 +126,7 @@ directive:
     if (!$.SharesSegment) {
         $.SharesSegment = $.ListSharesResponse;
         delete $.ListSharesResponse;
-        $.SharesSegment["x-ms-public"] = false;
+        $.SharesSegment["x-az-public"] = false;
     }
 - from: swagger-document
   where: $["x-ms-paths"]["/?comp=list"]
@@ -145,8 +145,8 @@ directive:
   where: $["x-ms-paths"]["/{shareName}?restype=share"]
   transform: >
     $.put.responses["201"].description = "Success";
-    $.put.responses["201"]["x-ms-client-name"] = "ShareInfo";
-    $.get.responses["200"]["x-ms-client-name"] = "ShareProperties";
+    $.put.responses["201"]["x-az-response-name"] = "ShareInfo";
+    $.get.responses["200"]["x-az-response-name"] = "ShareProperties";
 ```
 
 ### /{shareName}?restype=share&comp=snapshot
@@ -155,7 +155,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}?restype=share&comp=snapshot"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "ShareSnapshotInfo";
+    $.put.responses["201"]["x-az-response-name"] = "ShareSnapshotInfo";
 ```
 
 ### /{shareName}?restype=share&comp=properties
@@ -164,7 +164,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}?restype=share&comp=properties"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "ShareInfo";
+    $.put.responses["200"]["x-az-response-name"] = "ShareInfo";
     $.put.responses["200"].headers.ETag.description = "The ETag contains a value which represents the version of the share, in quotes.";
     $.put.responses["200"].headers["Last-Modified"].description = "Returns the date and time the share was last modified. Any operation that modifies the share or its properties or metadata updates the last modified time. Operations on files do not affect the last modified time of the share.";
 ```
@@ -175,7 +175,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}?restype=share&comp=metadata"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "ShareInfo";
+    $.put.responses["200"]["x-az-response-name"] = "ShareInfo";
     $.put.responses["200"].headers.ETag.description = "The ETag contains a value which represents the version of the share, in quotes.";
     $.put.responses["200"].headers["Last-Modified"].description = "Returns the date and time the share was last modified. Any operation that modifies the share or its properties or metadata updates the last modified time. Operations on files do not affect the last modified time of the share.";
 ```
@@ -186,9 +186,9 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}?restype=share&comp=acl"]
   transform: >
-    $.get.responses["200"].headers.ETag["x-ms-ignore"] = true;
-    $.get.responses["200"].headers["Last-Modified"]["x-ms-ignore"] = true;
-    $.put.responses["200"]["x-ms-client-name"] = "ShareInfo";
+    $.get.responses["200"].headers.ETag["x-az-demote-header"] = true;
+    $.get.responses["200"].headers["Last-Modified"]["x-az-demote-header"] = true;
+    $.put.responses["200"]["x-az-response-name"] = "ShareInfo";
     $.put.responses["200"].description = "Success";
     $.put.responses["200"].headers.ETag.description = "The ETag contains a value which represents the version of the share, in quotes.";
     $.put.responses["200"].headers["Last-Modified"].description = "Returns the date and time the share was last modified. Any operation that modifies the share or its properties or metadata updates the last modified time. Operations on files do not affect the last modified time of the share.";
@@ -213,8 +213,8 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}?restype=share&comp=stats"]
   transform: >
-    $.get.responses["200"].headers.ETag["x-ms-ignore"] = true;
-    $.get.responses["200"].headers["Last-Modified"]["x-ms-ignore"] = true;
+    $.get.responses["200"].headers.ETag["x-az-demote-header"] = true;
+    $.get.responses["200"].headers["Last-Modified"]["x-az-demote-header"] = true;
     const def = $.get.responses["200"].schema;
     if (!def["$ref"].endsWith("ShareStatistics")) {
         const path = def["$ref"].replace(/[#].*$/, "#/definitions/ShareStatistics");
@@ -228,9 +228,9 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}?restype=directory"]
   transform: >
-    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
-    $.put.responses["201"]["x-ms-client-name"] = "RawStorageDirectoryInfo";
-    $.get.responses["200"]["x-ms-client-name"] = "RawStorageDirectoryProperties";
+    $.put.responses["201"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
+    $.put.responses["201"]["x-az-response-name"] = "RawStorageDirectoryInfo";
+    $.get.responses["200"]["x-az-response-name"] = "RawStorageDirectoryProperties";
 ```
 
 ### /{shareName}/{directory}?restype=directory&comp=metadata
@@ -239,9 +239,9 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}?restype=directory&comp=metadata"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "RawStorageDirectoryInfo";
+    $.put.responses["200"]["x-az-response-name"] = "RawStorageDirectoryInfo";
     $.put.responses["200"].description = "Success, Directory created.";
-    $.put.responses["200"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["200"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
     $.put.responses["200"].headers["Last-Modified"] = {
       "type": "string",
       "format": "date-time-rfc1123",
@@ -255,9 +255,9 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}?restype=directory&comp=properties"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "RawStorageDirectoryInfo";
+    $.put.responses["200"]["x-az-response-name"] = "RawStorageDirectoryInfo";
     $.put.responses["200"].description = "Success, Directory created.";
-    $.put.responses["200"].headers["x-ms-request-server-encrypted"]["x-ms-ignore"] = true;
+    $.put.responses["200"].headers["x-ms-request-server-encrypted"]["x-az-demote-header"] = true;
     $.put.responses["200"].headers["Last-Modified"] = {
       "type": "string",
       "format": "date-time-rfc1123",
@@ -287,13 +287,13 @@ directive:
             "xml": { "name": "Entries", "wrapped": true }
         };
         delete $.FilesAndDirectoriesSegment.properties.Segment;
-        $.FilesAndDirectoriesSegment["x-ms-public"] = false;
+        $.FilesAndDirectoriesSegment["x-az-public"] = false;
         delete $.FilesAndDirectoriesListSegment;
     }
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}?restype=directory&comp=list"]
   transform: >
-    $.get.responses["200"].headers["Content-Type"]["x-ms-ignore"] = true;
+    $.get.responses["200"].headers["Content-Type"]["x-az-demote-header"] = true;
     const def = $.get.responses["200"].schema;
     if (!def["$ref"].endsWith("FilesAndDirectoriesSegment")) {
         const path = def["$ref"].replace(/[#].*$/, "#/definitions/FilesAndDirectoriesSegment");
@@ -314,7 +314,7 @@ directive:
     if (!$.StorageHandlesSegment) {
         $.StorageHandlesSegment = $.ListHandlesResponse;
         delete $.ListHandlesResponse;
-        $.StorageHandlesSegment["x-ms-public"] = false;
+        $.StorageHandlesSegment["x-az-public"] = false;
         const path = $.StorageHandlesSegment.properties.HandleList.items.$ref.replace(/[#].*$/, "#/definitions/");
         $.StorageHandlesSegment.properties.Handles = {
             "type": "array",
@@ -331,7 +331,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}?comp=listhandles"]
   transform: >
-    $.get.responses["200"].headers["Content-Type"]["x-ms-ignore"] = true;
+    $.get.responses["200"].headers["Content-Type"]["x-az-demote-header"] = true;
     const def = $.get.responses["200"].schema;
     if (!def["$ref"].endsWith("StorageHandlesSegment")) {
         const path = def["$ref"].replace(/[#].*$/, "#/definitions/StorageHandlesSegment");
@@ -345,7 +345,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}/{fileName}?comp=listhandles"]
   transform: >
-    $.get.responses["200"].headers["Content-Type"]["x-ms-ignore"] = true;
+    $.get.responses["200"].headers["Content-Type"]["x-az-demote-header"] = true;
     const def = $.get.responses["200"].schema;
     if (!def["$ref"].endsWith("StorageHandlesSegment")) {
         const path = def["$ref"].replace(/[#].*$/, "#/definitions/StorageHandlesSegment");
@@ -359,7 +359,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}?comp=forceclosehandles"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "StorageClosedHandlesSegment";
+    $.put.responses["200"]["x-az-response-name"] = "StorageClosedHandlesSegment";
 ```
 
 ### /{shareName}/{directory}/{fileName}?comp=forceclosehandles
@@ -368,7 +368,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}/{fileName}?comp=forceclosehandles"]
   transform: >
-    $.put.responses["200"]["x-ms-client-name"] = "StorageClosedHandlesSegment";
+    $.put.responses["200"]["x-az-response-name"] = "StorageClosedHandlesSegment";
 ```
 
 ### /{shareName}/{directory}/{fileName}
@@ -377,60 +377,60 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}/{fileName}"]
   transform: >
-    $.put.responses["201"]["x-ms-client-name"] = "RawStorageFileInfo";
+    $.put.responses["201"]["x-az-response-name"] = "RawStorageFileInfo";
     $.get.responses["200"].headers["Content-MD5"]["x-ms-client-name"] = "ContentHash";
     $.get.responses["200"].headers["x-ms-copy-source"].format = "url";
     $.get.responses["200"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
     $.get.responses["200"].headers["x-ms-content-md5"]["x-ms-client-name"] = "FileContentHash";
     $.get.responses["200"].headers["Content-Encoding"].type = "array";
-    $.get.responses["200"].headers["Content-Encoding"].collectionFormat = "multi";
+    $.get.responses["200"].headers["Content-Encoding"].collectionFormat = "csv";
     $.get.responses["200"].headers["Content-Encoding"].items = { "type": "string" };
     $.get.responses["200"].headers["Content-Language"].type = "array";
-    $.get.responses["200"].headers["Content-Language"].collectionFormat = "multi";
+    $.get.responses["200"].headers["Content-Language"].collectionFormat = "csv";
     $.get.responses["200"].headers["Content-Language"].items = { "type": "string" };
-    $.get.responses["200"]["x-ms-client-name"] = "FlattenedStorageFileProperties";
-    $.get.responses["200"]["x-ms-public"] = false;
-    $.get.responses["200"]["x-ms-schema-client-name"] = "Content";
+    $.get.responses["200"]["x-az-response-name"] = "FlattenedStorageFileProperties";
+    $.get.responses["200"]["x-az-public"] = false;
+    $.get.responses["200"]["x-az-response-schema-name"] = "Content";
     $.get.responses["206"].headers["Content-MD5"]["x-ms-client-name"] = "ContentHash";
     $.get.responses["206"].headers["x-ms-copy-source"].format = "url";
     $.get.responses["206"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
     $.get.responses["206"].headers["x-ms-content-md5"]["x-ms-client-name"] = "FileContentHash";
     $.get.responses["206"].headers["Content-Encoding"].type = "array";
-    $.get.responses["206"].headers["Content-Encoding"].collectionFormat = "multi";
+    $.get.responses["206"].headers["Content-Encoding"].collectionFormat = "csv";
     $.get.responses["206"].headers["Content-Encoding"].items = { "type": "string" };
     $.get.responses["206"].headers["Content-Language"].type = "array";
-    $.get.responses["206"].headers["Content-Language"].collectionFormat = "multi";
+    $.get.responses["206"].headers["Content-Language"].collectionFormat = "csv";
     $.get.responses["206"].headers["Content-Language"].items = { "type": "string" };
-    $.get.responses["206"]["x-ms-client-name"] = "FlattenedStorageFileProperties";
-    $.get.responses["206"]["x-ms-public"] = false;
-    $.get.responses["206"]["x-ms-schema-client-name"] = "Content";
+    $.get.responses["206"]["x-az-response-name"] = "FlattenedStorageFileProperties";
+    $.get.responses["206"]["x-az-public"] = false;
+    $.get.responses["206"]["x-az-response-schema-name"] = "Content";
     $.head.responses["200"].headers["Content-MD5"]["x-ms-client-name"] = "ContentHash";
     $.head.responses["200"].headers["Content-Encoding"].type = "array";
-    $.head.responses["200"].headers["Content-Encoding"].collectionFormat = "multi";
+    $.head.responses["200"].headers["Content-Encoding"].collectionFormat = "csv";
     $.head.responses["200"].headers["Content-Encoding"].items = { "type": "string" };
     $.head.responses["200"].headers["Content-Language"].type = "array";
-    $.head.responses["200"].headers["Content-Language"].collectionFormat = "multi";
+    $.head.responses["200"].headers["Content-Language"].collectionFormat = "csv";
     $.head.responses["200"].headers["Content-Language"].items = { "type": "string" };
     $.head.responses["200"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
-    $.head.responses["200"]["x-ms-client-name"] = "RawStorageFileProperties";
+    $.head.responses["200"]["x-az-response-name"] = "RawStorageFileProperties";
     $.head.responses.default = {
         "description": "Failure",
-        "x-ms-client-name": "FailureNoContent",
-        "x-ms-create-exception": true,
-        "x-ms-public": false,
+        "x-az-response-name": "FailureNoContent",
+        "x-az-create-exception": true,
+        "x-az-public": false,
         "headers": { "x-ms-error-code": { "x-ms-client-name": "ErrorCode", "type": "string" } }
     };
 - from: swagger-document
   where: $.parameters.FileContentLanguage
   transform: >
     $.type = "array";
-    $.collectionFormat = "multi";
+    $.collectionFormat = "csv";
     $.items = { "type": "string" };
 - from: swagger-document
   where: $.parameters.FileContentEncoding
   transform: >
     $.type = "array";
-    $.collectionFormat = "multi";
+    $.collectionFormat = "csv";
     $.items = { "type": "string" };
 ```
 
@@ -457,7 +457,7 @@ directive:
     $.put.operationId = "File_SetProperties";
     $.put.responses["200"].description = "Success, File created.";
     $.put.responses["200"].headers["Last-Modified"].description = "Returns the date and time the share was last modified. Any operation that modifies the directory or its properties updates the last modified time. Operations on files do not affect the last modified time of the directory.";
-    $.put.responses["200"]["x-ms-client-name"] = "RawStorageFileInfo";
+    $.put.responses["200"]["x-az-response-name"] = "RawStorageFileInfo";
 ```
 
 ### /{shareName}/{directory}/{fileName}?comp=metadata
@@ -472,7 +472,7 @@ directive:
         "format": "date-time-rfc1123",
         "description": "Returns the date and time the share was last modified. Any operation that modifies the directory or its properties updates the last modified time. Operations on files do not affect the last modified time of the directory."
     };
-    $.put.responses["200"]["x-ms-client-name"] = "RawStorageFileInfo";
+    $.put.responses["200"]["x-az-response-name"] = "RawStorageFileInfo";
 ```
 
 ### /{shareName}/{directory}/{fileName}?comp=range
@@ -482,7 +482,7 @@ directive:
   where: $["x-ms-paths"]["/{shareName}/{directory}/{fileName}?comp=range"]
   transform: >
     $.put.responses["201"].headers["Content-MD5"]["x-ms-client-name"] = "ContentHash";
-    $.put.responses["201"]["x-ms-client-name"] = "StorageFileUploadInfo";
+    $.put.responses["201"]["x-az-response-name"] = "StorageFileUploadInfo";
 ```
 
 ### /{shareName}/{directory}/{fileName}?comp=rangelist
@@ -491,8 +491,8 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{shareName}/{directory}/{fileName}?comp=rangelist"]
   transform: >
-    $.get.responses["200"]["x-ms-client-name"] = "StorageFileRangeInfo";
-    $.get.responses["200"]["x-ms-schema-client-name"] = "Ranges";
+    $.get.responses["200"]["x-az-response-name"] = "StorageFileRangeInfo";
+    $.get.responses["200"]["x-az-response-schema-name"] = "Ranges";
 ```
 
 ### /{shareName}/{directory}/{fileName}?comp=copy
@@ -502,7 +502,7 @@ directive:
   where: $["x-ms-paths"]["/{shareName}/{directory}/{fileName}?comp=copy"]
   transform: >
     $.put.responses["202"].headers["x-ms-copy-status"]["x-ms-enum"].name = "CopyStatus";
-    $.put.responses["202"]["x-ms-client-name"] = "StorageFileCopyInfo";
+    $.put.responses["202"]["x-az-response-name"] = "StorageFileCopyInfo";
 - from: swagger-document
   where: $.parameters.CopySource
   transform: >
@@ -514,7 +514,7 @@ directive:
 directive:
 - from: swagger-document
   where: $.definitions.DirectoryItem
-  transform: $["x-ms-public"] = false
+  transform: $["x-az-public"] = false
 ```
 
 ### FileItem
@@ -522,7 +522,7 @@ directive:
 directive:
 - from: swagger-document
   where: $.definitions.FileItem
-  transform: $["x-ms-public"] = false
+  transform: $["x-az-public"] = false
 ```
 
 ### ErrorCode
@@ -540,7 +540,7 @@ directive:
 - from: swagger-document
   where: $.definitions.FileProperty
   transform: >
-    $["x-ms-public"] = false;
+    $["x-az-public"] = false;
 ```
 
 ### Metrics
@@ -558,7 +558,7 @@ directive:
 - from: swagger-document
   where: $.definitions.StorageError
   transform: >
-    $["x-ms-public"] = false;
+    $["x-az-public"] = false;
     $.properties.Code = { "type": "string" };
 ```
 
@@ -584,7 +584,7 @@ directive:
     if (!$.ShareItemProperties) {
         $.ShareItemProperties = $.ShareProperties;
         delete $.ShareProperties;
-        $.ShareItemProperties.required = [];
+        delete $.ShareItemProperties.required;
         $.ShareItemProperties.xml = { "name": "Properties" };
     }
 ```

--- a/sdk/storage/Azure.Storage.Queues/swagger/readme.md
+++ b/sdk/storage/Azure.Storage.Queues/swagger/readme.md
@@ -28,9 +28,9 @@ directive:
     $["client-name"] = "QueueRestClient";
     $["client-extensions-name"] = "QueuesExtensions";
     $["client-model-factory-name"] = "QueuesModelFactory";
-    $["x-ms-skip-path-components"] = true;
-    $["x-ms-include-sync-methods"] = true;
-    $["x-ms-public"] = false;
+    $["x-az-skip-path-components"] = true;
+    $["x-az-include-sync-methods"] = true;
+    $["x-az-public"] = false;
 ```
 
 ### Clean up Failure response
@@ -39,10 +39,10 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]..responses.default
   transform: >
-    $["x-ms-client-name"] = "StorageErrorResult";
-    $["x-ms-create-exception"] = true;
-    $["x-ms-public"] = false;
-    $.headers["x-ms-error-code"]["x-ms-ignore"] = true;
+    $["x-az-response-name"] = "StorageErrorResult";
+    $["x-az-create-exception"] = true;
+    $["x-az-public"] = false;
+    $.headers["x-ms-error-code"]["x-az-demote-header"] = true;
 ```
 
 ### Ignore common headers
@@ -51,15 +51,15 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["x-ms-request-id"]
   transform: >
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["x-ms-version"]
   transform:
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 - from: swagger-document
   where: $["x-ms-paths"]..responses..headers["Date"]
   transform:
-    $["x-ms-ignore"] = true;
+    $["x-az-demote-header"] = true;
 ```
 
 ### QueueServiceProperties
@@ -128,7 +128,7 @@ directive:
     if (!$.QueuesSegment) {
         $.QueuesSegment = $.ListQueuesSegmentResponse;
         delete $.ListQueuesSegmentResponse;
-        $.QueuesSegment["x-ms-public"] = false;
+        $.QueuesSegment["x-az-public"] = false;
         $.QueuesSegment.required = ["ServiceEndpoint"];
     }
 - from: swagger-document
@@ -147,7 +147,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{queueName}?comp=metadata"]
   transform: >
-    $.get.responses["200"]["x-ms-client-name"] = "QueueProperties";
+    $.get.responses["200"]["x-az-response-name"] = "QueueProperties";
 ```
 
 ### /{queueName}/messages/{messageid}?popreceipt={popReceipt}&visibilitytimeout={visibilityTimeout}
@@ -156,7 +156,7 @@ directive:
 - from: swagger-document
   where: $["x-ms-paths"]["/{queueName}/messages/{messageid}?popreceipt={popReceipt}&visibilitytimeout={visibilityTimeout}"]
   transform: >
-    $.put.responses["204"]["x-ms-client-name"] = "UpdatedMessage";
+    $.put.responses["204"]["x-az-response-name"] = "UpdatedMessage";
 ```
 
 ### QueueErrorCode
@@ -182,7 +182,7 @@ directive:
 directive:
 - from: swagger-document
   where: $.definitions.Logging
-  transform: $["x-ms-disable-warnings"] = "CA1724"
+  transform: $["x-az-disable-warnings"] = "CA1724"
 ```
 
 ### StorageError
@@ -192,7 +192,7 @@ directive:
   where: $.definitions.StorageError
   transform: >
     $.properties.Code = { "type": "string" };
-    $["x-ms-public"] = false;
+    $["x-az-public"] = false;
 ```
 
 ### Metrics
@@ -210,7 +210,7 @@ directive:
 - from: swagger-document
   where: $.definitions.QueueMessage
   transform: >
-    $["x-ms-public"] = false;
+    $["x-az-public"] = false;
     $.xml = { "name": "QueueMessage" };
 - from: swagger-document
   where: $.parameters.QueueMessage
@@ -264,8 +264,8 @@ directive:
 - from: swagger-document
   where: $.parameters.ListQueuesInclude
   transform: >
-    $["x-ms-public"] = false;
-    $.items["x-ms-public"] = false;
+    $["x-az-public"] = false;
+    $.items["x-az-public"] = false;
 ```
 
 ### AccessPolicy
@@ -293,7 +293,7 @@ directive:
   transform: >
     $["x-ms-client-name"] = "resourceUri";
     $.format = "url";
-    $["x-ms-trace"] = true;
+    $["x-az-trace"] = true;
 ```
 
 ### Timeout docs

--- a/sdk/storage/generate.ps1
+++ b/sdk/storage/generate.ps1
@@ -2,12 +2,12 @@ pushd $PSScriptRoot/Azure.Storage.Common/swagger/Generator/
 npm install
 
 cd $PSScriptRoot/Azure.Storage.Blobs/swagger/
-autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose --version=3.0.5532 --interactive
+autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
 
 cd $PSScriptRoot/Azure.Storage.Files/swagger/
-autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose --version=3.0.5532 --interactive
+autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
 
 cd $PSScriptRoot/Azure.Storage.Queues/swagger/
-autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose --version=3.0.5532 --interactive
+autorest --use=$PSScriptRoot/Azure.Storage.Common/swagger/Generator/ --verbose
 
 popd


### PR DESCRIPTION
Updating all of our vendor extensions to use an `x-az-` prefix instead of `x-ms-` to
prevent the AutoRest schema validator from complaining.  Also fixing a couple of
other schema violations and changing from header `collectionFormat` `multi` to
`csv` (which is correct).

Please note there are **NO changes to the code** after regenerating.