### PR TITLE
Prototyped HEAD requests support

### DIFF
--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient.cs
@@ -103,7 +103,7 @@ namespace Azure.Data.AppConfiguration
                 {
                     case 200:
                     case 201:
-                        return await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false);
+                        return await CreateResponseAsync(response, request.Method, cancellationToken).ConfigureAwait(false);
                     default:
                         throw await response.CreateRequestFailedExceptionAsync().ConfigureAwait(false);
                 }
@@ -135,7 +135,7 @@ namespace Azure.Data.AppConfiguration
                 {
                     case 200:
                     case 201:
-                        return CreateResponse(response);
+                        return CreateResponse(response, request.Method);
                     default:
                         throw response.CreateRequestFailedException();
                 }
@@ -217,7 +217,7 @@ namespace Azure.Data.AppConfiguration
                 switch (response.Status)
                 {
                     case 200:
-                        return await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false);
+                        return await CreateResponseAsync(response, request.Method, cancellationToken).ConfigureAwait(false);
                     case 409:
                         throw await response.CreateRequestFailedExceptionAsync("The setting is locked").ConfigureAwait(false);
                     default:
@@ -251,7 +251,7 @@ namespace Azure.Data.AppConfiguration
                 switch (response.Status)
                 {
                     case 200:
-                        return CreateResponse(response);
+                        return CreateResponse(response, request.Method);
                     case 409:
                         throw response.CreateRequestFailedException("The setting is locked");
                     default:
@@ -336,7 +336,7 @@ namespace Azure.Data.AppConfiguration
                 switch (response.Status)
                 {
                     case 200:
-                        return await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false);
+                        return await CreateResponseAsync(response, request.Method, cancellationToken).ConfigureAwait(false);
                     default:
                         throw await response.CreateRequestFailedExceptionAsync().ConfigureAwait(false);
                 }
@@ -367,7 +367,7 @@ namespace Azure.Data.AppConfiguration
                 switch (response.Status)
                 {
                     case 200:
-                        return CreateResponse(response);
+                        return CreateResponse(response, request.Method);
                     default:
                         throw response.CreateRequestFailedException();
                 }
@@ -517,7 +517,7 @@ namespace Azure.Data.AppConfiguration
                 switch (response.Status)
                 {
                     case 200:
-                        return await CreateResponseAsync(response, cancellationToken).ConfigureAwait(false);
+                        return await CreateResponseAsync(response, request.Method, cancellationToken).ConfigureAwait(false);
                     default:
                         throw await response.CreateRequestFailedExceptionAsync().ConfigureAwait(false);
                 }
@@ -551,7 +551,7 @@ namespace Azure.Data.AppConfiguration
                     switch (response.Status)
                     {
                         case 200:
-                            return CreateResponse(response);
+                            return CreateResponse(response, request.Method);
                         default:
                             throw response.CreateRequestFailedException();
                     }

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/src/ConfigurationClient_private.cs
@@ -35,15 +35,34 @@ namespace Azure.Data.AppConfiguration
             "application/vnd.microsoft.appconfig.kv+json"
         );
 
-        static async Task<Response<ConfigurationSetting>> CreateResponseAsync(Response response, CancellationToken cancellation)
+        static async Task<Response<ConfigurationSetting>> CreateResponseAsync(Response response, RequestMethod method, CancellationToken cancellation)
         {
-            ConfigurationSetting result = await ConfigurationServiceSerializer.DeserializeSettingAsync(response.ContentStream, cancellation).ConfigureAwait(false);
+            ConfigurationSetting result;
+            if (method != RequestMethod.Head)
+            {
+               result  = await ConfigurationServiceSerializer.DeserializeSettingAsync(response.ContentStream, cancellation).ConfigureAwait(false);
+            }
+            else
+            {
+                Debug.Assert(response.ContentStream.Length == 0);
+                result = default;
+            }
             return new Response<ConfigurationSetting>(response, result);
         }
 
