### PR TITLE
Updating root readme to refer to github.io docs rather than relative readme location

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ These libraries follow the [Azure SDK Design Guidelines for .NET](https://azure.
 These preview libraries can be easily identified by their folder, package, and namespaces names starting with 'Azure', e.g. Azure.Storage.Blobs. 
 
 The libraries released in the July 2019 preview:
-* [Azure.ApplicationModel.Configuration](/sdk/appconfiguration/Azure.ApplicationModel.Configuration/README.md)
-* [Azure.Messaging.EventHubs](/sdk/eventhub/Azure.Messaging.EventHubs/README.md)
-* [Azure.Security.KeyVault.Keys](/sdk/keyvault/Azure.Security.KeyVault.Keys/README.md)
-* [Azure.Security.KeyVault.Secrets](/sdk/keyvault/Azure.Security.KeyVault.Secrets/README.md)
-* [Azure.Storage.Blobs](/sdk/storage/Azure.Storage.Blobs/README.md)
-* [Azure.Storage.Files](/sdk/storage/Azure.Storage.Files/README.md)
-* [Azure.Storage.Queues](/sdk/storage/Azure.Storage.Queues/README.md)
+* [Azure.ApplicationModel.Configuration](https://azure.github.io/azure-sdk-for-net/api/Azure.ApplicationModel.Configuration.html)
+* [Azure.Messaging.EventHubs](https://azure.github.io/azure-sdk-for-net/api/Azure.Messaging.EventHubs.html)
+* [Azure.Security.KeyVault.Keys](https://azure.github.io/azure-sdk-for-net/api/Azure.Security.KeyVault.Keys.html)
+* [Azure.Security.KeyVault.Secrets](https://azure.github.io/azure-sdk-for-net/api/Azure.Security.KeyVault.Secrets.html)
+* [Azure.Storage.Blobs](https://azure.github.io/azure-sdk-for-net/api/Azure.Storage.Blobs.html)
+* [Azure.Storage.Files](https://azure.github.io/azure-sdk-for-net/api/Azure.Storage.Files.html)
+* [Azure.Storage.Queues](https://azure.github.io/azure-sdk-for-net/api/Azure.Storage.Queues.html)
 
 >NOTE: If you need to ensure your code is ready for production, use one of the stable libraries.
 


### PR DESCRIPTION
If you navigate to [the .net doc site](https://azure.github.io/azure-sdk-for-net/#client-july-2019-preview) the links out to the readme for each specific package are broken. Check the "readme" links for each July 2019 preview package. The urls are rendering incorrectly because the actual `readme.md ` has _relative links_ vs  `github.io` paths that will actually work.

FYI 
@chidozieononiwu 
@weshaggard 
@ramya-rao-a 
@Azure/azure-sdk-eng 