### PR TITLE
Serialize timestamps as seconds since Unix epoch

### DIFF
--- a/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Certificates/src/CertificateAttributes.cs
@@ -104,7 +104,7 @@ namespace Azure.Security.KeyVault.Certificates
             }
         }
 
-        internal void WriteProperties(ref Utf8JsonWriter json)
+        internal void WriteProperties(Utf8JsonWriter json)
         {
             if (Enabled.HasValue)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeletedKey.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/DeletedKey.cs
@@ -49,12 +49,12 @@ namespace Azure.Security.KeyVault.Keys
 
             if (DeletedDate.HasValue)
             {
-                json.WriteNumber(DeletedDatePropertyNameBytes, DeletedDate.Value.ToUnixTimeMilliseconds());
+                json.WriteNumber(DeletedDatePropertyNameBytes, DeletedDate.Value.ToUnixTimeSeconds());
             }
 
             if (ScheduledPurgeDate.HasValue)
             {
-                json.WriteNumber(ScheduledPurgeDatePropertyNameBytes, ScheduledPurgeDate.Value.ToUnixTimeMilliseconds());
+                json.WriteNumber(ScheduledPurgeDatePropertyNameBytes, ScheduledPurgeDate.Value.ToUnixTimeSeconds());
             }
         }
 
@@ -69,10 +69,10 @@ namespace Azure.Security.KeyVault.Keys
                         RecoveryId = prop.Value.GetString();
                         break;
                     case DeletedDatePropertyName:
-                        DeletedDate = DateTimeOffset.FromUnixTimeMilliseconds(prop.Value.GetInt64());
+                        DeletedDate = DateTimeOffset.FromUnixTimeSeconds(prop.Value.GetInt64());
                         break;
                     case ScheduledPurgeDatePropertyName:
-                        ScheduledPurgeDate = DateTimeOffset.FromUnixTimeMilliseconds(prop.Value.GetInt64());
+                        ScheduledPurgeDate = DateTimeOffset.FromUnixTimeSeconds(prop.Value.GetInt64());
                         break;
                 }
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
@@ -65,16 +65,16 @@ namespace Azure.Security.KeyVault.Keys
                         Enabled = prop.Value.GetBoolean();
                         break;
                     case NotBeforePropertyName:
-                        NotBefore = DateTimeOffset.FromUnixTimeMilliseconds(prop.Value.GetInt64());
+                        NotBefore = DateTimeOffset.FromUnixTimeSeconds(prop.Value.GetInt64());
                         break;
                     case ExpiresPropertyName:
-                        Expires = DateTimeOffset.FromUnixTimeMilliseconds(prop.Value.GetInt64());
+                        Expires = DateTimeOffset.FromUnixTimeSeconds(prop.Value.GetInt64());
                         break;
                     case CreatedPropertyName:
-                        Created = DateTimeOffset.FromUnixTimeMilliseconds(prop.Value.GetInt64());
+                        Created = DateTimeOffset.FromUnixTimeSeconds(prop.Value.GetInt64());
                         break;
                     case UpdatedPropertyName:
-                        Updated = DateTimeOffset.FromUnixTimeMilliseconds(prop.Value.GetInt64());
+                        Updated = DateTimeOffset.FromUnixTimeSeconds(prop.Value.GetInt64());
                         break;
                     case RecoveryLevelPropertyName:
                         RecoveryLevel = prop.Value.GetString();
@@ -92,12 +92,12 @@ namespace Azure.Security.KeyVault.Keys
 
             if (NotBefore.HasValue)
             {
-                json.WriteNumber(NotBeforePropertyNameBytes, NotBefore.Value.ToUnixTimeMilliseconds());
+                json.WriteNumber(NotBeforePropertyNameBytes, NotBefore.Value.ToUnixTimeSeconds());
             }
 
             if (Expires.HasValue)
             {
-                json.WriteNumber(ExpiresPropertyNameBytes, Expires.Value.ToUnixTimeMilliseconds());
+                json.WriteNumber(ExpiresPropertyNameBytes, Expires.Value.ToUnixTimeSeconds());
             }
 
             // Created is read-only don't serialize

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyAttributes.cs
@@ -83,7 +83,7 @@ namespace Azure.Security.KeyVault.Keys
             }
         }
 
