### PR TITLE
[Event Hubs Client] Track Two: Third Preview (System Properties)

### DIFF
--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/Compatibility/TrackOneEventHubConsumer.cs
@@ -89,17 +89,13 @@ namespace Azure.Messaging.EventHubs.Compatibility
                                                                         CancellationToken cancellationToken)
         {
             static EventData TransformEvent(TrackOne.EventData eventData) =>
-                new EventData(eventData.Body)
-                {
-                    Properties = eventData.Properties,
-                    SystemProperties = new EventData.SystemEventProperties
-                    {
-                        SequenceNumber = eventData.SystemProperties.SequenceNumber,
-                        EnqueuedTime = new DateTimeOffset(eventData.SystemProperties.EnqueuedTimeUtc),
-                        Offset = Int64.Parse(eventData.SystemProperties.Offset),
-                        PartitionKey = eventData.SystemProperties.PartitionKey
-                    }
-                };
+                new EventData(eventData.Body,
+                              eventData.Properties,
+                              eventData.SystemProperties.WithoutTypedMembers(),
+                              eventData.SystemProperties.SequenceNumber,
+                              Int64.Parse(eventData.SystemProperties.Offset),
+                              new DateTimeOffset(eventData.SystemProperties.EnqueuedTimeUtc),
+                              eventData.SystemProperties.PartitionKey);
 
             try
             {

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/EventData.cs
@@ -45,7 +45,19 @@ namespace Azure.Messaging.EventHubs
         ///   </code>
         /// </example>
         ///
-        public IDictionary<string, object> Properties { get; internal set; } = new Dictionary<string, object>();
+        public IDictionary<string, object> Properties { get; }
+
+        /// <summary>
+        ///   The set of free-form event properties which were provided by the Event Hubs service to pass metadata associated with the
+        ///   event or associated Event Hubs operation.
+        /// </summary>
+        ///
+        /// <remarks>
+        ///   These properties are only populated for events received from the Event Hubs service.  The set is otherwise
+        ///   empty.
+        /// </remarks>
+        ///
+        public IReadOnlyDictionary<string, object> SystemProperties { get; }
 
         /// <summary>
         ///   The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.
@@ -55,7 +67,7 @@ namespace Azure.Messaging.EventHubs
         ///   This property is only populated for events received from the Event Hubs service.
         /// </remarks>
         ///
-        public long? SequenceNumber => SystemProperties?.SequenceNumber;
+        public long? SequenceNumber { get; }
 
         /// <summary>
         ///   The offset of the event when it was received from the associated Event Hub partition.
@@ -65,7 +77,7 @@ namespace Azure.Messaging.EventHubs
         ///   This property is only populated for events received from the Event Hubs service.
         /// </remarks>
         ///
-        public long? Offset => SystemProperties?.Offset;
+        public long? Offset { get; }
 
         /// <summary>
         ///   The date and time, in UTC, of when the event was enqueued in the Event Hub partition.
@@ -75,17 +87,17 @@ namespace Azure.Messaging.EventHubs
         ///   This property is only populated for events received from the Event Hubs service.
         /// </remarks>
         ///
-        public DateTimeOffset? EnqueuedTime => SystemProperties?.EnqueuedTime;
+        public DateTimeOffset? EnqueuedTime { get; }
 
         /// <summary>
-        ///   The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.
+        ///   The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was published with.
         /// </summary>
         ///
         /// <remarks>
         ///   This property is only populated for events received from the Event Hubs service.
         /// </remarks>
         ///
-        public string PartitionKey => SystemProperties?.PartitionKey;
+        public string PartitionKey { get; }
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="EventData"/> class.
@@ -93,30 +105,39 @@ namespace Azure.Messaging.EventHubs
         ///
         /// <param name="eventBody">The raw data to use as the body of the event.</param>
         ///
-        public EventData(ReadOnlyMemory<byte> eventBody)
+        public EventData(ReadOnlyMemory<byte> eventBody) : this(eventBody, null)
+
+        {
+        }
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="EventData"/> class.
+        /// </summary>
+        ///
+        /// <param name="eventBody">The raw data to use as the body of the event.</param>
+        /// <param name="properties">The set of free-form event properties to send with the event.</param>
+        /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
+        /// <param name="sequenceNumber">The sequence number assigned to the event when it was enqueued in the associated Event Hub partition.</param>
+        /// <param name="offset">The offset of the event when it was received from the associated Event Hub partition.</param>
+        /// <param name="enqueuedTime">The date and time, in UTC, of when the event was enqueued in the Event Hub partition.</param>
+        /// <param name="partitionKey">The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.</param>
+        ///
+        protected internal EventData(ReadOnlyMemory<byte> eventBody,
+                                     IDictionary<string, object> properties = null,
+                                     IReadOnlyDictionary<string, object> systemProperties = null,
+                                     long? sequenceNumber = null,
+                                     long? offset = null,
+                                     DateTimeOffset? enqueuedTime = null,
+                                     string partitionKey = null)
         {
             Body = eventBody;
+            Properties = properties ?? new Dictionary<string, object>();
+            SystemProperties = systemProperties ?? new Dictionary<string, object>();
+            SequenceNumber = sequenceNumber;
+            Offset = offset;
+            EnqueuedTime = enqueuedTime;
+            PartitionKey = partitionKey;
         }
-
-        /// <summary>
-        ///   Initializes a new instance of the <see cref="EventData"/> class.
-        /// </summary>
-        ///
-        /// <param name="eventBody">The raw data to use as the body of the event.</param>
-        /// <param name="systemProperties">The set of system properties received from the Event Hubs service.</param>
-        ///
-        internal EventData(ReadOnlyMemory<byte> eventBody,
-                           SystemEventProperties systemProperties) : this(eventBody)
-        {
-            SystemProperties = systemProperties;
-        }
-
-        /// <summary>
-        ///   The set of event properties which are owned and populated by the Event Hubs service during
-        ///   operations.
-        /// </summary>
-        ///
-        protected internal SystemEventProperties SystemProperties { get; set; }
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
@@ -146,78 +167,5 @@ namespace Azure.Messaging.EventHubs
         ///
         [EditorBrowsable(EditorBrowsableState.Never)]
         public override string ToString() => base.ToString();
-
-        /// <summary>
-        ///   The set of event properties which are owned and populated by the Event Hubs service.
-        /// </summary>
-        ///
-        protected internal sealed class SystemEventProperties
-        {
-            /// <summary>
-            ///   Initializes a new instance of the <see cref="SystemEventProperties"/> class.
-            /// </summary>
-            ///
-            public SystemEventProperties()
-            {
-            }
-
-            /// <summary>
-            ///   The logical sequence number of the <see cref="EventData" /> within the partition stream of the Event Hub.
-            /// </summary>
-            ///
-            public long SequenceNumber { get; set; }
-
-            /// <summary>
-            ///   The date and time, in UTC, that the <see cref="EventData" /> was received by the partition.
-            /// </summary>
-            ///
-            public DateTimeOffset EnqueuedTime { get; set; }
-
-            /// <summary>
-            ///   The offset of the <see cref="EventData" /> relative to the Event Hub partition stream.
-            /// </summary>
-            ///
-            /// <remarks>
-            ///   The offset is a marker or identifier for an event within the Event Hubs stream. The
-            ///   identifier is unique within a partition of the Event Hubs stream.
-            /// </remarks>
-            ///
-            public long Offset { get; set; }
-
-            /// <summary>
-            ///   The partition hashing key applied to the batch that the associated <see cref="EventData"/>, was sent with.
-            /// </summary>
-            ///
-            public string PartitionKey { get; set; }
-
-            /// <summary>
-            ///   Determines whether the specified <see cref="System.Object" /> is equal to this instance.
-            /// </summary>
-            ///
-            /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
-            ///
-            /// <returns><c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.</returns>
-            ///
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public override bool Equals(object obj) => base.Equals(obj);
-
-            /// <summary>
-            ///   Returns a hash code for this instance.
-            /// </summary>
-            ///
-            /// <returns>A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.</returns>
-            ///
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public override int GetHashCode() => base.GetHashCode();
-
-            /// <summary>
-            ///   Converts the instance to string representation.
-            /// </summary>
-            ///
-            /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
-            ///
-            [EditorBrowsable(EditorBrowsableState.Never)]
-            public override string ToString() => base.ToString();
-        }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/EventData.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/src/TrackOneClient/EventData.cs
@@ -5,6 +5,7 @@ namespace TrackOne
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.Azure.Amqp;
 
     /// <summary>
@@ -191,6 +192,14 @@ namespace TrackOne
                     return null;
                 }
             }
