### PR TITLE
[Event Hubs Client] Track One (Test Stability Tuning)

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/EventHubScope.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.EventHubs.Tests
     {
         private const int RetryMaximumAttemps = 15;
         private const double RetryExponentialBackoffSeconds = 2.5;
-        private const double RetryBaseJitterSeconds = 8.0;
+        private const double RetryBaseJitterSeconds = 10.0;
 
         private static readonly TimeSpan CredentialRefreshBuffer = TimeSpan.FromMinutes(5);
         private static readonly ThreadLocal<Random> RandomNumberGenerator = new ThreadLocal<Random>(() => new Random(Interlocked.Increment(ref s_randomSeed)), false);

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Azure.EventHubs.Tests
 
 
         // General
-        internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(30);
+        internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(90);
     }
 }

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/EventHubExceptionTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/EventHubExceptionTests.cs
@@ -191,15 +191,14 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
         {
             GeneralStartupFailure("NontransientGetRuntimeInfoFailure", EHErrorLocation.GetRuntimeInformation, true);
         }
-#if !FullNetFx
-        // Issue https://github.com/Azure/azure-sdk-for-net/issues/5995 tracking this test being re-enabled for netfx
-        [Fact]
+
+        [Fact(Skip="Results have been non-deterministic in CI and nightly runs.  Tracking with #5995")]
         [DisplayTestMethodName]
         public void HardGetRuntimeInfoFailure()
         {
             GeneralStartupFailure("HardGetRuntimeInfoFailure", EHErrorLocation.GetRuntimeInformation, false);
         }
-#endif
+
         [Fact]
         [DisplayTestMethodName]
         public void NontransientReceiverCreationFailure()


### PR DESCRIPTION
# Summary

The intent of these changes is to continue ongoing efforts to tune the test execution environment for maximum stability across local, CI, and nightly test runs.

### Goals

- Mark a test to be skipped, as its results have been non-deterministic and causing impact due to intermittent CI failures.

- Increase the baseline operation timeout used for testing; with the tests running in parallel and Azure resoures being created and torn down for each test, there have been intermittent slow downs in Azure responsiveness during test execution.  The hope is that the increased timeout will help to mitigate.  (note: This adjustment was made for test runs only; the default for client library use was not touched)

- Increase the base jitter for retries during management plane operations; this is intended to allow for a larger window of randomization when there are failures, as they seem to occur in clusters.  The additional randomization should reduce the "thundering herd" of retries in a short window.

# Last Upstream Rebase

Tuesday, September 3, 2019 4:49pm (EDT)

# Related and Follow-Up Issues

- [HardGetRuntimeInfoFailure failing on .NET Framework](https://github.com/Azure/azure-sdk-for-net/issues/5995)(#5995)