-        internal void WriteProperties(ref Utf8JsonWriter json)
+        internal void WriteProperties(Utf8JsonWriter json)
         {
             if (Enabled.HasValue)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyImportOptions.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyImportOptions.cs
@@ -57,12 +57,12 @@ namespace Azure.Security.KeyVault.Keys
 
                 if (NotBefore.HasValue)
                 {
-                    json.WriteNumber(NotBeforePropertyNameBytes, NotBefore.Value.ToUnixTimeMilliseconds());
+                    json.WriteNumber(NotBeforePropertyNameBytes, NotBefore.Value.ToUnixTimeSeconds());
                 }
 
                 if (Expires.HasValue)
                 {
-                    json.WriteNumber(ExpiresPropertyNameBytes, Expires.Value.ToUnixTimeMilliseconds());
+                    json.WriteNumber(ExpiresPropertyNameBytes, Expires.Value.ToUnixTimeSeconds());
                 }
 
                 json.WriteEndObject();

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyRequestParameters.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/src/KeyRequestParameters.cs
@@ -123,7 +123,7 @@ namespace Azure.Security.KeyVault.Keys
             {
                 json.WriteStartObject(AttributesPropertyNameBytes);
 
-                _attributes.WriteProperties(ref json);
+                _attributes.WriteProperties(json);
 
                 json.WriteEndObject();
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/KeyClientLiveTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -47,10 +48,15 @@ namespace Azure.Security.KeyVault.Keys.Tests
         [Test]
         public async Task CreateKeyWithOptions()
         {
+            var exp = new DateTimeOffset(new DateTime(637027248120000000, DateTimeKind.Utc));
+            var nbf = exp.AddDays(-30);
+
             var keyOptions = new KeyCreateOptions()
             {
                 KeyOperations = new List<KeyOperations>() { KeyOperations.Verify },
-                Enabled = false
+                Enabled = false,
+                Expires = exp,
+                NotBefore = nbf,
             };
 
             Key key = await Client.CreateKeyAsync(Recording.GenerateId(), KeyType.EllipticCurve, keyOptions);

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/KeyClientLiveTests/CreateKeyWithOptions.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/KeyClientLiveTests/CreateKeyWithOptions.json
@@ -47,7 +47,7 @@
       "RequestHeaders": {
         "Accept": "application\u002fjson",
         "Authorization": "Sanitized",
-        "Content-Length": "64",
+        "Content-Length": "98",
         "Content-Type": "application\u002fjson",
         "Request-Id": "|24a06eb4-44aa1cc26dede9d6.",
         "User-Agent": [
@@ -60,7 +60,9 @@
       "RequestBody": {
         "kty": "EC",
         "attributes": {
-          "enabled": false
+          "enabled": false,
+          "nbf": 1564536012,
+          "exp": 1567128012
         },
         "key_ops": [
           "verify"
@@ -69,7 +71,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "365",
+        "Content-Length": "399",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:43:23 GMT",
         "Expires": "-1",
@@ -96,6 +98,8 @@
           "y": "aJWhiZgaLjtP0J7ZBNEAKv3fShqjUZleGrQbinhGyp0"
         },
         "attributes": {
+          "nbf": 1564536012,
+          "exp": 1567128012,
           "enabled": false,
           "created": 1565113404,
           "updated": 1565113404,
@@ -122,7 +126,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "365",
+        "Content-Length": "399",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:43:23 GMT",
         "Expires": "-1",
@@ -150,6 +154,8 @@
         },
         "attributes": {
           "enabled": false,
+          "nbf": 1564536012,
+          "exp": 1567128012,
           "created": 1565113404,
           "updated": 1565113404,
           "recoveryLevel": "Recoverable\u002bPurgeable"
@@ -175,7 +181,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "500",
+        "Content-Length": "534",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:43:23 GMT",
         "Expires": "-1",
@@ -206,6 +212,8 @@
         },
         "attributes": {
           "enabled": false,
+          "nbf": 1564536012,
+          "exp": 1567128012,
           "created": 1565113404,
           "updated": 1565113404,
           "recoveryLevel": "Recoverable\u002bPurgeable"

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/KeyClientLiveTests/CreateKeyWithOptionsAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/KeyClientLiveTests/CreateKeyWithOptionsAsync.json
@@ -47,7 +47,7 @@
       "RequestHeaders": {
         "Accept": "application\u002fjson",
         "Authorization": "Sanitized",
-        "Content-Length": "64",
+        "Content-Length": "98",
         "Content-Type": "application\u002fjson",
         "Request-Id": "|24a06f71-44aa1cc26dede9d6.",
         "User-Agent": [
@@ -60,7 +60,9 @@
       "RequestBody": {
         "kty": "EC",
         "attributes": {
-          "enabled": false
+          "enabled": false,
+          "nbf": 1564536012,
+          "exp": 1567128012
         },
         "key_ops": [
           "verify"
@@ -69,7 +71,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "365",
+        "Content-Length": "399",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:48:45 GMT",
         "Expires": "-1",
@@ -96,9 +98,11 @@
           "y": "kOuyMhHZPiJzIOcsytFzQVZ8Bn1AdOosowKOsy2PILA"
         },
         "attributes": {
+          "nbf": 1564536012,
+          "exp": 1567128012,
           "enabled": false,
-          "created": 1565113726,
-          "updated": 1565113726,
+          "created": 1565113404,
+          "updated": 1565113404,
           "recoveryLevel": "Recoverable\u002bPurgeable"
         }
       }
@@ -122,7 +126,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "365",
+        "Content-Length": "399",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:48:45 GMT",
         "Expires": "-1",
@@ -150,8 +154,10 @@
         },
         "attributes": {
           "enabled": false,
-          "created": 1565113726,
-          "updated": 1565113726,
+          "nbf": 1564536012,
+          "exp": 1567128012,
+          "created": 1565113404,
+          "updated": 1565113404,
           "recoveryLevel": "Recoverable\u002bPurgeable"
         }
       }
@@ -175,7 +181,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "500",
+        "Content-Length": "534",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:48:45 GMT",
         "Expires": "-1",
@@ -206,8 +212,10 @@
         },
         "attributes": {
           "enabled": false,
-          "created": 1565113726,
-          "updated": 1565113726,
+          "nbf": 1564536012,
+          "exp": 1567128012,
+          "created": 1565113404,
+          "updated": 1565113404,
           "recoveryLevel": "Recoverable\u002bPurgeable"
         }
       }

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/KeyClientLiveTests/GetDeletedKeys.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/KeyClientLiveTests/GetDeletedKeys.json
@@ -288,7 +288,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1473",
+        "Content-Length": "1467",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:45:00 GMT",
         "Expires": "-1",
@@ -336,7 +336,7 @@
             "kid": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fkeys\u002fCloudECKey-f4230c5f-348f-4f2d-8aa0-80f4d3ac727d",
             "attributes": {
               "enabled": true,
-              "exp": 1596705912685,
+              "exp": 1596705912,
               "created": 1565083512,
               "updated": 1565083512,
               "recoveryLevel": "Recoverable\u002bPurgeable"
@@ -349,7 +349,7 @@
             "kid": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fkeys\u002fCloudRsaKey-f989e30d-d2db-4f87-bd23-ba28ca528ae4",
             "attributes": {
               "enabled": true,
-              "exp": 1596705913280,
+              "exp": 1596705913,
               "created": 1565083516,
               "updated": 1565083516,
               "recoveryLevel": "Recoverable\u002bPurgeable"

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/KeyClientLiveTests/GetDeletedKeysAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/tests/SessionRecords/KeyClientLiveTests/GetDeletedKeysAsync.json
@@ -288,7 +288,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1473",
+        "Content-Length": "1467",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:50:27 GMT",
         "Expires": "-1",
@@ -336,7 +336,7 @@
             "kid": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fkeys\u002fCloudECKey-f4230c5f-348f-4f2d-8aa0-80f4d3ac727d",
             "attributes": {
               "enabled": true,
-              "exp": 1596705912685,
+              "exp": 1596705912,
               "created": 1565083512,
               "updated": 1565083512,
               "recoveryLevel": "Recoverable\u002bPurgeable"
@@ -349,7 +349,7 @@
             "kid": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fkeys\u002fCloudRsaKey-f989e30d-d2db-4f87-bd23-ba28ca528ae4",
             "attributes": {
               "enabled": true,
-              "exp": 1596705913280,
+              "exp": 1596705913,
               "created": 1565083516,
               "updated": 1565083516,
               "recoveryLevel": "Recoverable\u002bPurgeable"

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeletedSecret.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeletedSecret.cs
@@ -43,12 +43,12 @@ namespace Azure.Security.KeyVault.Secrets
 
             if (DeletedDate.HasValue)
             {
-                json.WriteNumber("deletedDate", DeletedDate.Value.ToUnixTimeMilliseconds());
+                json.WriteNumber("deletedDate", DeletedDate.Value.ToUnixTimeSeconds());
             }
 
             if (ScheduledPurgeDate.HasValue)
             {
-                json.WriteNumber("scheduledPurgeDate", ScheduledPurgeDate.Value.ToUnixTimeMilliseconds());
+                json.WriteNumber("scheduledPurgeDate", ScheduledPurgeDate.Value.ToUnixTimeSeconds());
             }
         }
 
@@ -63,12 +63,12 @@ namespace Azure.Security.KeyVault.Secrets
 
             if (json.TryGetProperty("deletedDate", out JsonElement deletedDate))
             {
-                DeletedDate = DateTimeOffset.FromUnixTimeMilliseconds(deletedDate.GetInt64());
+                DeletedDate = DateTimeOffset.FromUnixTimeSeconds(deletedDate.GetInt64());
             }
 
             if (json.TryGetProperty("scheduledPurgeDate", out JsonElement scheduledPurgeDate))
             {
-                ScheduledPurgeDate = DateTimeOffset.FromUnixTimeMilliseconds(scheduledPurgeDate.GetInt64());
+                ScheduledPurgeDate = DateTimeOffset.FromUnixTimeSeconds(scheduledPurgeDate.GetInt64());
             }
         }
     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeletedSecret.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/DeletedSecret.cs
@@ -32,9 +32,9 @@ namespace Azure.Security.KeyVault.Secrets
         /// </summary>
         public DateTimeOffset? ScheduledPurgeDate { get; private set; }
 
-        internal override void WriteProperties(ref Utf8JsonWriter json)
+        internal override void WriteProperties(Utf8JsonWriter json)
         {
-            base.WriteProperties(ref json);
+            base.WriteProperties(json);
 
             if (RecoveryId != null)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Model.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Model.cs
@@ -30,7 +30,7 @@ namespace Azure.Security.KeyVault.Secrets
             {
                 json.WriteStartObject();
 
-                WriteProperties(ref json);
+                WriteProperties(json);
 
                 json.WriteEndObject();
 
@@ -40,7 +40,7 @@ namespace Azure.Security.KeyVault.Secrets
             }
         }
 
-        internal abstract void WriteProperties(ref Utf8JsonWriter json);
+        internal abstract void WriteProperties(Utf8JsonWriter json);
 
         internal abstract void ReadProperties(JsonElement json);
     }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Page.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Page.cs
@@ -65,7 +65,7 @@ namespace Azure.Security.KeyVault.Secrets
             }
         }
 
-        internal override void WriteProperties(ref Utf8JsonWriter json)
+        internal override void WriteProperties(Utf8JsonWriter json)
         {
             // serialization is not needed this type is only in responses
             throw new NotImplementedException();

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Secret.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/Secret.cs
@@ -44,14 +44,14 @@ namespace Azure.Security.KeyVault.Secrets
             base.ReadProperties(json);
         }
 
-        internal override void WriteProperties(ref Utf8JsonWriter json)
+        internal override void WriteProperties(Utf8JsonWriter json)
         {
             if (Value != null)
             {
                 json.WriteString("value", Value);
             }
 
-            base.WriteProperties(ref json);
+            base.WriteProperties(json);
         }
     }
 }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretBase.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/SecretBase.cs
@@ -145,7 +145,7 @@ namespace Azure.Security.KeyVault.Secrets
             }
         }
 
