### PR TITLE
Enable custom checkpointing scenario

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Lease.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/Lease.cs
@@ -75,7 +75,11 @@ namespace Microsoft.Azure.EventHubs.Processor
             return Task.FromResult(false);
         }
 
-        internal long IncrementEpoch()
+		/// <summary>
+		/// Increments the stored epoch in the checkpoint.
+		/// </summary>
+		/// <returns></returns>
+        public long IncrementEpoch()
         {
             this.Epoch++;
             return this.Epoch;

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/LeaseLostException.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/LeaseLostException.cs
@@ -14,7 +14,10 @@ namespace Microsoft.Azure.EventHubs.Processor
     {
         readonly string partitionId;
 
-        internal LeaseLostException(string partitionId, Exception innerException)
+		/// <summary>
+		/// Provides 
+		/// </summary>
+        public LeaseLostException(string partitionId, Exception innerException)
             : base(innerException.Message, innerException)
         {
             Guard.ArgumentNotNullOrWhiteSpace(nameof(partitionId), partitionId);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionContext.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs.Processor/src/PartitionContext.cs
@@ -149,11 +149,19 @@ namespace Microsoft.Azure.EventHubs.Processor
             return this.PersistCheckpointAsync(new Checkpoint(this.PartitionId, eventData.SystemProperties.Offset, eventData.SystemProperties.SequenceNumber));
         }
 
-        /// <summary>
-        /// Provides the parition context in the following format:"PartitionContext({EventHubPath}/{ConsumerGroupName}/{PartitionId}/{SequenceNumber})"
-        /// </summary>
-        /// <returns></returns>
-        public override string ToString()
+		/// <summary>
+		/// Writes the current offset and sequenceNumber to the checkpoint store via the checkpoint manager.
+		/// </summary>
+		public Task CheckpointAsync(Checkpoint checkPoint)
+		{
+			return this.PersistCheckpointAsync(checkPoint);
+		}
+
+		/// <summary>
+		/// Provides the parition context in the following format:"PartitionContext({EventHubPath}/{ConsumerGroupName}/{PartitionId}/{SequenceNumber})"
+		/// </summary>
+		/// <returns></returns>
+		public override string ToString()
         {
             return $"PartitionContext({this.EventHubPath}/{this.ConsumerGroupName}/{this.PartitionId}/{this.SequenceNumber})";
         }


### PR DESCRIPTION
Addressing 2 issues that makes custom LeaseManager implementation harder.
- Public ctor for LeaseLostException
- Public IncrementEpoch on Lease object

Adding PartitionContext.CheckpointAsync(Checkpoint checkPoint) to allow developer to build their own checkpoint objects.