### PR TITLE
Increase timeouts to fix flaky ServiceFabricProcessor test cases

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/CheckpointingTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/CheckpointingTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
 
     public class CheckpointingTests
     {
-        [Fact(Skip = "Test not reliable under macOS; to be investigated as art of issue #5451")]
+        [Fact]
         [DisplayTestMethodName]
         public void CheckpointBatchTest()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/EventHubExceptionTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/EventHubExceptionTests.cs
@@ -357,7 +357,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             EventHubReceiveFailure("NonTransient", new ReceiverDisconnectedException("ErrorInjector"), true);
         }
 
-        [Fact(Skip = "https://github.com/Azure/azure-sdk-for-net/issues/7335")]
+        [Fact]
         [DisplayTestMethodName]
         public void HardEventHubReceiveFailure()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/OptionsTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/OptionsTests.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             Assert.Null(state.ShutdownException);
         }
 
-        [Fact(Skip = "https://github.com/Azure/azure-sdk-for-net/issues/6056")]
+        [Fact]
         [DisplayTestMethodName]
         public void RuntimeInformationTest()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/TestState.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             int retries = 0;
             while (!this.Processor.IsOpened && !this.HasShutDown && (retries < maxRetries))
             {
-                Thread.Sleep(1000);
+                Thread.Sleep(5000);
                 retries++;
             }
             Assert.False(this.HasShutDown, "Shut down before open");

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/UserExceptionTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/UserExceptionTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             Assert.Null(state.ShutdownException);
         }
 
-        [Fact]
+        [Fact(Skip = "Test not reliable under macOS; to be investigated as art of issue #5451")]
         [DisplayTestMethodName]
         public void EventException()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/UserExceptionTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/UserExceptionTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             Assert.Null(state.ShutdownException);
         }
 
-        [Fact(Skip = "Test not reliable under macOS; to be investigated as art of issue #5451")]
+        [Fact]
         [DisplayTestMethodName]
         public void EventException()
         {
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             Assert.Null(state.ShutdownException);
         }
 
-        [Fact(Skip = "Test not reliable under macOS; to be investigated as art of issue #5451")]
+        [Fact]
         [DisplayTestMethodName]
         public void ErrorException()
         {


### PR DESCRIPTION
Multiple cases, including the ones marked as flaky, are failing because the processor does not start up as quickly as expected. All cases work fine on my desktop, but it is not surprising that a loaded common testbed would be slower. Increased the timeout.