+
+            public Dictionary<string, object> WithoutTypedMembers() =>
+                this
+                    .Where(pair => pair.Key != ClientConstants.SequenceNumberName
+                        && pair.Key != ClientConstants.OffsetName
+                        && pair.Key != ClientConstants.EnqueuedTimeUtcName
+                        && pair.Key != ClientConstants.PartitionKeyName)
+                    .ToDictionary(pair => pair.Key, pair => pair.Value);
         }
     }
 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/AmqpMessageConverterTests.cs
@@ -162,10 +162,9 @@ namespace Azure.Messaging.EventHubs.Tests
                 "hello"
             };
 
-            var eventData = new EventData(new byte[] { 0x11, 0x22, 0x33 })
-            {
-                Properties = propertyValues.ToDictionary(value => $"{ value.GetType().Name }Property", value => value)
-            };
+            var eventData = new EventData(
+                eventBody: new byte[] { 0x11, 0x22, 0x33 },
+                properties: propertyValues.ToDictionary(value => $"{ value.GetType().Name }Property", value => value));
 
             using var message = new AmqpMessageConverter().CreateMessageFromEvent(eventData);
 
@@ -197,10 +196,9 @@ namespace Azure.Messaging.EventHubs.Tests
                                                                                    object propertyValueRaw,
                                                                                    Func<object, object> propertyValueAccessor)
         {
-            var eventData = new EventData(new byte[] { 0x11, 0x22, 0x33 })
-            {
-                Properties = new Dictionary<string, object> { { "TestProp", propertyValueRaw } }
-            };
+            var eventData = new EventData(
+                eventBody: new byte[] { 0x11, 0x22, 0x33 },
+                properties: new Dictionary<string, object> { { "TestProp", propertyValueRaw } });
 
             using var message = new AmqpMessageConverter().CreateMessageFromEvent(eventData);
 
@@ -227,10 +225,9 @@ namespace Azure.Messaging.EventHubs.Tests
         public void CreateMessageFromEventTranslatesStreamApplicationProperties(object propertyStream,
                                                                                 byte[] contents)
         {
-            var eventData = new EventData(new byte[] { 0x11, 0x22, 0x33 })
-            {
-                Properties = new Dictionary<string, object> { { "TestProp", propertyStream } }
-            };
+            var eventData = new EventData(
+                eventBody: new byte[] { 0x11, 0x22, 0x33 },
+                properties: new Dictionary<string, object> { { "TestProp", propertyStream } });
 
             using var message = new AmqpMessageConverter().CreateMessageFromEvent(eventData);
 
@@ -254,10 +251,9 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void CreateMessageFromEventFailsForUnknownApplicationPropertyType()
         {
-            var eventData = new EventData(new byte[] { 0x11, 0x22, 0x33 })
-            {
-                Properties = new Dictionary<string, object> { { "TestProperty", new RankException() } }
-            };
+            var eventData = new EventData(
+                eventBody: new byte[] { 0x11, 0x22, 0x33 },
+                properties: new Dictionary<string, object> { { "TestProperty", new RankException() } });
 
             Assert.That(() => new AmqpMessageConverter().CreateMessageFromEvent(eventData), Throws.InstanceOf<SerializationException>());
         }
@@ -396,10 +392,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var body = new byte[] { 0x11, 0x22, 0x33 };
             var property = 65;
 
-            var eventData = new EventData(body)
-            {
-                Properties = new Dictionary<string, object> { { nameof(property), property } }
-            };
+            var eventData = new EventData(
+                eventBody: body,
+                properties: new Dictionary<string, object> { { nameof(property), property } });
 
             using var message = new AmqpMessageConverter().CreateBatchFromEvents(new[] { eventData }, "Something");
             Assert.That(message, Is.Not.Null, "The batch envelope should have been created.");
@@ -424,15 +419,13 @@ namespace Azure.Messaging.EventHubs.Tests
             using var firstEventStream = new MemoryStream(new byte[] { 0x37, 0x39 });
             using var secondEventStream = new MemoryStream(new byte[] { 0x73, 0x93 });
 
-            var firstEvent = new EventData(new byte[] { 0x11, 0x22, 0x33 })
-            {
-                Properties = new Dictionary<string, object> { { nameof(MemoryStream), firstEventStream } }
-            };
+            var firstEvent = new EventData(
+                eventBody: new byte[] { 0x11, 0x22, 0x33 },
+                properties: new Dictionary<string, object> { { nameof(MemoryStream), firstEventStream } });
 
-            var secondEvent = new EventData(new byte[] { 0x44, 0x55, 0x66 })
-            {
-                Properties = new Dictionary<string, object> { { nameof(MemoryStream), secondEventStream } }
-            };
+            var secondEvent = new EventData(
+                eventBody: new byte[] { 0x44, 0x55, 0x66 },
+                properties: new Dictionary<string, object> { { nameof(MemoryStream), secondEventStream } });
 
             var events = new[] { firstEvent, secondEvent };
             var converter = new AmqpMessageConverter();
@@ -600,10 +593,9 @@ namespace Azure.Messaging.EventHubs.Tests
             var body = new byte[] { 0x11, 0x22, 0x33 };
             var property = 65;
 
-            var eventData = new EventData(body)
-            {
-                Properties = new Dictionary<string, object> { { nameof(property), property } }
-            };
+            var eventData = new EventData(
+                eventBody: body,
+                properties: new Dictionary<string, object> { { nameof(property), property } });
 
             using var source = converter.CreateMessageFromEvent(eventData);
             using var batchEnvelope = converter.CreateBatchFromMessages(new[] { source }, "Something");
@@ -631,15 +623,13 @@ namespace Azure.Messaging.EventHubs.Tests
 
             var converter = new AmqpMessageConverter();
 
-            var firstEvent = new EventData(new byte[] { 0x11, 0x22, 0x33 })
-            {
-                Properties = new Dictionary<string, object> { { nameof(MemoryStream), firstEventStream } }
-            };
+            var firstEvent = new EventData(
+                eventBody: new byte[] { 0x11, 0x22, 0x33 },
+                properties: new Dictionary<string, object> { { nameof(MemoryStream), firstEventStream } });
 
-            var secondEvent = new EventData(new byte[] { 0x44, 0x55, 0x66 })
-            {
-                Properties = new Dictionary<string, object> { { nameof(MemoryStream), secondEventStream } }
-            };
+            var secondEvent = new EventData(
+                eventBody: new byte[] { 0x44, 0x55, 0x66 },
+                properties: new Dictionary<string, object> { { nameof(MemoryStream), secondEventStream } });
 
             using var firstMessage = converter.CreateMessageFromEvent(firstEvent);
             using var secondMessage = converter.CreateMessageFromEvent(secondEvent);
@@ -1019,10 +1009,9 @@ namespace Azure.Messaging.EventHubs.Tests
         [Test]
         public void AnEventCanBeTranslatedToItself()
         {
-            var sourceEvent = new EventData(new byte[] { 0x11, 0x22, 0x33 })
-            {
-                Properties = new Dictionary<string, object> { { "Test", 1234 } }
-            };
+            var sourceEvent = new EventData(
+                eventBody: new byte[] { 0x11, 0x22, 0x33 },
+                properties: new Dictionary<string, object> { { "Test", 1234 } });
 
             var converter = new AmqpMessageConverter();
             using var message = converter.CreateMessageFromEvent(sourceEvent);

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/CbsTokenProviderTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Amqp/CbsTokenProviderTests.cs
@@ -8,7 +8,7 @@ using Azure.Messaging.EventHubs.Authorization;
 using Moq;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Tests.Amqp
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for the <see cref="CbsTokenProvider" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparer.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparer.cs
@@ -24,7 +24,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <returns><c>true</c>, if the two events are structurally equivalent; otherwise, <c>false</c>.</returns>
         ///
         public static bool IsEventDataEquivalent(TrackOne.EventData trackOneEvent,
-                                                EventData trackTwoEvent)
+                                                 EventData trackTwoEvent)
         {
             // If the events are the same instance, they're equal.  This should only happen
             // if both are null, since the types differ.
@@ -68,50 +68,57 @@ namespace Azure.Messaging.EventHubs.Tests
                     return false;
                 }
 
+                if (trackOneEvent.SystemProperties.WithoutTypedMembers().Count != trackTwoEvent.SystemProperties.Count)
+                {
+                    return false;
+                }
+
                 foreach (var property in trackOneEvent.SystemProperties)
                 {
                     if (property.Key == TrackOne.ClientConstants.EnqueuedTimeUtcName)
                     {
                         var trackOneDate = (DateTime)trackOneEvent.SystemProperties[property.Key];
-                        var trackTwoDate = trackTwoEvent.SystemProperties.EnqueuedTime;
+                        var trackTwoDate = trackTwoEvent.EnqueuedTime;
 
-                        if (trackOneDate != trackTwoDate.UtcDateTime)
+                        if (trackOneDate != trackTwoDate.Value.UtcDateTime)
                         {
                             return false;
                         }
                     }
-
-                    if (property.Key == TrackOne.ClientConstants.SequenceNumberName)
+                    else if (property.Key == TrackOne.ClientConstants.SequenceNumberName)
                     {
                         var trackOneSequence = (long)trackOneEvent.SystemProperties[property.Key];
-                        var trackTwoSequence = trackTwoEvent.SystemProperties.SequenceNumber;
+                        var trackTwoSequence = trackTwoEvent.SequenceNumber;
 
                         if (trackOneSequence != trackTwoSequence)
                         {
                             return false;
                         }
                     }
-
-                    if (property.Key == TrackOne.ClientConstants.OffsetName)
+                    else if (property.Key == TrackOne.ClientConstants.OffsetName)
                     {
                         var trackOneOffset = (string)trackOneEvent.SystemProperties[property.Key];
-                        var trackTwoOffset = trackTwoEvent.SystemProperties.Offset.ToString();
+                        var trackTwoOffset = trackTwoEvent.Offset?.ToString();
 
                         if (trackOneOffset != trackTwoOffset)
                         {
                             return false;
                         }
                     }
-
-                    if (property.Key == TrackOne.ClientConstants.PartitionKeyName)
+                    else if (property.Key == TrackOne.ClientConstants.PartitionKeyName)
                     {
                         var trackOnePartitionKey = (string)trackOneEvent.SystemProperties[property.Key];
-                        var trackTwoPartitionKey = trackTwoEvent.SystemProperties.PartitionKey;
+                        var trackTwoPartitionKey = trackTwoEvent.PartitionKey;
 
                         if (trackOnePartitionKey != trackTwoPartitionKey)
                         {
                             return false;
                         }
+                    }
+                    else if ((!trackTwoEvent.SystemProperties.ContainsKey(property.Key))
+                        || (trackOneEvent.SystemProperties[property.Key] != trackTwoEvent.SystemProperties[property.Key]))
+                    {
+                        return false;
                     }
                 }
             }
@@ -154,7 +161,7 @@ namespace Azure.Messaging.EventHubs.Tests
         /// <returns><c>true</c>, if the two events are structurally equivalent; otherwise, <c>false</c>.</returns>
         ///
         public static bool IsEventPositionEquivalent(TrackOne.EventPosition trackOnePosition,
-                                                    EventPosition trackTwoPosition)
+                                                     EventPosition trackTwoPosition)
         {
             // If the positions are the same instance, they're equal.  This should only happen
             // if both are null, since the types differ.

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneComparerTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using Azure.Messaging.EventHubs.Compatibility;
 using NUnit.Framework;
 
@@ -71,17 +72,92 @@ namespace Azure.Messaging.EventHubs.Tests
         /// </summary>
         ///
         [Test]
-        public void IsEventDataEquivalentDetectsDifferentSystemProperties()
+        public void IsEventDataEquivalentDetectsDifferentSystemPropertiesWithTypedMember()
         {
             var body = new byte[] { 0x22, 0x44, 0x88 };
-            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
-            var trackTwoEvent = new EventData((byte[])body.Clone());
+            var trackTwoOffset = 27;
+            var trackTwoSystemProperties = new Dictionary<string, object>();
 
+            var trackTwoEvent = new EventData(
+                eventBody: (byte[])body.Clone(),
+                offset: trackTwoOffset,
+                systemProperties: trackTwoSystemProperties);
+
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
             trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
             trackOneEvent.SystemProperties[TrackOne.ClientConstants.OffsetName] = "4";
 
-            trackTwoEvent.SystemProperties = new EventData.SystemEventProperties();
-            trackTwoEvent.SystemProperties.Offset = 27;
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsDifferentSystemPropertiesWithMissingTypedMember()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var trackTwoSystemProperties = new Dictionary<string, object>();
+
+            var trackTwoEvent = new EventData(
+                eventBody: (byte[])body.Clone(),
+                systemProperties: trackTwoSystemProperties);
+
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
+            trackOneEvent.SystemProperties[TrackOne.ClientConstants.OffsetName] = "4";
+
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsDifferentSystemPropertiesWithMapMember()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var propertyName = "Something";
+            var trackTwoSystemProperties = new Dictionary<string, object>();
+
+            var trackTwoEvent = new EventData(
+                eventBody: (byte[])body.Clone(),
+                systemProperties: trackTwoSystemProperties);
+
+            trackTwoSystemProperties[propertyName] = nameof(trackTwoSystemProperties);
+
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
+            trackOneEvent.SystemProperties[propertyName] = nameof(trackOneEvent);
+
+            Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
+        }
+
+        /// <summary>
+        ///   Verifies functionality of the <see cref="TrackOneComparer.IsEventDataEquivalent" /> test
+        ///   helper.
+        /// </summary>
+        ///
+        [Test]
+        public void IsEventDataEquivalentDetectsDifferentSystemPropertiesMismatchedMembers()
+        {
+            var body = new byte[] { 0x22, 0x44, 0x88 };
+            var propertyValue = "one";
+            var trackTwoSystemProperties = new Dictionary<string, object>();
+
+            var trackTwoEvent = new EventData(
+                eventBody: (byte[])body.Clone(),
+                systemProperties: trackTwoSystemProperties);
+
+            trackTwoSystemProperties["two"] = propertyValue;
+
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
+            trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
+            trackOneEvent.SystemProperties["one"] = propertyValue;
 
             Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
         }
@@ -95,13 +171,14 @@ namespace Azure.Messaging.EventHubs.Tests
         public void IsEventDataEquivalentDetectsWhenOneSystemPropertySetIsNull()
         {
             var body = new byte[] { 0x22, 0x44, 0x88 };
-            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
-            var trackTwoEvent = new EventData((byte[])body.Clone());
 
+            var trackTwoEvent = new EventData(
+                eventBody: (byte[])body.Clone(),
+                systemProperties: null);
+
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
             trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
             trackOneEvent.SystemProperties["something"] = "trackOne";
-
-            trackTwoEvent.SystemProperties = null;
 
             Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.False);
         }