-        internal override void WriteProperties(ref Utf8JsonWriter json)
+        internal override void WriteProperties(Utf8JsonWriter json)
         {
             if (ContentType != null)
             {
@@ -156,7 +156,7 @@ namespace Azure.Security.KeyVault.Secrets
             {
                 json.WriteStartObject("attributes");
 
-                _attributes.WriteProperties(ref json);
+                _attributes.WriteProperties(json);
 
                 json.WriteEndObject();
             }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/VaultAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/VaultAttributes.cs
@@ -78,7 +78,7 @@ namespace Azure.Security.KeyVault.Secrets
             }
         }
 
-        internal void WriteProperties(ref Utf8JsonWriter json)
+        internal void WriteProperties(Utf8JsonWriter json)
         {
             if (Enabled.HasValue)
             {

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/VaultAttributes.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/VaultAttributes.cs
@@ -54,22 +54,22 @@ namespace Azure.Security.KeyVault.Secrets
 
             if (json.TryGetProperty("nbf", out JsonElement nbf))
             {
-                NotBefore = DateTimeOffset.FromUnixTimeMilliseconds(nbf.GetInt64());
+                NotBefore = DateTimeOffset.FromUnixTimeSeconds(nbf.GetInt64());
             }
 
             if (json.TryGetProperty("exp", out JsonElement exp))
             {
-                Expires = DateTimeOffset.FromUnixTimeMilliseconds(exp.GetInt64());
+                Expires = DateTimeOffset.FromUnixTimeSeconds(exp.GetInt64());
             }
 
             if (json.TryGetProperty("created", out JsonElement created))
             {
-                Created = DateTimeOffset.FromUnixTimeMilliseconds(created.GetInt64());
+                Created = DateTimeOffset.FromUnixTimeSeconds(created.GetInt64());
             }
 
             if (json.TryGetProperty("updated", out JsonElement updated))
             {
-                Updated = DateTimeOffset.FromUnixTimeMilliseconds(updated.GetInt64());
+                Updated = DateTimeOffset.FromUnixTimeSeconds(updated.GetInt64());
             }
 
             if (json.TryGetProperty("recoveryLevel", out JsonElement recoveryLevel))
@@ -87,12 +87,12 @@ namespace Azure.Security.KeyVault.Secrets
 
             if (NotBefore.HasValue)
             {
-                json.WriteNumber("nbf", NotBefore.Value.ToUnixTimeMilliseconds());
+                json.WriteNumber("nbf", NotBefore.Value.ToUnixTimeSeconds());
             }
 
             if (Expires.HasValue)
             {
-                json.WriteNumber("exp", Expires.Value.ToUnixTimeMilliseconds());
+                json.WriteNumber("exp", Expires.Value.ToUnixTimeSeconds());
             }
 
             // Created is read-only don't serialize

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/VaultBackup.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/src/VaultBackup.cs
@@ -18,7 +18,7 @@ namespace Azure.Security.KeyVault.Secrets
             }
         }
 
