### PR TITLE
Fix matching for skipped headers

### DIFF
--- a/sdk/core/Azure.Core/tests/RecordedTestTests.cs
+++ b/sdk/core/Azure.Core/tests/RecordedTestTests.cs
@@ -112,6 +112,31 @@ namespace Azure.Core.Tests
         }
 
         [Test]
+        public void RecordMatcherIgnoresIgnoredHeaders()
+        {
+            var matcher = new RecordMatcher(new RecordedTestSanitizer());
+
+            MockRequest mockRequest = new MockRequest();
+            mockRequest.Method = RequestMethod.Put;
+            mockRequest.UriBuilder.Uri = new Uri("http://localhost");
+
+            RecordEntry[] entries = new []
+            {
+                new RecordEntry()
+                {
+                    RequestUri = "http://localhost",
+                    RequestMethod = RequestMethod.Put,
+                    RequestHeaders =
+                    {
+                        { "Request-Id", new[] { "Non-Random value"}},
+                    }
+                }
+            };
+
+            Assert.NotNull(matcher.FindMatch(mockRequest, entries));
+        }
+
+        [Test]
         public void RecordMatcherThrowsExceptionsWhenNoRecordsLeft()
         {
             var matcher = new RecordMatcher(new RecordedTestSanitizer());

--- a/sdk/core/Azure.Core/tests/TestFramework/DiagnosticScopeValidatingInterceptor.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/DiagnosticScopeValidatingInterceptor.cs
@@ -21,7 +21,7 @@ namespace Azure.Core.Testing
                 var expectedEvents = new List<string>();
                 expectedEvents.Add(expectedEventPrefix + ".Start");
 
-                TestDiagnosticListener diagnosticListener = new TestDiagnosticListener("Azure.Clients");
+                using TestDiagnosticListener diagnosticListener = new TestDiagnosticListener("Azure.Clients");
                 invocation.Proceed();
 
                 bool strict = !invocation.Method.GetCustomAttributes(true).Any(a => a.GetType().FullName == "Azure.Core.ForwardsClientCallsAttribute");
@@ -49,7 +49,6 @@ namespace Azure.Core.Testing
                 }
                 finally
                 {
-                    diagnosticListener.Dispose();
                     if (strict)
                     {
                         foreach (var expectedEvent in expectedEvents)

--- a/sdk/core/Azure.Core/tests/TestFramework/UseSyncMethodsInterceptor.cs
+++ b/sdk/core/Azure.Core/tests/TestFramework/UseSyncMethodsInterceptor.cs
@@ -138,25 +138,6 @@ namespace Azure.Core.Testing
                     yield return new Page<T>(new [] { response.Value}, null, response.GetRawResponse());
                 }
             }
-
-            private class SingleEnumerable: IAsyncEnumerable<Page<T>>, IAsyncEnumerator<Page<T>>
-            {
-                public SingleEnumerable(Page<T> value)
-                {
-                    Current = value;
-                }
-
-                public ValueTask DisposeAsync() => default;
-
-                public ValueTask<bool> MoveNextAsync() => new ValueTask<bool>(false);
-
-                public Page<T> Current { get; }
-
-                public IAsyncEnumerator<Page<T>> GetAsyncEnumerator(CancellationToken cancellationToken = new CancellationToken())
-                {
-                    return this;
-                }
-            }
         }
     }
 }


### PR DESCRIPTION
And don't leak the listener in case of exceptions.