@@ -115,17 +192,19 @@ namespace Azure.Messaging.EventHubs.Tests
         public void IsEventDataEquivalentDetectsEqualEvents()
         {
             var body = new byte[] { 0x22, 0x44, 0x88 };
-            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
-            var trackTwoEvent = new EventData((byte[])body.Clone());
+            var offset = 27;
+            var trackTwoSystemProperties = new Dictionary<string, object>();
 
+            var trackTwoEvent = new EventData(
+                eventBody: (byte[])body.Clone(),
+                offset: offset,
+                systemProperties: trackTwoSystemProperties);
+
+            var trackOneEvent = new TrackOne.EventData((byte[])body.Clone());
             trackOneEvent.Properties["test"] = "same";
             trackTwoEvent.Properties["test"] = "same";
-
             trackOneEvent.SystemProperties = new TrackOne.EventData.SystemPropertiesCollection();
-            trackOneEvent.SystemProperties[TrackOne.ClientConstants.OffsetName] = "4";
-
-            trackTwoEvent.SystemProperties = new EventData.SystemEventProperties();
-            trackTwoEvent.SystemProperties.Offset = 4;
+            trackOneEvent.SystemProperties[TrackOne.ClientConstants.OffsetName] = offset.ToString();
 
             Assert.That(TrackOneComparer.IsEventDataEquivalent(trackOneEvent, trackTwoEvent), Is.True);
         }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubProducerTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Compatibility/TrackOneEventHubProducerTests.cs
