### PR TITLE
[WIP] Add cancellation token support to MessageReceiver ReceiveAsync.

### DIFF
--- a/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/IMessageReceiver.cs
+++ b/sdk/servicebus/Microsoft.Azure.ServiceBus/src/Core/IMessageReceiver.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.ServiceBus.Core
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -50,6 +51,14 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// <summary>
         /// Receive a message from the entity defined by <see cref="IClientEntity.Path"/> using <see cref="ReceiveMode"/> mode.
         /// </summary>
+        /// <param name="cancellationToken">The cancellation token to cancel the receive operation.</param>
+        /// <returns>The message received. Returns null if no message is found.</returns>
+        /// <remarks>Operation will time out after duration of <see cref="ClientEntity.OperationTimeout"/></remarks>
+        Task<Message> ReceiveAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Receive a message from the entity defined by <see cref="IClientEntity.Path"/> using <see cref="ReceiveMode"/> mode.
+        /// </summary>
         /// <param name="operationTimeout">The time span the client waits for receiving a message before it times out.</param>
         /// <returns>The message received. Returns null if no message is found.</returns>
         /// <remarks>
@@ -58,6 +67,19 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// times out, this will throw <see cref="ServiceBusTimeoutException"/>.
         /// </remarks>
         Task<Message> ReceiveAsync(TimeSpan operationTimeout);
+
+        /// <summary>
+        /// Receive a message from the entity defined by <see cref="IClientEntity.Path"/> using <see cref="ReceiveMode"/> mode.
+        /// </summary>
+        /// <param name="operationTimeout">The time span the client waits for receiving a message before it times out.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the receive operation.</param>
+        /// <returns>The message received. Returns null if no message is found.</returns>
+        /// <remarks>
+        /// The parameter <paramref name="operationTimeout"/> includes the time taken by the receiver to establish a connection
+        /// (either during the first receive or when connection needs to be re-established). If establishing the connection
+        /// times out, this will throw <see cref="ServiceBusTimeoutException"/>.
+        /// </remarks>
+        Task<Message> ReceiveAsync(TimeSpan operationTimeout, CancellationToken cancellationToken);
 
         /// <summary>
         /// Receives a maximum of <paramref name="maxMessageCount"/> messages from the entity defined by <see cref="IClientEntity.Path"/> using <see cref="ReceiveMode"/> mode.
@@ -71,6 +93,15 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// Receives a maximum of <paramref name="maxMessageCount"/> messages from the entity defined by <see cref="IClientEntity.Path"/> using <see cref="ReceiveMode"/> mode.
         /// </summary>
         /// <param name="maxMessageCount">The maximum number of messages that will be received.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the receive operation.</param>
+        /// <returns>List of messages received. Returns null if no message is found.</returns>
+        /// <remarks>Receiving less than <paramref name="maxMessageCount"/> messages is not an indication of empty entity.</remarks>
+        Task<IList<Message>> ReceiveAsync(int maxMessageCount, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Receives a maximum of <paramref name="maxMessageCount"/> messages from the entity defined by <see cref="IClientEntity.Path"/> using <see cref="ReceiveMode"/> mode.
+        /// </summary>
+        /// <param name="maxMessageCount">The maximum number of messages that will be received.</param>
         /// <param name="operationTimeout">The time span the client waits for receiving a message before it times out.</param>
         /// <returns>List of messages received. Returns null if no message is found.</returns>
         /// <remarks>Receiving less than <paramref name="maxMessageCount"/> messages is not an indication of empty entity.
@@ -79,6 +110,20 @@ namespace Microsoft.Azure.ServiceBus.Core
         /// times out, this will throw <see cref="ServiceBusTimeoutException"/>.
         /// </remarks>
         Task<IList<Message>> ReceiveAsync(int maxMessageCount, TimeSpan operationTimeout);
+
+        /// <summary>
+        /// Receives a maximum of <paramref name="maxMessageCount"/> messages from the entity defined by <see cref="IClientEntity.Path"/> using <see cref="ReceiveMode"/> mode.
+        /// </summary>
+        /// <param name="maxMessageCount">The maximum number of messages that will be received.</param>
+        /// <param name="operationTimeout">The time span the client waits for receiving a message before it times out.</param>
+        /// <param name="cancellationToken">The cancellation token to cancel the receive operation.</param>
+        /// <returns>List of messages received. Returns null if no message is found.</returns>
+        /// <remarks>Receiving less than <paramref name="maxMessageCount"/> messages is not an indication of empty entity.
+        /// The parameter <paramref name="operationTimeout"/> includes the time taken by the receiver to establish a connection
+        /// (either during the first receive or when connection needs to be re-established). If establishing the connection
+        /// times out, this will throw <see cref="ServiceBusTimeoutException"/>.
+        /// </remarks>
+        Task<IList<Message>> ReceiveAsync(int maxMessageCount, TimeSpan operationTimeout, CancellationToken cancellationToken);
 
         /// <summary>
         /// Receives a specific deferred message identified by <paramref name="sequenceNumber"/>.


### PR DESCRIPTION
Implemented cancellation token support in Microsoft.Azure.Amqp and incorporated into `MessageReceiver.ReceiveAsync`.

There are a number of tickets requesting cancellation token support for this method, with different reasons. The primary reason I see this functionality is critical is to be able to manage lock tokens. With the existing functionality, the following scenario is very tricky to implement correctly:

* There is a continuous receive loop, starting work based on incoming messages and tracking lock tokens;
* If work completes, the lock token is completed;
* If the receive loop ends, all lock tokens that weren't yet completed are abandoned.

The problem is that there are race conditions between closing the receiver and the managing the lock tokens. The following can happen:

* `ReceiveAsync` completes with new messages;
* Parallel to that, the application shuts down:
  * All outstanding lock tokens are abandoned;
  * `CloseAsync` is called;
* While the shut down is happening, new lock tokens are still being added to be abandoned.

This race condition ensures that we cannot cleanly shut down an application. If this would be because of scale down, this means that the messages that couldn't be abandoned would be stuck until the lock expires.

With these changes, the workflow would work as follows:

* The application shuts down;
* A `TaskCompletionSource` is prepared for signalling of the end of the receive loop;
* The cancellation token given to `ReceiveAsync` is signalled;
* The task of the `TaskCompletionSource` is awaited;
* Any outstanding lock tokens are abandoned;
* `CloseAsync` is called.

Depends on https://github.com/Azure/azure-amqp/pull/150.
Closes https://github.com/Azure/azure-service-bus-dotnet/issues/258 and others.