### PR TITLE
[Event Hubs Client] Track One (Test Timeout)

### DIFF
--- a/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
+++ b/sdk/eventhub/Microsoft.Azure.EventHubs/tests/Infrastructure/TestConstants.cs
@@ -16,6 +16,6 @@ namespace Microsoft.Azure.EventHubs.Tests
 
 
         // General
-        internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(90);
+        internal static readonly TimeSpan DefaultOperationTimeout = TimeSpan.FromSeconds(180);
     }
 }


### PR DESCRIPTION
# Summary

The intent of these changes is to increase the operation timeout used for tests _(only!)_ in order to help stabilize nightly runs.  The tests associated with large event and batch
sizes are still seeing intermittent failures due to timeout.

# Last Upstream Rebase

Thursday, September 5, 2019 11:51am (EDT)