@@ -122,6 +122,10 @@ namespace Azure.Messaging.EventHubs.Tests
 
             for (var index = 0; index < sentEvents.Length; ++index)
             {
+                // If the system properties for the sent events was null, then normalize it to an empty
+                // instance because the source event does not allow null.
+
+                sentEvents[index].SystemProperties = sentEvents[index].SystemProperties ?? new TrackOne.EventData.SystemPropertiesCollection();
                 Assert.That(TrackOneComparer.IsEventDataEquivalent(sentEvents[index], sourceEvents[index]), Is.True, $"The sequence of events sent should match; they differ at index: { index }");
             }
         }
@@ -162,6 +166,10 @@ namespace Azure.Messaging.EventHubs.Tests
 
             for (var index = 0; index < sentEvents.Length; ++index)
             {
+                // If the system properties for the sent events was null, then normalize it to an empty
+                // instance because the source event does not allow null.
+
+                sentEvents[index].SystemProperties = sentEvents[index].SystemProperties ?? new TrackOne.EventData.SystemPropertiesCollection();
                 Assert.That(TrackOneComparer.IsEventDataEquivalent(sentEvents[index], sourceEvents[index]), Is.True, $"The sequence of events sent should match; they differ at index: { index }");
             }
         }
@@ -540,10 +548,7 @@ namespace Azure.Messaging.EventHubs.Tests
         ///
         private class ClientMock : TrackOne.EventHubClient
         {
-            public ClientMock() : base(new TrackOne.EventHubsConnectionStringBuilder(new Uri("amqp://my.hub.com"), "aPath", "keyName", "KEY!"))
-            {
-            }
-
+            public ClientMock() : base(new TrackOne.EventHubsConnectionStringBuilder(new Uri("amqp://my.hub.com"), "aPath", "keyName", "KEY!")) {}
             protected override Task OnCloseAsync() => Task.CompletedTask;
             protected override PartitionReceiver OnCreateReceiver(string consumerGroupName, string partitionId, TrackOne.EventPosition eventPosition, long? epoch, ReceiverOptions consumerOptions) => default;
             protected override Task<EventHubPartitionRuntimeInformation> OnGetPartitionRuntimeInformationAsync(string partitionId) => Task.FromResult(default(EventHubPartitionRuntimeInformation));

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/TimeSpanExtensionsTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Core/TimeSpanExtensionsTests.cs
@@ -6,7 +6,7 @@ using System.Collections.Generic;
 using Azure.Messaging.EventHubs.Core;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Tests.Core
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of tests for the <see cref="TimeSpanExtensions" />

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensions.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Infrastructure/EventDataExtensions.cs
@@ -64,16 +64,25 @@ namespace Azure.Messaging.EventHubs.Tests
 
             if ((considerSystemProperties) && (!Object.ReferenceEquals(instance.SystemProperties, other.SystemProperties)))
             {
-
                 if ((instance.SystemProperties == null) || (other.SystemProperties == null))
                 {
                     return false;
                 }
 
-                if ((instance.SystemProperties.Offset != other.SystemProperties.Offset)
-                    || (instance.SystemProperties.EnqueuedTime != other.SystemProperties.EnqueuedTime)
-                    || (instance.SystemProperties.PartitionKey != other.SystemProperties.PartitionKey)
-                    || (instance.SystemProperties.SequenceNumber != other.SystemProperties.SequenceNumber))
+                if (instance.SystemProperties.Count != other.SystemProperties.Count)
+                {
+                    return false;
+                }
+
+                if ((instance.Offset != other.Offset)
+                    || (instance.EnqueuedTime != other.EnqueuedTime)
+                    || (instance.PartitionKey != other.PartitionKey)
+                    || (instance.SequenceNumber != other.SequenceNumber))
+                {
+                    return false;
+                }
+
+                if (!instance.SystemProperties.OrderBy(kvp => kvp.Key).SequenceEqual(other.SystemProperties.OrderBy(kvp => kvp.Key)))
                 {
                     return false;
                 }

--- a/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorLiveTests.cs
+++ b/sdk/eventhub/Azure.Messaging.EventHubs/tests/Processor/EventProcessorLiveTests.cs
@@ -12,7 +12,7 @@ using Azure.Messaging.EventHubs.Processor;
 using Azure.Messaging.EventHubs.Tests.Infrastructure;
 using NUnit.Framework;
 
-namespace Azure.Messaging.EventHubs.Tests.Processor
+namespace Azure.Messaging.EventHubs.Tests
 {
     /// <summary>
     ///   The suite of live tests for the <see cref="EventProcessor" />
@@ -242,7 +242,7 @@ namespace Azure.Messaging.EventHubs.Tests.Processor
 
                     await hub.StopAllAsync();
 
-                    // Validate results.  Make sure we received every event in the correct partition processor, 
+                    // Validate results.  Make sure we received every event in the correct partition processor,
                     // in the order they were sent.
 
                     foreach (var partitionId in partitionIds)


### PR DESCRIPTION
# Summary

The intent of these changes is to restore the concept of a dictionary of weakly typed system properties on the `EventData` type, while still elevating well-known properties to their corresponding strongly-typed members.

# Last Upstream Rebase

Wednesday, September 4, 2019 9:36am (EDT)

# Related and Follow-Up Issues

- [[Epic] Release Event Hubs Track 2 Library Preview 3 for .Net](https://github.com/Azure/azure-sdk-for-net/issues/7141) (#7141)  
- [Cannot access AMQP annotations (eg for iothub-* values)](https://github.com/Azure/azure-sdk-for-net/issues/7356) (#7356)  