-        internal override void WriteProperties(ref Utf8JsonWriter json)
+        internal override void WriteProperties(Utf8JsonWriter json)
         {
             json.WriteString("value", Base64Url.Encode(Value));
         }

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SecretClientLiveTests.cs
@@ -5,12 +5,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Azure.Security.KeyVault.Secrets;
 using Azure.Core.Testing;
 using System.Text;
+using NUnit.Framework.Constraints;
 
 namespace Azure.Security.KeyVault.Test
 {
@@ -54,12 +54,13 @@ namespace Azure.Security.KeyVault.Test
         public async Task SetSecretWithExtendedProps()
         {
             string secretName = Recording.GenerateId();
+            IResolveConstraint createdUpdatedConstraint = Is.EqualTo(DateTimeOffset.FromUnixTimeSeconds(1565114301));
 
             Secret setResult = null;
 
             try
             {
-                var exp = new DateTimeOffset(new DateTime(637027248124480000, DateTimeKind.Utc));
+                var exp = new DateTimeOffset(new DateTime(637027248120000000, DateTimeKind.Utc));
                 var nbf = exp.AddDays(-30);
 
                 var secret = new Secret(secretName, "CrudWithExtendedPropsValue1")
@@ -75,6 +76,11 @@ namespace Azure.Security.KeyVault.Test
                 };
 
                 setResult = await Client.SetAsync(secret);
+                if (Mode != RecordedTestMode.Playback)
+                {
+                    DateTimeOffset now = DateTimeOffset.UtcNow;
+                    createdUpdatedConstraint = Is.InRange(now.AddMinutes(-5), now.AddMinutes(5));
+                }
 
                 RegisterForCleanup(secret, delete: false);
 
@@ -89,8 +95,8 @@ namespace Azure.Security.KeyVault.Test
                 Assert.AreEqual("CrudWithExtendedPropsValue1", setResult.Value);
                 Assert.AreEqual(VaultUri, setResult.Vault);
                 Assert.AreEqual("Recoverable+Purgeable", setResult.RecoveryLevel);
-                Assert.NotNull(setResult.Created);
-                Assert.NotNull(setResult.Updated);
+                Assert.That(setResult.Created, createdUpdatedConstraint);
+                Assert.That(setResult.Updated, createdUpdatedConstraint);
 
                 Secret getResult = await Client.GetAsync(secretName);
 

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/GetDeletedSecrets.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/GetDeletedSecrets.json
@@ -5570,7 +5570,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1711",
+        "Content-Length": "1705",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:55:13 GMT",
         "Expires": "-1",
@@ -5618,7 +5618,7 @@
             "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002fStorageAccountPasswor9ebbe6fa-3561-4517-a621-58b8bc2335b7",
             "attributes": {
               "enabled": true,
-              "exp": 1596705801020,
+              "exp": 1596705801,
               "created": 1565083401,
               "updated": 1565083401,
               "recoveryLevel": "Recoverable\u002bPurgeable"
@@ -5631,7 +5631,7 @@
             "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002fStorageAccountPassworf3fb75f6-140a-4670-bec9-3730167cfe9e",
             "attributes": {
               "enabled": true,
-              "exp": 1596674204723,
+              "exp": 1596674204,
               "created": 1565051805,
               "updated": 1565051805,
               "recoveryLevel": "Recoverable\u002bPurgeable"

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/GetDeletedSecretsAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/GetDeletedSecretsAsync.json
@@ -5570,7 +5570,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "1711",
+        "Content-Length": "1705",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 18:00:35 GMT",
         "Expires": "-1",
@@ -5618,7 +5618,7 @@
             "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002fStorageAccountPasswor9ebbe6fa-3561-4517-a621-58b8bc2335b7",
             "attributes": {
               "enabled": true,
-              "exp": 1596705801020,
+              "exp": 1596705801,
               "created": 1565083401,
               "updated": 1565083401,
               "recoveryLevel": "Recoverable\u002bPurgeable"
@@ -5631,7 +5631,7 @@
             "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002fStorageAccountPassworf3fb75f6-140a-4670-bec9-3730167cfe9e",
             "attributes": {
               "enabled": true,
-              "exp": 1596674204723,
+              "exp": 1596674204,
               "created": 1565051805,
               "updated": 1565051805,
               "recoveryLevel": "Recoverable\u002bPurgeable"

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/SetSecretWithExtendedProps.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/SetSecretWithExtendedProps.json
@@ -47,7 +47,7 @@
       "RequestHeaders": {
         "Accept": "application\u002fjson",
         "Authorization": "Sanitized",
-        "Content-Length": "160",
+        "Content-Length": "154",
         "Content-Type": "application\u002fjson",
         "Request-Id": "|42981ca-4c61899ebaa789f5.",
         "User-Agent": [
@@ -61,8 +61,8 @@
         "value": "CrudWithExtendedPropsValue1",
         "contentType": "password",
         "attributes": {
-          "nbf": 1564536012448,
-          "exp": 1567128012448
+          "nbf": 1564536012,
+          "exp": 1567128012
         },
         "tags": {
           "tag1": "value1",
@@ -72,7 +72,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "356",
+        "Content-Length": "350",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:58:21 GMT",
         "Expires": "-1",
@@ -93,8 +93,8 @@
         "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002f1518274412\u002fc2d12adc8ef047dab96b268a694ea990",
         "attributes": {
           "enabled": true,
-          "nbf": 1564536012448,
-          "exp": 1567128012448,
+          "nbf": 1564536012,
+          "exp": 1567128012,
           "created": 1565114301,
           "updated": 1565114301,
           "recoveryLevel": "Recoverable\u002bPurgeable"
@@ -124,7 +124,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "356",
+        "Content-Length": "350",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:58:21 GMT",
         "Expires": "-1",
@@ -145,8 +145,8 @@
         "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002f1518274412\u002fc2d12adc8ef047dab96b268a694ea990",
         "attributes": {
           "enabled": true,
-          "nbf": 1564536012448,
-          "exp": 1567128012448,
+          "nbf": 1564536012,
+          "exp": 1567128012,
           "created": 1565114301,
           "updated": 1565114301,
           "recoveryLevel": "Recoverable\u002bPurgeable"
@@ -176,7 +176,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "456",
+        "Content-Length": "450",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 17:58:21 GMT",
         "Expires": "-1",
@@ -199,8 +199,8 @@
         "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002f1518274412\u002fc2d12adc8ef047dab96b268a694ea990",
         "attributes": {
           "enabled": true,
-          "nbf": 1564536012448,
-          "exp": 1567128012448,
+          "nbf": 1564536012,
+          "exp": 1567128012,
           "created": 1565114301,
           "updated": 1565114301,
           "recoveryLevel": "Recoverable\u002bPurgeable"

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/SetSecretWithExtendedPropsAsync.json
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/tests/SessionRecords/SecretClientLiveTests/SetSecretWithExtendedPropsAsync.json
@@ -47,7 +47,7 @@
       "RequestHeaders": {
         "Accept": "application\u002fjson",
         "Authorization": "Sanitized",
-        "Content-Length": "160",
+        "Content-Length": "154",
         "Content-Type": "application\u002fjson",
         "Request-Id": "|42984ad-4c61899ebaa789f5.",
         "User-Agent": [
@@ -61,8 +61,8 @@
         "value": "CrudWithExtendedPropsValue1",
         "contentType": "password",
         "attributes": {
-          "nbf": 1564536012448,
-          "exp": 1567128012448
+          "nbf": 1564536012,
+          "exp": 1567128012
         },
         "tags": {
           "tag1": "value1",
@@ -72,7 +72,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "356",
+        "Content-Length": "350",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 18:03:23 GMT",
         "Expires": "-1",
@@ -93,10 +93,10 @@
         "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002f1963134935\u002f451bdb9ada314902bcef2374b9d44eff",
         "attributes": {
           "enabled": true,
-          "nbf": 1564536012448,
-          "exp": 1567128012448,
-          "created": 1565114603,
-          "updated": 1565114603,
+          "nbf": 1564536012,
+          "exp": 1567128012,
+          "created": 1565114301,
+          "updated": 1565114301,
           "recoveryLevel": "Recoverable\u002bPurgeable"
         },
         "tags": {
@@ -124,7 +124,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "356",
+        "Content-Length": "350",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 18:03:23 GMT",
         "Expires": "-1",
@@ -145,10 +145,10 @@
         "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002f1963134935\u002f451bdb9ada314902bcef2374b9d44eff",
         "attributes": {
           "enabled": true,
-          "nbf": 1564536012448,
-          "exp": 1567128012448,
-          "created": 1565114603,
-          "updated": 1565114603,
+          "nbf": 1564536012,
+          "exp": 1567128012,
+          "created": 1565114301,
+          "updated": 1565114301,
           "recoveryLevel": "Recoverable\u002bPurgeable"
         },
         "tags": {
@@ -176,7 +176,7 @@
       "StatusCode": 200,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",
-        "Content-Length": "456",
+        "Content-Length": "450",
         "Content-Type": "application\u002fjson; charset=utf-8",
         "Date": "Tue, 06 Aug 2019 18:03:23 GMT",
         "Expires": "-1",
@@ -193,16 +193,16 @@
       },
       "ResponseBody": {
         "recoveryId": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fdeletedsecrets\u002f1963134935",
-        "deletedDate": 1565114603,
+        "deletedDate": 1565114301,
         "scheduledPurgeDate": 1572890603,
         "contentType": "password",
         "id": "https:\u002f\u002fdotnettestvault.vault.azure.net\u002fsecrets\u002f1963134935\u002f451bdb9ada314902bcef2374b9d44eff",
         "attributes": {
           "enabled": true,
-          "nbf": 1564536012448,
-          "exp": 1567128012448,
-          "created": 1565114603,
-          "updated": 1565114603,
+          "nbf": 1564536012,
+          "exp": 1567128012,
+          "created": 1565114301,
+          "updated": 1565114301,
           "recoveryLevel": "Recoverable\u002bPurgeable"
         },
         "tags": {


### PR DESCRIPTION
Fixes #7196 and #7197, as well as cleans up some related code from a change in .NET Core.