-        static Response<ConfigurationSetting> CreateResponse(Response response)
+        static Response<ConfigurationSetting> CreateResponse(Response response, RequestMethod method)
         {
-            return new Response<ConfigurationSetting>(response, ConfigurationServiceSerializer.DeserializeSetting(response.ContentStream));
+            ConfigurationSetting result;
+            if (method != RequestMethod.Head)
+            {
+                result = ConfigurationServiceSerializer.DeserializeSetting(response.ContentStream);
+            }
+            else
+            {
+                Debug.Assert(response.ContentStream.Length == 0);
+                result = default;
+            }
+            return new Response<ConfigurationSetting>(response, result);
         }
 
         static void ParseConnectionString(string connectionString, out Uri uri, out string credential, out byte[] secret)

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationHeadMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationHeadMockTests.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for
+// license information.
+
+using Azure.Core.Pipeline;
+using Azure.Core.Testing;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Core.Http;
+using NUnit.Framework;
+using System;
+
+namespace Azure.Data.AppConfiguration.Tests
+{
+    [TestFixture(true)]
+    [TestFixture(false)]
+    public partial class ConfigurationMockTests: ClientTestBase
+    {
+        class HeadRequestPolicy : SynchronousHttpPipelinePolicy
+        {
+            public readonly static HttpPipelinePolicy Shared = new HeadRequestPolicy();
+
+            private HeadRequestPolicy() { }
+
+            public override void OnSendingRequest(HttpPipelineMessage message)
+                => message.Request.Method = RequestMethod.Head;          
+        }
+
+        class HeadRequestTransport : MockTransport
+        {
+            static readonly Func<MockRequest, MockResponse> Impl = (MockRequest) =>
+            {
+                var response = new MockResponse(200);
+                response.ContentStream = Stream.Null;
+                return response;
+            };
+
+            public readonly static HttpPipelineTransport Shared = new HeadRequestTransport();
+
+            private HeadRequestTransport() : base(Impl) {
+            }
+        }
+
+        [Test]
+        public async Task HeadRequest()
+        {
+            ConfigurationClient service = CreateTestService(HeadRequestTransport.Shared, headRequests: true);
+
+            Response<ConfigurationSetting> typedRetting = await service.GetAsync(s_testSetting.Key);
+            Response response = typedRetting.GetRawResponse();
+
+            Assert.AreEqual(response.Status, 200);
+        }
+    }
+}

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationHeadMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationHeadMockTests.cs
@@ -27,7 +27,12 @@ namespace Azure.Data.AppConfiguration.Tests
             private HeadRequestPolicy() { }
 
             public override void OnSendingRequest(HttpPipelineMessage message)
-                => message.Request.Method = RequestMethod.Head;          
+            {
+                if (message.Request.Method == RequestMethod.Get)
+                {
+                    message.Request.Method = RequestMethod.Head;
+                }
+            }
         }
 
         class HeadRequestTransport : MockTransport

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationLiveTests.cs
@@ -12,7 +12,7 @@ using Azure.Core.Testing;
 
 namespace Azure.Data.AppConfiguration.Tests
 {
-    public class ConfigurationLiveTests: RecordedTestBase
+    public partial class ConfigurationLiveTests: RecordedTestBase
     {
         public ConfigurationLiveTests(bool isAsync) : base(isAsync)
         {

--- a/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
+++ b/sdk/appconfiguration/Azure.Data.AppConfiguration/tests/ConfigurationMockTests.cs
@@ -17,7 +17,7 @@ namespace Azure.Data.AppConfiguration.Tests
 {
     [TestFixture(true)]
     [TestFixture(false)]
-    public class ConfigurationMockTests: ClientTestBase
+    public partial class ConfigurationMockTests: ClientTestBase
     {
         static readonly string connectionString = "Endpoint=https://contoso.appconfig.io;Id=b1d9b31;Secret=aabbccdd";
         static readonly ConfigurationSetting s_testSetting = new ConfigurationSetting("test_key", "test_value")
@@ -33,10 +33,16 @@ namespace Azure.Data.AppConfiguration.Tests
 
         public ConfigurationMockTests(bool isAsync) : base(isAsync) { }
 
-        private ConfigurationClient CreateTestService(HttpPipelineTransport transport)
+        private ConfigurationClient CreateTestService(HttpPipelineTransport transport, bool headRequests = false)
         {
             var options = new ConfigurationClientOptions();
             options.Transport = transport;
+
+            if (headRequests)
+            {
+                options.AddPolicy(HttpPipelinePosition.PerCall, HeadRequestPolicy.Shared);
+            }
+
             return InstrumentClient(new ConfigurationClient(connectionString, options));
         }
 

--- a/sdk/core/Microsoft.Extensions.Azure/samples/Properties/launchSettings.json
+++ b/sdk/core/Microsoft.Extensions.Azure/samples/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:51839/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Microsoft.Extensions.Azure.Samples": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:51844/"
+    }
+  }
+}


### PR DESCRIPTION
This is a prototype for supporting HEAD requests with no changes to client APIs.
The idea is that users who want to issue HEAD requests would add a special policy that replaces the regular HTTP method/verb with HEAD. 
The only thing we would need to do in our client implementations would be to ensure that when an empty content comes back from the server, the deserializer can handle it.  

If we want to go with this design, we would of course add the HeadRequestPolicy to Azure.Core so users don't have to implement it.