### PR TITLE
Ignore live-only tests when in Playback or Record modes

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Azure.Data.AppConfiguration.Samples.Tests.csproj
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Azure.Data.AppConfiguration.Samples.Tests.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
+  <Import Project="..\..\..\core\Azure.Core\tests\LiveOnly.props" />
   <ItemGroup>
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample1_HelloWorld.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample1_HelloWorld.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [Category("Live")]
+    [LiveOnly]
     public partial class ConfigurationSamples
     {
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample2_HelloWorldExtended.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample2_HelloWorldExtended.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -10,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [Category("Live")]
+    [LiveOnly]
     public partial class ConfigurationSamples
     {
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample4_Logging.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample4_Logging.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
@@ -9,7 +10,7 @@ using System.Diagnostics.Tracing;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [Category("Live")]
+    [LiveOnly]
     public partial class ConfigurationSamples
     {
         // ConfigurationClient logs lots of useful information automatically to .NET's EventSource.

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample6_ConfiguringRetries.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample6_ConfiguringRetries.cs
@@ -2,13 +2,14 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using NUnit.Framework;
 using System;
 using Azure.Core.Pipeline;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [Category("Live")]
+    [LiveOnly]
     public partial class ConfigurationSamples
     {
         [Test]

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_ConfiguringPipeline.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/samples/Sample7_ConfiguringPipeline.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Core.Pipeline;
 using NUnit.Framework;
 using System;
@@ -9,7 +10,7 @@ using System.Net.Http;
 
 namespace Azure.Data.AppConfiguration.Samples
 {
-    [Category("Live")]
+    [LiveOnly]
     public partial class ConfigurationSamples
     {
         HttpClient s_client = new HttpClient();

--- a/sdk/core/Azure.Core/tests/LiveOnly.props
+++ b/sdk/core/Azure.Core/tests/LiveOnly.props
@@ -1,0 +1,7 @@
+﻿<Project ToolsVersion="15.0">
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)\TestFramework\LiveOnlyAttribute.cs" Link="TestFramework\LiveOnlyAttribute.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\TestFramework\RecordedTestMode.cs" Link="TestFramework\RecordedTestMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)\TestFramework\RecordedTestUtilities.cs" Link="TestFramework\RecordedTestUtilities.cs" />
+  </ItemGroup>
+</Project>

--- a/sdk/core/Azure.Core/tests/TestFramework.props
+++ b/sdk/core/Azure.Core/tests/TestFramework.props
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(ExcludeRecordingFramework)' == 'true'">
+    <Compile Remove="$(MSBuildThisFileDirectory)\TestFramework\LiveOnlyAttribute.cs" />
     <Compile Remove="$(MSBuildThisFileDirectory)\TestFramework\PlaybackTransport.cs" />
     <Compile Remove="$(MSBuildThisFileDirectory)\TestFramework\*Record*.cs" />
   </ItemGroup>

--- a/sdk/core/Azure.Core/tests/TestFramework/LiveOnlyAttribute.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/LiveOnlyAttribute.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using NUnit.Framework.Internal;
+
+namespace Azure.Core.Testing
+{
+    /// <summary>
+    /// Attribute on test assemblies, classes, or methods that run only against live resources.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Class | AttributeTargets.Assembly, AllowMultiple = true, Inherited = true)]
+    public class LiveOnlyAttribute : NUnitAttribute, IApplyToTest
+    {
+        /// <summary>
+        /// Modifies the <paramref name="test"/> by adding categories to it and changing the run state as needed.
+        /// </summary>
+        /// <param name="test">The <see cref="Test"/> to modify.</param>
+        public void ApplyToTest(Test test)
+        {
+            test.Properties.Add("Category", "Live");
+
+            if (test.RunState != RunState.NotRunnable)
+            {
+                RecordedTestMode mode = RecordedTestUtilities.GetModeFromEnvironment();
+                if (mode != RecordedTestMode.Live)
+                {
+                    test.RunState = RunState.Ignored;
+                    test.Properties.Set("_SKIPREASON", $"Live tests will not run when AZURE_TEST_MODE is {mode}");
+                }
+            }
+        }
+    }
+}

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordedTestBase.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordedTestBase.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
 using System.IO;
 using NUnit.Framework;
 
@@ -10,8 +9,6 @@ namespace Azure.Core.Testing
     [Category("Recorded")]
     public abstract class RecordedTestBase: ClientTestBase
     {
-        private const string ModeEnvironmentVariableName = "AZURE_TEST_MODE";
-
         protected RecordedTestSanitizer Sanitizer { get; set; }
 
         protected RecordMatcher Matcher { get; set; }
@@ -20,7 +17,7 @@ namespace Azure.Core.Testing
 
         protected RecordedTestMode Mode { get; }
 
-        protected RecordedTestBase(bool isAsync) : this(isAsync, GetModeFromEnvironment())
+        protected RecordedTestBase(bool isAsync) : this(isAsync, RecordedTestUtilities.GetModeFromEnvironment())
         {
         }
 
@@ -29,19 +26,6 @@ namespace Azure.Core.Testing
             Sanitizer = new RecordedTestSanitizer();
             Matcher = new RecordMatcher(Sanitizer);
             Mode = mode;
-        }
-
-        internal static RecordedTestMode GetModeFromEnvironment()
-        {
-            string modeString = Environment.GetEnvironmentVariable(ModeEnvironmentVariableName);
-
-            RecordedTestMode mode = RecordedTestMode.Playback;
-            if (!string.IsNullOrEmpty(modeString))
-            {
-                mode = (RecordedTestMode)Enum.Parse(typeof(RecordedTestMode), modeString, true);
-            }
-
-            return mode;
         }
 
         private string GetSessionFilePath(string name = null)

--- a/sdk/core/Azure.Core/tests/TestFramework/RecordedTestUtilities.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/RecordedTestUtilities.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace Azure.Core.Testing
+{
+    internal static class RecordedTestUtilities
+    {
+        private const string ModeEnvironmentVariableName = "AZURE_TEST_MODE";
+
+        internal static RecordedTestMode GetModeFromEnvironment()
+        {
+            string modeString = Environment.GetEnvironmentVariable(ModeEnvironmentVariableName);
+
+            RecordedTestMode mode = RecordedTestMode.Playback;
+            if (!string.IsNullOrEmpty(modeString))
+            {
+                mode = (RecordedTestMode)Enum.Parse(typeof(RecordedTestMode), modeString, true);
+            }
+
+            return mode;
+        }
+
+    }
+}

--- a/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
+++ b/sdk/core/Azure.Core/tests/samples/Sample1_HelloWorld.cs
@@ -3,6 +3,7 @@
 // license information.
 
 using Azure.Core.Pipeline;
+using Azure.Core.Testing;
 using NUnit.Framework;
 using System;
 using System.IO;
@@ -10,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace Azure.Core.Samples
 {
-    [Category("Live")]
+    [LiveOnly]
     public partial class BaseSamples
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Azure.Security.KeyVault.Keys.Samples.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Azure.Security.KeyVault.Keys.Samples.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
+  <Import Project="..\..\..\core\Azure.Core\tests\LiveOnly.props" />
   <ItemGroup>
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample1_HelloWorld.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
-using System.Security.Cryptography;
 using System.Threading;
 
 namespace Azure.Security.KeyVault.Keys.Samples
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// <summary>
     /// Sample demonstrates how to set, get, update and delete a key using the synchronous methods of the KeyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class HelloWorld
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample1_HelloWorldAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample1_HelloWorldAsync.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
-using System.Security.Cryptography;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Security.KeyVault.Keys.Samples
@@ -15,11 +14,11 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// <summary>
     /// Sample demonstrates how to set, get, update and delete a key using the asynchronous methods of the KeyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class HelloWorld
     {
         [Test]
-        public async Task HelloWorldASync()
+        public async Task HelloWorldAsync()
         {
             // Environment variable with the Key Vault endpoint.
             string keyVaultUrl = Environment.GetEnvironmentVariable("AZURE_KEYVAULT_URL");

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample2_BackupAndRestore.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample2_BackupAndRestore.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
@@ -14,7 +15,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// Sample demonstrates how to backup and restore keys in the Key Vault
     /// using the synchronous methods of the KeyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class BackupAndRestore
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample2_BackupAndRestoreAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample2_BackupAndRestoreAsync.cs
@@ -2,11 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
 using System.IO;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Security.KeyVault.Keys.Samples
@@ -15,7 +15,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// Sample demonstrates how to backup and restore keys in the Key Vault
     /// using the asynchronous methods of the KeyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class BackupAndRestore
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample3_GetKeys.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample3_GetKeys.cs
@@ -2,12 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Security.Cryptography;
 using System.Threading;
 
 namespace Azure.Security.KeyVault.Keys.Samples
@@ -17,7 +17,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// and list deleted keys in a soft-delete enabled Key Vault
     /// using the synchronous methods of the KeyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class GetKeys
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample3_GetKeysAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample3_GetKeysAsync.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Security.KeyVault.Keys.Samples
@@ -17,7 +16,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// and list deleted keys in a soft-delete enabled Key Vault
     /// using the asynchronous methods of the KeyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class GetKeys
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample4_EncryptDecrypt.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample4_EncryptDecrypt.cs
@@ -1,5 +1,5 @@
-﻿using Azure.Identity;
-using Azure.Security.KeyVault.Keys;
+﻿using Azure.Core.Testing;
+using Azure.Identity;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using NUnit.Framework;
 using System;
@@ -13,7 +13,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// <summary>
     /// Sample demonstrates how to encrypt and decrypt a single block of plain text with an RSA key using the synchronous methods of the CryptographyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class Sample4_EncryptDecypt
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample4_EncryptDecryptAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample4_EncryptDecryptAsync.cs
@@ -1,8 +1,8 @@
-﻿using Azure.Identity;
+﻿using Azure.Core.Testing;
+using Azure.Identity;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 using System.Threading.Tasks;
@@ -13,7 +13,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// <summary>
     /// Sample demonstrates how to encrypt and decrypt a single block of plain text with an RSA key using the asynchronous methods of the CryptographyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class Sample4_EncryptDecypt
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample5_SignVerify.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample5_SignVerify.cs
@@ -1,5 +1,5 @@
-﻿using Azure.Identity;
-using Azure.Security.KeyVault.Keys;
+﻿using Azure.Core.Testing;
+using Azure.Identity;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using NUnit.Framework;
 using System;
@@ -14,7 +14,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// <summary>
     /// Sample demonstrates how to sign data with both a RSA key and an EC key using the synchronous methods of the CryptographyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class Sample5_SignVerify
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample5_SignVerifyAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample5_SignVerifyAsync.cs
@@ -1,12 +1,11 @@
-﻿using Azure.Identity;
-using Azure.Security.KeyVault.Keys;
+﻿using Azure.Core.Testing;
+using Azure.Identity;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Security.KeyVault.Keys.Samples
@@ -15,7 +14,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// <summary>
     /// Sample demonstrates how to sign data with both a RSA key and an EC key using the synchronous methods of the CryptographyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class Sample5_SignVerify
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample6_WrapUnwrap.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample6_WrapUnwrap.cs
@@ -1,5 +1,5 @@
-﻿using Azure.Identity;
-using Azure.Security.KeyVault.Keys;
+﻿using Azure.Core.Testing;
+using Azure.Identity;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using NUnit.Framework;
 using System;
@@ -13,7 +13,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// <summary>
     /// Sample demonstrates how to wrap and unwrap a symmetric key with an RSA key using the synchronous methods of the CryptographyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class Sample6_WrapUnwrap
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample6_WrapUnwrapAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Keys/samples/Sample6_WrapUnwrapAsync.cs
@@ -1,12 +1,11 @@
-﻿using Azure.Identity;
-using Azure.Security.KeyVault.Keys;
+﻿using Azure.Core.Testing;
+using Azure.Identity;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using NUnit.Framework;
 using System;
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Security.KeyVault.Keys.Samples
@@ -14,7 +13,7 @@ namespace Azure.Security.KeyVault.Keys.Samples
     /// <summary>
     /// Sample demonstrates how to wrap and unwrap a symmetric key with an RSA key using the synchronous methods of the CryptographyClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class Sample6_WrapUnwrap
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Azure.Security.KeyVault.Secrets.Samples.csproj
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Azure.Security.KeyVault.Secrets.Samples.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(RequiredTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
+  <Import Project="..\..\..\core\Azure.Core\tests\LiveOnly.props" />
   <ItemGroup>
     <PackageReference Include="nunit" />
     <PackageReference Include="NUnit3TestAdapter" />

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorld.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
@@ -13,7 +14,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
     /// <summary>
     /// Sample demonstrates how to set, get, update and delete a secret using the synchronous methods of the SecretClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class HelloWorld
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorldAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample1_HelloWorldAsync.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
@@ -14,7 +15,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
     /// <summary>
     /// Sample demonstrates how to set, get, update and delete a secret using the asynchronous methods of the SecretClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class HelloWorld
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample2_BackupAndRestore.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample2_BackupAndRestore.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
@@ -15,7 +15,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
     /// Sample demonstrates how to backup and restore secrets in the key vault
     /// using the synchronous methods of the SecretClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class BackupAndRestore
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample2_BackupAndRestoreAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample2_BackupAndRestoreAsync.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -16,7 +16,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
     /// Sample demonstrates how to backup and restore secrets in the key vault using the 
     /// asynchronous methods of the SecretClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class BackupAndRestore
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample3_GetSecrets.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample3_GetSecrets.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
@@ -16,7 +17,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
     /// and list deleted secrets in a soft-delete enabled key vault
     /// using the synchronous methods of the SecretClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class GetSecrets
     {
         [Test]

--- a/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample3_GetSecretsAsync.cs
+++ b/sdk/keyvault/Azure.Security.KeyVault.Secrets/samples/Sample3_GetSecretsAsync.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License. See License.txt in the project root for
 // license information.
 
+using Azure.Core.Testing;
 using Azure.Identity;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +17,7 @@ namespace Azure.Security.KeyVault.Secrets.Samples
     /// and list deleted secrets in a soft-delete enabled key vault
     /// using the asynchronous methods of the SecretClient.
     /// </summary>
-    [Category("Live")]
+    [LiveOnly]
     public partial class GetSecrets
     {
         [Test]

--- a/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
+++ b/sdk/storage/Azure.Storage.Blobs/tests/BlobClientTests.cs
@@ -463,6 +463,7 @@ namespace Azure.Storage.Blobs.Test
             await this.UploadFileAndVerify(size, Constants.KB, new ParallelTransferOptions { MaximumBlockLength = Constants.KB });
 
         [Test]
+        [LiveOnly]
         [TestCase(33 * Constants.MB, 1)]
         [TestCase(33 * Constants.MB, 4)]
         [TestCase(33 * Constants.MB, 8)]
@@ -481,14 +482,11 @@ namespace Azure.Storage.Blobs.Test
         public async Task UploadStreamAsync_LargeBlobs(long size, int? maximumThreadCount)
         {
             // TODO: #6781 We don't want to add 1GB of random data in the recordings
-            if (this.Mode == RecordedTestMode.Live)
-            {
-                await this.UploadStreamAndVerify(size, 16 * Constants.MB, new ParallelTransferOptions { MaximumThreadCount = maximumThreadCount });
-            }
+            await this.UploadStreamAndVerify(size, 16 * Constants.MB, new ParallelTransferOptions { MaximumThreadCount = maximumThreadCount });
         }
 
         [Test]
-        [Category("Live")]
+        [LiveOnly]
         [TestCase(33 * Constants.MB, 1)]
         [TestCase(33 * Constants.MB, 4)]
         [TestCase(33 * Constants.MB, 8)]
@@ -507,10 +505,7 @@ namespace Azure.Storage.Blobs.Test
         public async Task UploadFileAsync_LargeBlobs(long size, int? maximumThreadCount)
         {
             // TODO: #6781 We don't want to add 1GB of random data in the recordings
-            if (this.Mode == RecordedTestMode.Live)
-            {
-                await this.UploadFileAndVerify(size, 16 * Constants.MB, new ParallelTransferOptions { MaximumThreadCount = maximumThreadCount });
-            }
+            await this.UploadFileAndVerify(size, 16 * Constants.MB, new ParallelTransferOptions { MaximumThreadCount = maximumThreadCount });
         }
     }
 }

--- a/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
+++ b/sdk/storage/Azure.Storage.Common/tests/Shared/StorageTestBase.cs
@@ -18,7 +18,7 @@ namespace Azure.Storage.Test.Shared
     public abstract class StorageTestBase : RecordedTestBase
     {
         public StorageTestBase(bool async, RecordedTestMode? mode = null)
-            : base(async, mode ?? GetModeFromEnvironment())
+            : base(async, mode ?? RecordedTestUtilities.GetModeFromEnvironment())
         {
             this.Sanitizer = new StorageRecordedTestSanitizer();
             this.Matcher = new StorageRecordMatcher(this.Sanitizer);


### PR DESCRIPTION
Partially fixes #7416. This is currently only applied to keyvault but would be applied to other services once the design is approved.

This ignores live-only tests when not using live test mode, which then doesn't simply cause live tests (like samples) to fail, potentially even taking some time before they do since they may partially run.

![image](https://user-images.githubusercontent.com/1532486/63978504-52255300-ca6b-11e9-8ca3-7dee01757234.png)

As you can see from the screenshot, a reason is given, and "Live" is still emitted as a category. I just made a single attribute to do that all for ease.