### PR TITLE
[Event Hubs Client] Track Two: Third Preview (AMQP Authorization)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/CbsTokenProvider.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Amqp/CbsTokenProvider.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Messaging.EventHubs.Authorization;
+using Azure.Messaging.EventHubs.Core;
+using Microsoft.Azure.Amqp;
+
+namespace Azure.Messaging.EventHubs.Amqp
+{
+    /// <summary>
+    ///   Performs the actions needed to generate <see cref="CbsToken" /> instances for
+    ///   authorization within an AMQP scope.
+    /// </summary>
+    ///
+    /// <seealso cref="Microsoft.Azure.Amqp.ICbsTokenProvider" />
+    ///
+    internal sealed class CbsTokenProvider : ICbsTokenProvider
+    {
+        /// <summary>The type to consider a token if it is based on an Event Hubs shared access signature.</summary>
+        private const string SharedAccessSignatureTokenType = "servicebus.windows.net:sastoken";
+
+        /// <summary>The type to consider a token if not based on a shared access signature.</summary>
+        private const string JsonWebTokenType = "jwt";
+
+        /// <summary>;The type to consider a token generated from the associated <see cref="Credential" />.</summary>
+        private readonly string TokenType;
+
+        /// <summary>The credential used to generate access tokens.</summary>
+        private readonly EventHubTokenCredential Credential;
+
+        /// <summary>The cancellation token to consider when making requests.</summary>
+        private readonly CancellationToken CancellationToken;
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="CbsTokenProvider"/> class.
+        /// </summary>
+        ///
+        /// <param name="credential">The credential to use for access token generation.</param>
+        /// <param name="cancellationToken">The cancellation token to consider when making requests.</param>
+        ///
+        public CbsTokenProvider(EventHubTokenCredential credential,
+                                CancellationToken cancellationToken)
+        {
+            Guard.ArgumentNotNull(nameof(credential), credential);
+
+            Credential = credential;
+            CancellationToken = cancellationToken;
+
+            TokenType = (credential.IsSharedAccessSignatureCredential)
+                ? SharedAccessSignatureTokenType
+                : JsonWebTokenType;
+        }
+
+        /// <summary>
+        ///   Asynchronously requests a CBS token to be used for authorization within an AMQP
+        ///   scope.
+        /// </summary>
+        ///
+        /// <param name="namespaceAddress">The address of the namespace to be authorized.</param>
+        /// <param name="appliesTo">The resource to which the token should apply.</param>
+        /// <param name="requiredClaims">The set of claims that are required for authorization.</param>
+        ///
+        /// <returns>The token to use for authorization.</returns>
+        ///
+        public async Task<CbsToken> GetTokenAsync(Uri namespaceAddress,
+                                                  string appliesTo,
+                                                  string[] requiredClaims)
+        {
+            var token = await Credential.GetTokenAsync(requiredClaims, CancellationToken);
+            return new CbsToken(token.Token, TokenType, token.ExpiresOn.UtcDateTime);
+        }
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/EventHubTokenCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/EventHubTokenCredential.cs
@@ -23,13 +23,22 @@ namespace Azure.Messaging.EventHubs.Authorization
         public string Resource { get; }
 
         /// <summary>
+        ///   Indicates whether the credential is based on an Event Hubs
+        ///   shared access signature.
+        /// </summary>
+        ///
+        /// <value><c>true</c> if the credential should be considered a SAS credential; otherwise, <c>false</c>.</value>
+        ///
+        public bool IsSharedAccessSignatureCredential { get; }
+
+        /// <summary>
         ///   The <see cref="TokenCredential" /> that forms the basis of this security token.
         /// </summary>
         ///
         private TokenCredential Credential { get; }
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="SharedAccessSignatureCredential"/> class.
+        ///   Initializes a new instance of the <see cref="EventHubTokenCredential"/> class.
         /// </summary>
         ///
         /// <param name="tokenCredential">The <see cref="TokenCredential" /> on which to base the token.</param>
@@ -43,6 +52,11 @@ namespace Azure.Messaging.EventHubs.Authorization
 
             Credential = tokenCredential;
             Resource = eventHubResource;
+
+            IsSharedAccessSignatureCredential =
+                (tokenCredential is EventHubSharedKeyCredential)
+                || (tokenCredential is SharedAccessSignatureCredential)
+                || ((tokenCredential as EventHubTokenCredential)?.IsSharedAccessSignatureCredential == true);
         }
 
         /// <summary>
@@ -55,7 +69,8 @@ namespace Azure.Messaging.EventHubs.Authorization
         ///
         /// <returns>The token representing the shared access signature for this credential.</returns>
         ///
-        public override AccessToken GetToken(string[] scopes, CancellationToken cancellationToken) => Credential.GetToken(scopes, cancellationToken);
+        public override AccessToken GetToken(string[] scopes,
+                                             CancellationToken cancellationToken) => Credential.GetToken(scopes, cancellationToken);
 
         /// <summary>
         ///   Retrieves the token that represents the shared access signature credential, for
@@ -67,6 +82,7 @@ namespace Azure.Messaging.EventHubs.Authorization
         ///
         /// <returns>The token representing the shared access signature for this credential.</returns>
         ///
-        public override Task<AccessToken> GetTokenAsync(string[] scopes, CancellationToken cancellationToken) => Credential.GetTokenAsync(scopes, cancellationToken);
+        public override Task<AccessToken> GetTokenAsync(string[] scopes,
+                                                        CancellationToken cancellationToken) => Credential.GetTokenAsync(scopes, cancellationToken);
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignatureCredential.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Authorization/SharedAccessSignatureCredential.cs
@@ -46,7 +46,8 @@ namespace Azure.Messaging.EventHubs.Authorization
         ///
         /// <returns>The token representing the shared access signature for this credential.</returns>
         ///
-        public override AccessToken GetToken(string[] scopes, CancellationToken cancellationToken) => new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.SignatureExpiration);
+        public override AccessToken GetToken(string[] scopes,
+                                             CancellationToken cancellationToken) => new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.SignatureExpiration);
 
         /// <summary>
         ///   Retrieves the token that represents the shared access signature credential, for
