### PR TITLE
Update Sql release notes

### DIFF
--- a/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Microsoft.Azure.Management.Sql.csproj
+++ b/sdk/sqlmanagement/Microsoft.Azure.Management.SqlManagement/src/Microsoft.Azure.Management.Sql.csproj
@@ -12,8 +12,6 @@
 		<PackageReleaseNotes>
 			<![CDATA[
 New features:
-- Added support for resource group based LTR APIs.
-- Added support for failover databases and elastic pools.
 - Added support for Azure AD administrator on managed instance.
       ]]>
 		</PackageReleaseNotes>


### PR DESCRIPTION
Recent PR #7243 bumped version to 1.34 and added release notes, but old release notes from 1.33 are still there and should be removed before 1.34 is released.