### PR TITLE
[Event Hubs Client] Tracks One and Two (Test Stability Tweaks)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -31,10 +31,10 @@ namespace Azure.Messaging.EventHubs.Tests.Infrastructure
         private const int RetryMaximumAttemps = 15;
 
         /// <summary>The number of seconds to use as the basis for backing off on retry attempts.</summary>
-        private const double RetryExponentialBackoffSeconds = 1.5;
+        private const double RetryExponentialBackoffSeconds = 2.0;
 
         /// <summary>The number of seconds to use as the basis for applying jitter to retry back-off calculations.</summary>
-        private const double RetryBaseJitterSeconds = 7.0;
+        private const double RetryBaseJitterSeconds = 8.0;
 
         /// <summary>The buffer to apply when considering refreshing; credentials that expire less than this duration will be refreshed.</summary>
         private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MiscTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Client/MiscTests.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Test is unstable during nightly runs.  Tracking with #7435")]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task ClosingEventHubClientClosesSenderEntities()
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.EventHubs.Tests.Client
             }
         }
 
-        [Fact]
+        [Fact(Skip = "Test is unstable during nightly runs.  Tracking with #7435")]
         [LiveTest]
         [DisplayTestMethodName]
         public async Task ClosingEventHubClientClosesReceiverEntities()

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -24,8 +24,8 @@ namespace Microsoft.Azure.EventHubs.Tests
     internal sealed class EventHubScope : IAsyncDisposable
     {
         private const int RetryMaximumAttemps = 15;
-        private const double RetryExponentialBackoffSeconds = 1.5;
-        private const double RetryBaseJitterSeconds = 7.0;
+        private const double RetryExponentialBackoffSeconds = 2.5;
+        private const double RetryBaseJitterSeconds = 8.0;
 
         private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);
         private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);


### PR DESCRIPTION
# Summary

The intent of these changes is to improve stability in the nightly test runs by adjusting retry behavior and annotating tests that require manual intervention.

# Last Upstream Rebase

Friday, August 30, 2019 11:19am (EDT)

# Related and Follow-Up Issues

- [[Track One] Tests for closing the Event Hub client are unstable during nightly runs](https://github.com/Azure/azure-sdk-for-net/issues/7435) (#7435)  