@@ -58,6 +59,7 @@ namespace Azure.Messaging.EventHubs.Authorization
         ///
         /// <returns>The token representing the shared access signature for this credential.</returns>
         ///
-        public override Task<AccessToken> GetTokenAsync(string[] scopes, CancellationToken cancellationToken) => Task.FromResult(new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.SignatureExpiration));
+        public override Task<AccessToken> GetTokenAsync(string[] scopes,
+                                                        CancellationToken cancellationToken) => Task.FromResult(new AccessToken(SharedAccessSignature.Value, SharedAccessSignature.SignatureExpiration));
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -840,7 +840,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void  CreateEventFromMessagePopulatesAnArrayApplicationPropertyType()
+        public void CreateEventFromMessagePopulatesAnArrayApplicationPropertyType()
         {
             using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
             using var message = AmqpMessage.Create(bodyStream, true);
@@ -867,7 +867,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void  CreateEventFromMessagePopulatesAFullArraySegmentApplicationPropertyType()
+        public void CreateEventFromMessagePopulatesAFullArraySegmentApplicationPropertyType()
         {
             using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
             using var message = AmqpMessage.Create(bodyStream, true);
@@ -894,7 +894,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void  CreateEventFromMessagePopulatesAnArraySegmentApplicationPropertyType()
+        public void CreateEventFromMessagePopulatesAnArraySegmentApplicationPropertyType()
         {
             using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
             using var message = AmqpMessage.Create(bodyStream, true);
@@ -921,7 +921,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void  CreateEventFromMessageDoesNotIncludeUnknownApplicationPropertyType()
+        public void CreateEventFromMessageDoesNotIncludeUnknownApplicationPropertyType()
         {
             using var bodyStream = new MemoryStream(new byte[] { 0x11, 0x22, 0x33 }, false);
             using var message = AmqpMessage.Create(bodyStream, true);
@@ -1020,7 +1020,7 @@ namespace Azure.Messaging.EventHubs.Tests
         {
             var sourceEvent = new EventData(new byte[] { 0x11, 0x22, 0x33 })
             {
-                Properties = new Dictionary<string, object> {{ "Test", 1234 }}
+                Properties = new Dictionary<string, object> { { "Test", 1234 } }
             };
 
             var converter = new AmqpMessageConverter();

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/CbsTokenProviderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/CbsTokenProviderTests.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core;
+using Azure.Messaging.EventHubs.Amqp;
+using Azure.Messaging.EventHubs.Authorization;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Messaging.EventHubs.Tests.Amqp
+{
+    /// <summary>
+    ///   The suite of tests for the <see cref="CbsTokenProvider" />
+    ///   class.
+    /// </summary>
+    ///
+    [TestFixture]
+    public class CbsTokenProviderTests
+    {
+        /// <summary>
+        ///   Verifies functionality of the constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorValidatesCredential()
+        {
+            Assert.That(() => new CbsTokenProvider(null, CancellationToken.None), Throws.ArgumentNullException);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CbsTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetTokenAsyncPassesAlongTheClaims()
+        {
+            var requiredClaims = new[] { "one", "two" };
+            var mockCredential = new Mock<TokenCredential>();
+            var credential = new EventHubTokenCredential(mockCredential.Object, "test");
+            var provider = new CbsTokenProvider(credential, default);
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.Is<string[]>(value => value == requiredClaims), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new AccessToken("blah", DateTimeOffset.Parse("2015-10-27T00:00:00Z"))))
+                .Verifiable();
+
+            await provider.GetTokenAsync(new Uri("http://www.here.com"), "nobody", requiredClaims);
+            mockCredential.Verify();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CbsTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetTokenAsyncPopulatesUsingTheCredentialAccessToken()
+        {
+            var tokenValue = "ValuE_oF_tHE_tokEn";
+            var expires = DateTimeOffset.Parse("2015-10-27T00:00:00Z");
+            var mockCredential = new Mock<TokenCredential>();
+            var credential = new EventHubTokenCredential(mockCredential.Object, "test");
+            var provider = new CbsTokenProvider(credential, default);
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new AccessToken(tokenValue, expires)));
+
+            var cbsToken = await provider.GetTokenAsync(new Uri("http://www.here.com"), "nobody", new string[0]);
+
+            Assert.That(cbsToken, Is.Not.Null, "The token should have been produced");
+            Assert.That(cbsToken.TokenValue, Is.EqualTo(tokenValue), "The token value should match");
+            Assert.That(cbsToken.ExpiresAtUtc, Is.EqualTo(expires.DateTime), "The token expiration should match");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CbsTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetTokenAsyncSetsTheCorrectTypeForSharedAccessSignatureTokens()
+        {
+            var value = "TOkEn!";
+            var signature = new SharedAccessSignature(String.Empty, "keyName", "key", value, DateTimeOffset.Parse("2015-10-27T00:00:00Z"));
+            var sasCredential = new SharedAccessSignatureCredential(signature);
+            var credential = new EventHubTokenCredential(sasCredential, "test");
+            var provider = new CbsTokenProvider(credential, default);
+            var cbsToken = await provider.GetTokenAsync(new Uri("http://www.here.com"), "nobody", new string[0]);
+
+            Assert.That(cbsToken, Is.Not.Null, "The token should have been produced");
+            Assert.That(cbsToken.TokenType, Is.EqualTo(GetSharedAccessTokenType()), "The token type should match");
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="CbsTokenProvider.GetTokenAsync" />
+        ///   method.
+        /// </summary>
+        ///
+        [Test]
+        public async Task GetTokenAsyncSetsTheCorrectTypeForOtherTokens()
+        {
+            var tokenValue = "ValuE_oF_tHE_tokEn";
+            var expires = DateTimeOffset.Parse("2015-10-27T00:00:00Z");
+            var mockCredential = new Mock<TokenCredential>();
+            var credential = new EventHubTokenCredential(mockCredential.Object, "test");
+            var provider = new CbsTokenProvider(credential, default);
+
+            mockCredential
+                .Setup(credential => credential.GetTokenAsync(It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new AccessToken(tokenValue, expires)));
+
+            var cbsToken = await provider.GetTokenAsync(new Uri("http://www.here.com"), "nobody", new string[0]);
+
+            Assert.That(cbsToken, Is.Not.Null, "The token should have been produced");
+            Assert.That(cbsToken.TokenType, Is.EqualTo(GetGenericTokenType()), "The token type should match");
+        }
+
+        /// <summary>
+        ///   Gets the token type used for SAS-based credentials, using the
+        ///   private field of the provider.
+        /// </summary>
+        ///
+        private static string GetSharedAccessTokenType() =>
+                    (string)typeof(CbsTokenProvider)
+                        .GetField("SharedAccessSignatureTokenType", BindingFlags.Static | BindingFlags.NonPublic)
+                        .GetValue(null);
+
+        /// <summary>
+        ///   Gets the token type used for generic token-based credentials, using the
+        ///   private field of the provider.
+        /// </summary>
+        ///
+        private static string GetGenericTokenType() =>
+                    (string)typeof(CbsTokenProvider)
+                        .GetField("JsonWebTokenType", BindingFlags.Static | BindingFlags.NonPublic)
+                        .GetValue(null);
+    }
+}

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Authorization/EventHubTokenCredentialTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -21,6 +22,22 @@ namespace Azure.Messaging.EventHubs.Tests
     [TestFixture]
     public class EventHubTokenCredentialTests
     {
+        /// <summary>
+        ///   The set of test cases for understanding whether a credential is considered to be
+        ///   based on a shared access signature.
+        /// </summary>
+        public static IEnumerable<object[]> SharedAccessSignatureCredentialTestCases()
+        {
+            var credentialMock = Mock.Of<TokenCredential>();
+            var signature = new SharedAccessSignature(String.Empty, "keyName", "key", "TOkEn!", DateTimeOffset.UtcNow.AddHours(4));
+
+            yield return new object[] { new SharedAccessSignatureCredential(signature), true };
+            yield return new object[] { new EventHubSharedKeyCredential("blah", "foo"), true };
+            yield return new object[] { new EventHubTokenCredential(new EventHubSharedKeyCredential("blah", "foo"), "hub"), true };
+            yield return new object[] { new EventHubTokenCredential(credentialMock, "thing"), false };
+            yield return new object[] { credentialMock, false };
+        }
+
         /// <summary>
         ///   Verifies functionality of the constructor.
         /// </summary>
@@ -106,6 +123,20 @@ namespace Azure.Messaging.EventHubs.Tests
 
             Assert.That(tokenResult, Is.EqualTo(accessToken), "The access token should match the return of the delegated call.");
             mockCredential.VerifyAll();
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="EventHubTokenCredential.IsSharedAccessSignatureCredential" />
+        ///   property.
+        /// </summary>
+        ///
+        [Test]
+        [TestCaseSource(nameof(SharedAccessSignatureCredentialTestCases))]
+        public void IsSharedAccessSignatureCredentialRecognizesSasCredentials(TokenCredential credential,
+                                                                              bool expectedResult)
+        {
+            var eventHubsCredential = new EventHubTokenCredential(credential, "dummy");
+            Assert.That(eventHubsCredential.IsSharedAccessSignatureCredential, Is.EqualTo(expectedResult));
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelReaderExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/ChannelReaderExtensionsTests.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Channels;
 using System.Threading.Tasks;

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Diagnostics/DiagnosticsTests.cs
@@ -85,7 +85,7 @@ namespace Azure.Messaging.EventHubs.Tests
                 .Setup(m => m.TryAdd(It.IsAny<EventData>()))
                 .Returns(() =>
                 {
-                    eventCount ++;
+                    eventCount++;
                     return eventCount <= 3;
                 });
 
@@ -137,12 +137,12 @@ namespace Azure.Messaging.EventHubs.Tests
 
             transportMock
                 .Setup(m => m.SendAsync(It.IsAny<IEnumerable<EventData>>(), It.IsAny<SendOptions>(), It.IsAny<CancellationToken>()))
-                .Callback<IEnumerable<EventData>, SendOptions, CancellationToken>((e, _, __)=> writtenEventsData = e.ToArray())
+                .Callback<IEnumerable<EventData>, SendOptions, CancellationToken>((e, _, __) => writtenEventsData = e.ToArray())
                 .Returns(Task.CompletedTask);
 
             var producer = new EventHubProducer(transportMock.Object, endpoint, eventHubName, new EventHubProducerOptions(), Mock.Of<EventHubRetryPolicy>());
 
-            await producer.SendAsync(new []
+            await producer.SendAsync(new[]
             {
                 new EventData(ReadOnlyMemory<byte>.Empty),
                 new EventData(ReadOnlyMemory<byte>.Empty)

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/EventHubClient/EventHubClientTests.cs
@@ -144,11 +144,25 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void ConstructoNotAllowTheEventHubToBePassedTwice()
+        public void ConstructorDoesNotAllowTheEventHubToBePassedTwiceIfDifferent()
         {
             var fakeConnection = "Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath=fake";
-            Assert.That(() => new EventHubClient(fakeConnection, "eventHub"), Throws.InstanceOf<ArgumentException>(), "The constructor without options should detect multiple Event Hubs");
-            Assert.That(() => new EventHubClient(fakeConnection, "eventHub", new EventHubClientOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should detect multiple Event Hubs");
+            Assert.That(() => new EventHubClient(fakeConnection, "eventHub"), Throws.InstanceOf<ArgumentException>(), "The constructor without options should detect multiple different Event Hubs");
+            Assert.That(() => new EventHubClient(fakeConnection, "eventHub", new EventHubClientOptions()), Throws.InstanceOf<ArgumentException>(), "The constructor with options should detect multiple different Event Hubs");
+        }
+
+        /// <summary>
+        ///    Verifies functionality of the <see cref="EventHubClient" />
+        ///    constructor.
+        /// </summary>
+        ///
+        [Test]
+        public void ConstructorAllowsTheEventHubToBePassedTwiceIfEqual()
+        {
+            var eventHubName = "myHub";
+            var fakeConnection = $"Endpoint=sb://not-real.servicebus.windows.net/;SharedAccessKeyName=DummyKey;SharedAccessKey=[not_real];EntityPath={ eventHubName }";
+            Assert.That(() => new EventHubClient(fakeConnection, eventHubName), Throws.Nothing, "The constructor without options should allow the same Event Hub in multiple places");
+            Assert.That(() => new EventHubClient(fakeConnection, eventHubName, new EventHubClientOptions()), Throws.Nothing, "The constructor with options should allow the same Event Hub in multiple places");
         }
 
         /// <summary>
@@ -886,7 +900,7 @@ namespace Azure.Messaging.EventHubs.Tests
                                      string host,
                                      string eventHubName) =>
              typeof(EventHubClient)
-                 .GetMethod("BuildResource", BindingFlags.Static | BindingFlags.NonPublic)
+                 .GetMethod("BuildAudienceResource", BindingFlags.Static | BindingFlags.NonPublic)
                  .Invoke(client, new object[] { transportType, host, eventHubName }) as string;
 
         /// <summary>

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensionTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensionTests.cs
@@ -118,7 +118,7 @@ namespace Azure.Messaging.EventHubs.Tests
             var secondEvent = new EventData((byte[])body.Clone());
 
             firstEvent.SystemProperties = new EventData.SystemEventProperties();
-            firstEvent.SystemProperties.PartitionKey= "trackOne";
+            firstEvent.SystemProperties.PartitionKey = "trackOne";
 
             secondEvent.SystemProperties = null;
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -235,7 +235,7 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
 
             using (var client = new EventHubManagementClient(new TokenCredentials(token)) { SubscriptionId = subscription })
             {
-                await CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName));;
+                await CreateRetryPolicy().ExecuteAsync(() => client.Namespaces.DeleteAsync(resourceGroup, namespaceName));
             }
         }
 

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorLiveTests.cs
@@ -668,7 +668,7 @@ namespace Azure.Messaging.EventHubs.Tests.Processor
 
                         for (int index = 1; index < partitionTimestamps.Count; index++)
                         {
-                            var elapsedTime = partitionTimestamps[index].Subtract(partitionTimestamps[index-1]).TotalSeconds;
+                            var elapsedTime = partitionTimestamps[index].Subtract(partitionTimestamps[index - 1]).TotalSeconds;
 
                             Assert.That(elapsedTime, Is.GreaterThan(maximumWaitTimeInSecs - 0.1), $"{ partitionId }: elapsed time between indexes { index - 1 } and { index } was too short.");
                             Assert.That(elapsedTime, Is.LessThan(maximumWaitTimeInSecs + 5), $"{ partitionId }: elapsed time between indexes { index - 1 } and { index } was too long.");

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorOptionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorOptionsTests.cs
@@ -5,7 +5,7 @@ using System;
 using Azure.Messaging.EventHubs.Processor;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Tests.Processor
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for the <see cref="EventProcessorOptions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorTests.cs
@@ -8,7 +8,7 @@ using Azure.Messaging.EventHubs.Processor;
 using Moq;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Tests.Processor
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for the <see cref="EventProcessor" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/InMemoryPartitionManagerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/InMemoryPartitionManagerTests.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 using Azure.Messaging.EventHubs.Processor;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Tests.Processor
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for the <see cref="InMemoryPartitionManager" />


### PR DESCRIPTION
# Summary

The intent of these changes is to begin building out the AMQP foundation, starting with authorization.

# Last Upstream Rebase

Friday, August 23, 2019 4:37pm (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 3 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7141) (#7141)  
- [AMQP Foundation (Connection, Session, Common Infrastructure)](https://github.com/Azure/azure-sdk-for-net/issues/7187) (#7187)  