### PR TITLE
[Event Hubs Client] Track One Tests (Service Fabric Processor Skips)

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/EventHubExceptionTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/EventHubExceptionTests.cs
@@ -11,35 +11,35 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
 
     public class EventHubExceptionTests
     {
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void SoftTransientClientCreationFailure()
         {
             SoftTransientFailures("ClientCreation", EHErrorLocation.EventHubClientCreation);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void SoftTransientGetRuntimeInfoFailure()
         {
             SoftTransientFailures("GetRuntimeInfo", EHErrorLocation.GetRuntimeInformation);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void SoftTransientReceiverCreationFailure()
         {
             SoftTransientFailures("ReceiverCreation", EHErrorLocation.CreateReceiver);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void SoftTransientReceiverClosingFailure()
         {
             SoftTransientFailures("ReceiverClosing", EHErrorLocation.ReceiverClosing);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void SoftTransientEventHubClientClosingFailure()
         {
@@ -88,28 +88,28 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             Assert.Null(state.ShutdownException);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardTransientClientCreationFailure()
         {
             HardTransientStartupFailure("ClientCreation", EHErrorLocation.EventHubClientCreation);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardTransientGetRuntimeInfoFailure()
         {
             HardTransientStartupFailure("GetRuntimeInfo", EHErrorLocation.GetRuntimeInformation);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardTransientReceiverCreationFailure()
         {
             HardTransientStartupFailure("ReceiverCreation", EHErrorLocation.CreateReceiver);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardTransientReceiverClosingFailure()
         {
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             NoFailures("HardTransientReceiverClosingFailure", injector);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardTransientEventHubClientClosingFailure()
         {
@@ -171,21 +171,21 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             }
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void NontransientClientCreationFailure()
         {
             GeneralStartupFailure("NontransientClientCreationFailure", EHErrorLocation.EventHubClientCreation, true);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardClientCreationFailure()
         {
             GeneralStartupFailure("HardClientCreationFailure", EHErrorLocation.EventHubClientCreation, false);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void NontransientGetRuntimeInfoFailure()
         {
@@ -199,21 +199,21 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             GeneralStartupFailure("HardGetRuntimeInfoFailure", EHErrorLocation.GetRuntimeInformation, false);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void NontransientReceiverCreationFailure()
         {
             GeneralStartupFailure("NontransientReceiverCreationFailure", EHErrorLocation.CreateReceiver, true);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardReceiverCreationFailure()
         {
             GeneralStartupFailure("HardReceiverCreationFailure", EHErrorLocation.CreateReceiver, false);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void NontransientReceiverClosingFailure()
         {
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             NoFailures("NontransientReceiverClosingFailure", injector);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardReceiverClosingFailure()
         {
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             NoFailures("HardReceiverClosingFailure", injector);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         void NontransientEventHubClientClosingFailure()
         {
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             NoFailures("NontransientEventHubClientClosingFailure", injector);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardEventHubClientClosingFailure()
         {
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             }
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void TransientEventHubReceiveFailure()
         {
@@ -346,7 +346,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             Assert.Null(state.ShutdownException);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void NonTransientEventHubReceiveFailure()
         {
@@ -356,7 +356,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             EventHubReceiveFailure("NonTransient", new ReceiverDisconnectedException("ErrorInjector"), true);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void HardEventHubReceiveFailure()
         {

--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/UserExceptionTests.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/ServiceFabricProcessor/UserExceptionTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
 
     public class UserExceptionTests
     {
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void OpenException()
         {
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             }
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void CloseException()
         {
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.EventHubs.Tests.ServiceFabricProcessor
             Assert.Null(state.ShutdownException);
         }
 
-        [Fact]
+        [Fact(Skip="Causing instability in CI and nightly runs.  Issue: #7472")]
         [DisplayTestMethodName]
         public void ErrorException()
         {


### PR DESCRIPTION
# Summary

The intent of these changes is to mark  tests related to exception handling (both user and system) as skipped due to them recently becoming unstable in both CI and nightly runs..

# Last Upstream Rebase

Wednesday, September 4, 2019 10:17am (EDT)

# Related and Follow-Up Issues

- [[Track One] Tests for Service Fabric Processor error handling are unstable for CI and nightly runs](https://github.com/Azure/azure-sdk-for-net/issues/7472) (#7472)  